### PR TITLE
Added UI to list channels

### DIFF
--- a/flow-typed/npm/redux-asserts_v0.x.x.js
+++ b/flow-typed/npm/redux-asserts_v0.x.x.js
@@ -1,0 +1,16 @@
+declare module 'redux-asserts' {
+  declare type State = any;
+  declare type StateFunc = ((state: State) => State);
+
+  declare type TestStore = {
+    dispatch: Dispatch,
+    getState: () => State,
+    subscribe: (listener: () => void) => () => void,
+    replaceReducer: (reducer: Reducer<any, any>) => void,
+    createListenForActions: (stateFunc?: StateFunc) => ((actions: Array<string>, () => void) => Promise<State>),
+    createDispatchThen: (stateFunc?: StateFunc) => (
+      (action: Action, expectedActions: Array<string>) => Promise<State>
+    )
+  }
+  declare export default function configureTestStore(reducerFunc?: (state: State) => State): TestStore;
+}

--- a/static/js/actions/channel.js
+++ b/static/js/actions/channel.js
@@ -1,0 +1,5 @@
+// @flow
+import { createAction } from "redux-actions"
+
+export const SET_CHANNEL_DATA = "SET_CHANNEL_DATA"
+export const setChannelData = createAction(SET_CHANNEL_DATA)

