### PR TITLE
add proper post title link

### DIFF
--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -15,6 +15,15 @@ const textContent = post => (
   </div>
 );
 
+const postTitle = (post: Post) =>
+  post.text
+    ? <Link className="post-title" to={postDetailURL(post.channel_name, post.id)}>
+      { post.title }
+    </Link>
+    : <a className="post-title" href={post.url} target="_blank">
+      { post.title }
+    </a>;
+
 export default class PostDisplay extends React.Component {
   props: {
     post:             Post,
@@ -42,7 +51,7 @@ export default class PostDisplay extends React.Component {
           <span className="votes">{post.score}</span>
         </div>
         <div className="summary">
-          <a className="post-title">{ post.title }</a>
+          { postTitle(post) }
           <div className="authored-by">
             by <a>{post.author_id || 'someone'}</a>, {formattedDate} { this.showChannelLink() }
           </div>

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -15,7 +15,10 @@ describe('PostDisplay', () => {
     const wrapper = renderPostDisplay({ post });
     const summary = wrapper.find('.summary');
     assert.equal(wrapper.find('.votes').text(), post.score.toString());
-    assert.equal(summary.find('a').at(0).text(), post.title);
+    assert.equal(
+      summary.find(Link).at(0).props().children,
+      post.title
+    );
     assert.deepEqual(
       wrapper.find('.num-comments').props().children,
       [post.num_comments, ' Comments']
@@ -30,7 +33,7 @@ describe('PostDisplay', () => {
     const post = makePost();
     post.channel_name = "channel_name";
     const wrapper = renderPostDisplay({ post: post, showChannelLink: true });
-    assert.equal(wrapper.find(Link).at(0).props().to, '/channel/channel_name');
+    assert.equal(wrapper.find(Link).at(1).props().to, '/channel/channel_name');
   });
 
   it("should display text, if given a text post and the 'expanded' flag", () => {
@@ -47,5 +50,22 @@ describe('PostDisplay', () => {
     post.text = string;
     const wrapper = renderPostDisplay({post: post});
     assert.notInclude(wrapper.text(), string);
+  });
+
+  it('should include an external link, if a url post', () => {
+    let post = makePost(true);
+    const wrapper = renderPostDisplay({ post: post });
+    const { href, target, children } = wrapper.find('a').at(0).props();
+    assert.equal(href, post.url);
+    assert.equal(target, "_blank");
+    assert.equal(children, post.title);
+  });
+
+  it('should link to the detail view, if a text post', () => {
+    let post = makePost();
+    const wrapper = renderPostDisplay({ post: post });
+    const { to, children } = wrapper.find(Link).at(0).props();
+    assert.equal(children, post.title);
+    assert.equal(to, `/channel/${post.channel_name}/${post.id}`);
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this basically sets the title display in `PostDisplay` to do the right thing. basically, if it's a text post, it links to the detail view (`/channel/${channel}/${postID}`). if it's a URL post, it's an anchor tag with `target="_blank"` pointing to `post.url`.

#### How should this be manually tested?

If you're on any page that shows lists of posts, you should be able to click on the title to open a URL post or visit a text posts' detail view.