### PR TITLE
use prettier to format JavaScript code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,16 @@
       "plugin:react/recommended"
   ],
   "rules": {
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true,
+      "align": {
+        "beforeColon": false,
+        "afterColon": true,
+        "mode": "minimum",
+        "on": "value"
+      }
+    }],
     "quotes": [0], // no opinion on ' vs "
     "object-curly-spacing": [0],
     "new-cap": [0], // allows function calls like Immutable.Map(...)
@@ -25,7 +35,7 @@
     }],
     "comma-dangle": [0],
     "no-unreachable": [2],
-    "semi": [2, "always"],
+    "semi": [2, "never"],
     "eqeqeq": [2],
     "no-var": [2],
     "camelcase": [2, {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "nyc": "^11.0.3",
     "object.entries": "^1.0.4",
     "postcss-loader": "^2.0.6",
+    "prettier-eslint-cli": "^4.1.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
     "react": "^15.6.1",
@@ -93,6 +94,7 @@
     "coverage": "COVERAGE=1 ./scripts/test/js_test.sh",
     "codecov": "CODECOV=1 ./scripts/test/js_test.sh",
     "watch": "WATCH=1 ./scripts/test/js_test.sh",
-    "flow": "flow check"
+    "flow": "flow check",
+    "fmt": "prettier-eslint --write --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'"
   }
 }

--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -1,28 +1,28 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import { BrowserRouter, Route } from 'react-router-dom';
+import React from "react"
+import { Provider } from "react-redux"
+import { BrowserRouter, Route } from "react-router-dom"
 
-import App from './containers/App';
-import withTracker from './util/withTracker';
+import App from "./containers/App"
+import withTracker from "./util/withTracker"
 
 export default class Router extends React.Component {
   props: {
-    store:  Store,
-  };
+    store: Store
+  }
 
-  render () {
-    const { store, children } = this.props;
+  render() {
+    const { store, children } = this.props
 
-    return <div>
-      <Provider store={store}>
-        <BrowserRouter>
-          {children}
-        </BrowserRouter>
-      </Provider>
-    </div>;
+    return (
+      <div>
+        <Provider store={store}>
+          <BrowserRouter>
+            {children}
+          </BrowserRouter>
+        </Provider>
+      </div>
+    )
   }
 }
 
-export const routes = (
-  <Route url="/" component={withTracker(App)}/>
-);
+export const routes = <Route url="/" component={withTracker(App)} />

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -1,11 +1,11 @@
 // @flow
-import { deriveActions } from 'redux-hammock';
+import { deriveActions } from "redux-hammock"
 
-import { endpoints } from '../lib/redux_rest';
+import { endpoints } from "../lib/redux_rest"
 
-const actions: Object = {};
+const actions: Object = {}
 endpoints.forEach(endpoint => {
-  actions[endpoint.name] = deriveActions(endpoint);
-});
+  actions[endpoint.name] = deriveActions(endpoint)
+})
 
-export { actions };
+export { actions }

--- a/static/js/actions/post.js
+++ b/static/js/actions/post.js
@@ -1,5 +1,5 @@
 // @flow
-import { createAction } from 'redux-actions';
+import { createAction } from "redux-actions"
 
-export const SET_POST_DATA = 'SET_POST_DATA';
-export const setPostData = createAction(SET_POST_DATA);
+export const SET_POST_DATA = "SET_POST_DATA"
+export const setPostData = createAction(SET_POST_DATA)

--- a/static/js/babelhook.js
+++ b/static/js/babelhook.js
@@ -1,20 +1,20 @@
-const { babelSharedLoader } = require("../../webpack.config.shared");
-require('babel-polyfill');
+const { babelSharedLoader } = require("../../webpack.config.shared")
+require("babel-polyfill")
 
 // window and global must be defined here before React is imported
-require('jsdom-global')(undefined, {
-  url: 'http://fake/'
-});
+require("jsdom-global")(undefined, {
+  url: "http://fake/"
+})
 
 // We need to explicitly change the URL when window.location is used
-const changeURL = require('jsdom/lib/old-api').changeURL;
+const changeURL = require("jsdom/lib/old-api").changeURL
 Object.defineProperty(window, "location", {
   set: value => {
     if (!value.startsWith("http")) {
-      value = `http://fake${value}`;
+      value = `http://fake${value}`
     }
-    changeURL(window, value);
-  },
-});
+    changeURL(window, value)
+  }
+})
 
-require('babel-register')(babelSharedLoader.query);
+require("babel-register")(babelSharedLoader.query)

--- a/static/js/components/Card.js
+++ b/static/js/components/Card.js
@@ -1,16 +1,15 @@
 // @flow
-import React from 'react';
+import React from "react"
 
 type CardProps = {
-  children: React$Element<*>,
-};
+  children: React$Element<*>
+}
 
-const Card = ({ children }: CardProps) => (
+const Card = ({ children }: CardProps) =>
   <div className="card">
     <div className="content">
-      { children }
+      {children}
     </div>
   </div>
-);
 
-export default Card;
+export default Card

--- a/static/js/components/Card_test.js
+++ b/static/js/components/Card_test.js
@@ -1,20 +1,21 @@
 // @flow
-import React from 'react';
-import { shallow } from 'enzyme';
-import { assert } from 'chai';
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
 
-import Card from './Card';
+import Card from "./Card"
 
-describe('Card component', () => {
-  let mountCard = children => shallow(
-    <Card>
-      { children }
-    </Card>
-  );
+describe("Card component", () => {
+  let mountCard = children =>
+    shallow(
+      <Card>
+        {children}
+      </Card>
+    )
 
-  it('should render children', () => {
-    let wrapper = mountCard(<div className="child">HEY</div>);
-    assert.lengthOf(wrapper.find('.child'), 1);
-    assert.equal(wrapper.text(), 'HEY');
-  });
-});
+  it("should render children", () => {
+    let wrapper = mountCard(<div className="child">HEY</div>)
+    assert.lengthOf(wrapper.find(".child"), 1)
+    assert.equal(wrapper.text(), "HEY")
+  })
+})

--- a/static/js/components/ChannelBreadcrumbs.js
+++ b/static/js/components/ChannelBreadcrumbs.js
@@ -1,23 +1,23 @@
 // @flow
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React from "react"
+import { Link } from "react-router-dom"
 
-import type { Channel } from '../flow/discussionTypes';
+import type { Channel } from "../flow/discussionTypes"
 
 type BreadCrumbProps = {
-  channel: Channel,
-};
+  channel: Channel
+}
 
 const ChannelBreadcrumbs = (props: BreadCrumbProps) => {
-  const { channel } = props;
+  const { channel } = props
 
-  return <div>
-    <Link to="/">Discussions</Link>&nbsp;
-    <span>&gt;</span>&nbsp;
-    <Link to={`/channel/${channel.name}`}>
-      { channel.title }
-    </Link>
-  </div>;
-};
+  return (
+    <div>
+      <Link to="/">Discussions</Link>&nbsp;
+      <span>&gt;</span>&nbsp;
+      <Link to={`/channel/${channel.name}`}>{channel.title}</Link>
+    </div>
+  )
+}
 
-export default ChannelBreadcrumbs;
+export default ChannelBreadcrumbs

--- a/static/js/components/ChannelBreadcrumbs_test.js
+++ b/static/js/components/ChannelBreadcrumbs_test.js
@@ -1,25 +1,23 @@
 // @flow
-import React from 'react';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+import { Link } from "react-router-dom"
 
-import ChannelBreadcrumbs from './ChannelBreadcrumbs';
+import ChannelBreadcrumbs from "./ChannelBreadcrumbs"
 
-import { makeChannel } from '../factories/channels';
+import { makeChannel } from "../factories/channels"
 
-describe('ChannelBreadcrumbs', () => {
-  const renderBreadcrumbs = channel => shallow(
-    <ChannelBreadcrumbs channel={channel} />
-  );
+describe("ChannelBreadcrumbs", () => {
+  const renderBreadcrumbs = channel => shallow(<ChannelBreadcrumbs channel={channel} />)
 
-  it('should render breadcrumbs', () => {
-    let channel = makeChannel();
-    let wrapper = renderBreadcrumbs(channel);
-    let [first, second] = wrapper.find(Link);
-    assert.equal(first.props.to, '/');
-    assert.equal(first.props.children, 'Discussions');
-    assert.equal(second.props.to, `/channel/${channel.name}`);
-    assert.equal(second.props.children, channel.title);
-  });
-});
+  it("should render breadcrumbs", () => {
+    let channel = makeChannel()
+    let wrapper = renderBreadcrumbs(channel)
+    let [first, second] = wrapper.find(Link)
+    assert.equal(first.props.to, "/")
+    assert.equal(first.props.children, "Discussions")
+    assert.equal(second.props.to, `/channel/${channel.name}`)
+    assert.equal(second.props.children, channel.title)
+  })
+})

--- a/static/js/components/ChannelSidebar.js
+++ b/static/js/components/ChannelSidebar.js
@@ -1,23 +1,29 @@
 // @flow
-import React from 'react';
+import React from "react"
 
-import type { Channel } from '../flow/discussionTypes';
+import type { Channel } from "../flow/discussionTypes"
 
 export default class ChannelSidebar extends React.Component {
   props: {
-    channel: Channel,
+    channel: Channel
   }
   render() {
-    const { channel } = this.props;
+    const { channel } = this.props
 
     return (
       <div className="sidebar">
         <button className="new-post">Submit a New Post</button>
-        <h3 className="title">{channel.title}</h3>
-        <p className="num-users">{channel.num_users} users</p>
+        <h3 className="title">
+          {channel.title}
+        </h3>
+        <p className="num-users">
+          {channel.num_users} users
+        </p>
         <h4 className="about">About</h4>
-        <p className="description">{channel.public_description}</p>
+        <p className="description">
+          {channel.public_description}
+        </p>
       </div>
-    );
+    )
   }
 }

--- a/static/js/components/ChannelSidebar_test.js
+++ b/static/js/components/ChannelSidebar_test.js
@@ -1,19 +1,19 @@
 // @flow
-import React from 'react';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
 
-import { makeChannel } from '../factories/channels';
-import ChannelSidebar from './ChannelSidebar';
+import { makeChannel } from "../factories/channels"
+import ChannelSidebar from "./ChannelSidebar"
 
-describe('ChannelSidebar', () => {
-  const renderSidebar = (channel) => shallow(<ChannelSidebar channel={channel}/>);
+describe("ChannelSidebar", () => {
+  const renderSidebar = channel => shallow(<ChannelSidebar channel={channel} />)
 
-  it('should render channel info correctly', () => {
-    const channel = makeChannel();
-    const wrapper = renderSidebar(channel);
-    assert.equal(wrapper.find('.title').text(), channel.title);
-    assert.equal(wrapper.find('.description').text(), channel.public_description);
-    assert.equal(wrapper.find('.num-users').text(), `${channel.num_users} users`);
-  });
-});
+  it("should render channel info correctly", () => {
+    const channel = makeChannel()
+    const wrapper = renderSidebar(channel)
+    assert.equal(wrapper.find(".title").text(), channel.title)
+    assert.equal(wrapper.find(".description").text(), channel.public_description)
+    assert.equal(wrapper.find(".num-users").text(), `${channel.num_users} users`)
+  })
+})

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -1,28 +1,27 @@
 // @flow
-import React from 'react';
+import React from "react"
 
-import { anyProcessing, anyError, allLoaded } from '../util/rest';
+import { anyProcessing, anyError, allLoaded } from "../util/rest"
 
-import type { RestState } from '../flow/restTypes';
-
+import type { RestState } from "../flow/restTypes"
 
 export default class Loading extends React.Component {
   props: {
-    restStates:     Array<RestState<*>>,
-    renderContents: Function,
+    restStates: Array<RestState<*>>,
+    renderContents: Function
   }
 
   render() {
-    const { restStates, renderContents } = this.props;
+    const { restStates, renderContents } = this.props
 
     if (anyProcessing(restStates) || !allLoaded(restStates)) {
-      return <div>Loading</div>;
+      return <div>Loading</div>
     }
 
     if (anyError(restStates)) {
-      return <div>Error loading page</div>;
+      return <div>Error loading page</div>
     }
 
-    return renderContents();
+    return renderContents()
   }
 }

--- a/static/js/components/Loading_test.js
+++ b/static/js/components/Loading_test.js
@@ -1,116 +1,135 @@
 // @flow
-import React from 'react';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
 
-import Loading from './Loading';
+import Loading from "./Loading"
 
-describe('Loading', () => {
-  const renderLoading = (restStates) => shallow(
-    <Loading
-      restStates={restStates}
-      renderContents={() => <div>CONTENT</div>}
-    />
-  );
+describe("Loading", () => {
+  const renderLoading = restStates =>
+    shallow(<Loading restStates={restStates} renderContents={() => <div>CONTENT</div>} />)
 
-  describe('should render loading correctly', () => {
-    it('single state with loaded:false', () => {
-      const wrapper = renderLoading([{
-        loaded: false,
-        processing: false,
-      }]);
-      assert.equal(wrapper.text(), 'Loading');
-    });
+  describe("should render loading correctly", () => {
+    it("single state with loaded:false", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     false,
+          processing: false
+        }
+      ])
+      assert.equal(wrapper.text(), "Loading")
+    })
 
-    it('multiple states with one loaded:false', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-      }, {
-        loaded: false,
-        processing: false,
-      }]);
-      assert.equal(wrapper.text(), 'Loading');
-    });
+    it("multiple states with one loaded:false", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false
+        },
+        {
+          loaded:     false,
+          processing: false
+        }
+      ])
+      assert.equal(wrapper.text(), "Loading")
+    })
 
-    it('single state with processing:true', () => {
-      const wrapper = renderLoading([{
-        loaded: false,
-        processing: true,
-      }]);
-      assert.equal(wrapper.text(), 'Loading');
-    });
+    it("single state with processing:true", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     false,
+          processing: true
+        }
+      ])
+      assert.equal(wrapper.text(), "Loading")
+    })
 
-    it('multiple states with one processing:true', () => {
-      const wrapper = renderLoading([{
-        loaded: false,
-        processing: false,
-      }, {
-        loaded: false,
-        processing: true,
-      }]);
-      assert.equal(wrapper.text(), 'Loading');
-    });
-  });
+    it("multiple states with one processing:true", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     false,
+          processing: false
+        },
+        {
+          loaded:     false,
+          processing: true
+        }
+      ])
+      assert.equal(wrapper.text(), "Loading")
+    })
+  })
 
