### PR TITLE
move reply button

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -9,6 +9,11 @@ import Card from "./Card"
 import { ReplyToCommentForm } from "./CreateCommentForm"
 import CommentVoteForm from "./CommentVoteForm"
 
+import {
+  replyToCommentKey,
+  getCommentReplyInitialValue
+} from "../components/CreateCommentForm"
+
 import type { Comment } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
 import type { CommentVoteFunc } from "./CommentVoteForm"
@@ -18,12 +23,13 @@ const renderTopLevelComment = R.curry(
     forms: FormsState,
     upvote: CommentVoteFunc,
     downvote: CommentVoteFunc,
+    beginReply,
     comment: Comment,
     idx: number
   ) =>
     <Card key={idx}>
       <div className="top-level-comment">
-        {renderComment(forms, upvote, downvote, 0, comment)}
+        {renderComment(forms, upvote, downvote, beginReply, 0, comment)}
       </div>
     </Card>
 )
@@ -33,49 +39,77 @@ const renderComment = R.curry(
     forms: FormsState,
     upvote: CommentVoteFunc,
     downvote: CommentVoteFunc,
+    beginReply: (fk: string, iv: Object, e: ?Object) => void,
     depth: number,
     comment: Comment
-  ) =>
-    <div className="comment" key={comment.id}>
-      <div className="author-info">
-        <a className="author-name">
-          {comment.author_id}
-        </a>
+  ) => {
+    const formKey = replyToCommentKey(comment)
+    const initialValue = getCommentReplyInitialValue(comment)
+
+    return (
+      <div className="comment" key={comment.id}>
+        <div className="author-info">
+          <a className="author-name">
+            {comment.author_id}
+          </a>
+          <div>
+            {moment(comment.created).fromNow()}
+          </div>
+        </div>
+        <div className="row">
+          <ReactMarkdown
+            disallowedTypes={["Image"]}
+            source={comment.text}
+            escapeHtml
+          />
+        </div>
+        <div className="row vote-reply">
+          <CommentVoteForm
+            comment={comment}
+            upvote={upvote}
+            downvote={downvote}
+          />
+          <div
+            className="reply-button"
+            onClick={e => {
+              beginReply(formKey, initialValue, e)
+            }}
+          >
+            <a href="#">Reply</a>
+          </div>
+        </div>
         <div>
-          {moment(comment.created).fromNow()}
+          <ReplyToCommentForm forms={forms} comment={comment} />
+        </div>
+        <div className="replies">
+          {R.map(
+            renderComment(forms, upvote, downvote, beginReply, depth + 1),
+            comment.replies
+          )}
         </div>
       </div>
-      <div className="row">
-        <ReactMarkdown
-          disallowedTypes={["Image"]}
-          source={comment.text}
-          escapeHtml
-        />
-      </div>
-      <CommentVoteForm comment={comment} upvote={upvote} downvote={downvote} />
-      <div>
-        <ReplyToCommentForm forms={forms} comment={comment} />
-      </div>
-      <div className="replies">
-        {R.map(
-          renderComment(forms, upvote, downvote, depth + 1),
-          comment.replies
-        )}
-      </div>
-    </div>
+    )
+  }
 )
 
 type CommentTreeProps = {
   comments: Array<Comment>,
   forms: FormsState,
   upvote: CommentVoteFunc,
-  downvote: CommentVoteFunc
+  downvote: CommentVoteFunc,
+  beginReply: (fk: string, iv: Object, e: ?Object) => void
 }
 
-const CommentTree = ({ comments, forms, upvote, downvote }: CommentTreeProps) =>
+const CommentTree = ({
+  comments,
+  forms,
+  upvote,
+  downvote,
+  beginReply
+  }: CommentTreeProps) =>
   <div className="comments">
     {R.addIndex(R.map)(
-      renderTopLevelComment(forms, upvote, downvote),
+      renderTopLevelComment(forms, upvote, downvote, beginReply),
       comments
     )}
   </div>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -12,9 +12,10 @@ import CommentTree from "./CommentTree"
 
 import { makeCommentTree } from "../factories/comments"
 import { makePost } from "../factories/posts"
