### PR TITLE
Added JWT auth to API

### DIFF
--- a/channels/views.py
+++ b/channels/views.py
@@ -6,6 +6,7 @@ from rest_framework.generics import (
     RetrieveUpdateAPIView,
     RetrieveUpdateDestroyAPIView,
 )
+from rest_framework.permissions import IsAuthenticated
 
 from channels.api import Api
 from channels.serializers import (
@@ -13,12 +14,14 @@ from channels.serializers import (
     CommentSerializer,
     PostSerializer,
 )
+from open_discussions.permissions import JwtIsStaffOrReadonlyPermission
 
 
 class ChannelListView(ListCreateAPIView):
     """
     View for listing and creating channels
     """
+    permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission,)
     serializer_class = ChannelSerializer
 
     def get_queryset(self):
@@ -31,6 +34,7 @@ class ChannelDetailView(RetrieveUpdateAPIView):
     """
     View for getting information about or updating a specific channel
     """
+    permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission,)
     serializer_class = ChannelSerializer
 
     def get_object(self):

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 """Configuration for pytest fixtures"""
 # pylint: disable=unused-argument, redefined-outer-name
 import pytest
+from rest_framework_jwt.settings import api_settings
 
 from open_discussions.factories import UserFactory
 
@@ -9,3 +10,36 @@ from open_discussions.factories import UserFactory
 def user(db):
     """Create a user"""
     return UserFactory.create()
+
+
+@pytest.fixture
+def staff_jwt_token(admin_user):
+    """Creates a JWT token for a staff user"""
+    jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+    jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+
+    payload = jwt_payload_handler(admin_user)
+    payload['roles'] = ['staff']
+    return jwt_encode_handler(payload)
+
+
+@pytest.fixture
+def jwt_token(user):
+    """Creates a JWT token for a regular user"""
+    jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+    jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+
+    payload = jwt_payload_handler(user)
+    return jwt_encode_handler(payload)
+
+
+@pytest.fixture
+def staff_jwt_header(staff_jwt_token):
+    """Generate a staff Authorization HTTP header"""
+    return dict(HTTP_AUTHORIZATION='Bearer {}'.format(staff_jwt_token))
+
+
+@pytest.fixture
+def jwt_header(jwt_token):
+    """Generate a nonstaff Authorization HTTP header"""
+    return dict(HTTP_AUTHORIZATION='Bearer {}'.format(jwt_token))

--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -1,0 +1,45 @@
+"""Custom permissions"""
+import jwt
+from rest_framework import permissions
+from rest_framework_jwt.settings import api_settings
+
+
+def _is_staff_jwt(request):
+    """
+    Args:
+        request: django request object
+
+    Returns:
+        bool: True if user is staff
+    """
+    if request.auth is None:
+        return False
+
+    jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+
+    try:
+        payload = jwt_decode_handler(request.auth)
+    except jwt.InvalidTokenError:
+        return False
+
+    return 'roles' in payload and 'staff' in payload['roles']
+
+
+class JwtIsStaffPermission(permissions.BasePermission):
+    """Checks the JWT payload for the staff permission"""
+
+    def has_permission(self, request, view):
+        """Returns True if the user has the staff role"""
+        return _is_staff_jwt(request)
+
+
+class JwtIsStaffOrReadonlyPermission(permissions.BasePermission):
+    """Checks the JWT payload for the staff permission"""
+
+    def has_permission(self, request, view):
+        """Returns True if the user has the staff role or if the request is readonly"""
+        print(request.method)
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return _is_staff_jwt(request)

