### PR TITLE
Add user on reddit when user is added via REST API

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -33,6 +33,23 @@ CHANNEL_SETTINGS = (
 User = get_user_model()
 
 
+def get_or_create_user(username):
+    """
+    Get or create a user on reddit using our refresh_token plugin
+
+    Args:
+        username (str): The reddit username
+
+    Returns:
+        str: A refresh token for use with praw to authenticate
+    """
+    refresh_token_url = urljoin(settings.OPEN_DISCUSSIONS_REDDIT_URL, '/api/v1/generate_refresh_token')
+
+    session = _get_session()
+    resp = session.get(refresh_token_url, params={'username': username}).json()
+    return resp['refresh_token']
+
+
 def _get_user_credentials(user):
     """
     Get credentials for authenticated user
@@ -43,11 +60,7 @@ def _get_user_credentials(user):
     Returns:
         dict: set of configuration credentials for the user
     """
-    refresh_token_url = urljoin(settings.OPEN_DISCUSSIONS_REDDIT_URL, '/api/v1/generate_refresh_token')
-
-    session = _get_session()
-    resp = session.get(refresh_token_url, params={'username': user.username}).json()
-    refresh_token = resp['refresh_token']
+    refresh_token = get_or_create_user(user.username)
 
     return {
         'client_id': settings.OPEN_DISCUSSIONS_REDDIT_CLIENT_ID,

--- a/channels/api.py
+++ b/channels/api.py
@@ -43,6 +43,10 @@ def get_or_create_user(username):
     Returns:
         str: A refresh token for use with praw to authenticate
     """
+    # This is using our custom refresh_token plugin which is installed against
+    # a modified instance of reddit. It registers a new user with a random password if
+    # one does not exist, then obtains an OAuth refresh token for that user. This is then used
+    # with praw to authenticate.
     refresh_token_url = urljoin(settings.OPEN_DISCUSSIONS_REDDIT_URL, '/api/v1/generate_refresh_token')
 
     session = _get_session()

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -7,6 +7,7 @@ from django.db import transaction
 import ulid
 from rest_framework import serializers
 
+from channels.api import get_or_create_user
 from profiles.models import Profile
 
 
@@ -31,6 +32,8 @@ class UserSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             user = get_user_model().objects.create(**validated_data)
             Profile.objects.create(user=user, **profile_data)
+
+        get_or_create_user(user.username)
         return user
 
     def update(self, instance, validated_data):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -27,7 +27,7 @@ def test_serialize_user(user):
     }
 
 
-def test_serialize_create_user(db):
+def test_serialize_create_user(db, mocker):
     """
     Test creating a user
     """
@@ -38,9 +38,11 @@ def test_serialize_create_user(db):
         'image_medium': 'image_medium',
     }
 
+    get_or_create_user_stub = mocker.patch('profiles.serializers.get_or_create_user')
     user = UserSerializer().create({
         'profile': profile
     })
+    get_or_create_user_stub.assert_called_once_with(user.username)
 
     assert UserSerializer(user).data == {
         'id': user.id,

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -35,7 +35,7 @@ def test_list_users(client, admin_user, staff_jwt_header):
     ]
 
 
-def test_create_user(client, staff_jwt_header):
+def test_create_user(client, staff_jwt_header, mocker):
     """
     Create a user and assert the response
     """
@@ -48,9 +48,11 @@ def test_create_user(client, staff_jwt_header):
             'image_medium': 'image_medium',
         }
     }
+    get_or_create_user_stub = mocker.patch('profiles.serializers.get_or_create_user')
     resp = client.post(url, data=json.dumps(payload), **API_KWARGS, **staff_jwt_header)
     assert resp.status_code == 201
     assert resp.json()['profile'] == payload['profile']
+    get_or_create_user_stub.assert_called_once_with(resp.json()['username'])
 
 
 def test_get_user(client, user, staff_jwt_header):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #155

#### What's this PR do?
Adds the user using the refresh token plugin when the user is created using the `/api/v0/users/` REST API

#### How should this be manually tested?
Create a user using `/api/v0/users/`, then go to reddit and verify that the user exists there (go to `/u/username`
