### PR TITLE
basic comment display

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -1,0 +1,45 @@
+// @flow
+import React from "react"
+import R from "ramda"
+import moment from "moment"
+
+import Card from "../components/Card"
+
+import type { Comment } from "../flow/discussionTypes"
+
+const renderTopLevelComment = (comment: Comment, idx: number) =>
+  <Card key={idx}>
+    <div className="top-level-comment">
+      {renderComment(0, comment)}
+    </div>
+  </Card>
+
+const renderComment = R.curry((depth: number, comment: Comment) =>
+  <div className="comment" key={`${depth}${comment.created}`}>
+    <div className="author-info">
+      <a className="author-name">
+        {comment.author_id}
+      </a>
+      <div>
+        {moment(comment.created).fromNow()}
+      </div>
+    </div>
+    <div>
+      {comment.text}
+    </div>
+    <div className="replies">
+      {R.map(renderComment(depth + 1), comment.replies)}
+    </div>
+  </div>
+)
+
+type CommentTreeProps = {
+  comments: Array<Comment>
+}
+
+const CommentTree = ({ comments }: CommentTreeProps) =>
+  <div className="comments">
+    {R.addIndex(R.map)(renderTopLevelComment, comments)}
+  </div>
+
+export default CommentTree

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -1,0 +1,42 @@
+// @flow
+import React from "react"
+import R from "ramda"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import Card from "../components/Card"
+import CommentTree from "./CommentTree"
+
+import { makeCommentTree } from "../factories/comments"
+import { makePost } from "../factories/posts"
+
+describe("CommentTree", () => {
+  let comments, post
+
+  beforeEach(() => {
+    post = makePost()
+    comments = makeCommentTree(post)
+  })
+
+  const renderCommentTree = comments => shallow(<CommentTree comments={comments} />)
+
+  it("should render all top-level comments as separate cards", () => {
+    let wrapper = renderCommentTree(comments)
+    assert.equal(wrapper.find(Card).length, comments.length)
+  })
+
+  it("should render all replies to a top-level comment", () => {
+    let wrapper = renderCommentTree(comments)
+    let firstComment = wrapper.find(".top-level-comment").at(0)
+    let replies = firstComment.find(".comment")
+    const countReplies = R.compose(R.reduce((acc, val) => acc + countReplies(val), 1), R.prop("replies"))
+    assert.equal(replies.length, countReplies(comments[0]))
+  })
+
+  it("should put a className on replies, to allow for indentation", () => {
+    let wrapper = renderCommentTree(comments)
+    let firstComment = wrapper.find(".top-level-comment").at(0)
+    assert.equal(firstComment.find(".comment").at(0).props().className, "comment")
+    assert.ok(firstComment.find(".replies > .comment").at(0))
+  })
+})

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -24,6 +24,12 @@ export const makeCommentTree = (post: Post): Array<Comment> => {
   topLevelComments.forEach((comment, index) => {
     if (casual.coin_flip || index === 0) {
       comment.replies = arrayN(5).map(() => makeComment(post))
+
+      comment.replies.forEach(reply => {
+        if (casual.coin_flip) {
+          reply.replies = arrayN(5).map(() => makeComment(post))
+        }
+      })
     }
   })
 

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -1,0 +1,24 @@
+.comments {
+  .top-level-comment {
+    padding: 15px 0;
+  }
+
+  .comment {
+    margin: 15px 0;
+
+    .author-info {
+      display: flex;
+      flex-direction: row;
+      font-size: 13px;
+      padding-bottom: 8px;
+
+      .author-name {
+        padding-right: 4px;
+      }
+    }
+
+    .replies > .comment {
+      margin-left: 25px;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -4,6 +4,7 @@
 @import "post";
 @import "card";
 @import "sidebar";
+@import "comment";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;


### PR DESCRIPTION
#### What are the relevant tickets?

part of #27 

#### What's this PR do?

this adds a very bare-bones display for showing the comments on a post

#### How should this be manually tested?

right now the comments reducer is not yet hooked up to the API, so every post will have a randomly generated comment tree. so you should be able to just navigate to a post and see a bunch of replies of varying depth. The first comment should always have two levels of replies.