-  describe('should render errors correctly', () => {
-    it('single state with error', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-        error: 'bad things',
-      }]);
-      assert.equal(wrapper.text(), 'Error loading page');
-    });
+  describe("should render errors correctly", () => {
+    it("single state with error", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false,
+          error:      "bad things"
+        }
+      ])
+      assert.equal(wrapper.text(), "Error loading page")
+    })
 
-    it('multiple states all with errors', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-        error: 'bad things',
-      }, {
-        loaded: true,
-        processing: false,
-        error: 'bad things',
-      }]);
-      assert.equal(wrapper.text(), 'Error loading page');
-    });
+    it("multiple states all with errors", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false,
+          error:      "bad things"
+        },
+        {
+          loaded:     true,
+          processing: false,
+          error:      "bad things"
+        }
+      ])
+      assert.equal(wrapper.text(), "Error loading page")
+    })
 
-    it('multiple states with one error', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-        error: undefined,
-      }, {
-        loaded: true,
-        processing: false,
-        error: 'bad things',
-      }]);
-      assert.equal(wrapper.text(), 'Error loading page');
-    });
-  });
+    it("multiple states with one error", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false,
+          error:      undefined
+        },
+        {
+          loaded:     true,
+          processing: false,
+          error:      "bad things"
+        }
+      ])
+      assert.equal(wrapper.text(), "Error loading page")
+    })
+  })
 
-  describe('should the contents if no errors', () => {
-    it('single state', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-        error: undefined,
-      }]);
-      assert.equal(wrapper.text(), 'CONTENT');
-    });
+  describe("should the contents if no errors", () => {
+    it("single state", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false,
+          error:      undefined
+        }
+      ])
+      assert.equal(wrapper.text(), "CONTENT")
+    })
 
-    it('multiple states', () => {
-      const wrapper = renderLoading([{
-        loaded: true,
-        processing: false,
-        error: undefined,
-      }, {
-        loaded: true,
-        processing: false,
-        error: undefined,
-      }]);
-      assert.equal(wrapper.text(), 'CONTENT');
-    });
-  });
-});
+    it("multiple states", () => {
+      const wrapper = renderLoading([
+        {
+          loaded:     true,
+          processing: false,
+          error:      undefined
+        },
+        {
+          loaded:     true,
+          processing: false,
+          error:      undefined
+        }
+      ])
+      assert.equal(wrapper.text(), "CONTENT")
+    })
+  })
+})

--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -1,66 +1,67 @@
 // @flow
-import React from 'react';
-import moment from 'moment';
-import { Link } from 'react-router-dom';
+import React from "react"
+import moment from "moment"
+import { Link } from "react-router-dom"
 
-import { postDetailURL } from '../lib/url';
+import { postDetailURL } from "../lib/url"
 
-import type { Post } from '../flow/discussionTypes';
+import type { Post } from "../flow/discussionTypes"
 
-const textContent = post => (
+const textContent = post =>
   <div className="text-content-border">
     <div className="text-content">
-      { post.text }
+      {post.text}
     </div>
   </div>
-);
 
 const postTitle = (post: Post) =>
   post.text
     ? <Link className="post-title" to={postDetailURL(post.channel_name, post.id)}>
-      { post.title }
+      {post.title}
     </Link>
     : <a className="post-title" href={post.url} target="_blank">
-      { post.title }
-    </a>;
+      {post.title}
+    </a>
 
 export default class PostDisplay extends React.Component {
   props: {
-    post:             Post,
+    post: Post,
     showChannelLink?: boolean,
-    expanded?:        boolean,
+    expanded?: boolean
   }
 
   showChannelLink = () => {
-    const { post, showChannelLink } = this.props;
+    const { post, showChannelLink } = this.props
 
     return showChannelLink && post.channel_name
       ? <Link to={`/channel/${post.channel_name}`}>
-        on {post.channel_name}
+          on {post.channel_name}
       </Link>
-      : null;
+      : null
   }
 
   render() {
-    const { post, expanded } = this.props;
-    const formattedDate = moment(post.created).fromNow();
+    const { post, expanded } = this.props
+    const formattedDate = moment(post.created).fromNow()
     return (
       <div className="post-summary">
         <div className="upvotes">
           <button> &uArr;</button>
-          <span className="votes">{post.score}</span>
+          <span className="votes">
+            {post.score}
+          </span>
         </div>
         <div className="summary">
-          { postTitle(post) }
+          {postTitle(post)}
           <div className="authored-by">
-            by <a>{post.author_id || 'someone'}</a>, {formattedDate} { this.showChannelLink() }
+            by <a>{post.author_id || "someone"}</a>, {formattedDate} {this.showChannelLink()}
           </div>
           <Link className="num-comments" to={postDetailURL(post.channel_name, post.id)}>
             {post.num_comments || 0} Comments
           </Link>
         </div>
-        { (expanded && post.text) ? textContent(post) : null }
+        {expanded && post.text ? textContent(post) : null}
       </div>
-    );
+    )
   }
 }

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -1,71 +1,65 @@
 // @flow
-import React from 'react';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+import { Link } from "react-router-dom"
 
-import { makePost } from '../factories/posts';
-import PostDisplay from './PostDisplay';
+import { makePost } from "../factories/posts"
+import PostDisplay from "./PostDisplay"
 
-describe('PostDisplay', () => {
-  const renderPostDisplay = props => shallow(<PostDisplay {...props}/>);
+describe("PostDisplay", () => {
+  const renderPostDisplay = props => shallow(<PostDisplay {...props} />)
 
-  it('should render a post correctly', () => {
-    const post = makePost();
-    const wrapper = renderPostDisplay({ post });
-    const summary = wrapper.find('.summary');
-    assert.equal(wrapper.find('.votes').text(), post.score.toString());
-    assert.equal(
-      summary.find(Link).at(0).props().children,
-      post.title
-    );
-    assert.deepEqual(
-      wrapper.find('.num-comments').props().children,
-      [post.num_comments, ' Comments']
-    );
-    const authoredBy = wrapper.find('.authored-by').text();
-    const expectedPrefix = `by ${post.author_id}, `;
-    assert(authoredBy.startsWith(expectedPrefix));
-    assert.isNotEmpty(authoredBy.substring(expectedPrefix.length));
-  });
+  it("should render a post correctly", () => {
+    const post = makePost()
+    const wrapper = renderPostDisplay({ post })
+    const summary = wrapper.find(".summary")
+    assert.equal(wrapper.find(".votes").text(), post.score.toString())
+    assert.equal(summary.find(Link).at(0).props().children, post.title)
+    assert.deepEqual(wrapper.find(".num-comments").props().children, [post.num_comments, " Comments"])
+    const authoredBy = wrapper.find(".authored-by").text()
+    const expectedPrefix = `by ${post.author_id}, `
+    assert(authoredBy.startsWith(expectedPrefix))
+    assert.isNotEmpty(authoredBy.substring(expectedPrefix.length))
+  })
 
-  it('should link to the subreddit, if told to', () => {
-    const post = makePost();
-    post.channel_name = "channel_name";
-    const wrapper = renderPostDisplay({ post: post, showChannelLink: true });
-    assert.equal(wrapper.find(Link).at(1).props().to, '/channel/channel_name');
-  });
+  it("should link to the subreddit, if told to", () => {
+    const post = makePost()
+    post.channel_name = "channel_name"
+    const wrapper = renderPostDisplay({ post: post, showChannelLink: true })
+    assert.equal(wrapper.find(Link).at(1).props().to, "/channel/channel_name")
+  })
 
   it("should display text, if given a text post and the 'expanded' flag", () => {
-    const  post = makePost();
-    let string = "JUST SOME GREAT TEXT!";
-    post.text = string;
-    const wrapper = renderPostDisplay({post: post, expanded: true});
-    assert.include(wrapper.text(), string);
-  });
+    const post = makePost()
+    let string = "JUST SOME GREAT TEXT!"
+    post.text = string
+    const wrapper = renderPostDisplay({ post: post, expanded: true })
+    assert.include(wrapper.text(), string)
+  })
 
   it("should not display text, if given a text post but lacking the 'expanded' flag", () => {
-    const  post = makePost();
-    let string = "JUST SOME GREAT TEXT!";
-    post.text = string;
-    const wrapper = renderPostDisplay({post: post});
-    assert.notInclude(wrapper.text(), string);
-  });
+    const post = makePost()
+    let string = "JUST SOME GREAT TEXT!"
+    post.text = string
+    const wrapper = renderPostDisplay({ post: post })
+    assert.notInclude(wrapper.text(), string)
+  })
 
-  it('should include an external link, if a url post', () => {
-    let post = makePost(true);
-    const wrapper = renderPostDisplay({ post: post });
-    const { href, target, children } = wrapper.find('a').at(0).props();
-    assert.equal(href, post.url);
-    assert.equal(target, "_blank");
-    assert.equal(children, post.title);
-  });
+  it("should include an external link, if a url post", () => {
+    let post = makePost(true)
+    const wrapper = renderPostDisplay({ post: post })
+    const { href, target, children } = wrapper.find("a").at(0).props()
+    assert.equal(href, post.url)
+    assert.equal(target, "_blank")
+    assert.equal(children, post.title)
+  })
 
-  it('should link to the detail view, if a text post', () => {
-    let post = makePost();
-    const wrapper = renderPostDisplay({ post: post });
-    const { to, children } = wrapper.find(Link).at(0).props();
-    assert.equal(children, post.title);
-    assert.equal(to, `/channel/${post.channel_name}/${post.id}`);
-  });
-});
+  it("should link to the detail view, if a text post", () => {
+    let post = makePost()
+    const wrapper = renderPostDisplay({ post: post })
+    const { to, children } = wrapper.find(Link).at(0).props()
+    assert.equal(children, post.title)
+    assert.equal(to, `/channel/${post.channel_name}/${post.id}`)
+  })
+})

--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -1,27 +1,26 @@
 // @flow
-import React from 'react';
+import React from "react"
 
-import PostDisplay from './PostDisplay';
+import PostDisplay from "./PostDisplay"
 
-import type { Post } from '../flow/discussionTypes';
+import type { Post } from "../flow/discussionTypes"
 
-const renderPosts = (posts, showChannelLinks) => posts.map((post, index) => (
-  <PostDisplay post={post} key={index} showChannelLink={showChannelLinks} />
-));
+const renderPosts = (posts, showChannelLinks) =>
+  posts.map((post, index) => <PostDisplay post={post} key={index} showChannelLink={showChannelLinks} />)
 
 type PostListProps = {
-  posts:             Array<Post>,
-  showChannelLinks?: boolean,
-};
+  posts: Array<Post>,
+  showChannelLinks?: boolean
+}
 
 const PostList = (props: PostListProps) => {
-  const { posts, showChannelLinks } = props;
+  const { posts, showChannelLinks } = props
 
   return (
     <div className="post-list">
-      { renderPosts(posts, showChannelLinks) }
+      {renderPosts(posts, showChannelLinks)}
     </div>
-  );
-};
+  )
+}
 
-export default PostList;
+export default PostList

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -1,33 +1,29 @@
 // @flow
-import React from 'react';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
 
-import PostList from './PostList';
-import PostDisplay from './PostDisplay';
-import { makeChannelPostList } from '../factories/posts';
+import PostList from "./PostList"
+import PostDisplay from "./PostDisplay"
+import { makeChannelPostList } from "../factories/posts"
 
-describe('PostList', () => {
-  const renderPostList = (props = {posts: makeChannelPostList()}) => shallow(
-    <PostList {...props} />
-  );
+describe("PostList", () => {
+  const renderPostList = (props = { posts: makeChannelPostList() }) => shallow(<PostList {...props} />)
 
-  it('should render a list of posts', () => {
-    let wrapper = renderPostList();
-    assert.lengthOf(wrapper.find(PostDisplay), 20);
-  });
+  it("should render a list of posts", () => {
+    let wrapper = renderPostList()
+    assert.lengthOf(wrapper.find(PostDisplay), 20)
+  })
 
-  it('should behave well if handed an empty list', () => {
-    let wrapper = renderPostList({ posts: []});
-    assert.lengthOf(wrapper.find(PostDisplay), 0);
-  });
+  it("should behave well if handed an empty list", () => {
+    let wrapper = renderPostList({ posts: [] })
+    assert.lengthOf(wrapper.find(PostDisplay), 0)
+  })
 
-  it('should pass the showChannelLinks prop to PostDisplay', () => {
-    let wrapper = renderPostList(
-      { posts: makeChannelPostList(), showChannelLinks: true }
-    );
+  it("should pass the showChannelLinks prop to PostDisplay", () => {
+    let wrapper = renderPostList({ posts: makeChannelPostList(), showChannelLinks: true })
     wrapper.find(PostDisplay).forEach(postSummary => {
-      assert.isTrue(postSummary.props().showChannelLink);
-    });
-  });
-});
+      assert.isTrue(postSummary.props().showChannelLink)
+    })
+  })
+})

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,5 +1,5 @@
 // Put constants here
 
 export const THING_RESPONSE = {
-  'value': 'thing'
-};
+  value: "thing"
+}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -1,26 +1,26 @@
 // @flow
-import React from 'react';
-import { Route } from 'react-router-dom';
+import React from "react"
+import { Route } from "react-router-dom"
 
-import HomePage from './HomePage';
-import ChannelPage from './ChannelPage';
-import PostPage from './PostPage';
+import HomePage from "./HomePage"
+import ChannelPage from "./ChannelPage"
+import PostPage from "./PostPage"
 
-import type { Match } from 'react-router';
+import type { Match } from "react-router"
 
 export default class App extends React.Component {
   props: {
-    match: Match,
+    match: Match
   }
 
   render() {
-    const { match } = this.props;
+    const { match } = this.props
     return (
       <div className="app">
-        <Route exact path={match.url} component={HomePage}/>
-        <Route exact path={`${match.url}channel/:channelName`} component={ChannelPage}/>
+        <Route exact path={match.url} component={HomePage} />
+        <Route exact path={`${match.url}channel/:channelName`} component={ChannelPage} />
         <Route path={`${match.url}channel/:channelName/:postID`} component={PostPage} />
       </div>
-    );
+    )
   }
 }

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -1,60 +1,57 @@
 // @flow
