### PR TITLE
add frontpage subreddit links

### DIFF
--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -1,24 +1,25 @@
 // @flow
 import React from 'react';
-import R from 'ramda';
 
 import PostSummary from './PostSummary';
+
 import type { Post } from '../flow/discussionTypes';
 
-const renderPosts = R.addIndex(R.map)((post, index) => (
-  <PostSummary post={post} key={index} />
+const renderPosts = (posts, showChannelLinks) => posts.map((post, index) => (
+  <PostSummary post={post} key={index} showChannelLink={showChannelLinks} />
 ));
 
 type PostListProps = {
-  posts: Array<Post>
+  posts:             Array<Post>,
+  showChannelLinks?: boolean,
 };
 
 const PostList = (props: PostListProps) => {
-  const { posts } = props;
+  const { posts, showChannelLinks } = props;
 
   return (
     <div className="post-list">
-      { renderPosts(posts) }
+      { renderPosts(posts, showChannelLinks) }
     </div>
   );
 };

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -8,17 +8,26 @@ import PostSummary from './PostSummary';
 import { makeChannelPostList } from '../factories/posts';
 
 describe('PostList', () => {
-  const renderPostList = posts => shallow(
-    <PostList posts={posts} />
+  const renderPostList = (props = {posts: makeChannelPostList()}) => shallow(
+    <PostList {...props} />
   );
 
   it('should render a list of posts', () => {
-    let wrapper = renderPostList(makeChannelPostList());
+    let wrapper = renderPostList();
     assert.lengthOf(wrapper.find(PostSummary), 20);
   });
 
   it('should behave well if handed an empty list', () => {
-    let wrapper = renderPostList([]);
+    let wrapper = renderPostList({ posts: []});
     assert.lengthOf(wrapper.find(PostSummary), 0);
+  });
+
+  it('should pass the showChannelLinks prop to PostSummary', () => {
+    let wrapper = renderPostList(
+      { posts: makeChannelPostList(), showChannelLinks: true }
+    );
+    wrapper.find(PostSummary).forEach(postSummary => {
+      assert.isTrue(postSummary.props().showChannelLink);
+    });
   });
 });

--- a/static/js/components/PostSummary.js
+++ b/static/js/components/PostSummary.js
@@ -1,12 +1,24 @@
 // @flow
 import React from 'react';
 import moment from 'moment';
+import { Link } from 'react-router-dom';
 
 import type { Post } from '../flow/discussionTypes';
 
 export default class PostSummary extends React.Component {
   props: {
-    post: Post,
+    post:             Post,
+    showChannelLink?: boolean,
+  }
+
+  showChannelLink = () => {
+    const { post, showChannelLink } = this.props;
+
+    return showChannelLink && post.channel_name
+      ? <Link to={`/channel/${post.channel_name}`}>
+        on {post.channel_name}
+      </Link>
+      : null;
   }
 
   render() {
@@ -20,9 +32,9 @@ export default class PostSummary extends React.Component {
         </div>
         <div className="summary">
           <a className="post-title">{ post.title }</a>
-          <span className="authored-by">
-            by <a>{post.author || 'someone'}</a>, {formattedDate}
-          </span>
+          <div className="authored-by">
+            by <a>{post.author || 'someone'}</a>, {formattedDate} { this.showChannelLink() }
+          </div>
           <a className="num-comments">{post.num_comments || 0} Comments</a>
         </div>
       </div>

--- a/static/js/components/PostSummary_test.js
+++ b/static/js/components/PostSummary_test.js
@@ -2,16 +2,17 @@
 import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
 
 import { makePost } from '../factories/posts';
 import PostSummary from './PostSummary';
 
 describe('PostSummary', () => {
-  const renderPostSummary = (post) => shallow(<PostSummary post={post}/>);
+  const renderPostSummary = props => shallow(<PostSummary {...props}/>);
 
   it('should render a post correctly', () => {
     const post = makePost();
-    const wrapper = renderPostSummary(post);
+    const wrapper = renderPostSummary({ post });
     const summary = wrapper.find('.summary');
     assert.equal(wrapper.find('.votes').text(), post.upvotes.toString());
     assert.equal(summary.find('a').at(0).text(), post.title);
@@ -20,5 +21,12 @@ describe('PostSummary', () => {
     const expectedPrefix = `by ${post.author}, `;
     assert(authoredBy.startsWith(expectedPrefix));
     assert.isNotEmpty(authoredBy.substring(expectedPrefix.length));
+  });
+
+  it('should link to the subreddit, if told to', () => {
+    const post = makePost();
+    post.channel_name = "channel_name";
+    const wrapper = renderPostSummary({ post: post, showChannelLink: true });
+    assert.equal(wrapper.find(Link).props().to, '/channel/channel_name');
   });
 });

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import R from 'ramda';
 
 import Card from '../components/Card';
 import ChannelSidebar from '../components/ChannelSidebar';
@@ -41,28 +42,33 @@ class ChannelPage extends React.Component {
   renderContents(channelName, channels, postsForChannel, posts) {
     const channel = channels.data.get(channelName);
     const postIds = postsForChannel.data.get(channelName);
-    return (
-      <div className="double-column">
-        <div>
-          <Link to="/">Discussions</Link>&nbsp;
-          <span>&gt;</span>&nbsp;
-          <span>{channel.title}</span>
+
+    if (R.isNil(channel) || R.isNil(postIds)) {
+      return null;
+    } else {
+      return (
+        <div className="double-column">
+          <div>
+            <Link to="/">Discussions</Link>&nbsp;
+            <span>&gt;</span>&nbsp;
+            <span>{channel.title}</span>
+          </div>
+          <div className="first-column">
+            <Card>
+              <PostList
+                channel={channel}
+                posts={safeBulkGet(postIds, posts.data)}
+              />
+            </Card>
+          </div>
+          <div className="second-column">
+            <Card>
+              <ChannelSidebar channel={channel} />
+            </Card>
+          </div>
         </div>
-        <div className="first-column">
-          <Card>
-            <PostList
-              channel={channel}
-              posts={safeBulkGet(postIds, posts.data)}
-            />
-          </Card>
-        </div>
-        <div className="second-column">
-          <Card>
-            <ChannelSidebar channel={channel} />
-          </Card>
-        </div>
-      </div>
-    );
+      );
+    }
   }
 
   render() {

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -32,6 +32,7 @@ class HomePage extends React.Component {
           <Card>
             <PostList
               posts={safeBulkGet(frontpage.data, posts.data)}
+              showChannelLinks={true}
             />
           </Card>
         </div>

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -21,3 +21,10 @@ export const makePost = (isURLPost: boolean = false): Post => ({
 export const makeChannelPostList = () => (
   R.range(0, 20).map(() => makePost(Math.random() > .5))
 );
+
+export const makeFrontpagePostList = () => (
+  makeChannelPostList().map(post => {
+    post.channel_name = casual.word;
+    return post;
+  })
+);

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -4,7 +4,8 @@ import R from 'ramda';
 
 import {
   makePost,
-  makeChannelPostList
+  makeChannelPostList,
+  makeFrontpagePostList,
 } from './posts';
 
 describe('posts factories', () => {
@@ -52,6 +53,14 @@ describe('posts factories', () => {
         assert.isNumber(post.upvotes);
         assert.equal(0, post.downvotes);
         assert.isString(post.author);
+      });
+    });
+  });
+
+  describe('makeFrontpagePostList', () => {
+    it('should return a list of posts, with the channel name', () => {
+      makeFrontpagePostList().forEach(post => {
+        assert.isString(post.channel_name);
       });
     });
   });

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -8,15 +8,16 @@ export type Channel = {
 };
 
 export type Post = {
-  id: string,
-  title: string,
-  author: string,  // username
-  upvotes: number,
-  downvotes: number,
-  upvoted: boolean,
-  downvoted: boolean,
-  url: ?string,
-  text: ?string,
-  created: string,
-  num_comments: number,
+  id:            string,
+  title:         string,
+  author:        string,  // username
+  upvotes:       number,
+  downvotes:     number,
+  upvoted:       boolean,
+  downvoted:     boolean,
+  url:           ?string,
+  text:          ?string,
+  created:       string,
+  num_comments:  number,
+  channel_name?: string,
 };

--- a/static/js/reducers/frontpage.js
+++ b/static/js/reducers/frontpage.js
@@ -1,7 +1,7 @@
 // @flow
 import { GET, INITIAL_STATE } from 'redux-hammock/constants';
 
-import { makeChannelPostList } from '../factories/posts';
+import { makeFrontpagePostList } from '../factories/posts';
 import type { Post } from '../flow/discussionTypes';
 
 export const frontPageEndpoint = {
@@ -9,7 +9,7 @@ export const frontPageEndpoint = {
   verbs: [ GET ],
   initialState: { ...INITIAL_STATE, data: [] },
   getFunc: async () => {
-    let posts = makeChannelPostList();
+    let posts = makeFrontpagePostList();
     return posts;
   },
   getSuccessHandler: (payload: Array<Post>) => (


### PR DESCRIPTION
#### What are the relevant tickets?

part of #15 

#### What's this PR do?

This adds, to the frontpage UI, a link for each post to the channel page for the channel on which the post originated.

#### How should this be manually tested?

Go to the homepage, you should see something like this:

![subreddtsdsfsdf](https://user-images.githubusercontent.com/6207644/28542733-4850d908-708b-11e7-920c-d2695beb8221.png)

on a subreddit page you should not see the link to the subreddit (just the author link).