### PR TITLE
add a command for running JS tests in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test": "./scripts/test/js_test.sh",
     "coverage": "COVERAGE=1 ./scripts/test/js_test.sh",
     "codecov": "CODECOV=1 ./scripts/test/js_test.sh",
+    "watch": "WATCH=1 ./scripts/test/js_test.sh",
     "flow": "flow check"
   }
 }

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -7,6 +7,9 @@ then
 elif [[ ! -z "$CODECOV" ]]
 then
     export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
+elif [[ ! -z "$WATCH" ]]
+then
+    export CMD="node ./node_modules/mocha/bin/_mocha --watch"
 else
     export CMD="node ./node_modules/mocha/bin/_mocha"
 fi


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

just adds tooling to run mocha in 'watch' mode, which re-runs the tests whenever a file is touched. very handy!

unfortunately mocha doesn't have the chops to figure out which files are relevant to re-run if a particular file is changed (we'd need to switch to a fancy, newer runner like AVA to get that) but this is still pretty nice :)

#### How should this be manually tested?

running tests in the normal way should still work, but you should also be able to do `npm run watch` instead of `npm run test`, and it should run the tests in watch mode.