### PR TITLE
Added list_posts to Api

### DIFF
--- a/themes/api.py
+++ b/themes/api.py
@@ -232,6 +232,19 @@ class Api:
             raise ValueError('Exactly one of text and url must be provided')
         return self.get_theme(theme_name).submit(title, selftext=text, url=url)
 
+    def list_posts(self, theme_name):
+        """
+        List posts using the 'hot' algorithm
+
+        Args:
+            theme_name(str): the theme name identifier
+
+        Returns:
+            praw.models.listing.generator.ListingGenerator:
+                A generator of posts for a subreddit
+        """
+        return self.get_theme(theme_name).hot()
+
     def get_post(self, post_id):
         """
         Gets the post

--- a/themes/api_test.py
+++ b/themes/api_test.py
@@ -152,9 +152,9 @@ def test_list_posts(mock_client):
     """list_posts should return a generator of posts"""
     client = api.Api()
     posts = client.list_posts('theme')
-    assert posts == mock_client.submission.return_value.hot.return_value
-    mock_client.submission.return_value.hot.assert_called_once_with()
-    mock_client.submission.assert_called_once_with('theme')
+    assert posts == mock_client.subreddit.return_value.hot.return_value
+    mock_client.subreddit.return_value.hot.assert_called_once_with()
+    mock_client.subreddit.assert_called_once_with('theme')
 
 
 def test_get_post(mock_client):

--- a/themes/api_test.py
+++ b/themes/api_test.py
@@ -148,6 +148,15 @@ def test_create_post_url_and_text(mock_client):
     assert mock_client.subreddit.call_count == 0
 
 
+def test_list_posts(mock_client):
+    """list_posts should return a generator of posts"""
+    client = api.Api()
+    posts = client.list_posts('theme')
+    assert posts == mock_client.submission.return_value.hot.return_value
+    mock_client.submission.return_value.hot.assert_called_once_with()
+    mock_client.submission.assert_called_once_with('theme')
+
+
 def test_get_post(mock_client):
     """Test get_post"""
     client = api.Api()


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #29 

#### What's this PR do?
Adds `list_posts` to the `Api` class. It uses the `hot` algorithm to list posts in a channel

#### How should this be manually tested?
In a shell run `list(api.list_posts("subreddit"))` and verify that you see a list of posts