-import React from 'react';
-import { connect } from 'react-redux';
-import R from 'ramda';
+import React from "react"
+import { connect } from "react-redux"
+import R from "ramda"
 
-import Card from '../components/Card';
-import ChannelSidebar from '../components/ChannelSidebar';
-import PostList from '../components/PostList';
-import Loading from '../components/Loading';
-import ChannelBreadcrumbs from '../components/ChannelBreadcrumbs';
+import Card from "../components/Card"
+import ChannelSidebar from "../components/ChannelSidebar"
+import PostList from "../components/PostList"
+import Loading from "../components/Loading"
+import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 
-import { actions } from '../actions';
-import { setPostData } from '../actions/post';
-import { safeBulkGet } from '../lib/maps';
+import { actions } from "../actions"
+import { setPostData } from "../actions/post"
+import { safeBulkGet } from "../lib/maps"
 
-import type { Dispatch } from 'redux';
-import type { Match } from 'react-router';
+import type { Dispatch } from "redux"
+import type { Match } from "react-router"
 
 class ChannelPage extends React.Component {
   props: {
-    match:            Match,
-    dispatch:         Dispatch,
-    channels:         Object,
-    postsForChannel:  Object,
-    posts:            Object,
+    match: Match,
+    dispatch: Dispatch,
+    channels: Object,
+    postsForChannel: Object,
+    posts: Object
   }
 
   getChannelName() {
-    const { match } = this.props;
-    return match.params.channelName;
+    const { match } = this.props
+    return match.params.channelName
   }
 
   componentWillMount() {
-    const { dispatch } = this.props;
-    const channelName = this.getChannelName();
-    dispatch(actions.channels.get(channelName));
+    const { dispatch } = this.props
+    const channelName = this.getChannelName()
+    dispatch(actions.channels.get(channelName))
     dispatch(actions.postsForChannel.get(channelName)).then(({ posts }) => {
-      dispatch(setPostData(posts));
-    });
+      dispatch(setPostData(posts))
+    })
   }
 
   renderContents(channelName, channels, postsForChannel, posts) {
-    const channel = channels.data.get(channelName);
-    const postIds = postsForChannel.data.get(channelName);
+    const channel = channels.data.get(channelName)
+    const postIds = postsForChannel.data.get(channelName)
 
     if (R.isNil(channel) || R.isNil(postIds)) {
-      return null;
+      return null
     } else {
       return (
         <div className="double-column">
           <ChannelBreadcrumbs channel={channel} />
           <div className="first-column">
             <Card>
-              <PostList
-                channel={channel}
-                posts={safeBulkGet(postIds, posts.data)}
-              />
+              <PostList channel={channel} posts={safeBulkGet(postIds, posts.data)} />
             </Card>
           </div>
           <div className="second-column">
@@ -63,32 +60,29 @@ class ChannelPage extends React.Component {
             </Card>
           </div>
         </div>
-      );
+      )
     }
   }
 
   render() {
-    const { channels, postsForChannel, posts } = this.props;
-    const channelName = this.getChannelName();
+    const { channels, postsForChannel, posts } = this.props
+    const channelName = this.getChannelName()
 
     return (
       <Loading
-        restStates={[
-          channels,
-          postsForChannel,
-        ]}
+        restStates={[channels, postsForChannel]}
         renderContents={() => this.renderContents(channelName, channels, postsForChannel, posts)}
       />
-    );
+    )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-    channels: state.channels,
+    channels:        state.channels,
     postsForChannel: state.postsForChannel,
-    posts: state.posts,
-  };
-};
+    posts:           state.posts
+  }
+}
 
-export default connect(mapStateToProps)(ChannelPage);
+export default connect(mapStateToProps)(ChannelPage)

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -1,53 +1,49 @@
 // @flow
-import React from 'react';
-import { connect } from 'react-redux';
+import React from "react"
+import { connect } from "react-redux"
 
-import PostList from '../components/PostList';
-import Card from '../components/Card';
+import PostList from "../components/PostList"
+import Card from "../components/Card"
 
-import { actions } from '../actions';
-import { setPostData } from '../actions/post';
-import { safeBulkGet } from '../lib/maps';
+import { actions } from "../actions"
+import { setPostData } from "../actions/post"
+import { safeBulkGet } from "../lib/maps"
 
 class HomePage extends React.Component {
-  componentWillMount () {
-    this.fetchFrontpage();
+  componentWillMount() {
+    this.fetchFrontpage()
   }
 
   fetchFrontpage = () => {
-    const { dispatch } = this.props;
+    const { dispatch } = this.props
 
     dispatch(actions.frontpage.get()).then(posts => {
-      dispatch(setPostData(posts));
-    });
-  };
+      dispatch(setPostData(posts))
+    })
+  }
 
   render() {
-    const { posts, frontpage } = this.props;
+    const { posts, frontpage } = this.props
 
     return (
       <div className="double-column">
         <div>Home page</div>
         <div className="first-column">
           <Card>
-            <PostList
-              posts={safeBulkGet(frontpage.data, posts.data)}
-              showChannelLinks={true}
-            />
+            <PostList posts={safeBulkGet(frontpage.data, posts.data)} showChannelLinks={true} />
           </Card>
         </div>
-        <div className="second-column">
-        </div>
+        <div className="second-column" />
       </div>
-    );
+    )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-    posts: state.posts,
+    posts:     state.posts,
     frontpage: state.frontpage
-  };
-};
+  }
+}
 
-export default connect(mapStateToProps)(HomePage);
+export default connect(mapStateToProps)(HomePage)

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -1,63 +1,63 @@
 // @flow
-import React from 'react';
-import { connect } from 'react-redux';
-import R from 'ramda';
+import React from "react"
+import { connect } from "react-redux"
+import R from "ramda"
 
-import Card from '../components/Card';
-import Loading from '../components/Loading';
-import ChannelBreadcrumbs from '../components/ChannelBreadcrumbs';
-import PostDisplay from '../components/PostDisplay';
+import Card from "../components/Card"
+import Loading from "../components/Loading"
+import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
+import PostDisplay from "../components/PostDisplay"
 
-import { actions } from '../actions';
-import { anyProcessing, allLoaded } from '../util/rest';
+import { actions } from "../actions"
+import { anyProcessing, allLoaded } from "../util/rest"
 
-import type { Dispatch } from 'redux';
-import type { Match } from 'react-router';
+import type { Dispatch } from "redux"
+import type { Match } from "react-router"
 
 class PostPage extends React.Component {
   props: {
-    match:            Match,
-    dispatch:         Dispatch,
-    posts:            Object,
-    channels:         Object,
-  };
+    match: Match,
+    dispatch: Dispatch,
+    posts: Object,
+    channels: Object
+  }
 
   getMatchParams = () => {
-    const { match: { params }} = this.props;
-    return [params.postID, params.channelName];
+    const { match: { params } } = this.props
+    return [params.postID, params.channelName]
   }
 
   updateRequirements = () => {
-    const { dispatch, channels, posts } = this.props;
-    const [postID, channelName] = this.getMatchParams();
+    const { dispatch, channels, posts } = this.props
+    const [postID, channelName] = this.getMatchParams()
 
     if (R.isNil(posts.data.get(postID)) && R.isNil(posts.error)) {
-      dispatch(actions.posts.get(postID));
+      dispatch(actions.posts.get(postID))
     }
     if (R.isNil(channels.data.get(channelName)) && R.isNil(channels.error)) {
-      dispatch(actions.channels.get(channelName));
+      dispatch(actions.channels.get(channelName))
     }
   }
 
   componentWillMount() {
-    this.updateRequirements();
+    this.updateRequirements()
   }
 
   componentDidUpdate() {
-    const { channels, posts } = this.props;
-    let restStates = [ channels, posts ];
+    const { channels, posts } = this.props
+    let restStates = [channels, posts]
 
     if (!anyProcessing(restStates) || allLoaded(restStates)) {
-      this.updateRequirements();
+      this.updateRequirements()
     }
   }
 
   renderContents(postID, posts, channelName, channels) {
-    const post = posts.get(postID);
-    const channel = channels.get(channelName);
+    const post = posts.get(postID)
+    const channel = channels.get(channelName)
 
     if (R.isNil(channel) || R.isNil(post)) {
-      return null;
+      return null
     }
     return (
       <div className="double-column">
@@ -68,25 +68,25 @@ class PostPage extends React.Component {
           </Card>
         </div>
       </div>
-    );
+    )
   }
 
   render() {
-    const { posts, channels } = this.props;
-    const [postId, channelName] = this.getMatchParams();
+    const { posts, channels } = this.props
+    const [postId, channelName] = this.getMatchParams()
 
     return (
       <Loading
-        restStates={[ posts, channels ]}
+        restStates={[posts, channels]}
         renderContents={() => this.renderContents(postId, posts.data, channelName, channels.data)}
       />
-    );
+    )
   }
 }
 
 const mapStateToProps = state => ({
-  posts: state.posts,
-  channels: state.channels,
-});
+  posts:    state.posts,
+  channels: state.channels
+})
 
-export default connect(mapStateToProps)(PostPage);
+export default connect(mapStateToProps)(PostPage)

--- a/static/js/entry/root.js
+++ b/static/js/entry/root.js
@@ -1,22 +1,22 @@
-require('react-hot-loader/patch');
+require("react-hot-loader/patch")
 /* global SETTINGS:false */
-__webpack_public_path__ = SETTINGS.public_path;  // eslint-disable-line no-undef, camelcase
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { AppContainer } from 'react-hot-loader';
+__webpack_public_path__ = SETTINGS.public_path // eslint-disable-line no-undef, camelcase
+import React from "react"
+import ReactDOM from "react-dom"
+import { AppContainer } from "react-hot-loader"
 
-import configureStore from '../store/configureStore';
-import Router, { routes } from '../Router';
+import configureStore from "../store/configureStore"
+import Router, { routes } from "../Router"
 
 // Object.entries polyfill
-import entries from 'object.entries';
+import entries from "object.entries"
 if (!Object.entries) {
-  entries.shim();
+  entries.shim()
 }
 
-const store = configureStore();
+const store = configureStore()
 
-const rootEl = document.getElementById("container");
+const rootEl = document.getElementById("container")
 
 const renderApp = Component => {
   ReactDOM.render(
@@ -26,14 +26,14 @@ const renderApp = Component => {
       </Component>
     </AppContainer>,
     rootEl
-  );
-};
+  )
+}
 
-renderApp(Router);
+renderApp(Router)
 
 if (module.hot) {
-  module.hot.accept('../Router', () => {
-    const RouterNext = require('../Router').default;
-    renderApp(RouterNext);
-  });
+  module.hot.accept("../Router", () => {
+    const RouterNext = require("../Router").default
+    renderApp(RouterNext)
+  })
 }

--- a/static/js/entry/style.js
+++ b/static/js/entry/style.js
@@ -1,3 +1,3 @@
 /* global SETTINGS:false */
-__webpack_public_path__ = SETTINGS.public_path;  // eslint-disable-line no-undef, camelcase
-import '../../scss/layout.scss';
+__webpack_public_path__ = SETTINGS.public_path // eslint-disable-line no-undef, camelcase
+import "../../scss/layout.scss"

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -1,10 +1,10 @@
 // @flow
-import casual from 'casual-browserify';
+import casual from "casual-browserify"
 
 export const makeChannel = (privateChannel: boolean = false) => ({
-  name: casual.word,
-  title: casual.title,
-  theme_type: privateChannel ? "private" : "public",
+  name:               casual.word,
+  title:              casual.title,
+  theme_type:         privateChannel ? "private" : "public",
   public_description: casual.description,
-  num_users: casual.integer(0, 500),
-});
+  num_users:          casual.integer(0, 500)
+})

--- a/static/js/factories/channels_test.js
+++ b/static/js/factories/channels_test.js
@@ -1,15 +1,15 @@
 // @flow
-import { assert } from 'chai';
+import { assert } from "chai"
 
-import { makeChannel } from './channels';
+import { makeChannel } from "./channels"
 
-describe('channels factory', () => {
-  it('should make a channel', () => {
-    let channel = makeChannel();
-    assert.isString(channel.name);
-    assert.isString(channel.title);
-    assert.equal(channel.theme_type, "public");
-    assert.isString(channel.public_description);
-    assert.isNumber(channel.num_users);
-  });
-});
+describe("channels factory", () => {
+  it("should make a channel", () => {
+    let channel = makeChannel()
+    assert.isString(channel.name)
+    assert.isString(channel.title)
+    assert.equal(channel.theme_type, "public")
+    assert.isString(channel.public_description)
+    assert.isNumber(channel.num_users)
+  })
+})

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -1,31 +1,31 @@
 // @flow
-import casual from 'casual-browserify';
+import casual from "casual-browserify"
 
-import { incrementer, arrayN } from './util';
+import { incrementer, arrayN } from "./util"
 
-import type { Post, Comment } from '../flow/discussionTypes';
+import type { Post, Comment } from "../flow/discussionTypes"
 
-const incr = incrementer();
+const incr = incrementer()
 
 const makeComment = (post: Post) => ({
-  id: incr.next().value,
-  post_id: post.id,
-  text: casual.text,
+  id:        incr.next().value,
+  post_id:   post.id,
+  text:      casual.text,
   author_id: casual.username,
-  score: casual.integer(-50,100),
-  upvoted: casual.coin_flip,
-  created: casual.moment.format(),
-  replies: []
-});
+  score:     casual.integer(-50, 100),
+  upvoted:   casual.coin_flip,
+  created:   casual.moment.format(),
+  replies:   []
+})
 
 export const makeCommentTree = (post: Post): Array<Comment> => {
-  let topLevelComments = arrayN(10).map(() => makeComment(post));
+  let topLevelComments = arrayN(10).map(() => makeComment(post))
 
   topLevelComments.forEach((comment, index) => {
     if (casual.coin_flip || index === 0) {
-      comment.replies = arrayN(5).map(() => makeComment(post));
+      comment.replies = arrayN(5).map(() => makeComment(post))
     }
-  });
+  })
 
-  return topLevelComments;
-};
+  return topLevelComments
+}

--- a/static/js/factories/comments_test.js
+++ b/static/js/factories/comments_test.js
@@ -1,33 +1,33 @@
 // @flow
-import { assert } from 'chai';
-import moment from 'moment';
+import { assert } from "chai"
+import moment from "moment"
 
-import { makePost } from './posts';
-import { makeCommentTree } from './comments';
+import { makePost } from "./posts"
+import { makeCommentTree } from "./comments"
 
-describe('comment factories', () => {
-  it('should make a tree of comments', () => {
-    let post = makePost();
+describe("comment factories", () => {
+  it("should make a tree of comments", () => {
+    let post = makePost()
     makeCommentTree(post).forEach(comment => {
-      assert.isNumber(comment.id);
-      assert.equal(comment.post_id, post.id);
-      assert.isString(comment.text);
-      assert.isString(comment.author_id);
-      assert.isNumber(comment.score);
-      assert.isBoolean(comment.upvoted);
-      assert.isString(comment.created);
-      assert(moment(comment.created).isValid());
-      assert.isArray(comment.replies);
-    });
-  });
+      assert.isNumber(comment.id)
+      assert.equal(comment.post_id, post.id)
+      assert.isString(comment.text)
+      assert.isString(comment.author_id)
+      assert.isNumber(comment.score)
+      assert.isBoolean(comment.upvoted)
+      assert.isString(comment.created)
+      assert(moment(comment.created).isValid())
+      assert.isArray(comment.replies)
+    })
+  })
 
-  it('should always put replies on the first comment', () => {
-    let [ firstComment ] = makeCommentTree(makePost());
-    assert.isNotEmpty(firstComment.replies);
-  });
+  it("should always put replies on the first comment", () => {
+    let [firstComment] = makeCommentTree(makePost())
+    assert.isNotEmpty(firstComment.replies)
+  })
 
-  it('should have unique IDs', () => {
-    let ids = makeCommentTree(makePost()).map(comment => comment.id);
-    assert.equal(ids.length, new Set(ids).size);
-  });
-});
+  it("should have unique IDs", () => {
+    let ids = makeCommentTree(makePost()).map(comment => comment.id)
+    assert.equal(ids.length, new Set(ids).size)
+  })
+})

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -1,22 +1,20 @@
 // @flow
-import R from 'ramda';
-import casual from 'casual-browserify';
+import R from "ramda"
+import casual from "casual-browserify"
 
-import type { Post } from '../flow/discussionTypes';
+import type { Post } from "../flow/discussionTypes"
 
 export const makePost = (isURLPost: boolean = false): Post => ({
-  id: String(Math.random()),
-  title: casual.sentence,
-  score: Math.round(Math.random() * 15),
-  upvoted: Math.random() < 0.5,
-  author_id: `justareddituser${String(Math.random())}`,
-  text: isURLPost ? null : casual.text,
-  url: isURLPost ? casual.url : null,
-  created: casual.moment.format(),
+  id:           String(Math.random()),
+  title:        casual.sentence,
+  score:        Math.round(Math.random() * 15),
+  upvoted:      Math.random() < 0.5,
+  author_id:    `justareddituser${String(Math.random())}`,
+  text:         isURLPost ? null : casual.text,
+  url:          isURLPost ? casual.url : null,
+  created:      casual.moment.format(),
   num_comments: Math.round(Math.random() * 10),
-  channel_name: casual.word,
-});
+  channel_name: casual.word
+})
 
-export const makeChannelPostList = () => (
-  R.range(0, 20).map(() => makePost(Math.random() > .5))
-);
+export const makeChannelPostList = () => R.range(0, 20).map(() => makePost(Math.random() > 0.5))

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -1,55 +1,50 @@
 // @flow
-import { assert } from 'chai';
-import R from 'ramda';
+import { assert } from "chai"
+import R from "ramda"
 
-import {
-  makePost,
-  makeChannelPostList,
-} from './posts';
+import { makePost, makeChannelPostList } from "./posts"
 
-describe('posts factories', () => {
-  describe('makePost', () => {
-    it('should make a text post', () => {
-      let post = makePost();
-      assert.isString(post.id);
-      assert.isString(post.title);
-      assert.isBoolean(post.upvoted);
-      assert.isString(post.author_id);
-      assert.isString(post.text);
-      assert.isNull(post.url);
-      assert.isString(post.created);
-      assert.isNumber(post.num_comments);
-    });
+describe("posts factories", () => {
+  describe("makePost", () => {
+    it("should make a text post", () => {
+      let post = makePost()
+      assert.isString(post.id)
+      assert.isString(post.title)
+      assert.isBoolean(post.upvoted)
+      assert.isString(post.author_id)
+      assert.isString(post.text)
+      assert.isNull(post.url)
+      assert.isString(post.created)
+      assert.isNumber(post.num_comments)
+    })
 
-    it('should make a URL post', () => {
-      let post = makePost(true);
-      assert.isNull(post.text);
-      assert.isString(post.url);
-    });
+    it("should make a URL post", () => {
+      let post = makePost(true)
+      assert.isNull(post.text)
+      assert.isString(post.url)
+    })
 
-    it('should randomly generate username', () => {
-      let firstPost = makePost();
-      let secondPost = makePost();
-      assert.notEqual(firstPost.author_id, secondPost.author_id);
-    });
+    it("should randomly generate username", () => {
+      let firstPost = makePost()
+      let secondPost = makePost()
+      assert.notEqual(firstPost.author_id, secondPost.author_id)
+    })
 
-    it('should randomly generate upvotes', () => {
-      let upvoteScores = R.range(1,20)
-        .map(makePost)
-        .map(R.prop('score'));
-      assert.isAbove(new Set(upvoteScores).size, 1);
-    });
-  });
+    it("should randomly generate upvotes", () => {
+      let upvoteScores = R.range(1, 20).map(makePost).map(R.prop("score"))
+      assert.isAbove(new Set(upvoteScores).size, 1)
+    })
+  })
 
-  describe('makeChannelPostList', () => {
-    it('should return a list of posts', () => {
+  describe("makeChannelPostList", () => {
+    it("should return a list of posts", () => {
       makeChannelPostList().forEach(post => {
-        assert.isString(post.id);
-        assert.isString(post.title);
-        assert.isNumber(post.score);
-        assert.isString(post.author_id);
-        assert.isString(post.channel_name);
-      });
-    });
-  });
-});
+        assert.isString(post.id)
+        assert.isString(post.title)
+        assert.isNumber(post.score)
+        assert.isString(post.author_id)
+        assert.isString(post.channel_name)
+      })
+    })
+  })
+})

--- a/static/js/factories/util.js
+++ b/static/js/factories/util.js
@@ -1,22 +1,20 @@
 // @flow
-import R from 'ramda';
-import casual from 'casual-browserify';
+import R from "ramda"
+import casual from "casual-browserify"
 
-let asciiNums = R.range(32, 127);
+let asciiNums = R.range(32, 127)
 
-const randomChoice = (xs: Array<*>) => (
-  xs[Math.floor(Math.random() * xs.length)]
-);
+const randomChoice = (xs: Array<*>) => xs[Math.floor(Math.random() * xs.length)]
 
-export const randomString = (n: number): string => (
+export const randomString = (n: number): string =>
   String.fromCharCode(...R.range(0, n).map(() => randomChoice(asciiNums)))
-);
 
-export const arrayN = (n: number) => R.range(0, casual.integer(1, n));
+export const arrayN = (n: number) => R.range(0, casual.integer(1, n))
 
 export function* incrementer(): Generator<number, *, *> {
-  let int = 1;
-  while (true) { // eslint-disable-line no-constant-condition
-    yield int++;
+  let int = 1
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    yield int++
   }
 }

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -7,16 +7,16 @@ declare var SETTINGS: {
   FEATURES: {
     [key: string]: boolean,
   },
-};
+}
 
 // mocha
-declare var it: Function;
-declare var beforeEach: Function;
-declare var afterEach: Function;
-declare var describe: Function;
+declare var it: Function
+declare var beforeEach: Function
+declare var afterEach: Function
+declare var describe: Function
 
 // webpack
-declare var __webpack_public_path__: string; // eslint-disable-line camelcase
+declare var __webpack_public_path__: string // eslint-disable-line camelcase
 
 declare var module: {
   hot: any,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -5,7 +5,7 @@ export type Channel = {
   public_description: string,
   theme_type:         string,
   num_users:          number,
-};
+}
 
 export type Post = {
   id:            string,
@@ -18,7 +18,7 @@ export type Post = {
   created:       string,
   num_comments:  number,
   channel_name:  string,
-};
+}
 
 export type Comment = {
   id:        string,
@@ -29,4 +29,4 @@ export type Comment = {
   created:   string,
   replies:   Array<Comment>,
   author_id: string,
-};
+}

--- a/static/js/flow/reduxTypes.js
+++ b/static/js/flow/reduxTypes.js
@@ -3,31 +3,31 @@ import type {
   Dispatch,
   Reducer,
   State,
-} from 'redux';
+} from 'redux'
 
-export type ActionType = string;
+export type ActionType = string
 
 export type Action<payload, meta> = {
   type: ActionType,
   payload: payload,
   meta: meta,
-};
+}
 
-export type Dispatcher<T> = (d: Dispatch) => Promise<T>;
+export type Dispatcher<T> = (d: Dispatch) => Promise<T>
 
-export type AsyncActionHelper = (...a: any) => Promise<*>;
+export type AsyncActionHelper = (...a: any) => Promise<*>
 
-export type ActionCreator = (...a: any) => Action<*, null>;
+export type ActionCreator = (...a: any) => Action<*, null>
 
-export type AsyncActionCreator<T> = (...a: any) => Dispatcher<T>;
+export type AsyncActionCreator<T> = (...a: any) => Dispatcher<T>
 
 export type AssertReducerResultState<T> = (
   actionFunc: () => Action<*,*>, stateFunc: ((reducerState: State) => T), defaultValue: any
-) => void;
+) => void
 
 export type TestStore = {
   dispatch: Dispatch,
   getState: () => State,
   subscribe: (listener: () => void) => () => void,
   replaceReducer: (reducer: Reducer<any, any>) => void,
-};
+}

--- a/static/js/flow/restTypes.js
+++ b/static/js/flow/restTypes.js
@@ -6,7 +6,7 @@ export type RestState<T> = {
   processing: boolean,
   loaded: boolean,
   getStatus?: string,
-};
+}
 
 export type Endpoint = {
   name:                  string,
@@ -28,4 +28,4 @@ export type Endpoint = {
   verbs:                 Array<string>,
   initialState?:         Object,
   usernameInitialState?: Object,
-};
+}

--- a/static/js/flow/sinonTypes.js
+++ b/static/js/flow/sinonTypes.js
@@ -1,3 +1,3 @@
 export type Sandbox = {
 
-};
+}

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,28 +1,29 @@
 // Define globals we would usually get from Django
-import ReactDOM from 'react-dom';
+import ReactDOM from "react-dom"
 
-const _createSettings = () => ({});
+const _createSettings = () => ({})
 
-global.SETTINGS = _createSettings();
+global.SETTINGS = _createSettings()
 
 // polyfill for Object.entries
-import entries from 'object.entries';
+import entries from "object.entries"
 if (!Object.entries) {
-  entries.shim();
+  entries.shim()
 }
 
 // cleanup after each test run
-afterEach(function () { // eslint-disable-line mocha/no-top-level-hooks
-  let node = document.querySelector("#integration_test_div");
+// eslint-disable-next-line mocha/no-top-level-hooks
+afterEach(function() {
+  let node = document.querySelector("#integration_test_div")
   if (node) {
-    ReactDOM.unmountComponentAtNode(node);
+    ReactDOM.unmountComponentAtNode(node)
   }
-  document.body.innerHTML = '';
-  global.SETTINGS = _createSettings();
-  window.location = 'http://fake/';
-});
+  document.body.innerHTML = ""
+  global.SETTINGS = _createSettings()
+  window.location = "http://fake/"
+})
 
 // enable chai-as-promised
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+chai.use(chaiAsPromised)

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -1,26 +1,23 @@
 // @flow
 /* global SETTINGS:false, fetch: false */
 // For mocking purposes we need to use 'fetch' defined as a global instead of importing as a local.
-import 'isomorphic-fetch';
-import { fetchJSONWithCSRF } from 'redux-hammock/django_csrf_fetch';
+import "isomorphic-fetch"
+import { fetchJSONWithCSRF } from "redux-hammock/django_csrf_fetch"
 
-import type {
-  Channel,
-  Post,
-} from '../flow/discussionTypes';
+import type { Channel, Post } from "../flow/discussionTypes"
 
 export function getFrontpage(): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/frontpage/`);
+  return fetchJSONWithCSRF(`/api/v0/frontpage/`)
 }
 
 export function getChannel(channelName: string): Promise<Channel> {
-  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/`);
+  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/`)
 }
 
 export function getPostsForChannel(channelName: string): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/posts/`);
+  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/posts/`)
 }
 
 export function getPost(postId: string): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/`);
