### PR TITLE
add preventDefault for cancel button on create post page

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react"
+import R from "ramda"
 
 import Card from "../components/Card"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
@@ -13,6 +14,11 @@ type CreatePostFormProps = {
   channel: Channel,
   history: Object
 }
+
+const goBackAndHandleEvent = R.curry((history, e) => {
+  e.preventDefault()
+  history.goBack()
+})
 
 export default class CreatePostForm extends React.Component {
   props: CreatePostFormProps
@@ -92,7 +98,10 @@ export default class CreatePostForm extends React.Component {
               <button className="submit-post" type="submit">
                 Submit Post
               </button>
-              <button className="cancel" onClick={() => history.goBack()}>
+              <button
+                className="cancel"
+                onClick={goBackAndHandleEvent(history)}
+              >
                 Cancel
               </button>
             </div>

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -108,4 +108,12 @@ describe("CreatePostPage", () => {
     wrapper.find(".cancel").simulate("click")
     assert.equal(helper.currentLocation.pathname, "/")
   })
+
+  it("cancel button onClick handler should preventDefault", async () => {
+    const [wrapper] = await renderPage()
+    const event = { preventDefault: helper.sandbox.stub() }
+    const cancelBtn = wrapper.find(".cancel")
+    cancelBtn.props().onClick(event)
+    sinon.assert.called(event.preventDefault)
+  })
 })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #151 

#### What's this PR do?

the cancel button in the create post form didn't have `e.preventDefault()`, so the form was issuing an unintentional POST.

#### How should this be manually tested?

go to the create post page, and click cancel. there shouldn't be any errors in the console, and it should instead just take you back to the subreddit. Also it's probably a good idea to confirm that you can reproduce the error (on `master`) by following the same steps.

note: I had trouble writing a regression test for this in enzyme, I think because of React's event system vs the browser one or something like that. Not sure exactly, but if the reviewer has ideas about strategies for that that would be :100: