### PR TITLE
post page tweaks

### DIFF
--- a/static/js/components/CommentVoteForm.js
+++ b/static/js/components/CommentVoteForm.js
@@ -58,30 +58,22 @@ export default class CommentVoteForm extends React.Component {
         <div className="score">
           {comment.score}
         </div>
-        <div className="votes">
-          <button
-            className={`vote upvote-button ${comment.upvoted ? "upvoted" : ""}`}
-            onClick={this.upvote}
-            disabled={voting}
-          >
-            <img
-              className="upvote-arrow"
-              src="/static/images/upvote_arrow.png"
-            />
-          </button>
-          <button
-            className={`vote downvote-button ${comment.downvoted
-              ? "downvoted"
-              : ""}`}
-            onClick={this.downvote}
-            disabled={voting}
-          >
-            <img
-              className="upvote-arrow"
-              src="/static/images/downvote_arrow.png"
-            />
-          </button>
-        </div>
+        <button
+          className={`vote upvote-button ${comment.upvoted ? "upvoted" : ""}`}
+          onClick={this.upvote}
+          disabled={voting}
+        >
+          <img className="vote-arrow" src="/static/images/upvote_arrow.png" />
+        </button>
+        <button
+          className={`vote downvote-button ${comment.downvoted
+            ? "downvoted"
+            : ""}`}
+          onClick={this.downvote}
+          disabled={voting}
+        >
+          <img className="vote-arrow" src="/static/images/downvote_arrow.png" />
+        </button>
       </div>
     )
   }

--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom"
 import ReactMarkdown from "react-markdown"
 
 import { channelURL, postDetailURL } from "../lib/url"
+import { formatCommentsCount } from "../lib/posts"
 
 import type { Post } from "../flow/discussionTypes"
 
@@ -69,28 +70,33 @@ class PostDisplay extends React.Component {
     })
   }
 