+  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/`)
 }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -1,77 +1,72 @@
 /* global SETTINGS: false */
-import { assert } from 'chai';
-import sinon from 'sinon';
+import { assert } from "chai"
+import sinon from "sinon"
 
-import {
-  getChannel,
-  getFrontpage,
-  getPost,
-  getPostsForChannel,
-} from './api';
-import { makeChannel } from '../factories/channels';
-import { makeChannelPostList, makePost } from '../factories/posts';
-import * as fetchFuncs from 'redux-hammock/django_csrf_fetch';
+import { getChannel, getFrontpage, getPost, getPostsForChannel } from "./api"
+import { makeChannel } from "../factories/channels"
+import { makeChannelPostList, makePost } from "../factories/posts"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 
-describe('api', function() {
-  this.timeout(5000);  // eslint-disable-line no-invalid-this
+describe("api", function() {
+  this.timeout(5000) // eslint-disable-line no-invalid-this
 
-  let sandbox;
+  let sandbox
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-  });
+    sandbox = sinon.sandbox.create()
+  })
   afterEach(function() {
-    sandbox.restore();
+    sandbox.restore()
 
     for (let cookie of document.cookie.split(";")) {
-      let key = cookie.split("=")[0].trim();
-      document.cookie = `${key}=`;
+      let key = cookie.split("=")[0].trim()
+      document.cookie = `${key}=`
     }
-  });
+  })
 
-  describe('REST functions', () => {
-    let fetchStub;
+  describe("REST functions", () => {
+    let fetchStub
     beforeEach(() => {
-      fetchStub = sandbox.stub(fetchFuncs, 'fetchJSONWithCSRF');
-    });
+      fetchStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+    })
 
-    it('gets channel posts', () => {
-      const posts = makeChannelPostList();
-      fetchStub.returns(Promise.resolve(posts));
+    it("gets channel posts", () => {
+      const posts = makeChannelPostList()
+      fetchStub.returns(Promise.resolve(posts))
 
-      return getPostsForChannel('channelone').then(result => {
-        assert.ok(fetchStub.calledWith('/api/v0/channels/channelone/posts/'));
-        assert.deepEqual(result, posts);
-      });
-    });
+      return getPostsForChannel("channelone").then(result => {
+        assert.ok(fetchStub.calledWith("/api/v0/channels/channelone/posts/"))
+        assert.deepEqual(result, posts)
+      })
+    })
 
-    it('gets channel', () => {
-      const channel = makeChannel();
-      fetchStub.returns(Promise.resolve(channel));
+    it("gets channel", () => {
+      const channel = makeChannel()
+      fetchStub.returns(Promise.resolve(channel))
 
-      return getChannel('channelone').then(result => {
-        assert.ok(fetchStub.calledWith('/api/v0/channels/channelone/'));
-        assert.deepEqual(result, channel);
-      });
-    });
+      return getChannel("channelone").then(result => {
+        assert.ok(fetchStub.calledWith("/api/v0/channels/channelone/"))
+        assert.deepEqual(result, channel)
+      })
+    })
 
-    it('gets post', () => {
-      const post = makePost();
-      fetchStub.returns(Promise.resolve(post));
+    it("gets post", () => {
+      const post = makePost()
+      fetchStub.returns(Promise.resolve(post))
 
-      return getPost('1').then(result => {
-        assert.ok(fetchStub.calledWith(`/api/v0/posts/1/`));
-        assert.deepEqual(result, post);
-      });
-    });
+      return getPost("1").then(result => {
+        assert.ok(fetchStub.calledWith(`/api/v0/posts/1/`))
+        assert.deepEqual(result, post)
+      })
+    })
 
-    it('gets the frontpage', () => {
-      const posts = makeChannelPostList();
-      fetchStub.returns(Promise.resolve(posts));
+    it("gets the frontpage", () => {
+      const posts = makeChannelPostList()
+      fetchStub.returns(Promise.resolve(posts))
 
       return getFrontpage().then(result => {
-        assert.ok(fetchStub.calledWith(`/api/v0/frontpage/`));
-        assert.deepEqual(result, posts);
-      });
-    });
-  });
-});
+        assert.ok(fetchStub.calledWith(`/api/v0/frontpage/`))
+        assert.deepEqual(result, posts)
+      })
+    })
+  })
+})

--- a/static/js/lib/maps.js
+++ b/static/js/lib/maps.js
@@ -1,8 +1,7 @@
 // @flow
-import R from 'ramda';
+import R from "ramda"
 
 // utilities for working with Map objects
 
-export const safeBulkGet = <T>(keys: Array<string>, data: Map<string, T>): Array<T> => (
+export const safeBulkGet = <T>(keys: Array<string>, data: Map<string, T>): Array<T> =>
   R.reject(R.isNil, keys.map(key => data.get(key)))
-);

--- a/static/js/lib/maps_test.js
+++ b/static/js/lib/maps_test.js
@@ -1,36 +1,31 @@
 // @flow
-import { assert } from 'chai';
-import R from 'ramda';
+import { assert } from "chai"
+import R from "ramda"
 
-import { safeBulkGet } from './maps';
+import { safeBulkGet } from "./maps"
 
-describe('Map helper utils', () => {
-  describe('safeBulkGet', () => {
-    let keys = [
-      'just',
-      'write',
-      'more',
-      'tests',
-    ];
+describe("Map helper utils", () => {
+  describe("safeBulkGet", () => {
+    let keys = ["just", "write", "more", "tests"]
 
-    it('should accept a list of IDs and a Map, and return the right entries', () => {
-      let map = new Map;
+    it("should accept a list of IDs and a Map, and return the right entries", () => {
+      let map = new Map()
       keys.forEach(key => {
-        map.set(key, R.toUpper(key));
-      });
-      assert.deepEqual(R.map(R.toUpper, keys), safeBulkGet(keys, map));
-    });
+        map.set(key, R.toUpper(key))
+      })
+      assert.deepEqual(R.map(R.toUpper, keys), safeBulkGet(keys, map))
+    })
 
-    it('should return an empty list, given an empty Map', () => {
-      assert.isEmpty(safeBulkGet(keys, new Map));
-    });
+    it("should return an empty list, given an empty Map", () => {
+      assert.isEmpty(safeBulkGet(keys, new Map()))
+    })
 
-    it('should return an empty list, given no keys', () => {
-      let map = new Map;
+    it("should return an empty list, given no keys", () => {
+      let map = new Map()
       keys.forEach(key => {
-        map.set(key, R.toUpper(key));
-      });
-      assert.isEmpty(safeBulkGet([], map));
-    });
-  });
-});
+        map.set(key, R.toUpper(key))
+      })
+      assert.isEmpty(safeBulkGet([], map))
+    })
+  })
+})

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -1,14 +1,8 @@
 // @flow
-import { postsEndpoint } from '../reducers/posts';
-import { channelsEndpoint } from '../reducers/channels';
-import { postsForChannelEndpoint } from '../reducers/posts_for_channel';
-import { frontPageEndpoint } from '../reducers/frontpage';
-import { commentsEndpoint } from '../reducers/comments';
+import { postsEndpoint } from "../reducers/posts"
+import { channelsEndpoint } from "../reducers/channels"
+import { postsForChannelEndpoint } from "../reducers/posts_for_channel"
+import { frontPageEndpoint } from "../reducers/frontpage"
+import { commentsEndpoint } from "../reducers/comments"
 
-export const endpoints = [
-  postsEndpoint,
-  channelsEndpoint,
-  postsForChannelEndpoint,
-  frontPageEndpoint,
-  commentsEndpoint,
-];
+export const endpoints = [postsEndpoint, channelsEndpoint, postsForChannelEndpoint, frontPageEndpoint, commentsEndpoint]

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -1,27 +1,25 @@
 // @flow
-import R from 'ramda';
-import { create, env } from 'sanctuary';
+import R from "ramda"
+import { create, env } from "sanctuary"
 
-export const S = create({ checkTypes: false, env: env });
+export const S = create({ checkTypes: false, env: env })
 
 /*
  * returns Just(items) if all items are Just, else Nothing
  */
-export const allJust = R.curry((items: S.Maybe[]) => (
-  R.all(S.isJust)(items) ? S.Just(items) : S.Nothing
-));
+export const allJust = R.curry((items: S.Maybe[]) => (R.all(S.isJust)(items) ? S.Just(items) : S.Nothing))
 
 /*
  * converts a Maybe<String> to a string
  */
-export const mstr = S.maybe("", String);
+export const mstr = S.maybe("", String)
 
 /*
  * returns Nothing if the input is undefined|null,
  * else passes the input through a provided function
  * (the third argument to R.ifElse)
  */
-export const ifNil = R.ifElse(R.isNil, () => S.Nothing);
+export const ifNil = R.ifElse(R.isNil, () => S.Nothing)
 
 /*
  * wraps a function in a guard, which will return Nothing
@@ -34,41 +32,33 @@ export const ifNil = R.ifElse(R.isNil, () => S.Nothing);
  */
 export const guard = (func: Function) => (...args: any) => {
   if (R.any(R.isNil, args)) {
-    return S.Nothing;
+    return S.Nothing
   } else {
-    return S.Just(func(...args));
+    return S.Just(func(...args))
   }
-};
+}
 
 // getm :: String -> Object -> Maybe a
-export const getm = R.curry((prop, obj) => (
-  S.toMaybe(R.prop(prop, obj))
-));
+export const getm = R.curry((prop, obj) => S.toMaybe(R.prop(prop, obj)))
 
 // parseJSON :: String -> Either Object Object
 // A Right value indicates the JSON parsed successfully,
 // a Left value indicates the JSON was malformed (a Left contains
 // an empty object)
-export const parseJSON = S.encaseEither(() => ({}), JSON.parse);
+export const parseJSON = S.encaseEither(() => ({}), JSON.parse)
 
 // filterE :: (Either -> Boolean) -> Either -> Either
 // filterE takes a function f and an either E(v).
 // if the Either is a Left, it returns it.
 // if the f(v) === true, it returns, E. Else,
 // if returns Left(v).
-export const filterE = R.curry((predicate, either) => S.either(
-  S.Left,
-  right => predicate(right) ? S.Right(right) : S.Left(right),
-  either
-));
+export const filterE = R.curry((predicate, either) =>
+  S.either(S.Left, right => (predicate(right) ? S.Right(right) : S.Left(right)), either)
+)
 
 // reduceM :: forall a b. b -> (a -> b) -> Maybe a -> b
 // this is how I think Sanctuary's `reduce` should handle a maybe
 // pass a default value, a function, and a maybe
 // if Nothing, return the function called with the default value
 // if Just, return the function called with the value in the Just
-export const reduceM = R.curry((def, fn, maybe) => S.maybe_(
-  () => fn(def),
-  fn,
-  maybe
-));
+export const reduceM = R.curry((def, fn, maybe) => S.maybe_(() => fn(def), fn, maybe))

--- a/static/js/lib/sanctuary_test.js
+++ b/static/js/lib/sanctuary_test.js
@@ -1,176 +1,151 @@
 // @flow
-import { assert } from 'chai';
-import R from 'ramda';
+import { assert } from "chai"
+import R from "ramda"
 
-import {
-  S,
-  allJust,
-  mstr,
-  ifNil,
-  guard,
-  getm,
-  parseJSON,
-  filterE,
-  reduceM,
-} from './sanctuary';
-const { Just, Nothing } = S;
-import {
-  assertMaybeEquality,
-  assertIsNothing,
-  assertIsJust,
-} from './test_utils';
+import { S, allJust, mstr, ifNil, guard, getm, parseJSON, filterE, reduceM } from "./sanctuary"
+const { Just, Nothing } = S
+import { assertMaybeEquality, assertIsNothing, assertIsJust } from "./test_utils"
 
 const assertIsLeft = (e, val) => {
-  assert(e.isLeft, "should be left");
-  assert.deepEqual(e.value, val);
-};
+  assert(e.isLeft, "should be left")
+  assert.deepEqual(e.value, val)
+}
 
 const assertIsRight = (e, val) => {
-  assert(e.isRight, "should be right");
-  assert.deepEqual(e.value, val);
-};
+  assert(e.isRight, "should be right")
+  assert.deepEqual(e.value, val)
+}
 
+describe("sanctuary util functions", () => {
+  describe("allJust", () => {
+    let maybes = [Just(2), Just("maybe?")]
 
-describe('sanctuary util functions', () => {
-  describe('allJust', () => {
-    let maybes = [
-      Just(2),
-      Just('maybe?')
-    ];
+    it("should return Just(values) if passed an array of Just values", () => {
+      let checked = allJust(maybes)
+      assert(S.isJust(checked))
+      checked.value.forEach((m, i) => assertMaybeEquality(m, maybes[i]))
+    })
 
-    it('should return Just(values) if passed an array of Just values', () => {
-      let checked = allJust(maybes);
-      assert(S.isJust(checked));
-      checked.value.forEach((m, i) => assertMaybeEquality(m, maybes[i]));
-    });
+    it("should return Nothing if passed an array with a Nothing in it", () => {
+      assertIsNothing(allJust(maybes.concat(Nothing)))
+    })
+  })
 
-    it('should return Nothing if passed an array with a Nothing in it', () => {
-      assertIsNothing(allJust(maybes.concat(Nothing)));
-    });
-  });
+  describe("mstr", () => {
+    it("should print an empty string if called on Nothing", () => {
+      assert.equal("", mstr(Nothing))
+    })
 
-  describe('mstr', () => {
-    it('should print an empty string if called on Nothing', () => {
-      assert.equal("", mstr(Nothing));
-    });
+    it("should print the value wrapped with Just", () => {
+      assert.equal("4", mstr(Just(4)))
+      assert.equal("some text", mstr(Just("some text")))
+    })
+  })
 
-    it('should print the value wrapped with Just', () => {
-      assert.equal("4", mstr(Just(4)));
-      assert.equal("some text", mstr(Just("some text")));
-    });
-  });
+  describe("ifNil", () => {
+    it("returns Nothing if the input is undefined", () => {
+      assertIsNothing(ifNil(x => x)(undefined))
+    })
 
-  describe('ifNil', () => {
-    it('returns Nothing if the input is undefined', () => {
-      assertIsNothing(ifNil(x => x)(undefined));
-    });
+    it("returns Nothing if the input is null", () => {
+      assertIsNothing(ifNil(x => x)(null))
+    })
 
-    it('returns Nothing if the input is null', () => {
-      assertIsNothing(ifNil(x => x)(null));
-    });
+    it("return func(input) if the input is not nil", () => {
+      let result = ifNil(x => x)("test input")
+      assert.equal("test input", result)
+    })
+  })
 
-    it('return func(input) if the input is not nil', () => {
-      let result = ifNil(x => x)('test input');
-      assert.equal('test input', result);
-    });
-  });
+  describe("guard", () => {
+    let wrappedFunc = guard(x => x + 2)
+    let wrappedRestFunc = guard((x, y, z) => [x, y, z])
 
-  describe('guard', () => {
-    let wrappedFunc = guard(x => x + 2);
-    let wrappedRestFunc = guard((x, y, z) => [x, y, z]);
+    it("takes a function and returns a function", () => {
+      assert.isFunction(wrappedFunc)
+      assert.isFunction(wrappedRestFunc)
+    })
 
-    it('takes a function and returns a function', () => {
-      assert.isFunction(wrappedFunc);
-      assert.isFunction(wrappedRestFunc);
-    });
+    it("returns a function that returns Nothing if any arguments are nil", () => {
+      assertIsNothing(wrappedFunc(null))
+      assertIsNothing(wrappedFunc(undefined))
+    })
 
-    it('returns a function that returns Nothing if any arguments are nil', () => {
-      assertIsNothing(wrappedFunc(null));
-      assertIsNothing(wrappedFunc(undefined));
-    });
+    it("returns a function that returns the Just(fn(args)) if no args are undefined", () => {
+      assertIsJust(wrappedFunc(2), 4)
+    })
 
-    it('returns a function that returns the Just(fn(args)) if no args are undefined', () => {
-      assertIsJust(wrappedFunc(2), 4);
-    });
+    it("accepts rest parameters", () => {
+      assertIsJust(wrappedRestFunc(1, 2, 3), [1, 2, 3])
+    })
 
-    it('accepts rest parameters', () => {
-      assertIsJust(wrappedRestFunc(1,2,3), [1,2,3]);
-    });
-
-    it('returns Nothing if any rest parameter arg is undefined', () => {
-      let args = [1,2,3];
-      [null, undefined].forEach(nilVal => {
+    it("returns Nothing if any rest parameter arg is undefined", () => {
+      let args = [1, 2, 3]
+      ;[null, undefined].forEach(nilVal => {
         for (let i = 0; i < 3; i++) {
-          assertIsNothing(wrappedRestFunc(...R.update(i, nilVal, args)));
+          assertIsNothing(wrappedRestFunc(...R.update(i, nilVal, args)))
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
-  describe('getm', () => {
-    it('returns Nothing if a prop is not present', () => {
-      assertIsNothing(getm('prop', {}));
-    });
-
-    [null, undefined].forEach(nil => {
+  describe("getm", () => {
+    it("returns Nothing if a prop is not present", () => {
+      assertIsNothing(getm("prop", {}))
+    })
+    ;[null, undefined].forEach(nil => {
       // $FlowFixMe
       it(`returns Nothing if a prop is ${nil}`, () => {
-        assertIsNothing(getm('prop', {'prop': nil}));
-      });
-    });
+        assertIsNothing(getm("prop", { prop: nil }))
+      })
+    })
 
-    it('returns Just(val) if a prop is present', () => {
-      assertIsJust(getm('prop', {prop: 'HI'}), 'HI');
-    });
-  });
+    it("returns Just(val) if a prop is present", () => {
+      assertIsJust(getm("prop", { prop: "HI" }), "HI")
+    })
+  })
 
-  describe('parseJSON', () => {
-    it('returns Left({}) if handed bad JSON', () => {
-      assertIsLeft(parseJSON(""), {});
-      assertIsLeft(parseJSON("[[[["), {});
-      assertIsLeft(parseJSON("@#R@#FASDF"), {});
-    });
+  describe("parseJSON", () => {
+    it("returns Left({}) if handed bad JSON", () => {
+      assertIsLeft(parseJSON(""), {})
+      assertIsLeft(parseJSON("[[[["), {})
+      assertIsLeft(parseJSON("@#R@#FASDF"), {})
+    })
 
-    it('returns Right(Object) if handed good JSON', () => {
-      let testObj = { foo: [
-        'bar', 'baz'
-      ]};
-      assertIsRight(parseJSON(JSON.stringify(testObj)), testObj);
-    });
-  });
+    it("returns Right(Object) if handed good JSON", () => {
+      let testObj = {
+        foo: ["bar", "baz"]
+      }
+      assertIsRight(parseJSON(JSON.stringify(testObj)), testObj)
+    })
+  })
 
-  describe('filterE', () => {
-    let left = S.Left(2);
-    let right = S.Right(4);
-    it('returns a Left if passed one, regardless of predicate', () => {
-      assertIsLeft(filterE(x => x === 2, left), 2);
-      assertIsLeft(filterE(x => x !== 2, left), 2);
-    });
+  describe("filterE", () => {
+    let left = S.Left(2)
+    let right = S.Right(4)
+    it("returns a Left if passed one, regardless of predicate", () => {
+      assertIsLeft(filterE(x => x === 2, left), 2)
+      assertIsLeft(filterE(x => x !== 2, left), 2)
+    })
 
-    it('returns a Left if predicate(right.value) === false', () => {
-      assertIsLeft(filterE(x => x === 2, right), 4);
-      assertIsLeft(filterE(R.isNil, right), 4);
-    });
+    it("returns a Left if predicate(right.value) === false", () => {
+      assertIsLeft(filterE(x => x === 2, right), 4)
+      assertIsLeft(filterE(R.isNil, right), 4)
+    })
 
-    it('returns a Right if predicate(right.value) === true', () => {
-      assertIsRight(filterE(x => x === 4, right), 4);
-      assertIsRight(filterE(x => x % 2 === 0, right), 4);
-    });
-  });
+    it("returns a Right if predicate(right.value) === true", () => {
+      assertIsRight(filterE(x => x === 4, right), 4)
+      assertIsRight(filterE(x => x % 2 === 0, right), 4)
+    })
+  })
 
-  describe('reduceM', () => {
-    it('returns fn(val) where maybe is Just(val)', () => {
-      assert.equal(
-        reduceM("default", str => `${str} value`, S.Just("maybe")),
-        "maybe value"
-      );
-    });
+  describe("reduceM", () => {
+    it("returns fn(val) where maybe is Just(val)", () => {
+      assert.equal(reduceM("default", str => `${str} value`, S.Just("maybe")), "maybe value")
+    })
 
-    it('returns fn(default) where maybe is Nothing', () => {
-      assert.equal(
-        reduceM("default", str => `${str} value`, S.Nothing),
-        "default value"
-      );
-    });
-  });
-});
+    it("returns fn(default) where maybe is Nothing", () => {
+      assert.equal(reduceM("default", str => `${str} value`, S.Nothing), "default value")
+    })
+  })
+})

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -1,18 +1,18 @@
 // @flow
-import { assert } from 'chai';
+import { assert } from "chai"
 
-import { S } from './sanctuary';
-const { Maybe } = S;
+import { S } from "./sanctuary"
+const { Maybe } = S
 
 export const assertMaybeEquality = (m1: Maybe, m2: Maybe) => {
-  assert(S.equals(m1, m2), `expected ${m1.value} to equal ${m2.value}`);
-};
+  assert(S.equals(m1, m2), `expected ${m1.value} to equal ${m2.value}`)
+}
 
 export const assertIsNothing = (m: Maybe) => {
-  assert(m.isNothing, `should be nothing, is ${m}`);
-};
+  assert(m.isNothing, `should be nothing, is ${m}`)
+}
 
 export const assertIsJust = (m: Maybe, val: any) => {
-  assert(m.isJust, `should be Just(${val}), is ${m}`);
-  assert.deepEqual(m.value, val);
-};
+  assert(m.isJust, `should be Just(${val}), is ${m}`)
+  assert.deepEqual(m.value, val)
+}

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -1,5 +1,3 @@
 // @flow
 
-export const postDetailURL = (channelName: string, postID: string) => (
-  `/channel/${channelName}/${postID}`
-);
+export const postDetailURL = (channelName: string, postID: string) => `/channel/${channelName}/${postID}`

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -1,15 +1,12 @@
 // @flow
-import { assert } from 'chai';
+import { assert } from "chai"
 
-import { postDetailURL } from './url';
+import { postDetailURL } from "./url"
 
-describe('url helper functions', () => {
-  describe('postDetailURL', () => {
-    it('should return a good URL', () => {
-      assert.equal(
-        postDetailURL('foobar', '23434j3j3'),
-        '/channel/foobar/23434j3j3'
-      );
-    });
-  });
-});
+describe("url helper functions", () => {
+  describe("postDetailURL", () => {
+    it("should return a good URL", () => {
+      assert.equal(postDetailURL("foobar", "23434j3j3"), "/channel/foobar/23434j3j3")
+    })
+  })
+})

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -1,17 +1,17 @@
 // @flow
-import { GET, INITIAL_STATE } from 'redux-hammock/constants';
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import type { Channel } from '../flow/discussionTypes';
-import * as api from '../lib/api';
+import type { Channel } from "../flow/discussionTypes"
+import * as api from "../lib/api"
 
 export const channelsEndpoint = {
-  name: 'channels',
-  verbs: [ GET ],
-  initialState: { ...INITIAL_STATE, data: new Map },
-  getFunc: (name: string) => api.getChannel(name),
+  name:              "channels",
+  verbs:             [GET],
+  initialState:      { ...INITIAL_STATE, data: new Map() },
+  getFunc:           (name: string) => api.getChannel(name),
   getSuccessHandler: (payload: Channel, data: Map<string, Channel>) => {
-    let update = new Map(data);
-    update.set(payload.name, payload);
-    return update;
-  },
-};
+    let update = new Map(data)
+    update.set(payload.name, payload)
+    return update
+  }
+}

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -1,18 +1,18 @@
 // @flow
-import { GET, INITIAL_STATE } from 'redux-hammock/constants';
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import { makeCommentTree } from '../factories/comments';
+import { makeCommentTree } from "../factories/comments"
 
-import type { Comment, Post } from '../flow/discussionTypes.js';
+import type { Comment, Post } from "../flow/discussionTypes.js"
 
 export const commentsEndpoint = {
-  name: 'comments',
-  verbs: [ GET ],
-  getFunc: async (post: Post) => makeCommentTree(post),
-  initialState: { ...INITIAL_STATE, data: new Map },
+  name:              "comments",
+  verbs:             [GET],
+  getFunc:           async (post: Post) => makeCommentTree(post),
+  initialState:      { ...INITIAL_STATE, data: new Map() },
   getSuccessHandler: (comments: Array<Comment>, data: Map<string, Array<Comment>>) => {
-    let update = new Map(data);
-    update.set(comments[0].post_id, comments);
-    return update;
-  },
-};
+    let update = new Map(data)
+    update.set(comments[0].post_id, comments)
+    return update
+  }
+}

--- a/static/js/reducers/frontpage.js
+++ b/static/js/reducers/frontpage.js
@@ -1,15 +1,13 @@
 // @flow
-import { GET, INITIAL_STATE } from 'redux-hammock/constants';
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from '../lib/api';
-import type { Post } from '../flow/discussionTypes';
+import * as api from "../lib/api"
+import type { Post } from "../flow/discussionTypes"
 
 export const frontPageEndpoint = {
-  name: 'frontpage',
-  verbs: [ GET ],
-  initialState: { ...INITIAL_STATE, data: [] },
-  getFunc: () => api.getFrontpage(),
-  getSuccessHandler: (payload: Array<Post>) => (
-    payload.map(post => post.id)
-  )
-};
+  name:              "frontpage",
+  verbs:             [GET],
+  initialState:      { ...INITIAL_STATE, data: [] },
+  getFunc:           () => api.getFrontpage(),
+  getSuccessHandler: (payload: Array<Post>) => payload.map(post => post.id)
+}

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -1,15 +1,15 @@
 // @flow
-import { combineReducers } from 'redux';
-import { deriveReducers } from 'redux-hammock';
+import { combineReducers } from "redux"
+import { deriveReducers } from "redux-hammock"
 
-import { actions } from '../actions';
-import { endpoints } from '../lib/redux_rest';
+import { actions } from "../actions"
+import { endpoints } from "../lib/redux_rest"
 
-const reducers: Object = {};
+const reducers: Object = {}
 endpoints.forEach(endpoint => {
-  reducers[endpoint.name] = deriveReducers(endpoint, actions[endpoint.name]);
-});
+  reducers[endpoint.name] = deriveReducers(endpoint, actions[endpoint.name])
+})
 
 export default combineReducers({
-  ...reducers,
-});
+  ...reducers
+})

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,221 +1,191 @@
 // @flow
-import { assert } from 'chai';
-import sinon from 'sinon';
-import configureTestStore from 'redux-asserts';
-import { INITIAL_STATE } from 'redux-hammock/constants';
+import { assert } from "chai"
+import sinon from "sinon"
+import configureTestStore from "redux-asserts"
+import { INITIAL_STATE } from "redux-hammock/constants"
 
-import rootReducer from '../reducers';
-import { actions } from '../actions';
-import * as api from '../lib/api';
-import { makePost, makeChannelPostList } from '../factories/posts';
-import { makeChannel } from '../factories/channels';
-import { setPostData } from '../actions/post';
+import rootReducer from "../reducers"
+import { actions } from "../actions"
+import * as api from "../lib/api"
+import { makePost, makeChannelPostList } from "../factories/posts"
+import { makeChannel } from "../factories/channels"
+import { setPostData } from "../actions/post"
 
-describe('reducers', () => {
-  let sandbox, store, dispatchThen;
+describe("reducers", () => {
+  let sandbox, store, dispatchThen
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    store = configureTestStore(rootReducer);
-  });
+    sandbox = sinon.sandbox.create()
+    store = configureTestStore(rootReducer)
+  })
 
   afterEach(() => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
-  describe('posts reducer', () => {
-    let getPostStub;
+  describe("posts reducer", () => {
+    let getPostStub
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.posts);
-      getPostStub = sandbox.stub(api, 'getPost');
-      getPostStub.callsFake(async (id) => {
-        let post = makePost();
-        post.id = id;
-        return post;
-      });
-    });
+      dispatchThen = store.createDispatchThen(state => state.posts)
+      getPostStub = sandbox.stub(api, "getPost")
+      getPostStub.callsFake(async id => {
+        let post = makePost()
+        post.id = id
+        return post
+      })
+    })
 
-    it('should have some initial state', () => {
-      assert.deepEqual(
-        store.getState().posts,
-        { ...INITIAL_STATE, data: new Map }
-      );
-    });
+    it("should have some initial state", () => {
+      assert.deepEqual(store.getState().posts, { ...INITIAL_STATE, data: new Map() })
+    })
 
-    it('should let you fetch a post', () => {
-      const { requestType, successType } = actions.posts.get;
-      return dispatchThen(
-        actions.posts.get('mypostid'),
-        [ requestType, successType ]
-      ).then(posts => {
-        let post = posts.data.get('mypostid');
-        assert.equal(post.id, 'mypostid');
-        assert.isString(post.title);
-      });
-    });
+    it("should let you fetch a post", () => {
+      const { requestType, successType } = actions.posts.get
+      return dispatchThen(actions.posts.get("mypostid"), [requestType, successType]).then(posts => {
+        let post = posts.data.get("mypostid")
+        assert.equal(post.id, "mypostid")
+        assert.isString(post.title)
+      })
+    })
 
-    it('should allow for multiple posts to coexist', () => {
+    it("should allow for multiple posts to coexist", () => {
       return Promise.all([
-        store.dispatch(actions.posts.get('first')),
-        store.dispatch(actions.posts.get('second')),
+        store.dispatch(actions.posts.get("first")),
+        store.dispatch(actions.posts.get("second"))
       ]).then(() => {
-        let { posts: { data }} = store.getState();
-        assert.equal(data.get('first').id, 'first');
-        assert.equal(data.get('second').id, 'second');
-        assert.equal(data.size, 2);
-      });
-    });
+        let { posts: { data } } = store.getState()
+        assert.equal(data.get("first").id, "first")
+        assert.equal(data.get("second").id, "second")
+        assert.equal(data.size, 2)
+      })
+    })
 
-    it('should allow setting a post record separately', () => {
-      let post = makePost();
-      post.id = 'my great post wow';
-      store.dispatch(setPostData(post));
-      const { posts } = store.getState();
-      assert.deepEqual(post, posts.data.get('my great post wow'));
-      assert.isTrue(posts.loaded);
-    });
+    it("should allow setting a post record separately", () => {
+      let post = makePost()
+      post.id = "my great post wow"
+      store.dispatch(setPostData(post))
+      const { posts } = store.getState()
+      assert.deepEqual(post, posts.data.get("my great post wow"))
+      assert.isTrue(posts.loaded)
+    })
 
-    it('should let you set a list of posts separately', () => {
-      let posts = makeChannelPostList();
-      store.dispatch(setPostData(posts));
-      const { posts: { data }} = store.getState();
-      assert.equal(data.size, 20);
-    });
-  });
+    it("should let you set a list of posts separately", () => {
+      let posts = makeChannelPostList()
+      store.dispatch(setPostData(posts))
+      const { posts: { data } } = store.getState()
+      assert.equal(data.size, 20)
+    })
+  })
 
-  describe('channels reducer', () => {
-    let getChannelStub;
+  describe("channels reducer", () => {
+    let getChannelStub
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.channels);
-      getChannelStub = sandbox.stub(api, 'getChannel');
-      getChannelStub.callsFake(async (name) => {
-        let channel = makeChannel();
-        channel.name = name;
-        return channel;
-      });
-    });
+      dispatchThen = store.createDispatchThen(state => state.channels)
+      getChannelStub = sandbox.stub(api, "getChannel")
+      getChannelStub.callsFake(async name => {
+        let channel = makeChannel()
+        channel.name = name
+        return channel
+      })
+    })
 
-    it('should have some initial state', () => {
-      assert.deepEqual(
-        store.getState().channels,
-        { ...INITIAL_STATE, data: new Map }
-      );
-    });
+    it("should have some initial state", () => {
+      assert.deepEqual(store.getState().channels, { ...INITIAL_STATE, data: new Map() })
+    })
 
-    it('should let you get a channel', () => {
-      const { requestType, successType } = actions.channels.get;
-      return dispatchThen(
-        actions.channels.get('wowowowow'),
-        [ requestType, successType ]
-      ).then(channels => {
-        let channel = channels.data.get('wowowowow');
-        assert.isString(channel.name);
-        assert.equal(channel.theme_type, "public");
-      });
-    });
+    it("should let you get a channel", () => {
+      const { requestType, successType } = actions.channels.get
+      return dispatchThen(actions.channels.get("wowowowow"), [requestType, successType]).then(channels => {
+        let channel = channels.data.get("wowowowow")
+        assert.isString(channel.name)
+        assert.equal(channel.theme_type, "public")
+      })
+    })
 
-    it('should support multiple channels', () => {
+    it("should support multiple channels", () => {
       return Promise.all([
-        store.dispatch(actions.channels.get('first')),
-        store.dispatch(actions.channels.get('second')),
+        store.dispatch(actions.channels.get("first")),
+        store.dispatch(actions.channels.get("second"))
       ]).then(() => {
-        let { channels: { data }} = store.getState();
-        assert.equal(data.get('first').name, 'first');
-        assert.equal(data.get('second').name, 'second');
-        assert.equal(data.size, 2);
-      });
-    });
-  });
+        let { channels: { data } } = store.getState()
+        assert.equal(data.get("first").name, "first")
+        assert.equal(data.get("second").name, "second")
+        assert.equal(data.size, 2)
+      })
+    })
+  })
 
-  describe('postsForChannel reducer', () => {
-    let getPostsForChannelStub;
+  describe("postsForChannel reducer", () => {
+    let getPostsForChannelStub
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.postsForChannel);
-      getPostsForChannelStub = sandbox.stub(api, 'getPostsForChannel');
-      getPostsForChannelStub.returns(Promise.resolve(makeChannelPostList()));
-    });
+      dispatchThen = store.createDispatchThen(state => state.postsForChannel)
+      getPostsForChannelStub = sandbox.stub(api, "getPostsForChannel")
+      getPostsForChannelStub.returns(Promise.resolve(makeChannelPostList()))
+    })
 
-    it('should have some initial state', () => {
-      assert.deepEqual(
-        store.getState().postsForChannel,
-        { ...INITIAL_STATE, data: new Map }
-      );
-    });
+    it("should have some initial state", () => {
+      assert.deepEqual(store.getState().postsForChannel, { ...INITIAL_STATE, data: new Map() })
+    })
 
-    it('should let you get the posts for a channel', () => {
-      const { requestType, successType } = actions.postsForChannel.get;
-      return dispatchThen(
-        actions.postsForChannel.get('channel'),
-        [ requestType, successType ]
-      ).then(({ data }) => {
-        let channel = data.get('channel');
-        assert.isArray(channel);
-        assert.lengthOf(channel, 20);
-      });
-    });
+    it("should let you get the posts for a channel", () => {
+      const { requestType, successType } = actions.postsForChannel.get
+      return dispatchThen(actions.postsForChannel.get("channel"), [requestType, successType]).then(({ data }) => {
+        let channel = data.get("channel")
+        assert.isArray(channel)
+        assert.lengthOf(channel, 20)
+      })
+    })
 
-    it('should support multiple channels', () => {
+    it("should support multiple channels", () => {
       return Promise.all([
-        store.dispatch(actions.postsForChannel.get('first')),
-        store.dispatch(actions.postsForChannel.get('second')),
+        store.dispatch(actions.postsForChannel.get("first")),
+        store.dispatch(actions.postsForChannel.get("second"))
       ]).then(() => {
-        let { postsForChannel: { data }} = store.getState();
-        assert.isArray(data.get('first'));
-        assert.isArray(data.get('second'));
-        assert.equal(data.size, 2);
-      });
-    });
-  });
+        let { postsForChannel: { data } } = store.getState()
+        assert.isArray(data.get("first"))
+        assert.isArray(data.get("second"))
+        assert.equal(data.size, 2)
+      })
+    })
+  })
 
-  describe('frontpage reducer', () => {
-    let frontpageStub;
+  describe("frontpage reducer", () => {
+    let frontpageStub
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.frontpage);
-      frontpageStub = sandbox.stub(api, 'getFrontpage');
-      frontpageStub.returns(Promise.resolve(makeChannelPostList()));
-    });
+      dispatchThen = store.createDispatchThen(state => state.frontpage)
+      frontpageStub = sandbox.stub(api, "getFrontpage")
+      frontpageStub.returns(Promise.resolve(makeChannelPostList()))
+    })
 
-    it('should have some initial state', () => {
-      assert.deepEqual(
-        store.getState().frontpage,
-        { ...INITIAL_STATE, data: [] }
-      );
-    });
+    it("should have some initial state", () => {
+      assert.deepEqual(store.getState().frontpage, { ...INITIAL_STATE, data: [] })
+    })
 
-    it('should let you get the frontpage', () => {
-      const { requestType, successType } = actions.frontpage.get;
-      return dispatchThen(
-        actions.frontpage.get(),
-        [ requestType, successType ]
-      ).then(({ data }) => {
-        assert.lengthOf(data, 20);
-      });
-    });
-  });
+    it("should let you get the frontpage", () => {
+      const { requestType, successType } = actions.frontpage.get
+      return dispatchThen(actions.frontpage.get(), [requestType, successType]).then(({ data }) => {
+        assert.lengthOf(data, 20)
+      })
+    })
+  })
 
-  describe('comments reducer', () => {
+  describe("comments reducer", () => {
     beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.comments);
-    });
+      dispatchThen = store.createDispatchThen(state => state.comments)
+    })
 
-    it('should have some initial state', () => {
-      assert.deepEqual(
-        store.getState().comments,
-        { ...INITIAL_STATE, data: new Map }
-      );
-    });
+    it("should have some initial state", () => {
+      assert.deepEqual(store.getState().comments, { ...INITIAL_STATE, data: new Map() })
+    })
 
-    it('should let you get the comments for a Post', () => {
-      let post = makePost();
-      const { requestType, successType } = actions.comments.get;
-      return dispatchThen(
-        actions.comments.get(post),
-        [ requestType, successType ],
-      ).then(({ data }) => {
-        let comments = data.get(post.id);
-        assert.isArray(comments);
-        assert.isNotEmpty(comments[0].replies);
-      });
-    });
-  });
-});
+    it("should let you get the comments for a Post", () => {
+      let post = makePost()
+      const { requestType, successType } = actions.comments.get
+      return dispatchThen(actions.comments.get(post), [requestType, successType]).then(({ data }) => {
+        let comments = data.get(post.id)
+        assert.isArray(comments)
+        assert.isNotEmpty(comments[0].replies)
+      })
+    })
+  })
+})

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -1,37 +1,38 @@
 // @flow
-import * as api from '../lib/api';
-import { GET, INITIAL_STATE } from 'redux-hammock/constants';
+import * as api from "../lib/api"
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import { SET_POST_DATA } from '../actions/post';
+import { SET_POST_DATA } from "../actions/post"
 
-import type { Post } from '../flow/discussionTypes';
+import type { Post } from "../flow/discussionTypes"
 
 const mergePostData = (post: Post, data: Map<string, Post>): Map<string, Post> => {
-  let update = new Map(data);
-  update.set(post.id, post);
-  return update;
-};
+  let update = new Map(data)
+  update.set(post.id, post)
+  return update
+}
 
 const mergeMultiplePosts = (posts: Array<Post>, data: Map<string, Post>): Map<string, Post> => {
-  let update = new Map(data);
+  let update = new Map(data)
   posts.forEach(post => {
-    update.set(post.id, post);
-  });
-  return update;
-};
+    update.set(post.id, post)
+  })
+  return update
+}
 
 export const postsEndpoint = {
-  name: 'posts',
-  verbs: [ GET ],
-  getFunc: (id: string) => api.getPost(id),
-  initialState: { ...INITIAL_STATE, data: new Map },
+  name:              "posts",
+  verbs:             [GET],
+  getFunc:           (id: string) => api.getPost(id),
+  initialState:      { ...INITIAL_STATE, data: new Map() },
   getSuccessHandler: mergePostData,
-  extraActions: {
+  extraActions:      {
     [SET_POST_DATA]: (state, action) => {
-      let update = action.payload instanceof Array
-        ? mergeMultiplePosts(action.payload, state.data)
-        : mergePostData(action.payload, state.data);
-      return Object.assign({}, state, { data: update, loaded: true });
+      let update =
+        action.payload instanceof Array
+          ? mergeMultiplePosts(action.payload, state.data)
+          : mergePostData(action.payload, state.data)
+      return Object.assign({}, state, { data: update, loaded: true })
     }
-  },
-};
+  }
+}

--- a/static/js/reducers/posts_for_channel.js
+++ b/static/js/reducers/posts_for_channel.js
@@ -1,26 +1,26 @@
 // @flow
-import { GET, INITIAL_STATE } from 'redux-hammock/constants';
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from '../lib/api';
-import type { Post } from '../flow/discussionTypes';
+import * as api from "../lib/api"
+import type { Post } from "../flow/discussionTypes"
 
 type ChannelEndpointResponse = {
   channelName: string,
   posts: Array<Post>
-};
+}
 
 export const postsForChannelEndpoint = {
-  name: 'postsForChannel',
-  verbs: [ GET ],
+  name:    "postsForChannel",
+  verbs:   [GET],
   getFunc: async (channelName: string) => {
-    const posts = await api.getPostsForChannel(channelName);
-    return { channelName, posts };
+    const posts = await api.getPostsForChannel(channelName)
+    return { channelName, posts }
   },
-  initialState: { ...INITIAL_STATE, data: new Map },
+  initialState:      { ...INITIAL_STATE, data: new Map() },
   getSuccessHandler: (payload: ChannelEndpointResponse, data: Map<string, Array<string>>) => {
-    const { channelName, posts } = payload;
-    let update = new Map(data);
-    update.set(channelName, posts.map(post => post.id));
-    return update;
+    const { channelName, posts } = payload
+    let update = new Map(data)
+    update.set(channelName, posts.map(post => post.id))
+    return update
   }
-};
+}

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -1,38 +1,31 @@
 /* global require:false, module:false */
-import { compose, createStore, applyMiddleware } from 'redux';
-import thunkMiddleware from 'redux-thunk';
-import { createLogger } from 'redux-logger';
+import { compose, createStore, applyMiddleware } from "redux"
+import thunkMiddleware from "redux-thunk"
+import { createLogger } from "redux-logger"
 
-import rootReducer from '../reducers';
+import rootReducer from "../reducers"
 
-let createStoreWithMiddleware;
+let createStoreWithMiddleware
 if (process.env.NODE_ENV !== "production") {
   createStoreWithMiddleware = compose(
-    applyMiddleware(
-      thunkMiddleware,
-      createLogger()
-    ),
+    applyMiddleware(thunkMiddleware, createLogger()),
     window.devToolsExtension ? window.devToolsExtension() : f => f
-  )(createStore);
+  )(createStore)
 } else {
-  createStoreWithMiddleware = compose(
-    applyMiddleware(
-      thunkMiddleware
-    )
-  )(createStore);
+  createStoreWithMiddleware = compose(applyMiddleware(thunkMiddleware))(createStore)
 }
 
 export default function configureStore(initialState: Object) {
-  const store = createStoreWithMiddleware(rootReducer, initialState);
+  const store = createStoreWithMiddleware(rootReducer, initialState)
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
-    module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers');
+    module.hot.accept("../reducers", () => {
+      const nextRootReducer = require("../reducers")
 
-      store.replaceReducer(nextRootReducer);
-    });
+      store.replaceReducer(nextRootReducer)
+    })
   }
 
-  return store;
+  return store
 }

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -1,59 +1,57 @@
 /* global SETTINGS: false */
-import React from 'react';
-import { mount } from 'enzyme';
-import sinon from 'sinon';
-import { createMemoryHistory } from 'react-router';
-import { mergePersistedState }  from 'redux-localstorage';
-import { compose } from 'redux';
+import React from "react"
+import { mount } from "enzyme"
+import sinon from "sinon"
+import { createMemoryHistory } from "react-router"
+import { mergePersistedState } from "redux-localstorage"
+import { compose } from "redux"
 
-import TestRouter from '../TestRouter';
-import * as api from '../lib/api';
-import rootReducer from '../reducers';
-import { testRoutes } from './test_utils';
-import { configureMainTestStore } from '../store/configureStore';
-import type { Action } from '../flow/reduxTypes';
-import type { TestStore } from '../flow/reduxTypes';
-import type { Sandbox } from '../flow/sinonTypes';
+import TestRouter from "../TestRouter"
+import * as api from "../lib/api"
+import rootReducer from "../reducers"
+import { testRoutes } from "./test_utils"
+import { configureMainTestStore } from "../store/configureStore"
+import type { Action } from "../flow/reduxTypes"
+import type { TestStore } from "../flow/reduxTypes"
+import type { Sandbox } from "../flow/sinonTypes"
 
 export default class IntegrationTestHelper {
-  listenForActions: (a: Array<string>, f: Function) => Promise<*>;
-  dispatchThen: (a: Action) => Promise<*>;
-  sandbox: Sandbox;
-  store: TestStore;
-  browserHistory: History;
+  listenForActions: (a: Array<string>, f: Function) => Promise<*>
+  dispatchThen: (a: Action) => Promise<*>
+  sandbox: Sandbox
+  store: TestStore
+  browserHistory: History
 
   constructor() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.sandbox.create()
     this.store = configureMainTestStore((...args) => {
       // uncomment to listen on dispatched actions
       // console.log(args);
-      const reducer = compose(
-        mergePersistedState()
-      )(rootReducer);
-      return reducer(...args);
-    });
+      const reducer = compose(mergePersistedState())(rootReducer)
+      return reducer(...args)
+    })
 
     // we need this to deal with the 'endpoint' objects, it's now necessary
     // to directly mock out the fetch call because at module load time the
     // endpoint object already holds a reference to the unmocked API function
     // (e.g. getCoupons) which Sinon doesn't seem to be able to deal with.
-    this.fetchJSONWithCSRFStub = this.sandbox.stub(api, 'fetchJSONWithCSRF');
+    this.fetchJSONWithCSRFStub = this.sandbox.stub(api, "fetchJSONWithCSRF")
 
-    this.listenForActions = this.store.createListenForActions();
-    this.dispatchThen = this.store.createDispatchThen();
+    this.listenForActions = this.store.createListenForActions()
+    this.dispatchThen = this.store.createDispatchThen()
 
-    this.scrollIntoViewStub = this.sandbox.stub();
-    window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub;
-    window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub;
-    this.browserHistory = createMemoryHistory();
-    this.currentLocation = null;
+    this.scrollIntoViewStub = this.sandbox.stub()
+    window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub
+    window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub
+    this.browserHistory = createMemoryHistory()
+    this.currentLocation = null
     this.browserHistory.listen(url => {
-      this.currentLocation = url;
-    });
+      this.currentLocation = url
+    })
   }
 
   cleanup() {
-    this.sandbox.restore();
+    this.sandbox.restore()
   }
 
   /**
@@ -63,21 +61,21 @@ export default class IntegrationTestHelper {
    * If null, actions types for the success case is assumed.
    * @returns {Promise<*>} A promise which provides [wrapper, div] on success
    */
-  renderComponent(url: string = "/", typesToAssert: Array<string>|null = null): Promise<*> {
-    let expectedTypes = [];
+  renderComponent(url: string = "/", typesToAssert: Array<string> | null = null): Promise<*> {
+    let expectedTypes = []
     if (typesToAssert === null) {
-      expectedTypes = [];
+      expectedTypes = []
     } else {
-      expectedTypes = typesToAssert;
+      expectedTypes = typesToAssert
     }
 
-    let wrapper, div;
+    let wrapper, div
 
     return this.listenForActions(expectedTypes, () => {
-      this.browserHistory.push(url);
-      div = document.createElement("div");
-      div.setAttribute("id", "integration_test_div");
-      document.body.appendChild(div);
+      this.browserHistory.push(url)
+      div = document.createElement("div")
+      div.setAttribute("id", "integration_test_div")
+      document.body.appendChild(div)
       wrapper = mount(
         <div>
           <TestRouter
@@ -90,9 +88,9 @@ export default class IntegrationTestHelper {
         {
           attachTo: div
         }
-      );
+      )
     }).then(() => {
-      return Promise.resolve([wrapper, div]);
-    });
+      return Promise.resolve([wrapper, div])
+    })
   }
 }

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -1,8 +1,8 @@
 // @flow
-import R from 'ramda';
+import R from "ramda"
 
-export const anyProcessing = R.any(R.propEq('processing', true));
+export const anyProcessing = R.any(R.propEq("processing", true))
 
-export const allLoaded = R.all(R.propEq('loaded', true));
+export const allLoaded = R.all(R.propEq("loaded", true))
 
-export const anyError = R.any(R.propSatisfies(R.complement(R.isNil), 'error'));
+export const anyError = R.any(R.propSatisfies(R.complement(R.isNil), "error"))

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -1,31 +1,27 @@
 /* global SETTINGS: false */
 // @flow
-import React from 'react';
-import { Route } from 'react-router';
-import { assert } from 'chai';
-import _ from 'lodash';
-import R from 'ramda';
+import React from "react"
+import { Route } from "react-router"
+import { assert } from "chai"
+import _ from "lodash"
+import R from "ramda"
 
-import type { Action } from '../flow/reduxTypes';
-import type { Store } from 'redux';
-import App from '../containers/App';
+import type { Action } from "../flow/reduxTypes"
+import type { Store } from "redux"
+import App from "../containers/App"
 
 export function createAssertReducerResultState<State>(store: Store, getReducerState: (x: any) => State) {
-  return (
-    action: (payload: any) => Action<*,*>, stateLookup: (state: State) => any, defaultValue: any
-  ): void => {
-    const getState = () => stateLookup(getReducerState(store.getState()));
+  return (action: (payload: any) => Action<*, *>, stateLookup: (state: State) => any, defaultValue: any): void => {
+    const getState = () => stateLookup(getReducerState(store.getState()))
 
-    assert.deepEqual(defaultValue, getState());
-    for (let value of [true, null, false, 0, 3, 'x', {'a': 'b'}, {}, [3, 4, 5], [], '']) {
-      store.dispatch(action(value));
-      assert.deepEqual(value, getState());
+    assert.deepEqual(defaultValue, getState())
+    for (let value of [true, null, false, 0, 3, "x", { a: "b" }, {}, [3, 4, 5], [], ""]) {
+      store.dispatch(action(value))
+      assert.deepEqual(value, getState())
     }
-  };
+  }
 }
 
-export const testRoutes = (
-  <Route path="/" component={App}/>
-);
+export const testRoutes = <Route path="/" component={App} />
 
-export const stringStrip = R.compose(R.join(" "), _.words);
+export const stringStrip = R.compose(R.join(" "), _.words)

--- a/static/js/util/withTracker.js
+++ b/static/js/util/withTracker.js
@@ -2,25 +2,23 @@
 /* global SETTINGS: false */
 
 // From https://github.com/ReactTraining/react-router/issues/4278#issuecomment-299692502
-import React from 'react';
-import ga from 'react-ga';
+import React from "react"
+import ga from "react-ga"
 
 const withTracker = (WrappedComponent: Class<React.Component<*, *, *>>) => {
-  const debug = SETTINGS.reactGaDebug === "true";
+  const debug = SETTINGS.reactGaDebug === "true"
 
   if (SETTINGS.gaTrackingID) {
-    ga.initialize(SETTINGS.gaTrackingID, { debug: debug });
+    ga.initialize(SETTINGS.gaTrackingID, { debug: debug })
   }
 
   const HOC = (props: Object) => {
-    const page = props.location.pathname;
-    ga.pageview(page);
-    return (
-      <WrappedComponent {...props} />
-    );
-  };
+    const page = props.location.pathname
+    ga.pageview(page)
+    return <WrappedComponent {...props} />
+  }
 
-  return HOC;
-};
+  return HOC
+}
 
-export default withTracker;
+export default withTracker

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ ansi-regex@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-1.1.1.tgz#41c847194646375e6a1a5d10c3ca054ef9fc980d"
 
-ansi-regex@^2.0.0:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -119,7 +119,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:
@@ -289,7 +289,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -984,6 +984,10 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
+boolify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/boolify/-/boolify-1.0.1.tgz#b5c09e17cacd113d11b7bb3ed384cc012994d86b"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1122,6 +1126,14 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
+
+camelcase-keys@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.1.0.tgz#214d348cc5457f39316a2c31cc3e37246325e73f"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -1384,6 +1396,12 @@ commander@2.9.0, commander@^2.8.1, commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -1392,7 +1410,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.6.0:
+concat-stream@^1.4.6, concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1770,6 +1788,10 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dlv@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.0.tgz#fee1a7c43f63be75f3f679e85262da5f102764a7"
+
 doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2080,6 +2102,46 @@ eslint@^2.7.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
 eslint@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.2.0.tgz#a2b3184111b198e02e9c7f3cca625a5e01c56b3d"
@@ -2118,7 +2180,7 @@ eslint@^4.2.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.1.6, espree@^3.4.3:
+espree@^3.1.6, espree@^3.4.0, espree@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
@@ -2545,6 +2607,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -2586,7 +2652,7 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2597,6 +2663,17 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@~7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -2604,7 +2681,7 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^9.0.0, globals@^9.17.0, globals@^9.2.0:
+globals@^9.0.0, globals@^9.14.0, globals@^9.17.0, globals@^9.2.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -2834,7 +2911,7 @@ iflow-react-router@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/iflow-react-router/-/iflow-react-router-1.2.1.tgz#7688a0a2d483817b4bd193f4af2968632a47f04a"
 
-ignore@^3.1.2, ignore@^3.3.3:
+ignore@^3.1.2, ignore@^3.2.0, ignore@^3.2.7, ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -2851,6 +2928,10 @@ indent-string@^2.1.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -3558,6 +3639,17 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+loglevel-colored-level-prefix@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz#6a40218fdc7ae15fc76c3d0f3e676c465388603e"
+  dependencies:
+    chalk "^1.1.3"
+    loglevel "^1.4.1"
+
+loglevel@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.4.1.tgz#95b383f91a3c2756fd4ab093667e4309161f2bcd"
+
 lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
@@ -3596,9 +3688,19 @@ make-dir@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+make-plural@~3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-3.0.6.tgz#2033a03bac290b8f3bb91258f65b9df7e8b01ca7"
+  optionalDependencies:
+    minimist "^1.2.0"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -3663,6 +3765,20 @@ merge@^1.2.0:
 mersenne-twister@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
+
+messageformat-parser@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-1.1.0.tgz#13ba2250a76bbde8e0fca0dbb3475f95c594a90a"
+
+messageformat@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-1.0.2.tgz#908f4691f29ff28dae35c45436a24cff93402388"
+  dependencies:
+    glob "~7.0.6"
+    make-plural "~3.0.6"
+    messageformat-parser "^1.0.0"
+    nopt "~3.0.6"
+    reserved-words "^0.1.1"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -3898,7 +4014,7 @@ node-sass@^4.5.3:
     sass-graph "^2.1.1"
     stdout-stream "^1.4.0"
 
-"nopt@2 || 3":
+"nopt@2 || 3", nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -4583,6 +4699,53 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier-eslint-cli@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint-cli/-/prettier-eslint-cli-4.1.1.tgz#b2630e31ac3b3379ecf02c130f5b219c04a0bc3c"
+  dependencies:
+    arrify "^1.0.1"
+    babel-runtime "^6.23.0"
+    boolify "^1.0.0"
+    camelcase-keys "^4.1.0"
+    chalk "^1.1.3"
+    common-tags "^1.4.0"
+    find-up "^2.1.0"
+    get-stdin "^5.0.1"
+    glob "^7.1.1"
+    ignore "^3.2.7"
+    indent-string "^3.1.0"
+    lodash.memoize "^4.1.2"
+    loglevel-colored-level-prefix "^1.0.0"
+    messageformat "^1.0.2"
+    prettier-eslint "^6.0.0"
+    rxjs "^5.3.0"
+    yargs "^7.1.0"
+
+prettier-eslint@^6.0.0:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-6.4.2.tgz#9bafd9549e0827396c75848e8dbeb65525b9096e"
+  dependencies:
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^3.19.0"
+    indent-string "^3.1.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.5.0"
+    pretty-format "^20.0.3"
+    require-relative "^0.8.7"
+
+prettier@^1.5.0:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
+    ansi-styles "^3.0.0"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -4679,6 +4842,10 @@ querystring-es3@^0.2.0:
 querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
 ramda@^0.24.1:
   version "0.24.1"
@@ -4863,6 +5030,12 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
 
 redbox-react@^1.3.6:
   version "1.4.3"
@@ -5092,12 +5265,20 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 require-uncached@^1.0.2, require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+reserved-words@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.1.tgz#6f7c15e5e5614c50da961630da46addc87c0cef2"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -5110,6 +5291,12 @@ resolve-from@^2.0.0:
 resolve-pathname@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.1.0.tgz#e8358801b86b83b17560d4e3c382d7aef2100944"
+
+resolve@^1.1.6:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -5169,6 +5356,12 @@ rx-lite@*, rx-lite@^4.0.8:
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
+rxjs@^5.3.0:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
+  dependencies:
+    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0:
   version "5.1.0"
@@ -5330,6 +5523,14 @@ shallow-clone@^0.1.2:
 shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
+
+shelljs@^0.7.5:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
@@ -5606,7 +5807,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.3:
+symbol-observable@^1.0.1, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -6097,7 +6298,7 @@ yargs@^6.0.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^7.0.0:
+yargs@^7.0.0, yargs@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
   dependencies:


### PR DESCRIPTION
#### What are the relevant tickets?

closes #64 

#### What's this PR do?

This installs [prettier-eslint](https://github.com/prettier/prettier-eslint-cli), which is a little wrapper than basically does

`prettier` ➡️`eslint --fix`

I added a command to `package.json` which runs the formatter (`npm run fmt`). It's also handy to configure your editor to run it, either on save or with a key command.

#### How should this be manually tested?

If all the tests are passing and all that I think we're good.