### PR TITLE
Added JWT session renewal

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -2,9 +2,12 @@
 open_discussions views
 """
 import json
+from datetime import timedelta
 
+import jwt
 from django.conf import settings
 from django.shortcuts import render
+from rest_framework_jwt.settings import api_settings
 
 from open_discussions.templatetags.render_bundle import public_path
 
@@ -13,10 +16,28 @@ def index(request):
     """
     The index view.
     """
+    auth = request.COOKIES.get(api_settings.JWT_AUTH_COOKIE)
+
+    try:
+        # verify with JWT instead of JWT_DECODE_HANDLER because we want to decode expired tokens
+        payload = jwt.decode(
+            auth,
+            api_settings.JWT_SECRET_KEY,
+            # use a high leeway because we're interested in whether this token was ever valid
+            leeway=timedelta(days=365),
+            algorithms=[api_settings.JWT_ALGORITHM]
+        )
+        auth_url = payload.get("auth_url", None)
+        session_url = payload.get("session_url", None)
+    except jwt.InvalidTokenError:
+        auth_url = None
+        session_url = None
 
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "public_path": public_path(request),
+        "auth_url": auth_url,
+        "session_url": session_url,
     }
 
     return render(request, "index.html", context={

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -30,4 +30,6 @@ class ViewsTest(TestCase):
         assert js_settings == {
             'gaTrackingID': 'fake',
             'public_path': '/static/bundles/',
+            'auth_url': None,
+            'session_url': None,
         }

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -4,6 +4,8 @@ declare var SETTINGS: {
   gaTrackingID: string,
   reactGaDebug: boolean,
   public_path: string,
+  auth_url: string|null,
+  session_url: string|null,
   FEATURES: {
     [key: string]: boolean,
   },

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -3,8 +3,9 @@
 // For mocking purposes we need to use "fetch" defined as a global instead of importing as a local.
 import R from "ramda"
 import "isomorphic-fetch"
-import { fetchJSONWithCSRF } from "redux-hammock/django_csrf_fetch"
 import { PATCH, POST } from "redux-hammock/constants"
+
+import { fetchWithAuthFailure } from "./auth"
 
 import type {
   Channel,
@@ -15,19 +16,19 @@ import type {
 import type { CommentResponse } from "../reducers/comments"
 
 export function getFrontpage(): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/frontpage/`)
+  return fetchWithAuthFailure(`/api/v0/frontpage/`)
 }
 
 export function getChannel(channelName: string): Promise<Channel> {
-  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/`)
+  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/`)
 }
 
 export function getChannels(): Promise<Array<Channel>> {
-  return fetchJSONWithCSRF("/api/v0/channels/")
+  return fetchWithAuthFailure("/api/v0/channels/")
 }
 
 export function createChannel(channel: Channel): Promise<Channel> {
-  return fetchJSONWithCSRF(`/api/v0/channels/`, {
+  return fetchWithAuthFailure(`/api/v0/channels/`, {
     method: POST,
     body:   JSON.stringify(
       R.pickAll(
@@ -39,7 +40,7 @@ export function createChannel(channel: Channel): Promise<Channel> {
 }
 
 export function getPostsForChannel(channelName: string): Promise<Array<Post>> {
-  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/posts/`)
+  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/posts/`)
 }
 
 export function createPost(
@@ -47,7 +48,7 @@ export function createPost(
   payload: CreatePostPayload
 ): Promise<Post> {
   const { text, url, title } = payload
-  return fetchJSONWithCSRF(`/api/v0/channels/${channelName}/posts/`, {
+  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/posts/`, {
     method: "POST",
     body:   JSON.stringify({
       url:   url,
@@ -58,11 +59,11 @@ export function createPost(
 }
 
 export function getPost(postId: string): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/`)
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`)
 }
 
 export async function getComments(postID: string): Promise<CommentResponse> {
-  let response = await fetchJSONWithCSRF(`/api/v0/posts/${postID}/comments/`)
+  let response = await fetchWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
   return { postID, data: response }
 }
 
@@ -76,14 +77,14 @@ export function createComment(
       ? { text: comment }
       : { text: comment, comment_id: commentId }
 
-  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/comments/`, {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/comments/`, {
     method: POST,
     body:   JSON.stringify(body)
   })
 }
 
 export function updateUpvote(postId: string, upvoted: boolean): Promise<Post> {
-  return fetchJSONWithCSRF(`/api/v0/posts/${postId}/`, {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
     method: "PATCH",
     body:   JSON.stringify({ upvoted })
   })
@@ -93,7 +94,7 @@ export function updateComment(
   commentId: string,
   commentPayload: Object
 ): Promise<Comment> {
-  return fetchJSONWithCSRF(`/api/v0/comments/${commentId}/`, {
+  return fetchWithAuthFailure(`/api/v0/comments/${commentId}/`, {
     method: PATCH,
     body:   JSON.stringify(commentPayload)
   })

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -1,0 +1,78 @@
+/* global SETTINGS: false */
+import { assert } from "chai"
+import sinon from "sinon"
+import fetchMock from "fetch-mock/src/server"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import * as auth from "./auth"
+
+describe("auth", function() {
+  this.timeout(5000) // eslint-disable-line no-invalid-this
+
+  let sandbox, fetchStub
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    fetchStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+
+    SETTINGS.session_url = "/session/url"
+    SETTINGS.auth_url = "/auth/url"
+  })
+  afterEach(function() {
+    sandbox.restore()
+    fetchMock.restore()
+    for (let cookie of document.cookie.split(";")) {
+      let key = cookie.split("=")[0].trim()
+      document.cookie = `${key}=`
+    }
+  })
+
+  it("does not renew if request returned ok", async () => {
+    fetchStub.returns(Promise.resolve())
+
+    await assert.isFulfilled(auth.fetchWithAuthFailure("/url"))
+
+    assert.ok(fetchStub.calledWith("/url"))
+    assert.equal(window.location.pathname, "/") // no redirect happened
+  })
+
+  it("renews and retries if the request failed", async () => {
+    fetchStub.onFirstCall().returns(Promise.reject()) // original api call
+    fetchStub.onSecondCall().returns(Promise.resolve()) // original api call again
+    fetchMock.mock(SETTINGS.session_url, {
+      has_token: true
+    })
+
+    await assert.isFulfilled(auth.fetchWithAuthFailure("/url"))
+
+    assert.ok(fetchMock.called)
+    assert.ok(fetchStub.calledTwice)
+    assert.ok(fetchStub.firstCall.calledWith("/url"))
+    assert.ok(fetchStub.secondCall.calledWith("/url"))
+    assert.equal(window.location.pathname, "/") // no redirect happened
+  })
+
+  it("redirects and rejects if no token", async () => {
+    fetchStub.onFirstCall().returns(Promise.reject()) // original api call
+    fetchMock.mock(SETTINGS.session_url, {
+      has_token: false
+    })
+
+    await assert.isRejected(auth.fetchWithAuthFailure("/url"))
+
+    assert.ok(fetchMock.called)
+    assert.ok(fetchStub.calledOnce)
+    assert.ok(fetchStub.calledWith("/url"))
+    assert.equal(window.location.pathname, SETTINGS.auth_url)
+  })
+
+  it("renews and redirect to auth_url if renew fails", async () => {
+    fetchStub.returns(Promise.reject()) // original api call
+    fetchMock.mock(SETTINGS.session_url, 401)
+
+    await assert.isRejected(auth.fetchWithAuthFailure("/url"))
+
+    assert.ok(fetchMock.called)
+    assert.ok(fetchStub.calledOnce)
+    assert.ok(fetchStub.calledWith("/url"))
+    assert.equal(window.location.pathname, SETTINGS.auth_url)
+  })
+})


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #153 
Fixes mitodl/micromasters#3479

#### What's this PR do?
Adds code to renew JWT session and redirect to MM if logged out

#### How should this be manually tested?
Follow configuration steps in mitodl/micromasters#3523 and verify in the chrome inspector that when your JWT token expires it queries MM for a new token at `/api/v0/discussion_token` and retries the failed API request(s).

Use this setting in MM  `.env` to lower your JWT lifespan to 30s:

```
OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA=30
```