### PR TITLE
Refactored loading component

### DIFF
--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -1,27 +1,33 @@
 // @flow
 import React from "react"
 
-import { anyProcessing, anyError, allLoaded } from "../util/rest"
+type LoadingProps = {
+  loaded: boolean,
+  errored: boolean
+}
 
-import type { RestState } from "../flow/restTypes"
+const withLoading = (LoadedComponent: Class<React.Component<*, *, *>>) => {
+  return class extends LoadedComponent {
+    props: LoadingProps
 
-export default class Loading extends React.Component {
-  props: {
-    restStates: Array<RestState<*>>,
-    renderContents: Function
-  }
+    render() {
+      const { loaded, errored } = this.props
 
-  render() {
-    const { restStates, renderContents } = this.props
+      if (errored) {
+        return <div className="errored">Error loading page</div>
+      }
 
-    if (anyProcessing(restStates) || !allLoaded(restStates)) {
-      return <div>Loading</div>
+      if (!loaded) {
+        return <div className="loading">Loading</div>
+      }
+
+      return (
+        <div className="loaded">
+          {super.render()}
+        </div>
+      )
     }
-
-    if (anyError(restStates)) {
-      return <div>Error loading page</div>
-    }
-
-    return renderContents()
   }
 }
+
+export default withLoading

--- a/static/js/components/Loading_test.js
+++ b/static/js/components/Loading_test.js
@@ -1,135 +1,40 @@
 // @flow
 import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 
-import Loading from "./Loading"
+import withLoading from "./Loading"
+
+class Content extends React.Component {
+  render() {
+    return <div>CONTENT</div>
+  }
+}
+
+const LoadingContent = withLoading(Content)
 
 describe("Loading", () => {
-  const renderLoading = restStates =>
-    shallow(<Loading restStates={restStates} renderContents={() => <div>CONTENT</div>} />)
+  const renderLoading = (loaded: boolean, errored: boolean) => {
+    return mount(<LoadingContent loaded={loaded} errored={errored} />)
+  }
 
-  describe("should render loading correctly", () => {
-    it("single state with loaded:false", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     false,
-          processing: false
-        }
-      ])
-      assert.equal(wrapper.text(), "Loading")
-    })
-
-    it("multiple states with one loaded:false", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false
-        },
-        {
-          loaded:     false,
-          processing: false
-        }
-      ])
-      assert.equal(wrapper.text(), "Loading")
-    })
-
-    it("single state with processing:true", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     false,
-          processing: true
-        }
-      ])
-      assert.equal(wrapper.text(), "Loading")
-    })
-
-    it("multiple states with one processing:true", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     false,
-          processing: false
-        },
-        {
-          loaded:     false,
-          processing: true
-        }
-      ])
-      assert.equal(wrapper.text(), "Loading")
-    })
+  it("render loading if not loaded and not errored", () => {
+    const wrapper = renderLoading(false, false)
+    assert.equal(wrapper.text(), "Loading")
   })
 
-  describe("should render errors correctly", () => {
-    it("single state with error", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false,
-          error:      "bad things"
-        }
-      ])
-      assert.equal(wrapper.text(), "Error loading page")
-    })
-
-    it("multiple states all with errors", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false,
-          error:      "bad things"
-        },
-        {
-          loaded:     true,
-          processing: false,
-          error:      "bad things"
-        }
-      ])
-      assert.equal(wrapper.text(), "Error loading page")
-    })
-
-    it("multiple states with one error", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false,
-          error:      undefined
-        },
-        {
-          loaded:     true,
-          processing: false,
-          error:      "bad things"
-        }
-      ])
-      assert.equal(wrapper.text(), "Error loading page")
-    })
+  it("should render errors correctly if not loaded", () => {
+    const wrapper = renderLoading(false, true)
+    assert.equal(wrapper.text(), "Error loading page")
   })
 
-  describe("should the contents if no errors", () => {
-    it("single state", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false,
-          error:      undefined
-        }
-      ])
-      assert.equal(wrapper.text(), "CONTENT")
-    })
+  it("should render errors correctly if loaded", () => {
+    const wrapper = renderLoading(true, true)
+    assert.equal(wrapper.text(), "Error loading page")
+  })
 
