### PR TITLE
Fixed API tests

### DIFF
--- a/themes/api.py
+++ b/themes/api.py
@@ -190,7 +190,7 @@ class Api:
             **other_settings (dict): dict of additional settings
 
         Returns:
-            praw.models.Subreddit: the created subreddit
+            praw.models.Subreddit: the updated subreddit
         """
         if theme_type is not None and theme_type not in VALID_THEME_TYPES:
             raise ValueError('Invalid argument theme_type={}'.format(theme_type))

--- a/themes/api.py
+++ b/themes/api.py
@@ -136,7 +136,7 @@ class Api:
         Returns:
             ListingGenerator(praw.models.Subreddit): a generator over theme listings
         """
-        return self.reddit.user.subreddits() if self.is_anonymous is not None else self.reddit.subreddits.default()
+        return self.reddit.user.subreddits() if not self.is_anonymous else self.reddit.subreddits.default()
 
     def get_theme(self, name):
         """
@@ -260,7 +260,7 @@ class Api:
         post = self.get_post(post_id)
 
         if not post.selftext:
-            raise ValueError('Post a url cannot be updated')
+            raise ValueError('Posts with a url cannot be updated')
 
         return post.edit(text)
 

--- a/themes/api_test.py
+++ b/themes/api_test.py
@@ -143,7 +143,7 @@ def test_get_post(mock_client):
     """Test get_post"""
     client = api.Api()
     client.get_post('id')
-    assert mock_client.submission.called_once_with(id='id')
+    mock_client.submission.assert_called_once_with(id='id')
 
 
 def test_update_post_valid(mock_client):
@@ -198,7 +198,7 @@ def test_list_comments(mock_client):
     """Test list_comments"""
     client = api.Api()
     result = client.list_comments('id')
-    assert mock_client.submission.called_once_with('id')
+    mock_client.submission.assert_called_once_with(id='id')
     assert result == mock_client.submission.return_value.comments
 
 
@@ -233,7 +233,7 @@ def test_more_comments(mock_client, mocker):
     more_patch = mocker.patch('praw.models.reddit.more.MoreComments')
     result = client.more_comments('t1_gh_3i', 't3_iru_i2', 5, children=children)
 
-    assert more_patch.called_once_with(client.reddit, {
+    more_patch.assert_called_once_with(client.reddit, {
         'id': 'gh_3i',
         'name': 't1_gh_3i',
         'parent_id': 't3_iru_i2',

--- a/themes/api_test.py
+++ b/themes/api_test.py
@@ -24,7 +24,8 @@ def mock_client(mock_get_client):
 def test_get_theme_user(mock_get_client, create_user):
     """Test get_themes for logged-in user"""
     user = UserFactory.create() if create_user else None
-    api.Api(user=user).get_theme('test')
+    theme = api.Api(user=user).get_theme('test')
+    assert theme == mock_get_client.return_value.subreddit.return_value
     mock_get_client.assert_called_once_with(user=user)
     mock_get_client.return_value.subreddit.assert_called_once_with('test')
 
@@ -32,14 +33,16 @@ def test_get_theme_user(mock_get_client, create_user):
 def test_list_themes_user(mock_get_client):
     """Test list_themes for logged-in user"""
     user = UserFactory.create()
-    api.Api(user=user).list_themes()
+    themes = api.Api(user=user).list_themes()
+    assert themes == mock_get_client.return_value.user.subreddits.return_value
     mock_get_client.assert_called_once_with(user=user)
     mock_get_client.return_value.user.subreddits.assert_called_once_with()
 
 
 def test_list_themes_no_user(mock_get_client):
     """Test list_themes for anonymous user"""
-    api.Api().list_themes()
+    themes = api.Api().list_themes()
+    assert themes == mock_get_client.return_value.subreddits.default.return_value
     mock_get_client.assert_called_once_with(user=None)
     mock_get_client.return_value.subreddits.default.assert_called_once_with()
 
@@ -48,7 +51,8 @@ def test_list_themes_no_user(mock_get_client):
 def test_create_theme_user(mock_get_client, theme_type):
     """Test create_theme for logged-in user"""
     user = UserFactory.create()
-    api.Api(user=user).create_theme('name', 'Title', theme_type=theme_type)
+    theme = api.Api(user=user).create_theme('name', 'Title', theme_type=theme_type)
+    assert theme == mock_get_client.return_value.subreddit.create.return_value
     mock_get_client.assert_called_once_with(user=user)
     mock_get_client.return_value.subreddit.create.assert_called_once_with(
         'name', title='Title', subreddit_type=theme_type
@@ -60,7 +64,8 @@ def test_create_theme_setting(mock_client, theme_setting):
     """Test create_theme for {theme_setting}"""
     user = UserFactory.create()
     kwargs = {theme_setting: 'value'}
-    api.Api(user=user).create_theme('name', 'Title', **kwargs)
+    theme = api.Api(user=user).create_theme('name', 'Title', **kwargs)
+    assert theme == mock_client.subreddit.create.return_value
     mock_client.subreddit.create.assert_called_once_with(
         'name', title='Title', subreddit_type=api.THEME_TYPE_PUBLIC, **kwargs
     )
@@ -96,7 +101,8 @@ def test_create_theme_no_user(mock_client):
 def test_update_theme_type(mock_client, theme_type):
     """Test create_theme for theme_type"""
     user = UserFactory.create()
-    api.Api(user=user).update_theme('name', theme_type=theme_type)
+    theme = api.Api(user=user).update_theme('name', theme_type=theme_type)
+    assert theme == mock_client.subreddit.return_value.mod.update.return_value
     mock_client.subreddit.assert_called_once_with('name')
     mock_client.subreddit.return_value.mod.update.assert_called_once_with(subreddit_type=theme_type)
 
@@ -106,7 +112,8 @@ def test_update_theme_setting(mock_client, theme_setting):
     """Test update_theme for {theme_setting}"""
     user = UserFactory.create()
     kwargs = {theme_setting: 'value'}
-    api.Api(user=user).update_theme('name', **kwargs)
+    theme = api.Api(user=user).update_theme('name', **kwargs)
+    assert theme == mock_client.subreddit.return_value.mod.update.return_value
     mock_client.subreddit.assert_called_once_with('name')
     mock_client.subreddit.return_value.mod.update.assert_called_once_with(**kwargs)
 
@@ -114,7 +121,8 @@ def test_update_theme_setting(mock_client, theme_setting):
 def test_create_post_text(mock_client):
     """Test create_post with text"""
     client = api.Api()
-    client.create_post('theme', 'Title', text='Text')
+    post = client.create_post('theme', 'Title', text='Text')
+    assert post == mock_client.subreddit.return_value.submit.return_value
     mock_client.subreddit.assert_called_once_with('theme')
     mock_client.subreddit.return_value.submit.assert_called_once_with('Title', selftext='Text', url=None)
 
@@ -122,7 +130,8 @@ def test_create_post_text(mock_client):
 def test_create_post_url(mock_client):
     """Test create_post with url"""
     client = api.Api()
-    client.create_post('theme', 'Title', url='http://google.com')
+    post = client.create_post('theme', 'Title', url='http://google.com')
+    assert post == mock_client.subreddit.return_value.submit.return_value
     mock_client.subreddit.assert_called_once_with('theme')
     mock_client.subreddit.return_value.submit.assert_called_once_with(
         'Title', selftext=None, url='http://google.com'
@@ -142,7 +151,8 @@ def test_create_post_url_and_text(mock_client):
 def test_get_post(mock_client):
     """Test get_post"""
     client = api.Api()
-    client.get_post('id')
+    post = client.get_post('id')
+    assert post == mock_client.submission.return_value
     mock_client.submission.assert_called_once_with(id='id')
 
 
@@ -150,7 +160,8 @@ def test_update_post_valid(mock_client):
     """Test update_post passes"""
     mock_client.submission.return_value.selftext = 'text'
     client = api.Api()
-    client.update_post('id', 'Text')
+    post = client.update_post('id', 'Text')
+    assert post == mock_client.submission.return_value.edit.return_value
     mock_client.submission.assert_called_once_with(id='id')
     mock_client.submission.return_value.edit.assert_called_once_with('Text')
 
@@ -168,7 +179,8 @@ def test_update_post_invalid(mock_client):
 def test_create_comment_on_post(mock_client):
     """Makes correct calls for comment on post"""
     client = api.Api()
-    client.create_comment('text', post_id='id1')
+    comment = client.create_comment('text', post_id='id1')
+    assert comment == mock_client.submission.return_value.reply.return_value
     assert mock_client.comment.call_count == 0
     mock_client.submission.assert_called_once_with(id='id1')
     mock_client.submission.return_value.reply.assert_called_once_with('text')
@@ -177,7 +189,8 @@ def test_create_comment_on_post(mock_client):
 def test_create_comment_on_comment(mock_client):
     """Makes correct calls for comment on comment"""
     client = api.Api()
-    client.create_comment('text', comment_id='id2')
+    comment = client.create_comment('text', comment_id='id2')
+    assert comment == mock_client.comment.return_value.reply.return_value
     assert mock_client.submission.call_count == 0
     mock_client.comment.assert_called_once_with('id2')
     mock_client.comment.return_value.reply.assert_called_once_with('text')
@@ -205,7 +218,8 @@ def test_list_comments(mock_client):
 def test_get_comment(mock_client):
     """Test get_comment"""
     client = api.Api()
-    client.get_comment('id')
+    comment = client.get_comment('id')
+    assert comment == mock_client.comment.return_value
     mock_client.comment.assert_called_once_with('id')
 
 
@@ -220,7 +234,8 @@ def test_delete_comment(mock_client):
 def test_update_comment(mock_client):
     """Test update_post passes"""
     client = api.Api()
-    client.update_comment('id', 'Text')
+    comment = client.update_comment('id', 'Text')
+    assert comment == mock_client.comment.return_value.edit.return_value
     mock_client.comment.assert_called_once_with('id')
     mock_client.comment.return_value.edit.assert_called_once_with('Text')
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes asserts in `themes/api_test.py` and fixes a bug in `list_themes`. The `assert mock.called_once_with(...)` syntax isn't valid since `called_once_with` isn't a method, so it evaluates to a mock which is always true.

#### How should this be manually tested?
`list_themes` should return the right results for anonymous users
