### PR TITLE
Only redirect to auth on a 401 response

### DIFF
--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -25,7 +25,12 @@ const redirectAndReject = async (reason: string) => {
 export const fetchWithAuthFailure = async (...args: any) => {
   try {
     return await fetchJSONWithCSRF(...args)
-  } catch (_) {
+  } catch (fetchError) {
+    if (!fetchError || fetchError.errorStatusCode !== 401) {
+      // not an authentication failure, rethrow
+      throw fetchError
+    }
+
     try {
       // renew the session
       const session = await renewSession()

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -39,8 +39,8 @@ describe("auth", function() {
   })
 
   for (let [message, error] of [
-    ['a 500 error', error500],
-    ['an unexpected exception', typeError],
+    ["a 500 error", error500],
+    ["an unexpected exception", typeError]
   ]) {
     it(`does not renew auth for ${message}`, async () => {
       fetchStub.returns(Promise.reject(error))


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #181

#### What's this PR do?
Changes behavior to redirect only on a 401 status code

#### How should this be manually tested?
Add a `raise Exception()` to the frontpage API to simulate an error case. Add another `raise Exception()` to the `discussions_token` function on Micromasters. Check out master on open-discussions and go to `/discussions/` on micromasters. You should see a redirect loop. Check out this PR and the loop should not happen anymore.
