### PR TITLE
fix mobile post submit

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
 
-import { newPostURL } from "../lib/url"
+import { newPostURL, getChannelNameFromPathname } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
@@ -17,12 +17,14 @@ const submitPostButton = channelName =>
   </Link>
 
 type NavigationProps = {
-  channelName?: string,
+  pathname: string,
   subscribedChannels: Array<Channel>
 }
 
 const Navigation = (props: NavigationProps) => {
-  const { subscribedChannels, channelName } = props
+  const { subscribedChannels, pathname } = props
+
+  const channelName = getChannelNameFromPathname(pathname)
 
   return (
     <div className="navigation">

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -24,7 +24,7 @@ describe("Navigation", () => {
     it("should show create post link if channelName is in URL", () => {
       let wrapper = renderComponent({
         ...defaultProps,
-        channelName: "foobar"
+        pathname: "/channel/foobar"
       })
       let link = wrapper.find(Link)
       assert.equal(link.props().to, newPostURL("foobar"))

--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -24,8 +24,7 @@ class Drawer extends React.Component {
     location: Location,
     dispatch: Dispatch,
     showDrawer: boolean,
-    subscribedChannels: Array<Channel>,
-    channelName?: string
+    subscribedChannels: Array<Channel>
   }
 
   componentDidMount() {
@@ -55,7 +54,7 @@ class Drawer extends React.Component {
   }
 
   render() {
-    const { subscribedChannels, channelName } = this.props
+    const { subscribedChannels, location: { pathname } } = this.props
 
     return (
       <aside
@@ -66,7 +65,7 @@ class Drawer extends React.Component {
           <nav className="mdc-temporary-drawer__content mdc-list">
             <Navigation
               subscribedChannels={subscribedChannels}
-              channelName={channelName}
+              pathname={pathname}
             />
           </nav>
         </nav>

--- a/static/js/hoc/withNavSidebar.js
+++ b/static/js/hoc/withNavSidebar.js
@@ -7,14 +7,14 @@ import Navigation from "../components/Navigation"
 const withNavSidebar = (WrappedComponent: Class<React.Component<*, *, *>>) => {
   class WithNavSidebar extends React.Component {
     render() {
-      const { subscribedChannels, channelName } = this.props
+      const { subscribedChannels, location: { pathname } } = this.props
 
       return (
         <div className="content">
           <Sidebar>
             <Navigation
               subscribedChannels={subscribedChannels}
-              channelName={channelName}
+              pathname={pathname}
             />
           </Sidebar>
           <div className="main-content">

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -1,4 +1,6 @@
 // @flow
+import R from "ramda"
+
 export const channelURL = (channelName: string) => `/channel/${channelName}`
 
 export const postDetailURL = (channelName: string, postID: string) =>
@@ -7,3 +9,12 @@ export const postDetailURL = (channelName: string, postID: string) =>
 export const newPostURL = (channelName: string) => `/create_post/${channelName}`
 
 export const frontPageURL = () => "/"
+
+// pull the channel name out of location.pathname
+// see here for why this hackish approach was necessary:
+// https://github.com/mitodl/open-discussions/pull/118#discussion_r135284591
+export const getChannelNameFromPathname = R.compose(
+  R.defaultTo(null),
+  R.view(R.lensIndex(1)),
+  R.match(/^\/channel\/([^/]+)\/?/)
+)

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -1,7 +1,13 @@
 // @flow
 import { assert } from "chai"
 
-import { channelURL, frontPageURL, newPostURL, postDetailURL } from "./url"
+import {
+  channelURL,
+  frontPageURL,
+  newPostURL,
+  postDetailURL,
+  getChannelNameFromPathname
+} from "./url"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {
@@ -28,6 +34,26 @@ describe("url helper functions", () => {
   describe("frontPageURL", () => {
     it("should return a url for the front page", () => {
       assert.equal(frontPageURL(), "/")
+    })
+  })
+
+  describe("getChannelNameFromPathname", () => {
+    it("should return a channel", () => {
+      [
+        ["/channel/foobar/", "foobar"],
+        ["/channel/foobar", "foobar"],
+        ["/channel/foobar/baz/", "foobar"],
+        ["/channel/foobar_baz/boz", "foobar_baz"],
+        ["/channel/foobarbaz9/boz", "foobarbaz9"],
+        ["/channel/Foobarbaz9/boz", "Foobarbaz9"],
+        ["/channel/fOObar_Baz9/boz", "fOObar_Baz9"]
+      ].forEach(([url, expectation]) => {
+        assert.equal(expectation, getChannelNameFromPathname(url))
+      })
+    })
+
+    it("should return null otherwise", () => {
+      assert.equal(null, getChannelNameFromPathname(""))
     })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?

#147 

#### What's this PR do?

see the issue, this adds the 'create post' button back on mobile by reverting an earlier change which removed it.

#### How should this be manually tested?

If you open the application in chrome's mobile device mode you should be able to see and use a 'create post' button in the mobile side nav menu.