-    it("multiple states", () => {
-      const wrapper = renderLoading([
-        {
-          loaded:     true,
-          processing: false,
-          error:      undefined
-        },
-        {
-          loaded:     true,
-          processing: false,
-          error:      undefined
-        }
-      ])
-      assert.equal(wrapper.text(), "CONTENT")
-    })
+  it("should the contents if no errors and loaded", () => {
+    const wrapper = renderLoading(true, false)
+    assert.equal(wrapper.text(), "CONTENT")
   })
 })

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -1,12 +1,13 @@
 // @flow
 import React from "react"
+import R from "ramda"
 import { connect } from "react-redux"
 
 import SubscriptionsSidebar from "../components/SubscriptionsSidebar"
 import Card from "../components/Card"
 import ChannelSidebar from "../components/ChannelSidebar"
 import PostList from "../components/PostList"
-import Loading from "../components/Loading"
+import withLoading from "../components/Loading"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 
 import { actions } from "../actions"
@@ -15,80 +16,66 @@ import { setChannelData } from "../actions/channel"
 import { safeBulkGet } from "../lib/maps"
 import { getChannelName } from "../lib/util"
 import { toggleUpvote } from "../util/api_actions"
+import { anyError } from "../util/rest"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
-import type { RestState } from "../flow/restTypes"
 import type { Channel, Post } from "../flow/discussionTypes"
 
