### PR TITLE
fix scroll position on route change

### DIFF
--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -1,14 +1,19 @@
+// @flow
 import React from "react"
 import { Provider } from "react-redux"
 import { Route, Router as ReactRouter } from "react-router-dom"
 
 import App from "./containers/App"
 import withTracker from "./util/withTracker"
+import ScrollToTop from "./components/ScrollToTop"
+
+import type { Store } from "redux"
 
 export default class Router extends React.Component {
   props: {
     store: Store,
-    history: Object
+    history: Object,
+    children: React$Element<*>
   }
 
   render() {
@@ -18,7 +23,9 @@ export default class Router extends React.Component {
       <div>
         <Provider store={store}>
           <ReactRouter history={history}>
-            {children}
+            <ScrollToTop>
+              {children}
+            </ScrollToTop>
           </ReactRouter>
         </Provider>
       </div>

--- a/static/js/components/ScrollToTop.js
+++ b/static/js/components/ScrollToTop.js
@@ -1,0 +1,20 @@
+// @flow
+import React from "react"
+
+import { withRouter } from "react-router"
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { history, location } = this.props
+    if (location !== prevProps.location && history.action === "PUSH") {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  render() {
+    const { children } = this.props
+    return children
+  }
+}
+
+export default withRouter(ScrollToTop)

--- a/static/js/components/ScrollToTop_test.js
+++ b/static/js/components/ScrollToTop_test.js
@@ -1,0 +1,53 @@
+// @flow
+import React from "react"
+import { Router } from "react-router"
+import { assert } from "chai"
+import { mount } from "enzyme"
+import sinon from "sinon"
+import { createMemoryHistory } from "history"
+
+import ScrollToTop from "./ScrollToTop"
+
+describe("ScrollToTop", () => {
+  let scrollStub, sandbox, browserHistory
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    scrollStub = sandbox.stub()
+    window.scrollTo = scrollStub
+    browserHistory = createMemoryHistory()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const renderComponent = () =>
+    mount(
+      <Router history={browserHistory}>
+        <ScrollToTop>
+          <div className="child" />
+        </ScrollToTop>
+      </Router>
+    )
+
+  it("should scroll to top when visiting a new link", () => {
+    renderComponent()
+    browserHistory.push("/foo")
+    sinon.assert.calledWith(window.scrollTo, 0, 0)
+  })
+
+  it("should not scroll to top when user clicks forward or back", () => {
+    browserHistory.push("/foo")
+    browserHistory.push("/bar")
+    renderComponent()
+    browserHistory.goBack()
+    browserHistory.goForward()
+    sinon.assert.notCalled(window.scrollTo)
+  })
+
+  it("should render children", () => {
+    const wrapper = renderComponent()
+    assert.lengthOf(wrapper.find(".child"), 1)
+  })
+})

--- a/static/js/entry/root.js
+++ b/static/js/entry/root.js
@@ -1,3 +1,4 @@
+// @flow
 require("react-hot-loader/patch")
 /* global SETTINGS:false */
 __webpack_public_path__ = SETTINGS.public_path // eslint-disable-line no-undef, camelcase


### PR DESCRIPTION
#### What are the relevant tickets?

closes #157 

#### What's this PR do?

This fixes the scroll position behavior on react-router route changes to be, well, normal. The normal way that this should work is this:

1. when you click on an `<a>` tag you open the new page, scrolled to the top, regardless of whether you've visited it before
2. if you use the forward / backward buttons to navigate around the scroll position on any pages you visit should be preserved.

This adds a little component (called `ScrollToTop`) which wraps the whole app and gives us this behavior. Basically, we can check that the location has changed by checking that the `location` prop from the `withRouter` HOC is different, and we can look at `history.action` to figure out why it has changed. If the user clicked on a `<Link />` the `history.action` will be `'PUSH'`, so in this case we can scroll to the top, and otherwise we can allow react-routers default behavior to happen (preserving scroll position with the backward / forward buttons).

#### How should this be manually tested?

On any pages in the app you should no longer be able to reproduce the bug described in the linked issue. You should also be able to use the forward / backward buttons and have your scroll position preserved. Navigating to a new page by clicking a `<Link />` should _always_ leave you scrolled to the top, on the new page.