--- a/static/js/components/ChannelBreadcrumbs.js
+++ b/static/js/components/ChannelBreadcrumbs.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
+import { channelURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type BreadCrumbProps = {
@@ -15,7 +16,7 @@ const ChannelBreadcrumbs = (props: BreadCrumbProps) => {
     <div className="breadcrumbs">
       <Link to="/">Discussions</Link>&nbsp;
       <span>&gt;</span>&nbsp;
-      <Link to={`/channel/${channel.name}`}>{channel.title}</Link>
+      <Link to={channelURL(channel.name)}>{channel.title}</Link>
     </div>
   )
 }

--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -4,7 +4,7 @@ import moment from "moment"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 
-import { postDetailURL } from "../lib/url"
+import { channelURL, postDetailURL } from "../lib/url"
 
 import type { Post } from "../flow/discussionTypes"
 
@@ -45,7 +45,7 @@ class PostDisplay extends React.Component {
     const { post, showChannelLink } = this.props
 
     return showChannelLink && post.channel_name
-      ? <Link to={`/channel/${post.channel_name}`}>
+      ? <Link to={channelURL(post.channel_name)}>
           on {post.channel_name}
       </Link>
       : null

--- a/static/js/components/SubscriptionsSidebar.js
+++ b/static/js/components/SubscriptionsSidebar.js
@@ -1,0 +1,30 @@
+// @flow
+import React from "react"
+import { Link } from "react-router-dom"
+
+import { channelURL } from "../lib/url"
+import type { Channel } from "../flow/discussionTypes"
+
+type SubscriptionsSidebarProps = {
+  subscribedChannels: Array<Channel>
+}
+
+export default class SubscriptionsSidebar extends React.Component {
+  props: SubscriptionsSidebarProps
+
+  render() {
+    const { subscribedChannels } = this.props
+
+    return (
+      <div className="subscriptions">
+        {subscribedChannels.map(channel =>
+          <div key={channel.name}>
+            <Link to={channelURL(channel.name)}>
+              {channel.title}
+            </Link>
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -1,8 +1,8 @@
 // @flow
 import React from "react"
 import { connect } from "react-redux"
-import R from "ramda"
 
+import SubscriptionsSidebar from "../components/SubscriptionsSidebar"
 import Card from "../components/Card"
 import ChannelSidebar from "../components/ChannelSidebar"
 import PostList from "../components/PostList"
@@ -11,53 +11,87 @@ import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
+import { setChannelData } from "../actions/channel"
 import { safeBulkGet } from "../lib/maps"
 import { getChannelName } from "../lib/util"
 import { toggleUpvote } from "../util/api_actions"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
+import type { RestState } from "../flow/restTypes"
+import type { Channel, Post } from "../flow/discussionTypes"
 
 class ChannelPage extends React.Component {
   props: {
     match: Match,
     dispatch: Dispatch,
-    channels: Object,
-    postsForChannel: Object,
-    posts: Object
+    channels: RestState<Map<string, Channel>>,
+    postsForChannel: RestState<Map<string, Array<string>>>,
+    posts: RestState<Map<string, Post>>,
+    subscribedChannels: RestState<Array<string>>,
   }
 
   componentWillMount() {
-    const { dispatch } = this.props
+    this.updateRequirements()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (getChannelName(this.props) !== getChannelName(prevProps)) {
+      // if the channel was changed, fetch the new information for this channel
+      this.updateRequirements()
+    }
+  }
+
+  updateRequirements = () => {
+    const { dispatch, subscribedChannels } = this.props
     const channelName = getChannelName(this.props)
     dispatch(actions.channels.get(channelName))
     dispatch(actions.postsForChannel.get(channelName)).then(({ posts }) => {
       dispatch(setPostData(posts))
     })
+
+    if (!subscribedChannels.loaded && !subscribedChannels.processing) {
+      dispatch(actions.subscribedChannels.get()).then(channels => {
+        dispatch(setChannelData(channels))
+      })
+    }
   }
 
   renderContents = () => {
-    const { channels, postsForChannel, posts, dispatch } = this.props
+    const { channels, postsForChannel, posts, subscribedChannels, dispatch } = this.props
     const channelName = getChannelName(this.props)
+    if (!channels.data) {
+      return
+    }
     const channel = channels.data.get(channelName)
+    if (!postsForChannel.data) {
+      return
+    }
     const postIds = postsForChannel.data.get(channelName)
 
-    if (R.isNil(channel) || R.isNil(postIds)) {
+    if (!channel || !postIds || !posts.data) {
       return null
     } else {
       return (
-        <div className="double-column">
+        <div className="triple-column">
           <ChannelBreadcrumbs channel={channel} />
           <div className="first-column">
+            <SubscriptionsSidebar
+              // $FlowFixMe: flow doesn't know that we already checked if these are undefined
+              subscribedChannels={safeBulkGet(subscribedChannels.data, channels.data)}
+            />
+          </div>
+          <div className="second-column">
             <Card title={channel.title}>
               <PostList
                 channel={channel}
+                // $FlowFixMe: flow doesn't know that the safeBulkGet above doesn't affect this one
                 posts={safeBulkGet(postIds, posts.data)}
                 toggleUpvote={toggleUpvote(dispatch)}
               />
             </Card>
           </div>
-          <div className="second-column">
+          <div className="third-column">
             <Card>
               <ChannelSidebar channel={channel} />
             </Card>
@@ -76,9 +110,10 @@ class ChannelPage extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    channels:        state.channels,
-    postsForChannel: state.postsForChannel,
-    posts:           state.posts
+    channels:           state.channels,
+    postsForChannel:    state.postsForChannel,
+    posts:              state.posts,
+    subscribedChannels:   state.subscribedChannels,
   }
 }
 

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -1,25 +1,31 @@
 // @flow
 import { assert } from "chai"
+import sinon from 'sinon'
 
 import PostList from "../components/PostList"
 
-import { makeChannel } from "../factories/channels"
+import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
+import { SET_CHANNEL_DATA } from "../actions/channel"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { channelURL } from "../lib/url"
 
 describe("ChannelPage", () => {
-  let helper, renderComponent, channel, postList
+  let helper, renderComponent, listenForActions, channels, currentChannel, otherChannel, postList
 
   beforeEach(() => {
-    channel = makeChannel()
+    channels = makeChannelList(10)
+    currentChannel = channels[3]
+    otherChannel = channels[4]
     postList = makeChannelPostList()
     helper = new IntegrationTestHelper()
-    helper.getChannelStub.returns(Promise.resolve(channel))
+    helper.getChannelStub.returns(Promise.resolve(currentChannel))
+    helper.getChannelsStub.returns(Promise.resolve(channels))
     helper.getPostsForChannelStub.returns(Promise.resolve(postList))
     renderComponent = helper.renderComponent.bind(helper)
+    listenForActions = helper.listenForActions.bind(helper)
   })
 
   afterEach(() => {
@@ -32,11 +38,14 @@ describe("ChannelPage", () => {
       actions.channels.get.successType,
       actions.postsForChannel.get.requestType,
       actions.postsForChannel.get.successType,
-      SET_POST_DATA
+      actions.subscribedChannels.get.requestType,
+      actions.subscribedChannels.get.successType,
+      SET_POST_DATA,
+      SET_CHANNEL_DATA,
     ])
 
   it("should fetch postsForChannel, set post data, and render", async () => {
-    let [wrapper] = await renderPage(channel)
+    let [wrapper] = await renderPage(currentChannel)
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
   })
 
@@ -45,5 +54,29 @@ describe("ChannelPage", () => {
     otherChannel.name = "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
     let [wrapper] = await renderPage(otherChannel)
     assert.equal(wrapper.text(), "")
+  })
+
+  it('lists subscriptions', () => {
+    return renderPage(currentChannel).then(([wrapper]) => {
+      sinon.assert.calledOnce(helper.getChannelsStub)
+
+      assert.deepEqual(wrapper.find("SubscriptionsSidebar").props().subscribedChannels, channels)
+    })
+  })
+
+  it('updates requirements when channel name changes', () => {
+    return renderPage(currentChannel).then(() => {
+      sinon.assert.neverCalledWith(helper.getChannelStub, otherChannel.name)
+      return listenForActions([
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
+        actions.postsForChannel.get.requestType,
+        actions.postsForChannel.get.successType,
+      ], () => {
+        helper.browserHistory.push(channelURL(otherChannel.name))
+      }).then(() => {
+        sinon.assert.calledWith(helper.getChannelStub, otherChannel.name)
+      })
+    })
   })
 })

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -2,43 +2,71 @@
 import React from "react"
 import { connect } from "react-redux"
 
+import SubscriptionsSidebar from "../components/SubscriptionsSidebar"
 import PostList from "../components/PostList"
 import Card from "../components/Card"
 
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
+import { setChannelData } from "../actions/channel"
 import { safeBulkGet } from "../lib/maps"
 import { toggleUpvote } from "../util/api_actions"
 
+import type { Dispatch } from "redux"
+import type { RestState } from "../flow/restTypes"
+import type { Channel, Post } from "../flow/discussionTypes"
+
 class HomePage extends React.Component {
+  props: {
+    dispatch: Dispatch,
+    frontpage: RestState<Array<string>>,
+    posts: RestState<Map<string, Post>>,
+    subscribedChannels: RestState<Array<string>>,
+    channels: RestState<Map<string, Channel>>,
+  }
+
   componentWillMount() {
     this.fetchFrontpage()
   }
 
   fetchFrontpage = () => {
-    const { dispatch } = this.props
+    const { dispatch, subscribedChannels } = this.props
 
     dispatch(actions.frontpage.get()).then(posts => {
       dispatch(setPostData(posts))
     })
+
+    if (!subscribedChannels.loaded && !subscribedChannels.processing) {
+      dispatch(actions.subscribedChannels.get()).then(channels => {
+        dispatch(setChannelData(channels))
+      })
+    }
   }
 
   render() {
-    const { posts, frontpage, dispatch } = this.props
+    const { posts, frontpage, subscribedChannels, channels, dispatch } = this.props
     const dispatchableToggleUpvote = toggleUpvote(dispatch)
 
     return (
-      <div className="double-column">
+      <div className="triple-column">
+        <div>Home page</div>
         <div className="first-column">
+          <SubscriptionsSidebar
+            // $FlowFixMe: flow thinks these might be undefined
+            subscribedChannels={safeBulkGet(subscribedChannels.data, channels.data)}
+          />
+        </div>
+        <div className="second-column">
           <Card title="Home Page">
             <PostList
+              // $FlowFixMe: flow thinks these might be undefined
               posts={safeBulkGet(frontpage.data, posts.data)}
               toggleUpvote={dispatchableToggleUpvote}
               showChannelLinks={true}
             />
           </Card>
         </div>
-        <div className="second-column" />
+        <div className="third-column" />
         <br className="clear" />
       </div>
     )
@@ -47,8 +75,10 @@ class HomePage extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    posts:     state.posts,
-    frontpage: state.frontpage
+    posts:              state.posts,
+    frontpage:          state.frontpage,
+    subscribedChannels: state.subscribedChannels,
+    channels:           state.channels,
   }
 }
 

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -3,18 +3,22 @@ import { assert } from "chai"
 
 import PostList from "../components/PostList"
 
+import { makeChannelList } from '../factories/channels'
 import { makeChannelPostList } from "../factories/posts"
 import { actions } from "../actions"
+import { SET_CHANNEL_DATA } from '../actions/channel'
 import { SET_POST_DATA } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("HomePage", () => {
-  let helper, renderComponent, postList
+  let helper, renderComponent, postList, channels
 
   beforeEach(() => {
+    channels = makeChannelList()
     postList = makeChannelPostList()
     helper = new IntegrationTestHelper()
     helper.getFrontpageStub.returns(Promise.resolve(postList))
+    helper.getChannelsStub.returns(Promise.resolve(channels))
     renderComponent = helper.renderComponent.bind(helper)
   })
 
@@ -23,10 +27,23 @@ describe("HomePage", () => {
   })
 
   const renderPage = () =>
-    renderComponent("/", [actions.frontpage.get.requestType, actions.frontpage.get.successType, SET_POST_DATA])
+    renderComponent("/", [
+      actions.frontpage.get.requestType,
+      actions.frontpage.get.successType,
+      actions.subscribedChannels.get.requestType,
+      actions.subscribedChannels.get.successType,
+      SET_POST_DATA,
+      SET_CHANNEL_DATA,
+    ])
 
   it("should fetch frontpage, set post data, render", async () => {
     let [wrapper] = await renderPage()
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
+  })
+
+  it('lists subscriptions', () => {
+    return renderPage().then(([wrapper]) => {
+      assert.deepEqual(wrapper.find("SubscriptionsSidebar").props().subscribedChannels, channels)
+    })
   })
 })

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -1,10 +1,20 @@
 // @flow
 import casual from "casual-browserify"
+import R from 'ramda'
+
+import { incrementer } from "../factories/util"
+
+const incr = incrementer()
 
 export const makeChannel = (privateChannel: boolean = false) => ({
-  name:               casual.word,
+  // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
+  name:               `channel_${incr.next().value}`,
   title:              casual.title,
   channel_type:       privateChannel ? "private" : "public",
   public_description: casual.description,
   num_users:          casual.integer(0, 500)
 })
+
+export const makeChannelList = (numChannels: number = 20) => {
+  return R.range(0, numChannels).map(() => makeChannel(Math.random() > 0.5))
+}

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -2,10 +2,14 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
+import { incrementer } from "../factories/util"
 import type { Post } from "../flow/discussionTypes"
 
-export const makePost = (isURLPost: boolean = false): Post => ({
-  id:           String(Math.random()),
+const incr = incrementer()
+
+export const makePost = (isURLPost: boolean = false, channelName: string = casual.word): Post => ({
+  // $FlowFixMe: incr.next().value is never undefined but Flow thinks it may be
+  id:           `post${incr.next().value}`,
   title:        casual.sentence,
   score:        Math.round(Math.random() * 15),
   upvoted:      Math.random() < 0.5,
@@ -14,7 +18,11 @@ export const makePost = (isURLPost: boolean = false): Post => ({
   url:          isURLPost ? casual.url : null,
   created:      casual.moment.format(),
   num_comments: Math.round(Math.random() * 10),
-  channel_name: casual.word
+  channel_name: channelName
 })
 
-export const makeChannelPostList = () => R.range(0, 20).map(() => makePost(Math.random() > 0.5))
+export const makeChannelPostList = (channelName: string = casual.word) => R.range(0, 20).map(
+  () => makePost(Math.random() > 0.5, channelName)
+)
+
+export const makeFrontPageList = () => R.range(0, 30).map(() => makePost(Math.random() > 0.5))

--- a/static/js/flow/reduxTypes.js
+++ b/static/js/flow/reduxTypes.js
@@ -1,7 +1,6 @@
 // @flow
 import type {
   Dispatch,
-  Reducer,
   State,
 } from 'redux'
 
@@ -24,10 +23,3 @@ export type AsyncActionCreator<T> = (...a: any) => Dispatcher<T>
 export type AssertReducerResultState<T> = (
   actionFunc: () => Action<*,*>, stateFunc: ((reducerState: State) => T), defaultValue: any
 ) => void
-
-export type TestStore = {
-  dispatch: Dispatch,
-  getState: () => State,
-  subscribe: (listener: () => void) => () => void,
-  replaceReducer: (reducer: Reducer<any, any>) => void,
-}

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -21,6 +21,11 @@ afterEach(function() {
   document.body.innerHTML = ""
   global.SETTINGS = _createSettings()
   window.location = "http://fake/"
+
+  // Uncomment this to diagnose stray API calls
+  // This adds a 200 ms delay between tests. Since fetchMock is still enabled at this point the next unmatched
+  // fetch attempt which occurs within 200 ms after the test finishes will cause a warning.
+  // return require('./lib/util').wait(200)
 })
 
 // enable chai-as-promised

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -17,6 +17,10 @@ export function getChannel(channelName: string): Promise<Channel> {
   return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/`)
 }
 
+export function getChannels(): Promise<Array<Channel>> {
+  return fetchJSONWithCSRF("/api/v0/channels/")
+}
+
 export function createChannel(channel: Channel): Promise<Channel> {
   return fetchJSONWithCSRF(`/api/v0/channels/`, {
     method: POST,

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -7,6 +7,7 @@ import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 import {
   createChannel,
   getChannel,
+  getChannels,
   getFrontpage,
   getPost,
   getPostsForChannel,
@@ -14,7 +15,7 @@ import {
   createComment,
   createPost
 } from "./api"
-import { makeChannel } from "../factories/channels"
+import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
 import { makeCommentTree } from "../factories/comments"
 
@@ -57,6 +58,16 @@ describe("api", function() {
       return getChannel("channelone").then(result => {
         assert.ok(fetchStub.calledWith("/api/v0/channels/channelone/"))
         assert.deepEqual(result, channel)
+      })
+    })
+
+    it("gets a list of channels", () => {
+      const channelList = makeChannelList()
+      fetchStub.returns(Promise.resolve(channelList))
+
+      return getChannels().then(result => {
+        assert.ok(fetchStub.calledWith(("/api/v0/channels/")))
+        assert.deepEqual(result, channelList)
       })
     })
 

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -1,5 +1,6 @@
 // @flow
 import { postsEndpoint } from "../reducers/posts"
+import { subscribedChannelsEndpoint } from "../reducers/subscribedChannels"
 import { channelsEndpoint } from "../reducers/channels"
 import { postsForChannelEndpoint } from "../reducers/posts_for_channel"
 import { frontPageEndpoint } from "../reducers/frontpage"
@@ -8,9 +9,10 @@ import { postUpvotesEndpoint } from "../reducers/post_upvotes"
 
 export const endpoints = [
   postsEndpoint,
+  subscribedChannelsEndpoint,
   channelsEndpoint,
   postsForChannelEndpoint,
   frontPageEndpoint,
   commentsEndpoint,
-  postUpvotesEndpoint
+  postUpvotesEndpoint,
 ]

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -5,3 +5,5 @@ export const channelURL = (channelName: string) => `/channel/${channelName}`
 export const postDetailURL = (channelName: string, postID: string) => `/channel/${channelName}/${postID}`
 
 export const newPostURL = (channelName: string) => `/create_post/${channelName}`
+
+export const frontPageURL = () => '/'

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -1,7 +1,12 @@
 // @flow
 import { assert } from "chai"
 
-import { channelURL, newPostURL, postDetailURL } from "./url"
+import {
+  channelURL,
+  frontPageURL,
+  newPostURL,
+  postDetailURL,
+} from "./url"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {
@@ -19,6 +24,12 @@ describe("url helper functions", () => {
   describe("newPostURL", () => {
     it("should return a url for creating a new post", () => {
       assert.equal(newPostURL("channel_name"), "/create_post/channel_name")
+    })
+  })
+
+  describe("frontPageURL", () => {
+    it("should return a url for the front page", () => {
+      assert.equal(frontPageURL(), "/")
     })
   })
 })

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -2,3 +2,10 @@
 import type { Match } from "react-router"
 
 export const getChannelName = (props: { match: Match }): string => props.match.params.channelName || ""
+
+/**
+ * Returns a promise which resolves after a number of milliseconds have elapsed
+ */
+export const wait = (millis: number): Promise<void> => (
+  new Promise(resolve => setTimeout(resolve, millis))
+)

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -1,0 +1,23 @@
+// @flow
+import { assert } from 'chai'
+
+import { wait } from './util'
+
+describe('utility functions', () => {
+  it('waits some milliseconds', done => {
+    let executed = false
+    wait(30).then(() => {
+      executed = true
+    })
+
+    setTimeout(() => {
+      assert.isFalse(executed)
+
+      setTimeout(() => {
+        assert.isTrue(executed)
+
+        done()
+      }, 20)
+    }, 20)
+  })
+})

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -1,6 +1,7 @@
 // @flow
 import { GET, POST, INITIAL_STATE } from "redux-hammock/constants"
 
+import { SET_CHANNEL_DATA } from "../actions/channel"
 import type { Channel } from "../flow/discussionTypes"
 import * as api from "../lib/api"
 
@@ -19,5 +20,18 @@ export const channelsEndpoint = {
     let update = new Map(data)
     update.set(payload.name, payload)
     return update
+  },
+  extraActions: {
+    [SET_CHANNEL_DATA]: (state, action) => {
+      const updatedData = new Map(state.data)
+      for (const channel of action.payload) {
+        updatedData.set(channel.name, channel)
+      }
+
+      return {
+        ...state,
+        data: updatedData
+      }
+    }
   }
 }

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -3,11 +3,12 @@ import { assert } from "chai"
 import { INITIAL_STATE } from "redux-hammock/constants"
 
 import { actions } from "../actions"
+import { setChannelData } from "../actions/channel"
 import { setPostData } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 import { makePost, makeChannelPostList } from "../factories/posts"
-import { makeChannel } from "../factories/channels"
+import { makeChannel, makeChannelList } from "../factories/channels"
 
 describe("reducers", () => {
   let helper, store, dispatchThen
@@ -117,6 +118,32 @@ describe("reducers", () => {
       let channel = makeChannel()
       let channels = await dispatchThen(actions.channels.post(channel), [requestType, successType])
       assert.deepEqual(channel, channels.data.get(channel.name))
+    })
+
+    it("should let you set a list of channels separately", () => {
+      const numChannels = 9
+      let channels = makeChannelList(numChannels)
+      store.dispatch(setChannelData(channels))
+      let data = store.getState().channels.data
+      assert.equal(data.size, numChannels)
+      for (const channel of channels) {
+        assert.deepEqual(data.get(channel.name), channel)
+      }
+
+      // it should also let you overwrite a channel
+      const newChannel = makeChannel()
+      const oldChannel = channels[1]
+      newChannel.name = oldChannel.name
+      assert.notEqual(newChannel.title, oldChannel.title)
+      store.dispatch(setChannelData([newChannel]))
+      data = store.getState().channels.data
+      for (const channel of channels) {
+        if (channel.name === newChannel.name) {
+          assert.deepEqual(data.get(channel.name), newChannel)
+        } else {
+          assert.deepEqual(data.get(channel.name), channel)
+        }
+      }
     })
   })
 

--- a/static/js/reducers/subscribedChannels.js
+++ b/static/js/reducers/subscribedChannels.js
@@ -1,0 +1,13 @@
+// @flow
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
+
+import type { Channel } from "../flow/discussionTypes"
+import * as api from "../lib/api"
+
+export const subscribedChannelsEndpoint = {
+  name:              "subscribedChannels",
+  verbs:             [GET],
+  initialState:      { ...INITIAL_STATE, data: [] },
+  getFunc:           () => api.getChannels(),
+  getSuccessHandler: (payload: Array<Channel>) => payload.map(channel => channel.name),
+}

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -8,13 +8,9 @@ import configureTestStore from "redux-asserts"
 import Router, { routes } from "../Router"
 import * as api from "../lib/api"
 import rootReducer from "../reducers"
-import type { Action } from "../flow/reduxTypes"
-import type { TestStore } from "../flow/reduxTypes"
 import type { Sandbox } from "../flow/sinonTypes"
 
 export default class IntegrationTestHelper {
-  listenForActions: (a: Array<string>, f: Function) => Promise<*>
-  dispatchThen: (a: Action) => Promise<*>
   sandbox: Sandbox
   store: TestStore
   browserHistory: History

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -7,6 +7,7 @@
 @import "createPost";
 @import "sidebar";
 @import "comment";
+@import "subscriptions";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;
@@ -44,6 +45,30 @@ body {
       width: 30%;
       float: left;
       padding-left: 15px;
+    }
+  }
+
+  .triple-column {
+    margin: auto;
+    width: 1300px;
+
+    .first-column {
+      width: 15%;
+      float: left;
+    }
+
+    .second-column {
+      width: 70%;
+      float: left;
+
+      .card {
+        margin-left: 10px;
+      }
+    }
+
+    .third-column {
+      width: 15%;
+      float: left;
     }
   }
 }

--- a/static/scss/subscriptions.scss
+++ b/static/scss/subscriptions.scss
@@ -1,0 +1,3 @@
+.subscriptions {
+  margin: 20px;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #83

#### What's this PR do?
Shows the list of channels the user is subscribed to

#### How should this be manually tested?
View the front page. You should see a new sidebar on the left with your channels. Click on a channel and you should be directed to the page for that channel. Press the back button then click on another channel. You should see the posts for that channel.
