### PR TITLE
add prettier to things we check on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "codecov": "CODECOV=1 ./scripts/test/js_test.sh",
     "watch": "WATCH=1 ./scripts/test/js_test.sh",
     "flow": "flow check",
-    "fmt": "prettier-eslint --write --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'"
+    "fmt": "prettier-eslint --write --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'",
+    "fmt:check": "prettier-eslint --list-different --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'"
   }
 }

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -28,7 +28,7 @@ class ChannelPage extends React.Component {
     channels: RestState<Map<string, Channel>>,
     postsForChannel: RestState<Map<string, Array<string>>>,
     posts: RestState<Map<string, Post>>,
-    subscribedChannels: RestState<Array<string>>,
+    subscribedChannels: RestState<Array<string>>
   }
 
   componentWillMount() {
@@ -113,7 +113,7 @@ const mapStateToProps = state => {
     channels:           state.channels,
     postsForChannel:    state.postsForChannel,
     posts:              state.posts,
-    subscribedChannels:   state.subscribedChannels,
+    subscribedChannels: state.subscribedChannels
   }
 }
 

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -1,6 +1,6 @@
 // @flow
 import { assert } from "chai"
-import sinon from 'sinon'
+import sinon from "sinon"
 
 import PostList from "../components/PostList"
 