--- a/open_discussions/permissions_test.py
+++ b/open_discussions/permissions_test.py
@@ -1,0 +1,55 @@
+"""Tests for permissions"""
+import pytest
+
+from open_discussions.permissions import (
+    JwtIsStaffPermission,
+    JwtIsStaffOrReadonlyPermission,
+)
+
+
+@pytest.mark.parametrize('perm', [
+    JwtIsStaffPermission(),
+    JwtIsStaffOrReadonlyPermission(),
+])
+def test_staff_anonymous_users_blocked(mocker, perm):
+    """
+    Test that anonymous users are not allowed
+    """
+    assert perm.has_permission(mocker.Mock(), mocker.Mock()) is False
+
+
+def test_staff_deny_non_staff_user(mocker, jwt_token):
+    """
+    Test that nonstaff users are not allowed
+    """
+    perm = JwtIsStaffPermission()
+    request = mocker.Mock(auth=jwt_token)
+    assert perm.has_permission(request, mocker.Mock()) is False
+
+
+@pytest.mark.parametrize('perm', [
+    JwtIsStaffPermission(),
+    JwtIsStaffOrReadonlyPermission(),
+])
+def test_staff_allow_staff_user(mocker, staff_jwt_token, perm):
+    """
+    Test that staff users are allowed
+    """
+    request = mocker.Mock(auth=staff_jwt_token)
+    assert perm.has_permission(request, mocker.Mock()) is True
+
+
+@pytest.mark.parametrize('method,result', [
+    ('GET', True),
+    ('HEAD', True),
+    ('OPTIONS', True),
+    ('POST', False),
+    ('PUT', False),
+])
+def test_readonly(mocker, jwt_token, method, result):
+    """
+    Test that mutation HTTP verbs return appropriately if nonstaff
+    """
+    perm = JwtIsStaffOrReadonlyPermission()
+    request = mocker.Mock(auth=jwt_token, method=method)
+    assert perm.has_permission(request, mocker.Mock()) is result

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -9,6 +9,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.10/ref/settings/
 
 """
+import datetime
 import logging
 import os
 import platform
@@ -71,7 +72,6 @@ INSTALLED_APPS = (
     'server_status',
     'raven.contrib.django.raven_compat',
     'rest_framework',
-    'rest_framework.authtoken',
     # Put our apps after this point
     'open_discussions',
     'profiles'
@@ -382,6 +382,23 @@ OPEN_DISCUSSIONS_REDDIT_SECRET = get_string('OPEN_DISCUSSIONS_REDDIT_SECRET', No
 OPEN_DISCUSSIONS_REDDIT_URL = get_string('OPEN_DISCUSSIONS_REDDIT_URL', '')
 OPEN_DISCUSSIONS_REDDIT_VALIDATE_SSL = get_bool('OPEN_DISCUSSIONS_REDDIT_VALIDATE_SSL', True)
 
+# JWT authentication settings
+OPEN_DISCUSSIONS_JWT_SECRET = get_string(
+    'OPEN_DISCUSSIONS_JWT_SECRET',
+    'terribly_unsafe_default_jwt_secret_key'
+)
+
+JWT_AUTH = {
+    'JWT_SECRET_KEY': OPEN_DISCUSSIONS_JWT_SECRET,
+    'JWT_VERIFY': True,
+    'JWT_VERIFY_EXPIRATION': True,
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=60*60),
+    'JWT_ALLOW_REFRESH': True,
+    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
+    'JWT_AUTH_COOKIE': 'open_discussions_jwt',
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
+}
+
 
 # features flags
 def get_all_config_keys():
@@ -421,5 +438,9 @@ if DEBUG:
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
 }

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from rest_framework_jwt.views import refresh_jwt_token
 
 from open_discussions.views import index
 
@@ -25,6 +26,7 @@ urlpatterns = [
     url(r'^status/', include('server_status.urls')),
     url(r'', include('channels.urls')),
     url(r'', include('profiles.urls')),
+    url(r'^api/token/refresh/', refresh_jwt_token),
 
     # React App
     url(r'^$', index, name='open_discussions-index'),

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -3,16 +3,15 @@
 from django.contrib.auth import get_user_model
 
 from rest_framework import viewsets
-from rest_framework.authentication import TokenAuthentication
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated
 
+from open_discussions.permissions import JwtIsStaffPermission
 from profiles.serializers import UserSerializer
 
 
 class UserViewSet(viewsets.ModelViewSet):
     """View for users"""
-    authentication_classes = (TokenAuthentication,)
-    permission_classes = (IsAuthenticated, IsAdminUser,)
+    permission_classes = (IsAuthenticated, JwtIsStaffPermission,)
 
     serializer_class = UserSerializer
     queryset = get_user_model().objects.all()

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -2,7 +2,6 @@
 import json
 
 from django.core.urlresolvers import reverse
-from rest_framework.authtoken.models import Token
 import pytest
 
 from profiles.factories import ProfileFactory
@@ -14,36 +13,18 @@ pytestmark = pytest.mark.django_db
 API_KWARGS = dict(content_type='application/json', format='json')
 
 
-@pytest.fixture
-def staff_token(admin_user):
-    """Create a token for a staff user"""
-    return Token.objects.create(user=admin_user)
-
-
-@pytest.fixture
-def user_token(user):
-    """Create a token for a non-staff user"""
-    return Token.objects.create(user=user)
-
-
-def _authorization_header(token):
-    """Generate a Authorization HTTP header"""
-    return dict(HTTP_AUTHORIZATION='Token {}'.format(token.key))
-
-
-def test_list_users(client, staff_token):
+def test_list_users(client, admin_user, staff_jwt_header):
     """
     List users
     """
-    user = staff_token.user
-    profile = ProfileFactory.create(user=user)
+    profile = ProfileFactory.create(user=admin_user)
     url = reverse('user_api-list')
-    resp = client.get(url, **_authorization_header(staff_token))
+    resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == 200
     assert resp.json() == [
         {
-            'id': user.id,
-            'username': user.username,
+            'id': admin_user.id,
+            'username': admin_user.username,
             'profile': {
                 'name': profile.name,
                 'image': profile.image,
@@ -54,7 +35,7 @@ def test_list_users(client, staff_token):
     ]
 
 
-def test_create_user(client, staff_token):
+def test_create_user(client, staff_jwt_header):
     """
     Create a user and assert the response
     """
@@ -67,19 +48,18 @@ def test_create_user(client, staff_token):
             'image_medium': 'image_medium',
         }
     }
-    resp = client.post(url, data=json.dumps(payload), **API_KWARGS, **_authorization_header(staff_token))
+    resp = client.post(url, data=json.dumps(payload), **API_KWARGS, **staff_jwt_header)
     assert resp.status_code == 201
     assert resp.json()['profile'] == payload['profile']
 
 
-def test_get_user(client, staff_token):
+def test_get_user(client, user, staff_jwt_header):
     """
     Get a user
     """
-    user = staff_token.user
     profile = ProfileFactory.create(user=user)
     url = reverse('user_api-detail', kwargs={'username': user.username})
-    resp = client.get(url, **_authorization_header(staff_token))
+    resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == 200
     assert resp.json() == {
         'id': user.id,
@@ -93,18 +73,17 @@ def test_get_user(client, staff_token):
     }
 
 
-def test_patch_user(client, staff_token):
+def test_patch_user(client, user, staff_jwt_header):
     """
