### PR TITLE
disable post submit while it is in progress

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -24,12 +24,21 @@ const renderTopLevelComment = R.curry(
     upvote: CommentVoteFunc,
     downvote: CommentVoteFunc,
     beginReply,
+    processing: boolean,
     comment: Comment,
     idx: number
   ) =>
     <Card key={idx}>
       <div className="top-level-comment">
-        {renderComment(forms, upvote, downvote, beginReply, 0, comment)}
+        {renderComment(
+          forms,
+          upvote,
+          downvote,
+          beginReply,
+          processing,
+          0,
+          comment
+        )}
       </div>
     </Card>
 )
@@ -40,6 +49,7 @@ const renderComment = R.curry(
     upvote: CommentVoteFunc,
     downvote: CommentVoteFunc,
     beginReply: (fk: string, iv: Object, e: ?Object) => void,
+    processing: boolean,
     depth: number,
     comment: Comment
   ) => {
@@ -81,11 +91,22 @@ const renderComment = R.curry(
             </div>
           </div>
           <div>
-            <ReplyToCommentForm forms={forms} comment={comment} />
+            <ReplyToCommentForm
+              forms={forms}
+              comment={comment}
+              processing={processing}
+            />
           </div>
           <div className="replies">
             {R.map(
-              renderComment(forms, upvote, downvote, beginReply, depth + 1),
+              renderComment(
+                forms,
+                upvote,
+                downvote,
+                beginReply,
+                processing,
+                depth + 1
+              ),
               comment.replies
             )}
           </div>
@@ -100,7 +121,8 @@ type CommentTreeProps = {
   forms: FormsState,
   upvote: CommentVoteFunc,
   downvote: CommentVoteFunc,
-  beginReply: (fk: string, iv: Object, e: ?Object) => void
+  beginReply: (fk: string, iv: Object, e: ?Object) => void,
+  processing: boolean
 }
 
 const CommentTree = ({
@@ -108,11 +130,12 @@ const CommentTree = ({
   forms,
   upvote,
   downvote,
-  beginReply
+  beginReply,
+  processing
   }: CommentTreeProps) =>
   <div className="comments">
     {R.addIndex(R.map)(
-      renderTopLevelComment(forms, upvote, downvote, beginReply),
+      renderTopLevelComment(forms, upvote, downvote, beginReply, processing),
       comments
     )}
   </div>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -40,6 +40,7 @@ describe("CommentTree", () => {
         beginReply={R.curry((formKey, initialValue, e) => {
           beginReplyStub(formKey, initialValue, e)
         })}
+        processing={false}
         {...props}
       />
     )

--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -20,7 +20,8 @@ type CreateCommentFormProps = {
   onSubmit: (p: string, t: string, c: string, p: Post) => () => void,
   onUpdate: (e: Object) => void,
   cancelReply: () => void,
-  formDataLens: (s: string) => Object
+  formDataLens: (s: string) => Object,
+  processing: boolean
 }
 
 export const replyToCommentKey = (comment: Comment) =>
@@ -39,12 +40,15 @@ const getPostReplyInitialValue = (parent: Post) => ({
   text:    ""
 })
 
+const isEmptyCommentBody = R.compose(R.isEmpty, R.trim, R.defaultTo(""))
+
 const commentForm = (
   onSubmit: () => void,
   text: string,
   onUpdate: (e: any) => void,
   cancelReply: () => void,
-  isComment: boolean
+  isComment: boolean,
+  disabled: boolean
 ) =>
   <div className="reply-form">
     <form onSubmit={onSubmit} className="form">
@@ -58,7 +62,11 @@ const commentForm = (
           onChange={onUpdate}
         />
       </div>
-      <button type="submit" className="blue-button">
+      <button
+        type="submit"
+        className={`blue-button ${disabled ? "disabled" : ""}`}
+        disabled={disabled || isEmptyCommentBody(text)}
+      >
         Submit
       </button>
       {isComment
@@ -148,7 +156,8 @@ export const ReplyToCommentForm = connect(
     post,
     onSubmit,
     onUpdate,
-    cancelReply
+    cancelReply,
+    processing
     }: CreateCommentFormProps) => {
     if (R.has(formKey, forms)) {
       const { post_id, text, comment_id } = R.prop(formKey, forms).value
@@ -158,7 +167,8 @@ export const ReplyToCommentForm = connect(
         text,
         onUpdate,
         cancelReply,
-        true
+        true,
+        processing
       )
     }
     return null
@@ -206,7 +216,8 @@ export const ReplyToPostForm = connect(mapStateToProps, mapDispatchToProps)(
         onSubmit,
         onUpdate,
         cancelReply,
-        formDataLens
+        formDataLens,
+        processing
       } = this.props
       const { post_id, text, comment_id } = getFormData(formDataLens, forms)
 
@@ -215,7 +226,8 @@ export const ReplyToPostForm = connect(mapStateToProps, mapDispatchToProps)(
         text,
         onUpdate,
         cancelReply,
-        false
+        false,
+        processing
       )
     }
   }

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -12,7 +12,8 @@ type CreatePostFormProps = {
   updateIsText: (isText: boolean) => void,
   postForm: ?PostForm,
   channel: Channel,
-  history: Object
+  history: Object,
+  processing: boolean
 }
 
 const goBackAndHandleEvent = R.curry((history, e) => {
@@ -30,7 +31,8 @@ export default class CreatePostForm extends React.Component {
       onUpdate,
       onSubmit,
       updateIsText,
-      history
+      history,
+      processing
     } = this.props
     if (!postForm) {
       return null
@@ -95,12 +97,17 @@ export default class CreatePostForm extends React.Component {
               </span>
             </div>
             <div className="actions row">
-              <button className="submit-post" type="submit">
+              <button
+                className={`submit-post ${processing ? "disabled" : ""}`}
+                type="submit"
+                disabled={processing}
+              >
                 Submit Post
               </button>
               <button
                 className="cancel"
                 onClick={goBackAndHandleEvent(history)}
+                disabled={processing}
               >
                 Cancel
               </button>

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -21,7 +21,8 @@ type CreatePostPageProps = {
   postForm: ?FormValue,
   channel: Channel,
   channels: RestState<Array<Channel>>,
-  history: Object
+  history: Object,
+  processing: boolean
 }
 
 const CREATE_POST_KEY = "post:new"
@@ -90,7 +91,7 @@ class CreatePostPage extends React.Component {
   }
 
   render() {
-    const { channel, postForm, history } = this.props
+    const { channel, postForm, history, processing } = this.props
 
     if (!postForm || R.isNil(channel)) {
       return null
@@ -106,6 +107,7 @@ class CreatePostPage extends React.Component {
             postForm={postForm.value}
             channel={channel}
             history={history}
+            processing={processing}
           />
         </div>
       </div>
@@ -117,11 +119,13 @@ const mapStateToProps = (state, props) => {
   const channelName = getChannelName(props)
   const channels = state.channels
   const channel = channels.data.get(channelName)
+  const processing = state.posts.processing
 
   return {
-    channel:  channel,
-    channels: channels,
-    postForm: getForm(state.forms)
+    postForm: getForm(state.forms),
+    channel,
+    channels,
+    processing
   }
 }
 

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -94,6 +94,16 @@ describe("CreatePostPage", () => {
     })
   }
 
+  it("should disable the submit button when processing", async () => {
+    helper.store.dispatch({
+      type: actions.posts.post.requestType
+    })
+    const [wrapper] = await renderPage()
+    const btnProps = wrapper.find(".submit-post").props()
+    assert.isTrue(btnProps.disabled)
+    assert.equal(btnProps.className, "submit-post disabled")
+  })
+
   it("goes back when cancel is clicked", async () => {
     const [wrapper] = await renderPage()
     assert.equal(

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -31,6 +31,7 @@ type PostPageProps = {
   channel: Channel,
   commentsTree: Array<Comment>,
   forms: FormsState,
+  commentInFlight: boolean,
   // from the router match
   channelName: string,
   postID: string
@@ -87,7 +88,14 @@ class PostPage extends React.Component {
   }
 
   render() {
-    const { dispatch, post, channel, commentsTree, forms } = this.props
+    const {
+      dispatch,
+      post,
+      channel,
+      commentsTree,
+      forms,
+      commentInFlight
+    } = this.props
     if (!channel || !post || !commentsTree) {
       return null
     }
@@ -102,7 +110,11 @@ class PostPage extends React.Component {
               toggleUpvote={toggleUpvote(dispatch)}
               expanded
             />
-            <ReplyToPostForm forms={forms} post={post} />
+            <ReplyToPostForm
+              forms={forms}
+              post={post}
+              processing={commentInFlight}
+            />
           </div>
         </Card>
         <div className="comments-count">
@@ -114,6 +126,7 @@ class PostPage extends React.Component {
           upvote={this.upvote}
           downvote={this.downvote}
           beginReply={beginReply(dispatch)}
+          processing={commentInFlight}
         />
       </div>
     )
@@ -136,7 +149,8 @@ const mapStateToProps = (state, ownProps) => {
     commentsTree,
     loaded:             R.none(R.isNil, [post, channel, commentsTree]),
     errored:            anyError([posts, channels, comments]),
-    subscribedChannels: getSubscribedChannels(state)
+    subscribedChannels: getSubscribedChannels(state),
+    commentInFlight:    comments.processing
   }
 }
 

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -77,7 +77,7 @@ input[type=submit], button[type=submit], button.cancel {
   }
 }
 
-button.cancel {
+button.cancel, button.disabled {
   background: #cecece;
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #150 
closes #175

#### What's this PR do?

this disables the 'submit' button on the create post form when the request is in-flight, and it also adds a `.disabled` class to the button so we can grey it out a little bit.

#### How should this be manually tested?

If you go to the create post form you should be able to create a post as normal. when you click the button it should get greyed out, and you should not be able to click multiple times and create duplicate posts.