@@ -41,7 +41,7 @@ describe("ChannelPage", () => {
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
       SET_POST_DATA,
-      SET_CHANNEL_DATA,
+      SET_CHANNEL_DATA
     ])
 
   it("should fetch postsForChannel, set post data, and render", async () => {
@@ -56,7 +56,7 @@ describe("ChannelPage", () => {
     assert.equal(wrapper.text(), "")
   })
 
-  it('lists subscriptions', () => {
+  it("lists subscriptions", () => {
     return renderPage(currentChannel).then(([wrapper]) => {
       sinon.assert.calledOnce(helper.getChannelsStub)
 
@@ -64,17 +64,20 @@ describe("ChannelPage", () => {
     })
   })
 
-  it('updates requirements when channel name changes', () => {
+  it("updates requirements when channel name changes", () => {
     return renderPage(currentChannel).then(() => {
       sinon.assert.neverCalledWith(helper.getChannelStub, otherChannel.name)
-      return listenForActions([
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
-        actions.postsForChannel.get.requestType,
-        actions.postsForChannel.get.successType,
-      ], () => {
-        helper.browserHistory.push(channelURL(otherChannel.name))
-      }).then(() => {
+      return listenForActions(
+        [
+          actions.channels.get.requestType,
+          actions.channels.get.successType,
+          actions.postsForChannel.get.requestType,
+          actions.postsForChannel.get.successType
+        ],
+        () => {
+          helper.browserHistory.push(channelURL(otherChannel.name))
+        }
+      ).then(() => {
         sinon.assert.calledWith(helper.getChannelStub, otherChannel.name)
       })
     })

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -30,7 +30,7 @@ describe("CreatePostPage", () => {
     return renderComponent(newPostURL(currentChannel.name), [
       actions.forms.FORM_BEGIN_EDIT,
       actions.channels.get.requestType,
-      actions.channels.get.successType,
+      actions.channels.get.successType
     ])
   }
 

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -22,7 +22,7 @@ class HomePage extends React.Component {
     frontpage: RestState<Array<string>>,
     posts: RestState<Map<string, Post>>,
     subscribedChannels: RestState<Array<string>>,
-    channels: RestState<Map<string, Channel>>,
+    channels: RestState<Map<string, Channel>>
   }
 
   componentWillMount() {
@@ -77,7 +77,7 @@ const mapStateToProps = state => {
     posts:              state.posts,
     frontpage:          state.frontpage,
     subscribedChannels: state.subscribedChannels,
-    channels:           state.channels,
+    channels:           state.channels
   }
 }
 

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -3,10 +3,10 @@ import { assert } from "chai"
 
 import PostList from "../components/PostList"
 
-import { makeChannelList } from '../factories/channels'
+import { makeChannelList } from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
 import { actions } from "../actions"
-import { SET_CHANNEL_DATA } from '../actions/channel'
+import { SET_CHANNEL_DATA } from "../actions/channel"
 import { SET_POST_DATA } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
@@ -33,7 +33,7 @@ describe("HomePage", () => {
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
       SET_POST_DATA,
-      SET_CHANNEL_DATA,
+      SET_CHANNEL_DATA
     ])
 
   it("should fetch frontpage, set post data, render", async () => {
@@ -41,7 +41,7 @@ describe("HomePage", () => {
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
   })
 
-  it('lists subscriptions', () => {
+  it("lists subscriptions", () => {
     return renderPage().then(([wrapper]) => {
       assert.deepEqual(wrapper.find("SubscriptionsSidebar").props().subscribedChannels, channels)
     })

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -1,6 +1,6 @@
 // @flow
 import casual from "casual-browserify"
-import R from 'ramda'
+import R from "ramda"
 
 import { incrementer } from "../factories/util"
 

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -21,8 +21,7 @@ export const makePost = (isURLPost: boolean = false, channelName: string = casua
   channel_name: channelName
 })
 
-export const makeChannelPostList = (channelName: string = casual.word) => R.range(0, 20).map(
-  () => makePost(Math.random() > 0.5, channelName)
-)
+export const makeChannelPostList = (channelName: string = casual.word) =>
+  R.range(0, 20).map(() => makePost(Math.random() > 0.5, channelName))
 
 export const makeFrontPageList = () => R.range(0, 30).map(() => makePost(Math.random() > 0.5))

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -66,7 +66,7 @@ describe("api", function() {
       fetchStub.returns(Promise.resolve(channelList))
 
       return getChannels().then(result => {
-        assert.ok(fetchStub.calledWith(("/api/v0/channels/")))
+        assert.ok(fetchStub.calledWith("/api/v0/channels/"))
         assert.deepEqual(result, channelList)
       })
     })

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -14,5 +14,5 @@ export const endpoints = [
   postsForChannelEndpoint,
   frontPageEndpoint,
   commentsEndpoint,
-  postUpvotesEndpoint,
+  postUpvotesEndpoint
 ]

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -6,4 +6,4 @@ export const postDetailURL = (channelName: string, postID: string) => `/channel/
 
 export const newPostURL = (channelName: string) => `/create_post/${channelName}`
 
-export const frontPageURL = () => '/'
+export const frontPageURL = () => "/"

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -1,12 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import {
-  channelURL,
-  frontPageURL,
-  newPostURL,
-  postDetailURL,
-} from "./url"
+import { channelURL, frontPageURL, newPostURL, postDetailURL } from "./url"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -6,6 +6,4 @@ export const getChannelName = (props: { match: Match }): string => props.match.p
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
  */
-export const wait = (millis: number): Promise<void> => (
-  new Promise(resolve => setTimeout(resolve, millis))
-)
+export const wait = (millis: number): Promise<void> => new Promise(resolve => setTimeout(resolve, millis))

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -1,10 +1,10 @@
 // @flow
-import { assert } from 'chai'
+import { assert } from "chai"
 
-import { wait } from './util'
+import { wait } from "./util"
 
-describe('utility functions', () => {
-  it('waits some milliseconds', done => {
+describe("utility functions", () => {
+  it("waits some milliseconds", done => {
     let executed = false
     wait(30).then(() => {
       executed = true

--- a/static/js/reducers/subscribedChannels.js
+++ b/static/js/reducers/subscribedChannels.js
@@ -9,5 +9,5 @@ export const subscribedChannelsEndpoint = {
   verbs:             [GET],
   initialState:      { ...INITIAL_STATE, data: [] },
   getFunc:           () => api.getChannels(),
-  getSuccessHandler: (payload: Array<Channel>) => payload.map(channel => channel.name),
+  getSuccessHandler: (payload: Array<Channel>) => payload.map(channel => channel.name)
 }

--- a/travis/js_tests.sh
+++ b/travis/js_tests.sh
@@ -13,6 +13,7 @@ function run_test {
 
 run_test docker run --env-file .env -t travis-watch npm run codecov
 run_test docker run --env-file .env -t travis-watch npm run lint
+run_test docker run --env-file .env -t travis-watch npm run fmt:check
 run_test docker run --env-file .env -t travis-watch npm run scss_lint
 run_test docker run --env-file .env -t travis-watch npm run flow
 run_test docker run --env-file .env -e "NODE_ENV=production" -t travis-watch ./webpack_if_prod.sh


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

runs `prettier-eslint` with the `--list-different` flag, which will basically error if there are any files that `prettier` _would_ change, if it were called. this means in order to get your code to pass CI you will have to call `npm run fmt`.

#### How should this be manually tested?

This should fail CI initially. then, after a review, I will introduce a commit that is just the result of calling `npm run fmt`, after that, it should pass CI.