+type ChannelPageProps = {
+  match: Match,
+  dispatch: Dispatch,
+  channelName: string,
+  channel: ?Channel,
+  postsForChannel: ?Array<string>,
+  posts: ?Array<Post>,
+  subscribedChannels: ?Array<Channel>
+}
+
+// if channelName values don't match
+const shouldLoadData = R.complement(R.eqProps("channelName"))
+
 class ChannelPage extends React.Component {
-  props: {
-    match: Match,
-    dispatch: Dispatch,
-    channels: RestState<Map<string, Channel>>,
-    postsForChannel: RestState<Map<string, Array<string>>>,
-    posts: RestState<Map<string, Post>>,
-    subscribedChannels: RestState<Array<string>>
-  }
+  props: ChannelPageProps
 
   componentWillMount() {
-    this.updateRequirements()
+    this.loadData()
   }
 
   componentDidUpdate(prevProps) {
-    if (getChannelName(this.props) !== getChannelName(prevProps)) {
-      // if the channel was changed, fetch the new information for this channel
-      this.updateRequirements()
+    if (shouldLoadData(prevProps, this.props)) {
+      this.loadData()
     }
   }
 
-  updateRequirements = () => {
-    const { dispatch, subscribedChannels } = this.props
-    const channelName = getChannelName(this.props)
-    dispatch(actions.channels.get(channelName))
-    dispatch(actions.postsForChannel.get(channelName)).then(({ posts }) => {
-      dispatch(setPostData(posts))
-    })
-
-    if (!subscribedChannels.loaded && !subscribedChannels.processing) {
-      dispatch(actions.subscribedChannels.get()).then(channels => {
-        dispatch(setChannelData(channels))
-      })
-    }
+  loadData = () => {
+    const { dispatch, subscribedChannels, channelName } = this.props
+    Promise.all([
+      dispatch(actions.channels.get(channelName)),
+      dispatch(actions.postsForChannel.get(channelName)).then(({ posts }) => {
+        dispatch(setPostData(posts))
+      }),
+      subscribedChannels ||
+        dispatch(actions.subscribedChannels.get()).then(channels => {
+          dispatch(setChannelData(channels))
+        })
+    ])
   }
 
-  renderContents = () => {
-    const { channels, postsForChannel, posts, subscribedChannels, dispatch } = this.props
-    const channelName = getChannelName(this.props)
-    if (!channels.data) {
-      return
-    }
-    const channel = channels.data.get(channelName)
-    if (!postsForChannel.data) {
-      return
-    }
-    const postIds = postsForChannel.data.get(channelName)
-
-    if (!channel || !postIds || !posts.data) {
+  render() {
+    const { dispatch, channel, subscribedChannels, posts } = this.props
+    if (!channel || !subscribedChannels || !posts) {
       return null
     } else {
       return (
         <div className="triple-column">
           <ChannelBreadcrumbs channel={channel} />
           <div className="first-column">
-            <SubscriptionsSidebar
-              // $FlowFixMe: flow doesn't know that we already checked if these are undefined
-              subscribedChannels={safeBulkGet(subscribedChannels.data, channels.data)}
-            />
+            <SubscriptionsSidebar subscribedChannels={subscribedChannels} />
           </div>
           <div className="second-column">
             <Card title={channel.title}>
-              <PostList
-                channel={channel}
-                // $FlowFixMe: flow doesn't know that the safeBulkGet above doesn't affect this one
-                posts={safeBulkGet(postIds, posts.data)}
-                toggleUpvote={toggleUpvote(dispatch)}
-              />
+              <PostList channel={channel} posts={posts} toggleUpvote={toggleUpvote(dispatch)} />
             </Card>
           </div>
           <div className="third-column">
@@ -101,20 +88,22 @@ class ChannelPage extends React.Component {
       )
     }
   }
-
-  render() {
-    const { channels, postsForChannel } = this.props
-    return <Loading restStates={[channels, postsForChannel]} renderContents={this.renderContents} />
-  }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
+  const channelName = getChannelName(ownProps)
+  const postIds = state.postsForChannel.data.get(channelName)
+  const channel = state.channels.data.get(channelName)
   return {
-    channels:           state.channels,
-    postsForChannel:    state.postsForChannel,
-    posts:              state.posts,
-    subscribedChannels: state.subscribedChannels
+    channelName,
+    channel,
+    posts:              safeBulkGet(postIds || [], state.posts.data),
+    subscribedChannels: state.subscribedChannels.loaded
+      ? safeBulkGet(state.subscribedChannels.data, state.channels.data)
+      : null,
+    loaded:  R.none(R.isNil, [channel, postIds]),
+    errored: anyError([state.channels, state.posts, state.subscribedChannels])
   }
 }
 
-export default connect(mapStateToProps)(ChannelPage)
+export default R.compose(connect(mapStateToProps), withLoading)(ChannelPage)

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -53,7 +53,7 @@ describe("ChannelPage", () => {
     let otherChannel = makeChannel()
     otherChannel.name = "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
     let [wrapper] = await renderPage(otherChannel)
-    assert.equal(wrapper.text(), "")
+    assert.equal(wrapper.text(), "Loading")
   })
 
   it("lists subscriptions", () => {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -2,6 +2,7 @@
 import type { Match } from "react-router"
 
 export const getChannelName = (props: { match: Match }): string => props.match.params.channelName || ""
+export const getPostID = (props: { match: Match }): string => props.match.params.postID || ""
 
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #102 

#### What's this PR do?
Updates `<Loading />`

#### How should this be manually tested?

- Exercise the channel and post pages and verify they load correctly including over a full page refresh.
- Verify the page doesn't flash when adding a comment to a post

#### Any background context you want to provide?

I reimplemented `<Loading/>` as the HOC `withLoading`. This new design has a few benefits:

- The wrapped component is simpler and implements only a `render()` method instead of the previous design with both a `render()` and `renderContent()` implementation.
- The wrapped component now determines if it is loaded or not in its `mapStateToProps` implementation

Some design tradeoffs to achieve this:

- We need to pass two functions to `withLoading`: 
  - `shouldUpdateRequirements`: this function is pass the previous and current props and returns true if the difference in values indicates the requirements should be updated
  - `updateRequirements`: this function dispatches all actions required to update the requirements

It was necessary to move this type logic out of where it previously lived (the wrapped component's `componentWillMount` and `componentDidUpdate`) because those methods don't get called until after the component's data has been loaded. Instead, I chose to pass them to `withLoading` so they could be called in the HOC's `componentWillMount` and `componentDidUpdate` independent of whether the wrapped component was mounted/mounting yet or not.

The only piece I'm not completely satisfied with is the `mapStateToProps` implementations themselves, I feel they could be a little cleaner with some more time and effort, but they're functional and I didn't want to go down a rabbit hole of trying to make those DRY/simpler.

#### What GIF best describes this PR or how it makes you feel?
![Loading](https://media.giphy.com/media/LyuWqvhAU93XO/giphy.gif)
