### PR TITLE
prevent submission of empty posts

### DIFF
--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux"
 
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
+import { isEmptyText } from "../lib/util"
 
 import type { Comment, Post, CommentForm } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
@@ -40,8 +41,6 @@ const getPostReplyInitialValue = (parent: Post) => ({
   text:    ""
 })
 
-const isEmptyCommentBody = R.compose(R.isEmpty, R.trim, R.defaultTo(""))
-
 const commentForm = (
   onSubmit: () => void,
   text: string,
@@ -65,7 +64,7 @@ const commentForm = (
       <button
         type="submit"
         className={`blue-button ${disabled ? "disabled" : ""}`}
-        disabled={disabled || isEmptyCommentBody(text)}
+        disabled={disabled || isEmptyText(text)}
       >
         Submit
       </button>

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -4,6 +4,9 @@ import R from "ramda"
 
 import Card from "../components/Card"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
+
+import { isEmptyText } from "../lib/util"
+
 import type { Channel, PostForm } from "../flow/discussionTypes"
 
 type CreatePostFormProps = {
@@ -39,6 +42,10 @@ export default class CreatePostForm extends React.Component {
     }
 
     const { isText, text, url, title } = postForm
+
+    const shouldDisableSubmit = isText
+      ? isEmptyText(text) || isEmptyText(title)
+      : isEmptyText(url) || isEmptyText(title)
 
     return (
       <div>
@@ -100,7 +107,7 @@ export default class CreatePostForm extends React.Component {
               <button
                 className={`submit-post ${processing ? "disabled" : ""}`}
                 type="submit"
-                disabled={processing}
+                disabled={processing || shouldDisableSubmit}
               >
                 Submit Post
               </button>

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -1,4 +1,6 @@
 // @flow
+import R from "ramda"
+
 import type { Match } from "react-router"
 
 export const getChannelName = (props: { match: Match }): string =>
@@ -25,3 +27,5 @@ export function* enumerate<T>(
     ++i
   }
 }
+
+export const isEmptyText = R.compose(R.isEmpty, R.trim, R.defaultTo(""))

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import { wait, enumerate } from "./util"
+import { wait, enumerate, isEmptyText } from "./util"
 
 describe("utility functions", () => {
   it("waits some milliseconds", done => {
@@ -32,5 +32,19 @@ describe("utility functions", () => {
     }
 
     assert.deepEqual(list, [[0, 6], [1, 7], [2, 8], [3, 9], [4, 10]])
+  })
+
+  it("isEmptyText works as expected", () => {
+    [
+      [" ", true],
+      ["", true],
+      ["\n\t   ", true],
+      ["                   \t ", true],
+      ["foo \n", false],
+      ["foo", false],
+      ["   \n\tfoo", false]
+    ].forEach(([text, exp]) => {
+      assert.equal(isEmptyText(text), exp)
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #179 

#### What's this PR do?

It makes it so the user can't submit a post which doesn't have a title and either a text body or a URL.

#### How should this be manually tested?

Make sure you can't submit an empty post. So for a text post you shouldn't be able to submit until you have a title and a body, and for a URL post you shouldn't be able to submit until you have a title and a URL. Make sure you can submit posts normally otherwise.