### PR TITLE
Hide cancel button for post reply, and also use preventDefault

### DIFF
--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -53,7 +53,11 @@ const commentForm = (onSubmit, text, onUpdate, cancelReply) =>
         />
       </div>
       <button type="submit">Submit</button>
-      <a href="#" onClick={cancelReply} className="cancel-button">
+      <a
+        href="#"
+        onClick={R.compose(cancelReply, e => e.preventDefault())}
+        className="cancel-button"
+      >
         Cancel
       </a>
     </form>

--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -17,7 +17,7 @@ type CreateCommentFormProps = {
   initialValue: CommentForm,
   formKey: string,
   beginReply: (initialValue: Object, e: ?Object) => void,
-  onSubmit: (p: string, t: string, c: string, p: Post) => string,
+  onSubmit: (p: string, t: string, c: string, p: Post) => () => void,
   onUpdate: (e: Object) => void,
   cancelReply: () => void,
   formDataLens: (s: string) => Object
@@ -39,7 +39,13 @@ const getPostReplyInitialValue = (parent: Post) => ({
   text:    ""
 })
 
-const commentForm = (onSubmit, text, onUpdate, cancelReply) =>
+const commentForm = (
+  onSubmit: () => void,
+  text: string,
+  onUpdate: (e: any) => void,
+  cancelReply: () => void,
+  isComment: boolean
+) =>
   <div className="reply-form">
     <form onSubmit={onSubmit} className="form">
       <div className="form-item">
@@ -53,13 +59,15 @@ const commentForm = (onSubmit, text, onUpdate, cancelReply) =>
         />
       </div>
       <button type="submit">Submit</button>
-      <a
-        href="#"
-        onClick={R.compose(cancelReply, e => e.preventDefault())}
-        className="cancel-button"
-      >
-        Cancel
-      </a>
+      {isComment
+        ? <a
+          href="#"
+          onClick={R.compose(cancelReply, e => e.preventDefault())}
+          className="cancel-button"
+        >
+            Cancel
+        </a>
+        : null}
     </form>
   </div>
 
@@ -147,7 +155,8 @@ export const ReplyToCommentForm = connect(
         onSubmit(post_id, text, comment_id, post),
         text,
         onUpdate,
-        cancelReply
+        cancelReply,
+        true
       )
     }
 
@@ -210,7 +219,8 @@ export const ReplyToPostForm = connect(mapStateToProps, mapDispatchToProps)(
         onSubmit(post_id, text, comment_id, post),
         text,
         onUpdate,
-        cancelReply
+        cancelReply,
+        false
       )
     }
   }

--- a/static/js/components/CreateCommentForm_test.js
+++ b/static/js/components/CreateCommentForm_test.js
@@ -72,8 +72,8 @@ describe("CreateCommentForm", () => {
       }
     })
 
-    it("should not render a reply button", () => {
-      assert.notInclude(wrapper.find("a").text(), "Reply")
+    it("should not render a reply or cancel button", () => {
+      assert.lengthOf(wrapper.find("a"), 0)
     })
 
     it("should begin form editing on load", async () => {
@@ -100,27 +100,6 @@ describe("CreateCommentForm", () => {
         value:  expectedKeys,
         errors: {}
       })
-    })
-
-    it("should cancel and delete unsaved input the form", async () => {
-      await helper.listenForActions([forms.FORM_UPDATE], () => {
-        wrapper.find("textarea[name='text']").simulate("change", {
-          target: {
-            name:  "text",
-            value: expectedKeys.text
-          }
-        })
-      })
-      await helper.listenForActions(
-        [forms.FORM_BEGIN_EDIT, forms.FORM_END_EDIT],
-        () => {
-          wrapper.find(".cancel-button").simulate("click")
-        }
-      )
-      assert.deepEqual(
-        helper.store.getState().forms[replyToPostKey(post)],
-        emptyFormState
-      )
     })
 
     it("should submit the form", async () => {
@@ -207,7 +186,7 @@ describe("CreateCommentForm", () => {
       })
       const state = await helper.listenForActions([forms.FORM_END_EDIT], () => {
         wrapper.find(".cancel-button").simulate("click", {
-          preventDefault: mockPreventDefault,
+          preventDefault: mockPreventDefault
         })
       })
       assert.deepEqual(state.forms, {})

--- a/static/js/components/CreateCommentForm_test.js
+++ b/static/js/components/CreateCommentForm_test.js
@@ -4,6 +4,7 @@ import R from "ramda"
 import { Provider } from "react-redux"
 import { assert } from "chai"
 import { mount } from "enzyme"
+import sinon from "sinon"
 
 import {
   ReplyToCommentForm,
@@ -200,14 +201,18 @@ describe("CreateCommentForm", () => {
     })
 
     it("should cancel and hide the form", async () => {
+      let mockPreventDefault = helper.sandbox.stub()
       await helper.listenForActions([forms.FORM_BEGIN_EDIT], () => {
         wrapper.find("a").simulate("click")
       })
       const state = await helper.listenForActions([forms.FORM_END_EDIT], () => {
-        wrapper.find(".cancel-button").simulate("click")
+        wrapper.find(".cancel-button").simulate("click", {
+          preventDefault: mockPreventDefault,
+        })
       })
       assert.deepEqual(state.forms, {})
       assert.isNotOk(wrapper.find("textarea[name='text']").exists())
+      sinon.assert.calledWith(mockPreventDefault)
     })
 
     it("should submit the form", async () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #134 

#### What's this PR do?
Hides the cancel button for post reply and uses preventDefault so that clicking the link won't result in the `#` showing up in the URL

#### How should this be manually tested?
Go to the post detail page. You shouldn't see a cancel link for the post reply, just the submit button. Go to a comment and click 'Reply'. You should see 'Submit' and 'Cancel' buttons. Click the 'Cancel' button and it should close the box. Verify that the URL does not have a `#` at the end.
