### PR TITLE
Update webpack_dev_server.sh for changes from cookiecutter

### DIFF
--- a/webpack_dev_server.sh
+++ b/webpack_dev_server.sh
@@ -1,36 +1,21 @@
 #!/bin/bash
 set -ef -o pipefail
 
-if [[ $(uname -s) == "Darwin" ]] ; then
-  IS_OSX_HOST_MACHINE="true"
-else
-  IS_OSX_HOST_MACHINE="false"
-fi
+# Define some environment variables to figure out where we are running
+source ./scripts/envs.sh
 
-if [[ "$IS_OSX_HOST_MACHINE" == 'true' ]] ; then
-  WEBPACK_HOST='127.0.0.1'
-elif [ -z "$WEBPACK_DEV_SERVER_HOST" ] ; then
-  WEBPACK_HOST='0.0.0.0'
-else
-  WEBPACK_HOST="$WEBPACK_DEV_SERVER_HOST"
-fi
-
-if [ -z "$WEBPACK_DEV_SERVER_PORT" ] ; then
-  WEBPACK_PORT='8062'
-else
-  WEBPACK_PORT="$WEBPACK_DEV_SERVER_PORT"
-fi
+WEBPACK_HOST='0.0.0.0'
+WEBPACK_PORT='8062'
 
 # The webpack server should only be run in one of two cases:
-#    1) The WEBPACK_DEV_SERVER_HOST env variable is not set. This means that the webpack server will run within the
-#       Docker container, so we'll want to run the server when this script is invoked.
+#    1) We are running Linux and inside the Docker container
 #    2) We're on an OSX host machine. Our current workflow for developing on a Docker container involves running
 #       the webpack server on the host machine rather than the container.
 # If neither of those are true, running this script is basically a no-op.
 
-if [[ ! -z "$WEBPACK_DEV_SERVER_HOST" && "$IS_OSX_HOST_MACHINE" == 'false' ]] ; then
+if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
   echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
-elif [[ -z "$WEBPACK_DEV_SERVER_HOST" || "$IS_OSX_HOST_MACHINE" == 'true' ]] ; then
+else
   if [[ "$1" == "--install" ]] ; then
     yarn install --pure-lockfile && echo "Finished yarn install"
   fi


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #22 

#### What's this PR do?
Updates `webpack_dev_server.sh` to use environment variables from `scripts/envs.sh`.

#### How should this be manually tested?
You should be able to start the webpack dev server. Everything should still work (I think this is just the checkbox and blue border at this point).