-    Update a users's profile
+    Update a users' profile
     """
-    user = staff_token.user
     profile = ProfileFactory.create(user=user)
     url = reverse('user_api-detail', kwargs={'username': user.username})
     resp = client.patch(url, data=json.dumps({
         'profile': {
             'name': 'othername',
         }
-    }), **API_KWARGS, **_authorization_header(staff_token))
+    }), **API_KWARGS, **staff_jwt_header)
     assert resp.status_code == 200
     assert resp.json() == {
         'id': user.id,
@@ -118,15 +97,14 @@ def test_patch_user(client, staff_token):
     }
 
 
-def test_patch_username(client, staff_token):
+def test_patch_username(client, user, staff_jwt_header):
     """
     Trying to update a users's username does not change anything
     """
-    user = staff_token.user
     ProfileFactory.create(user=user)
     url = reverse('user_api-detail', kwargs={'username': user.username})
     resp = client.patch(url, data=json.dumps({
         'username': 'notallowed'
-    }), **API_KWARGS, **_authorization_header(staff_token))
+    }), **API_KWARGS, **staff_jwt_header)
     assert resp.status_code == 200
     assert resp.json()['username'] == user.username

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ django-redis==4.7.0
 django-server-status==0.3.2
 django-webpack-loader==0.4.1
 djangorestframework==3.5.2
+djangorestframework-jwt==1.11.0
 factory_boy
 faker
 html5lib==0.999999999

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-redis==4.7.0
 django-server-status==0.3.2
 django-webpack-loader==0.4.1
 django==1.10.5            # via django-server-status
+djangorestframework-jwt==1.11.0
 djangorestframework==3.5.2
 elasticsearch==5.4.0      # via django-server-status
 factory-boy==2.8.1
@@ -39,6 +40,7 @@ prompt-toolkit==1.0.14    # via ipython
 psycopg2==2.6
 ptyprocess==0.5.1         # via pexpect
 pygments==2.2.0           # via ipython
+pyjwt==1.5.2              # via djangorestframework-jwt
 python-dateutil==2.6.0    # via faker
 pytz==2017.2              # via celery
 pyyaml==3.11


### PR DESCRIPTION
#### What are the relevant tickets?
Part of mitodl/micromasters#3479

#### What's this PR do?
Adds JWT authentication to APIs, requires a staff role for admin APIs

#### How should this be manually tested?
In a django shell (n.b. token is good for an hour):
```python
from rest_framework_jwt.settings import api_settings
jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
payload = jwt_payload_handler(user)
payload['roles'] = ['staff']
token = jwt_encode_handler(payload)
```
In a bash shell:
```bash
TOKEN=<PASTE TOKEN VALUE>

# test users API
# works
curl -H "Authorization: Bearer $TOKEN" localhost:8063/api/v0/users/
# return 401
curl -H "Authorization: Bearer BAD" localhost:8063/api/v0/users/
# return 401
curl localhost:8063/api/v0/users/

# POST/PATCH channels
# these should work:
curl -H "Authorization: Bearer $TOKEN" localhost:8063/api/v0/channels/ -X POST -d '{"name":"testchan","title":"testchan","channel_type":"public", "public_description":"ggg" }'
curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json"  localhost:8063/api/v0/channels/testchan/ -X PATCH -d '{"public_description":"ggg" }'
# return 401
curl -H "Authorization: Bearer BADTOKEN" localhost:8063/api/v0/channels/ -X POST -d '{"name":"testchan","title":"testchan","channel_type":"public", "public_description":"ggg" }'
curl -H "Authorization: Bearer BADTOKEN" -H "Content-Type: application/json"  localhost:8063/api/v0/channels/testchan/ -X PATCH -d '{"public_description":"ggg" }'
# return 401
curl -H "Content-Type: application/json" localhost:8063/api/v0/channels/ -X POST -d '{"name":"testchan","title":"testchan","channel_type":"public", "public_description":"ggg" }'
curl localhost:8063/api/v0/channels/testchan/ -X PATCH -d '{"public_description":"ggg" }'

```