### PR TITLE
Integrate with frontpage api

### DIFF
--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -9,6 +9,10 @@ import type {
   Post,
 } from '../flow/discussionTypes';
 
+export function getFrontpage(): Promise<Post> {
+  return fetchJSONWithCSRF(`/api/v0/frontpage/`);
+}
+
 export function getChannel(channelName: string): Promise<Channel> {
   return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/`);
 }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 
 import {
   getChannel,
+  getFrontpage,
   getPost,
   getPostsForChannel,
 } from './api';
@@ -60,6 +61,16 @@ describe('api', function() {
       return getPost('1').then(result => {
         assert.ok(fetchStub.calledWith(`/api/v0/posts/1/`));
         assert.deepEqual(result, post);
+      });
+    });
+
+    it('gets the frontpage', () => {
+      const posts = makeChannelPostList();
+      fetchStub.returns(Promise.resolve(posts));
+
+      return getFrontpage().then(result => {
+        assert.ok(fetchStub.calledWith(`/api/v0/frontpage/`));
+        assert.deepEqual(result, posts);
       });
     });
   });

--- a/static/js/reducers/frontpage.js
+++ b/static/js/reducers/frontpage.js
@@ -1,17 +1,14 @@
 // @flow
 import { GET, INITIAL_STATE } from 'redux-hammock/constants';
 
-import { makeChannelPostList } from '../factories/posts';
+import * as api from '../lib/api';
 import type { Post } from '../flow/discussionTypes';
 
 export const frontPageEndpoint = {
   name: 'frontpage',
   verbs: [ GET ],
   initialState: { ...INITIAL_STATE, data: [] },
-  getFunc: async () => {
-    let posts = makeChannelPostList();
-    return posts;
-  },
+  getFunc: () => api.getFrontpage(),
   getSuccessHandler: (payload: Array<Post>) => (
     payload.map(post => post.id)
   )

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -168,8 +168,11 @@ describe('reducers', () => {
   });
 
   describe('frontpage reducer', () => {
+    let frontpageStub;
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.frontpage);
+      frontpageStub = sandbox.stub(api, 'getFrontpage');
+      frontpageStub.returns(Promise.resolve(makeChannelPostList()));
     });
 
     it('should have some initial state', () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #15 

#### What's this PR do?
Integrates the existing frontpage ui with the backend api

#### How should this be manually tested?
Be sure you are subscribed. You may need to:
```python
from channels.api import Api
user  = User.objects.get(username='you')
api = Api(user)
api.reddit.subreddit('micromasters').subscribe()
```

Go to http://localhost:8063/ and verify you see data. 
