### PR TITLE
Updated IntegrationTestHelper to mock all api functions

### DIFF
--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -79,6 +79,7 @@ describe("CreatePostPage", () => {
   }
 
   it("goes back when cancel is clicked", () => {
+    helper.getFrontpageStub.returns(Promise.resolve([]))
     return renderPage().then(([wrapper]) => {
       assert.equal(helper.currentLocation.pathname, newPostURL(channel.name))
       wrapper.find(".cancel").simulate("click")

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,35 +1,31 @@
 // @flow
 import { assert } from "chai"
-import sinon from "sinon"
-import configureTestStore from "redux-asserts"
 import { INITIAL_STATE } from "redux-hammock/constants"
 
-import rootReducer from "../reducers"
 import { actions } from "../actions"
-import * as api from "../lib/api"
 import { setPostData } from "../actions/post"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 import { makePost, makeChannelPostList } from "../factories/posts"
 import { makeChannel } from "../factories/channels"
 
 describe("reducers", () => {
-  let sandbox, store, dispatchThen
+  let helper, store, dispatchThen
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create()
-    store = configureTestStore(rootReducer)
+    helper = new IntegrationTestHelper()
+    store = helper.store
   })
 
   afterEach(() => {
-    sandbox.restore()
+    helper.cleanup()
   })
 
   describe("posts reducer", () => {
-    let getPostStub
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.posts)
-      getPostStub = sandbox.stub(api, "getPost")
-      getPostStub.callsFake(async id => {
+      helper.getPostStub.resetBehavior() // needed because ``callsFake`` doesn't override the ``throws``
+      helper.getPostStub.callsFake(async id => {
         let post = makePost()
         post.id = id
         return post
@@ -79,11 +75,10 @@ describe("reducers", () => {
   })
 
   describe("channels reducer", () => {
-    let getChannelStub
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.channels)
-      getChannelStub = sandbox.stub(api, "getChannel")
-      getChannelStub.callsFake(async name => {
+      helper.getChannelStub.resetBehavior() // needed because ``callsFake`` doesn't override the ``throws``
+      helper.getChannelStub.callsFake(async name => {
         let channel = makeChannel()
         channel.name = name
         return channel
@@ -117,11 +112,9 @@ describe("reducers", () => {
   })
 
   describe("postsForChannel reducer", () => {
-    let getPostsForChannelStub
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.postsForChannel)
-      getPostsForChannelStub = sandbox.stub(api, "getPostsForChannel")
-      getPostsForChannelStub.returns(Promise.resolve(makeChannelPostList()))
+      helper.getPostsForChannelStub.returns(Promise.resolve(makeChannelPostList()))
     })
 
     it("should have some initial state", () => {
@@ -151,12 +144,9 @@ describe("reducers", () => {
   })
 
   describe("frontpage reducer", () => {
-    let frontpageStub
-
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.frontpage)
-      frontpageStub = sandbox.stub(api, "getFrontpage")
-      frontpageStub.returns(Promise.resolve(makeChannelPostList()))
+      helper.getFrontpageStub.returns(Promise.resolve(makeChannelPostList()))
     })
 
     it("should have some initial state", () => {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -36,21 +36,17 @@ export default class IntegrationTestHelper {
     this.listenForActions = this.store.createListenForActions()
     this.dispatchThen = this.store.createDispatchThen()
 
-    this.getChannelStub = this.sandbox.stub(api, "getChannel")
-    this.getChannelStub.throws(new Error("not implemented"))
-    this.createPostStub = this.sandbox.stub(api, "createPost")
-    this.createPostStub.throws(new Error("not implemented"))
-    this.createCommentStub = this.sandbox.stub(api, "createComment")
-    this.createCommentStub.throws(new Error("not implemented"))
+    // stub all the api functions
+    // NOTE: due to a regression in sinon 2.x, if you use `callsFake` you must
+    //       call `resetBehavior()` on the stub first or the error still raises
+    for (let methodName in api) {
+      if (typeof api[methodName] === "function") {
+        let stubName = `${methodName}Stub`
+        this[stubName] = this.sandbox.stub(api, methodName).throws(new Error(`${stubName} not implemented`))
+      }
+    }
+
     this.scrollIntoViewStub = this.sandbox.stub()
-    this.getPostsForChannelStub = this.sandbox.stub(api, "getPostsForChannel")
-    this.getPostsForChannelStub.throws(new Error("not implemented"))
-    this.getPostStub = this.sandbox.stub(api, "getPost")
-    this.getPostStub.throws(new Error("not implemented"))
-    this.getFrontpageStub = this.sandbox.stub(api, "getFrontpage")
-    this.getFrontpageStub.throws(new Error("not implemented"))
-    this.getCommentsStub = this.sandbox.stub(api, "getComments")
-    this.getCommentsStub.throws(new Error("not implemented"))
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub
     this.browserHistory = createMemoryHistory()


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Refactors `IntegrationTestHelper` to stub out all the API methods.

#### How should this be manually tested?
Test should pass
