### PR TITLE
render markdown posts and comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dom": "^15.6.1",
     "react-ga": "^2.2.0",
     "react-hot-loader": "next",
+    "react-markdown": "^2.5.0",
     "react-redux": "^5.0.5",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -3,6 +3,8 @@ import React from "react"
 import R from "ramda"
 import moment from "moment"
 
+import ReactMarkdown from "react-markdown"
+
 import Card from "./Card"
 import { ReplyToCommentForm } from "./CreateCommentForm"
 import CommentVoteForm from "./CommentVoteForm"
@@ -33,9 +35,7 @@ const renderComment = R.curry(
       </div>
       <div className="row">
         <CommentVoteForm comment={comment} upvote={upvote} downvote={downvote} />
-        <div>
-          {comment.text}
-        </div>
+        <ReactMarkdown disallowedTypes={["Image"]} source={comment.text} escapeHtml />
       </div>
       <div>
         <ReplyToCommentForm forms={forms} comment={comment} />

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -5,6 +5,8 @@ import R from "ramda"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 
+import ReactMarkdown from "react-markdown"
+
 import Card from "../components/Card"
 import CommentTree from "./CommentTree"
 
@@ -40,6 +42,14 @@ describe("CommentTree", () => {
     let replies = firstComment.find(".comment")
     const countReplies = R.compose(R.reduce((acc, val) => acc + countReplies(val), 1), R.prop("replies"))
     assert.equal(replies.length, countReplies(comments[0]))
+  })
+
+  it("should use markdown to render comments, should skip images", () => {
+    comments[0].text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
+    let wrapper = renderCommentTree()
+    let firstComment = wrapper.find(".top-level-comment").at(0)
+    assert.equal(firstComment.find(ReactMarkdown).first().props().source, comments[0].text)
+    assert.lengthOf(firstComment.find("img"), 0)
   })
 
   it("should put a className on replies, to allow for indentation", () => {

--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -3,15 +3,14 @@ import React from "react"
 import moment from "moment"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
+import ReactMarkdown from "react-markdown"
 
 import { channelURL, postDetailURL } from "../lib/url"
 
 import type { Post } from "../flow/discussionTypes"
 
 const textContent = post =>
-  <div className="text-content">
-    {post.text}
-  </div>
+  <ReactMarkdown disallowedTypes={["Image"]} source={post.text} escapeHtml className="text-content" />
 
 const postTitle = (post: Post) =>
   post.text

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -3,6 +3,7 @@ import React from "react"
 import { assert } from "chai"
 import { mount } from "enzyme"
 import { Link } from "react-router-dom"
+import ReactMarkdown from "react-markdown"
 
 import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
@@ -55,7 +56,15 @@ describe("PostDisplay", () => {
     let string = "JUST SOME GREAT TEXT!"
     post.text = string
     const wrapper = renderPostDisplay({ post: post, expanded: true })
-    assert.include(wrapper.text(), string)
+    assert.equal(wrapper.find(ReactMarkdown).props().source, string)
+  })
+
+  it("should not display images from markdown", () => {
+    const post = makePost()
+    post.text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
+    const wrapper = renderPostDisplay({ post: post, expanded: true })
+    assert.equal(wrapper.find(ReactMarkdown).props().source, post.text)
+    assert.lengthOf(wrapper.find("img"), 0)
   })
 
   it("should not display text, if given a text post but lacking the 'expanded' flag", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,24 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
+commonmark-react-renderer@^4.2.4:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/commonmark-react-renderer/-/commonmark-react-renderer-4.3.3.tgz#9c4bca138bc83287bae792ccf133738be9cbc6fa"
+  dependencies:
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.isplainobject "^4.0.6"
+    pascalcase "^0.1.1"
+    xss-filters "^1.2.6"
+
+commonmark@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.24.0.tgz#b80de0182c546355643aa15db12bfb282368278f"
+  dependencies:
+    entities "~ 1.1.1"
+    mdurl "~ 1.0.1"
+    string.prototype.repeat "^0.2.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1895,7 +1913,7 @@ enhanced-resolve@^3.3.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
-entities@^1.1.1, entities@~1.1.1:
+entities@^1.1.1, "entities@~ 1.1.1", entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
@@ -3579,6 +3597,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.kebabcase@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
@@ -3719,6 +3741,10 @@ md5-hex@^1.2.0:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+"mdurl@~ 1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -4299,6 +4325,10 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -4780,7 +4810,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6:
+prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4919,6 +4949,15 @@ react-hot-loader@next:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.4.4"
+
+react-markdown@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-2.5.0.tgz#b1c61904fee5895886803bd9df7db23c3dc3a89e"
+  dependencies:
+    commonmark "^0.24.0"
+    commonmark-react-renderer "^4.2.4"
+    in-publish "^2.0.0"
+    prop-types "^15.5.1"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
@@ -5710,6 +5749,10 @@ string-width@^2.0.0, string-width@^2.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
+
 string_decoder@^0.10.25:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -6253,6 +6296,10 @@ write@^0.2.1:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xss-filters@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
 
 xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
#### What are the relevant tickets?

this closes #105 

#### What's this PR do?

this adds the [react-markdown](https://github.com/rexxars/react-markdown) package and uses it to render comment and post text.

#### How should this be manually tested?

make a comment or text post containing some markdown stuff, make sure it works! you should be able to do fun stuff like this:

![markdown](https://user-images.githubusercontent.com/6207644/29284789-138f62e6-80fa-11e7-95c3-0c419100b482.png)
