### PR TITLE
empty post list display

### DIFF
--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -26,7 +26,9 @@ const PostList = (props: PostListProps) => {
 
   return (
     <div className="post-list">
-      {renderPosts(posts, showChannelLinks, toggleUpvote)}
+      {posts.length > 0
+        ? renderPosts(posts, showChannelLinks, toggleUpvote)
+        : <div className="empty-list-msg">There are no posts to display.</div>}
     </div>
   )
 }

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -19,6 +19,7 @@ describe("PostList", () => {
   it("should behave well if handed an empty list", () => {
     let wrapper = renderPostList({ posts: [] })
     assert.lengthOf(wrapper.find(PostDisplay), 0)
+    assert.equal(wrapper.text(), "There are no posts to display.")
   })
 
   it("should pass the showChannelLinks prop to PostDisplay", () => {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -9,6 +9,7 @@
 @import "breadcrumbs";
 @import "form";
 @import "post";
+@import "post-list";
 @import "card";
 @import "createPost";
 @import "sidebar";

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -1,0 +1,8 @@
+.post-list {
+  .empty-list-msg {
+    height: 200px;
+    text-align: center;
+    line-height: 200px;
+    color: $font-grey;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #127 

#### What's this PR do?

This implements a little 'hey there's nothing here' placeholder if a `PostList` is handed an empty array (i.e. the channel is empty, the frontpage is empty, etc).

#### How should this be manually tested?

Create a fresh empty channel, or visit an existing channel which lacks any posts. you should see this:

![bbbbbb](https://user-images.githubusercontent.com/6207644/29944110-25c5d346-8e6a-11e7-95ab-c484f5b5a383.png)

On a 'populated' channel you should see the normal display of posts.