-  render() {
+  upvoteDisplay = () => {
     const { post, expanded } = this.props
     const { upvoting } = this.state
-    const formattedDate = moment(post.created).fromNow()
     const upvoteClass = post.upvoted ? "upvoted" : ""
+
     return (
-      <div className="post-summary">
-        <div className={`upvotes ${upvoteClass}`}>
-          <button
-            className="upvote-button"
-            onClick={this.onToggleUpvote}
-            disabled={upvoting}
-          >
-            <img
-              className="upvote-arrow"
-              src="/static/images/upvote_arrow.png"
-            />
-          </button>
-          <span className="votes">
-            {post.score}
-          </span>
-        </div>
+      <div className={`upvotes ${upvoteClass} ${expanded ? "expanded" : ""}`}>
+        <button
+          className="upvote-button"
+          onClick={this.onToggleUpvote}
+          disabled={upvoting}
+        >
+          <img className="vote-arrow" src="/static/images/upvote_arrow.png" />
+        </button>
+        <span className="votes">
+          {post.score}
+        </span>
+      </div>
+    )
+  }
+
+  render() {
+    const { post, expanded } = this.props
+    const formattedDate = moment(post.created).fromNow()
+    return (
+      <div className={`post-summary ${expanded ? "expanded" : ""}`}>
+        {expanded ? null : this.upvoteDisplay()}
         <div className="summary">
           <div className="post-title">
             {postTitle(post)}
@@ -100,12 +106,15 @@ class PostDisplay extends React.Component {
             {this.showChannelLink()}
           </div>
           <div className="num-comments">
-            <Link to={postDetailURL(post.channel_name, post.id)}>
-              {post.num_comments || 0} Comments
-            </Link>
+            {expanded
+              ? null
+              : <Link to={postDetailURL(post.channel_name, post.id)}>
+                {formatCommentsCount(post)}
+              </Link>}
           </div>
         </div>
         {expanded && post.text ? textContent(post) : null}
+        {expanded ? this.upvoteDisplay() : null}
       </div>
     )
   }

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -5,10 +5,12 @@ import { mount } from "enzyme"
 import { Link } from "react-router-dom"
 import ReactMarkdown from "react-markdown"
 
-import { makePost } from "../factories/posts"
-import IntegrationTestHelper from "../util/integration_test_helper"
 import PostDisplay from "./PostDisplay"
 import Router from "../Router"
+
+import { formatCommentsCount } from "../lib/posts"
+import { makePost } from "../factories/posts"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("PostDisplay", () => {
   let helper
@@ -40,7 +42,7 @@ describe("PostDisplay", () => {
     assert.equal(summary.find(Link).at(0).props().children, post.title)
     assert.deepEqual(
       wrapper.find(".num-comments").find(Link).props().children,
-      [post.num_comments, " Comments"]
+      formatCommentsCount(post)
     )
     const authoredBy = wrapper.find(".authored-by").text()
     assert(authoredBy.startsWith(post.author_id))

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -9,11 +9,14 @@ import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 import PostDisplay from "../components/PostDisplay"
 import CommentTree from "../components/CommentTree"
 import { ReplyToPostForm } from "../components/CreateCommentForm"
+import withNavSidebar from "../hoc/withNavSidebar"
 
+import { formatCommentsCount } from "../lib/posts"
 import { actions } from "../actions"
 import { toggleUpvote } from "../util/api_actions"
 import { getChannelName, getPostID } from "../lib/util"
 import { anyError } from "../util/rest"
+import { getSubscribedChannels } from "../lib/redux_selectors"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
@@ -87,25 +90,29 @@ class PostPage extends React.Component {
     if (!channel || !post || !commentsTree) {
       return null
     }
+
     return (
-      <div className="content">
-        <div className="main-content">
-          <ChannelBreadcrumbs channel={channel} />
-          <Card>
+      <div>
+        <ChannelBreadcrumbs channel={channel} />
+        <Card>
+          <div className="post-card">
             <PostDisplay
               post={post}
               toggleUpvote={toggleUpvote(dispatch)}
               expanded
             />
             <ReplyToPostForm forms={forms} post={post} />
-          </Card>
-          <CommentTree
-            comments={commentsTree}
-            forms={forms}
-            upvote={this.upvote}
-            downvote={this.downvote}
-          />
+          </div>
+        </Card>
+        <div className="comments-count">
+          {formatCommentsCount(post)}
         </div>
+        <CommentTree
+          comments={commentsTree}
+          forms={forms}
+          upvote={this.upvote}
+          downvote={this.downvote}
+        />
       </div>
     )
   }
@@ -125,9 +132,12 @@ const mapStateToProps = (state, ownProps) => {
     post,
     channel,
     commentsTree,
-    loaded:  R.none(R.isNil, [post, channel, commentsTree]),
-    errored: anyError([posts, channels, comments])
+    loaded:             R.none(R.isNil, [post, channel, commentsTree]),
+    errored:            anyError([posts, channels, comments]),
+    subscribedChannels: getSubscribedChannels(state)
   }
 }
 
-export default R.compose(connect(mapStateToProps), withLoading)(PostPage)
+export default R.compose(connect(mapStateToProps), withNavSidebar, withLoading)(
+  PostPage
+)

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { PostForm } from "../flow/discussionTypes"
+import type { PostForm, Post } from "../flow/discussionTypes"
 
 export const newPostForm = (): PostForm => ({
   isText: true,
@@ -8,3 +8,6 @@ export const newPostForm = (): PostForm => ({
   url:    "",
   title:  ""
 })
+
+export const formatCommentsCount = (post: Post): string =>
+  post.num_comments === 1 ? "1 Comment" : `${post.num_comments || 0} Comments`

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -1,7 +1,8 @@
 // @flow
 import { assert } from "chai"
 
-import { newPostForm } from "./posts"
+import { newPostForm, formatCommentsCount } from "./posts"
+import { makePost } from "../factories/posts"
 
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
@@ -10,6 +11,18 @@ describe("Post utils", () => {
       text:   "",
       url:    "",
       title:  ""
+    })
+  })
+
+  it("should correctly format comments", () => {
+    let post = makePost()
+    ;[
+      [0, "0 Comments"],
+      [1, "1 Comment"],
+      [10, "10 Comments"]
+    ].forEach(([num, expectation]) => {
+      post.num_comments = num
+      assert.equal(formatCommentsCount(post), expectation)
     })
   })
 })

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -13,29 +13,18 @@
       p {
         margin: 0 0 15px 0;
       }
+    }
 
-      .votes-form {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+    .votes-form {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      width: 65px;
 
-        .votes {
-          margin-right: 10px;
-
-          .vote {
-            display: inline-block;
-          }
-
-          .upvoted, .downvoted {
-            &:not(:disabled) {
-              color: $voted-blue;
-            }
-          }
-        }
-
-        .score {
-          margin-right: 10px;
-          display: inline-block;
+      .upvoted, .downvoted {
+        &:not(:disabled) {
+          color: $voted-blue;
         }
       }
     }
@@ -52,13 +41,12 @@
       }
     }
 
-    .replies > .comment {
-      padding-left: 25px;
+    .replies {
       border-left: 1px solid #e0e0e0;
     }
 
-    .upvote-button, .downvote-button {
-      border-right: 1px solid #ccc;
+    .replies > .comment {
+      padding-left: 25px;
     }
   }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -1,12 +1,18 @@
-.post-summary {
-  padding: 22px 0;
+.post-card {
+  padding: 22px 22px 0 22px;
+}
 
-  &:not(:last-child) {
+.post-summary {
+  display: flex;
+  flex-direction: column;
+
+  &:not(:last-child):not(.expanded) {
     border-bottom: 1px solid $border-grey;
   }
 
-  .text-content {
-    padding: 10px 23px;
+  &:not(.expanded) {
+    flex-direction: row;
+    padding: 22px 0;
   }
 
   .post-title {
@@ -34,28 +40,33 @@
 }
 
 .upvotes {
-  float: left;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   width: 60px;
-  text-align: center;
+
+  &.expanded {
+    flex-direction: row;
+    justify-content: space-between;
+    width: 35px;
+  }
 
   span.votes {
     display: block;
     color: #6f99be;
     font-weight: 500;
     font-size: 14px;
-    margin: 5px 0 0;
   }
 }
 
-img.upvote-arrow {
+img.vote-arrow {
   width: 18px;
 }
 
 .upvote-button, .downvote-button {
   background: none;
   border: none;
-  position: relative;
-  padding: 0 10px;
+  padding: 0;
 
   &:disabled {
     color: $border-grey;
@@ -66,15 +77,7 @@ img.upvote-arrow {
   }
 }
 
-.upvote-button {
-  bottom: 2px;
-}
-
-.downvote-button {
-  top: -1px;
-}
-
-div.score {
-  float: left;
-  margin-right: 10px;
+.comments-count {
+  margin: 0 0 18px 22px;
+  font-size: 15px;
 }


### PR DESCRIPTION
#### What are the relevant tickets?

part of #125 

this does everything except moving the 'reply' button, which is a little more complicated (so I'm putting it off for now).

#### What's this PR do?

- fixes the PostDisplay layout, so that it shows the voting buttons in the right place and doesn't show comments when on the post detail view page
- show the comment count on the post page in the gutter between the post and the first comment
- add the navigation sidebar to the post page
- some small CSS layout cleanups / tweaks, moving a few things that were manually positioned to use flexbox instead.

#### testing

Just make sure everything looks good and is cleanly laid out, on a phone and on the desktop. We should be getting closer to the mocks for the post page. There should be no style regressions on the frontpage or the channel page display.