### PR TITLE
add spinner to loader component

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "sass-lint": "^1.10.2",
     "sass-loader": "^6.0.6",
     "sinon": "^2.3.8",
+    "spinkit": "^1.2.5",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.9",
     "webpack": "^3.2.0",

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -18,7 +18,15 @@ const withLoading = (LoadedComponent: Class<React.Component<*, *, *>>) => {
       }
 
       if (!loaded) {
-        return <div className="loading">Loading</div>
+        return (
+          <div className="loading">
+            <div className="sk-three-bounce">
+              <div className="sk-child sk-bounce1" />
+              <div className="sk-child sk-bounce2" />
+              <div className="sk-child sk-bounce3" />
+            </div>
+          </div>
+        )
       }
 
       return (

--- a/static/js/components/Loading_test.js
+++ b/static/js/components/Loading_test.js
@@ -18,9 +18,9 @@ describe("Loading", () => {
     return mount(<LoadingContent loaded={loaded} errored={errored} />)
   }
 
-  it("render loading if not loaded and not errored", () => {
+  it("should show a spinner if not loaded and not errored", () => {
     const wrapper = renderLoading(false, false)
-    assert.equal(wrapper.text(), "Loading")
+    assert.lengthOf(wrapper.find(".loading").find(".sk-three-bounce"), 1)
   })
 
   it("should render errors correctly if not loaded", () => {

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -61,7 +61,7 @@ describe("ChannelPage", () => {
     otherChannel.name =
       "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
     let [wrapper] = await renderPage(otherChannel)
-    assert.include(wrapper.text(), "Loading")
+    assert.lengthOf(wrapper.find(".loading").find(".sk-three-bounce"), 1)
   })
 
   it("lists subscriptions", async () => {

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -6,6 +6,7 @@ import R from "ramda"
 import PostList from "../components/PostList"
 import Card from "../components/Card"
 
+import withLoading from "../components/Loading"
 import withNavSidebar from "../hoc/withNavSidebar"
 
 import { actions } from "../actions"
@@ -48,7 +49,7 @@ class HomePage extends React.Component {
       <Card title="Home Page">
         <PostList
           // $FlowFixMe: flow thinks these might be undefined
-          posts={safeBulkGet(frontpage.data, posts.data)}
+          posts={safeBulkGet(frontpage, posts.data)}
           toggleUpvote={dispatchableToggleUpvote}
           showChannelLinks={true}
         />
@@ -60,11 +61,14 @@ class HomePage extends React.Component {
 const mapStateToProps = state => {
   return {
     posts:              state.posts,
-    frontpage:          state.frontpage,
+    frontpage:          state.frontpage.data,
     subscribedChannels: getSubscribedChannels(state),
     channels:           state.channels,
-    showSidebar:        state.ui.showSidebar
+    showSidebar:        state.ui.showSidebar,
+    loaded:             state.frontpage.loaded
   }
 }
 
-export default R.compose(connect(mapStateToProps), withNavSidebar)(HomePage)
+export default R.compose(connect(mapStateToProps), withNavSidebar, withLoading)(
+  HomePage
+)

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -2,6 +2,7 @@
 @import "node_modules/@material/toolbar/dist/mdc.toolbar";
 @import "node_modules/@material/list/dist/mdc.list";
 @import "node_modules/@material/button/dist/mdc.button";
+@import "node_modules/spinkit/scss/spinners/7-three-bounce";
 @import "breakpoints";
 @import "variables";
 @import "basic";
@@ -14,6 +15,7 @@
 @import "comment";
 @import "button";
 @import "navigation";
+@import "loader";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/loader.scss
+++ b/static/scss/loader.scss
@@ -1,0 +1,5 @@
+.loading {
+  height: 90vh;
+  display: flex;
+  align-items: center;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5755,6 +5755,10 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+spinkit@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/spinkit/-/spinkit-1.2.5.tgz#90f9f466a20e8e39ef24da959c1e611c2a30dd54"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"


### PR DESCRIPTION
#### What are the relevant tickets?

part of #127 

#### What's this PR do?

this adds a spinner component to the `Loader` component that we have, so we show something a little nicer to look at than just the `Loading` text. I also added the `withLoading` HOC to the home page component, where it hadn't yet been added.

#### How should this be manually tested?

Visit a post page, a channel page, and the front page. you should see a spinner-ey thing there (when the requests are in flight) instead of some text that just says 'Loading'.