### PR TITLE
add an easy way to open a nodejs repl with common libraries required

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "watch": "WATCH=1 ./scripts/test/js_test.sh",
     "flow": "flow check",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'",
-    "fmt:check": "prettier-eslint --list-different --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'"
+    "fmt:check": "prettier-eslint --list-different --no-semi --ignore 'static/js/flow/**/*.js' 'static/js/**/*.js'",
+    "repl": "node --require ./scripts/repl.js"
   }
 }

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,0 +1,7 @@
+require("babel-register")
+
+R = require("ramda")
+moment = require("moment")
+S = require("sanctuary")
+sinon = require("sinon")
+assert = require("chai").assert


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

Adds a `package.json` script (`repl`) which opens `node.js` with Ramda, Moment, chai/assert, Sanctuary, and Sinon required as globals. This makes it just a little easier to experiment with these libs in the repl.

There's a script (`scripts/repl`) where these are declared.

#### How should this be manually tested?

you can `npm run repl` and play with ramda n stuff.