### PR TITLE
Human readable cassettes

### DIFF
--- a/open_discussions/betamax_config.py
+++ b/open_discussions/betamax_config.py
@@ -2,6 +2,7 @@
 from betamax import Betamax
 from betamax.util import deserialize_prepared_request
 from betamax.matchers.body import BodyMatcher
+from betamax_serializers.pretty_json import PrettyJSONSerializer
 
 
 class CustomBodyMatcher(BodyMatcher):
@@ -25,7 +26,9 @@ class CustomBodyMatcher(BodyMatcher):
 def setup_betamax():
     """Do global configuration for betamax. This function is idempotent."""
     Betamax.register_request_matcher(CustomBodyMatcher)
+    Betamax.register_serializer(PrettyJSONSerializer)
 
     config = Betamax.configure()
     config.cassette_library_dir = "cassettes"
     config.default_cassette_options['match_requests_on'] = ['uri', 'method', 'custom-body']
+    config.default_cassette_options['serialize_with'] = 'prettyjson'

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 Django==1.10.5
 PyYAML==3.11
 betamax
+betamax_serializers
 boto==2.39.0
 celery==4.0.2
 dj-database-url==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 amqp==2.1.4               # via kombu
+betamax-serializers==0.2.0
 betamax==0.8.0
 billiard==3.5.0.2         # via celery
 boto==2.39.0


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Configures betamax to write pretty printed JSON for cassettes

#### How should this be manually tested?
Start `./manage.py shell` and run this code:

    from django.contrib.auth.models import User
    from open_discussions.recorder import record
    user = User.objects.get(username='some username here')
    with record('pretty_printed', user) as api:
        list(api.list_channels())

The cassette created in `cassettes/` should have pretty printed JSON
