### PR TITLE
Use channelName parsed via react-router

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
 
-import { newPostURL, getChannelNameFromPathname } from "../lib/url"
+import { newPostURL } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
@@ -17,14 +17,12 @@ const submitPostButton = channelName =>
   </Link>
 
 type NavigationProps = {
-  pathname: string,
+  channelName?: string,
   subscribedChannels: Array<Channel>
 }
 
 const Navigation = (props: NavigationProps) => {
-  const { subscribedChannels, pathname } = props
-
-  const channelName = getChannelNameFromPathname(pathname)
+  const { subscribedChannels, channelName } = props
 
   return (
     <div className="navigation">

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -24,7 +24,7 @@ describe("Navigation", () => {
     it("should show create post link if channelName is in URL", () => {
       let wrapper = renderComponent({
         ...defaultProps,
-        pathname: "/channel/foobar"
+        channelName: "foobar"
       })
       let link = wrapper.find(Link)
       assert.equal(link.props().to, newPostURL("foobar"))

--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -24,7 +24,8 @@ class Drawer extends React.Component {
     location: Location,
     dispatch: Dispatch,
     showDrawer: boolean,
-    subscribedChannels: Array<Channel>
+    subscribedChannels: Array<Channel>,
+    channelName?: string
   }
 
   componentDidMount() {
@@ -54,7 +55,7 @@ class Drawer extends React.Component {
   }
 
   render() {
-    const { subscribedChannels, location: { pathname } } = this.props
+    const { subscribedChannels, channelName } = this.props
 
     return (
       <aside
@@ -70,7 +71,7 @@ class Drawer extends React.Component {
           <nav className="mdc-temporary-drawer__content mdc-list">
             <Navigation
               subscribedChannels={subscribedChannels}
-              pathname={pathname}
+              channelName={channelName}
             />
           </nav>
         </nav>

--- a/static/js/hoc/withNavSidebar.js
+++ b/static/js/hoc/withNavSidebar.js
@@ -7,14 +7,14 @@ import Navigation from "../components/Navigation"
 const withNavSidebar = (WrappedComponent: Class<React.Component<*, *, *>>) => {
   class WithNavSidebar extends React.Component {
     render() {
-      const { subscribedChannels, location: { pathname } } = this.props
+      const { subscribedChannels, channelName } = this.props
 
       return (
         <div className="content">
           <Sidebar>
             <Navigation
               subscribedChannels={subscribedChannels}
-              pathname={pathname}
+              channelName={channelName}
             />
           </Sidebar>
           <div className="main-content">

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -9,10 +9,3 @@ export const postDetailURL = (channelName: string, postID: string) =>
 export const newPostURL = (channelName: string) => `/create_post/${channelName}`
 
 export const frontPageURL = () => "/"
-
-// pull the channel name out of location.pathname
-export const getChannelNameFromPathname = R.compose(
-  R.defaultTo(null),
-  R.view(R.lensIndex(1)),
-  R.match(/^\/channel\/([a-z]+)\/?/)
-)

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -1,6 +1,4 @@
 // @flow
-import R from "ramda"
-
 export const channelURL = (channelName: string) => `/channel/${channelName}`
 
 export const postDetailURL = (channelName: string, postID: string) =>

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -1,13 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import {
-  channelURL,
-  frontPageURL,
-  newPostURL,
-  postDetailURL,
-  getChannelNameFromPathname
-} from "./url"
+import { channelURL, frontPageURL, newPostURL, postDetailURL } from "./url"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {
@@ -34,22 +28,6 @@ describe("url helper functions", () => {
   describe("frontPageURL", () => {
     it("should return a url for the front page", () => {
       assert.equal(frontPageURL(), "/")
-    })
-  })
-
-  describe("getChannelNameFromPathname", () => {
-    it("should return a channel", () => {
-      [
-        "/channel/foobar/",
-        "/channel/foobar",
-        "/channel/foobar/baz/"
-      ].forEach(channel => {
-        assert.equal("foobar", getChannelNameFromPathname(channel))
-      })
-    })
-
-    it("should return null otherwise", () => {
-      assert.equal(null, getChannelNameFromPathname(""))
     })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #142

#### What's this PR do?
Uses the react-router URL parsing to get the channel name. The regex in the function didn't account for underscores which caused the link to be incomplete

#### How should this be manually tested?
Create a channel with an underscore in the name. Go to the channel page and click 'Submit a new post'. Verify that creating a new post works properly
