### PR TITLE
Fix a failing test due to random channel name collision

### DIFF
--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -42,6 +42,7 @@ describe("ChannelPage", () => {
 
   it("should handle missing data gracefully", async () => {
     let otherChannel = makeChannel()
+    otherChannel.name = 'somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue'
     let [wrapper] = await renderPage(otherChannel)
     assert.equal(wrapper.text(), "")
   })


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a failing test due to random channel name collision

#### How should this be manually tested?
I was seeing about a 1% failure rate in master for this, so apply this patch locally and verify you see no failures:

```
diff --git i/static/js/containers/ChannelPage_test.js w/static/js/containers/ChannelPage_test.js
index df96b0b..dccfab6 100644
--- i/static/js/containers/ChannelPage_test.js
+++ w/static/js/containers/ChannelPage_test.js
@@ -40,10 +40,12 @@ describe("ChannelPage", () => {
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
   })

-  it("should handle missing data gracefully", async () => {
+  for (const x of new Array(1000)) {
+  it.only("should handle missing data gracefully", async () => {
     let otherChannel = makeChannel()
     otherChannel.name = 'somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue'
     let [wrapper] = await renderPage(otherChannel)
     assert.equal(wrapper.text(), "")
   })
+  }
 })
```