+import { replyToCommentKey } from "../components/CreateCommentForm"
 
 describe("CommentTree", () => {
-  let comments, post, sandbox, upvoteStub, downvoteStub
+  let comments, post, sandbox, upvoteStub, downvoteStub, beginReplyStub
 
   beforeEach(() => {
     post = makePost()
@@ -22,6 +23,7 @@ describe("CommentTree", () => {
     sandbox = sinon.sandbox.create()
     upvoteStub = sandbox.stub()
     downvoteStub = sandbox.stub()
+    beginReplyStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -35,6 +37,9 @@ describe("CommentTree", () => {
         forms={{}}
         upvote={upvoteStub}
         downvote={downvoteStub}
+        beginReply={R.curry((formKey, initialValue, e) => {
+          beginReplyStub(formKey, initialValue, e)
+        })}
         {...props}
       />
     )
@@ -74,5 +79,12 @@ describe("CommentTree", () => {
       "comment"
     )
     assert.ok(firstComment.find(".replies > .comment").at(0))
+  })
+
+  it('should include a "reply" button', () => {
+    let wrapper = renderCommentTree()
+    wrapper.find(".reply-button").at(0).simulate("click")
+    assert.ok(beginReplyStub.called)
+    assert.ok(beginReplyStub.calledWith(replyToCommentKey(comments[0])))
   })
 })

--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -28,7 +28,7 @@ export const replyToCommentKey = (comment: Comment) =>
 
 export const replyToPostKey = (post: Post) => `post:${post.id}:comment:new`
 
-const getCommentReplyInitialValue = (parent: Comment) => ({
+export const getCommentReplyInitialValue = (parent: Comment) => ({
   post_id:    parent.post_id,
   comment_id: parent.id,
   text:       ""
@@ -93,6 +93,18 @@ const cancelReply = R.curry((dispatch, formKey) => () =>
   dispatch(actions.forms.formEndEdit({ formKey }))
 )
 
+export const beginReply = R.curry((dispatch, formKey, initialValue, e) => {
+  if (e) {
+    e.preventDefault()
+  }
+  dispatch(
+    actions.forms.formBeginEdit({
+      formKey,
+      value: R.clone(initialValue)
+    })
+  )
+})
+
 const mapDispatchToProps = (dispatch, ownProps) => {
   const formKey = getFormKeyFromOwnProps(ownProps)
 
@@ -107,18 +119,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       )
     },
     cancelReply: cancelReply(dispatch, formKey),
-    beginReply:  R.curry((initialValue, e) => {
-      if (e) {
-        e.preventDefault()
-      }
-      dispatch(
-        actions.forms.formBeginEdit({
-          formKey,
-          value: R.clone(initialValue)
-        })
-      )
-    }),
-    onSubmit: R.curry((postID, text, commentID, post, e) => {
+    beginReply:  beginReply(dispatch, formKey),
+    onSubmit:    R.curry((postID, text, commentID, post, e) => {
       e.preventDefault()
       dispatch(actions.comments.post(postID, text, commentID)).then(() => {
         dispatch(
@@ -141,10 +143,8 @@ export const ReplyToCommentForm = connect(
   ({
     forms,
     formKey,
-    initialValue,
     post,
     onSubmit,
-    beginReply,
     onUpdate,
     cancelReply
     }: CreateCommentFormProps) => {
@@ -159,14 +159,7 @@ export const ReplyToCommentForm = connect(
         true
       )
     }
-
-    return (
-      <div className="reply-button">
-        <a href="#" onClick={beginReply(initialValue)}>
-          Reply
-        </a>
-      </div>
-    )
+    return null
   }
 )
 

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -17,6 +17,7 @@ import { toggleUpvote } from "../util/api_actions"
 import { getChannelName, getPostID } from "../lib/util"
 import { anyError } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
+import { beginReply } from "../components/CreateCommentForm"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
@@ -112,6 +113,7 @@ class PostPage extends React.Component {
           forms={forms}
           upvote={this.upvote}
           downvote={this.downvote}
+          beginReply={beginReply(dispatch)}
         />
       </div>
     )

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -1,14 +1,20 @@
 .comments {
   .top-level-comment {
-    padding: 10px 15px 10px 23px;
+    padding: 0 15px 0 23px;
   }
 
   .comment {
-    margin: 5px 0;
+    margin: 10px 0;
 
     .row {
       display: flex;
       flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+
+      &.vote-reply {
+        width: 110px;
+      }
 
       p {
         margin: 0 0 15px 0;
@@ -52,13 +58,12 @@
 
   .reply-button {
     font-size: 0.8em;
-    padding: 10px 0;
   }
 }
 
 .reply-form {
   width: 100%;
-  padding: 10px 0;
+  padding-top: 10px;
 
   .form-item {
     margin: 0 0 12px 0;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -1,5 +1,5 @@
 .post-card {
-  padding: 22px 22px 0 22px;
+  padding: 6px 22px 0 22px;
 }
 
 .post-summary {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #125 

#### What's this PR do?

This makes the changes necessary to move the 'Reply' button to be next to the voting buttons for comments.

#### How should this be manually tested?

Replying to comments, posts, etc should work as normal.