### PR TITLE
connect comments reducer to API

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -34,15 +34,11 @@ class PostPage extends React.Component {
     const [postID, channelName] = this.getMatchParams()
 
     if (R.isNil(posts.data.get(postID)) && R.isNil(posts.error)) {
-      dispatch(actions.posts.get(postID)).then(post => {
-        dispatch(actions.comments.get(post))
-      })
-    } else {
-      if (R.isNil(comments.data.get(postID))) {
-        dispatch(actions.comments.get(posts.data.get(postID)))
-      }
+      dispatch(actions.posts.get(postID))
     }
-
+    if (R.isNil(comments.data.get(postID)) && R.isNil(comments.error)) {
+      dispatch(actions.comments.get(postID))
+    }
     if (R.isNil(channels.data.get(channelName)) && R.isNil(channels.error)) {
       dispatch(actions.channels.get(channelName))
     }

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -3,10 +3,11 @@
 // For mocking purposes we need to use "fetch" defined as a global instead of importing as a local.
 import R from "ramda"
 import "isomorphic-fetch"
-import { POST } from "redux-hammock/constants"
 import { fetchJSONWithCSRF } from "redux-hammock/django_csrf_fetch"
+import { POST } from "redux-hammock/constants"
 
 import type { Channel, Post } from "../flow/discussionTypes"
+import type { CommentResponse } from "../reducers/comments"
 
 export function getFrontpage(): Promise<Post> {
   return fetchJSONWithCSRF(`/api/v0/frontpage/`)
@@ -29,4 +30,18 @@ export function getPostsForChannel(channelName: string): Promise<Post> {
 
 export function getPost(postId: string): Promise<Post> {
   return fetchJSONWithCSRF(`/api/v0/posts/${postId}/`)
+}
+
+export async function getComments(postID: string): Promise<CommentResponse> {
+  let response = await fetchJSONWithCSRF(`/api/v0/posts/${postID}/comments/`)
+  return { postID, data: response }
+}
+
+export function createComment(postId: string, comment: string, commentId: ?string) {
+  let body = commentId === undefined ? { text: comment } : { text: comment, comment_id: commentId }
+
+  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/comments/`, {
+    method: POST,
+    body:   JSON.stringify(body)
+  })
 }

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -1,18 +1,29 @@
 // @flow
-import { GET, INITIAL_STATE } from "redux-hammock/constants"
+import { GET, POST, INITIAL_STATE } from "redux-hammock/constants"
 
-import { makeCommentTree } from "../factories/comments"
+import * as api from "../lib/api"
 
-import type { Comment, Post } from "../flow/discussionTypes.js"
+import type { Comment } from "../flow/discussionTypes.js"
+
+export type CommentResponse = {
+  postID: string,
+  data: Array<Comment>
+}
 
 export const commentsEndpoint = {
   name:              "comments",
-  verbs:             [GET],
-  getFunc:           async (post: Post) => makeCommentTree(post),
+  verbs:             [GET, POST],
+  getFunc:           (postID: string) => api.getComments(postID),
   initialState:      { ...INITIAL_STATE, data: new Map() },
-  getSuccessHandler: (comments: Array<Comment>, data: Map<string, Array<Comment>>) => {
+  getSuccessHandler: (response: CommentResponse, data: Map<string, Array<Comment>>) => {
     let update = new Map(data)
-    update.set(comments[0].post_id, comments)
+    update.set(response.postID, response.data)
     return update
+  },
+  postFunc: (postID: string, comment: string, commentId: ?string) => {
+    return api.createComment(postID, comment, commentId)
+  },
+  postSuccessHandler: (payload: Comment, data: Map<string, Comment>) => {
+    return new Map(data)
   }
 }

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -2,14 +2,16 @@
 import { assert } from "chai"
 import sinon from "sinon"
 import configureTestStore from "redux-asserts"
-import { INITIAL_STATE } from "redux-hammock/constants"
+import { INITIAL_STATE, FETCH_SUCCESS } from "redux-hammock/constants"
 
 import rootReducer from "../reducers"
 import { actions } from "../actions"
 import * as api from "../lib/api"
+import { setPostData } from "../actions/post"
+
 import { makePost, makeChannelPostList } from "../factories/posts"
 import { makeChannel } from "../factories/channels"
-import { setPostData } from "../actions/post"
+import { makeCommentTree } from "../factories/comments"
 
 describe("reducers", () => {
   let sandbox, store, dispatchThen
@@ -151,6 +153,7 @@ describe("reducers", () => {
 
   describe("frontpage reducer", () => {
     let frontpageStub
+
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.frontpage)
       frontpageStub = sandbox.stub(api, "getFrontpage")
@@ -170,8 +173,16 @@ describe("reducers", () => {
   })
 
   describe("comments reducer", () => {
+    let getCommentsStub, postCommentsStub, post, tree
+
     beforeEach(() => {
+      post = makePost()
+      tree = makeCommentTree(post)
       dispatchThen = store.createDispatchThen(state => state.comments)
+      getCommentsStub = sandbox.stub(api, "getComments")
+      getCommentsStub.returns(Promise.resolve({ data: tree, postID: post.id }))
+      postCommentsStub = sandbox.stub(api, "createComment")
+      postCommentsStub.returns(Promise.resolve())
     })
 
     it("should have some initial state", () => {
@@ -179,12 +190,42 @@ describe("reducers", () => {
     })
 
     it("should let you get the comments for a Post", () => {
-      let post = makePost()
       const { requestType, successType } = actions.comments.get
       return dispatchThen(actions.comments.get(post), [requestType, successType]).then(({ data }) => {
         let comments = data.get(post.id)
         assert.isArray(comments)
         assert.isNotEmpty(comments[0].replies)
+      })
+    })
+
+    it("should handle an empty response ok", () => {
+      const { requestType, successType } = actions.comments.get
+      getCommentsStub.returns(Promise.resolve({ data: [], postID: post.id }))
+      return dispatchThen(actions.comments.get(post), [requestType, successType]).then(({ data }) => {
+        assert.deepEqual([], data.get(post.id))
+      })
+    })
+
+    it("should let you reply to a post", () => {
+      const { requestType, successType } = actions.comments.post
+      return dispatchThen(actions.comments.post(post.id, "comment text"), [requestType, successType]).then(state => {
+        assert.isTrue(state.loaded)
+        assert.deepEqual(state.data, new Map())
+        assert.equal(state.postStatus, FETCH_SUCCESS)
+        assert.ok(postCommentsStub.calledWith(post.id, "comment text"))
+      })
+    })
+
+    it("should let you reply to a comment", () => {
+      const { requestType, successType } = actions.comments.post
+      return dispatchThen(actions.comments.post(post.id, "comment text", tree[0].id), [
+        requestType,
+        successType
+      ]).then(state => {
+        assert.isTrue(state.loaded)
+        assert.equal(state.postStatus, FETCH_SUCCESS)
+        assert.deepEqual(state.data, new Map())
+        assert.ok(postCommentsStub.calledWith(post.id, "comment text", tree[0].id))
       })
     })
   })


### PR DESCRIPTION
#### What are the relevant tickets?

part of #18 

#### What's this PR do?

This adds support for creating comments (replies to a post) and replies to comments. 

#### How should this be manually tested?

You could open up `PostPage.js` and add a line like `actions = window.actions`, and then try calling `actions.comments.post(postId, commentText, ?commentId)` to try things out.