### PR TITLE
add cors stuff

### DIFF
--- a/open_discussions/envs_test.py
+++ b/open_discussions/envs_test.py
@@ -9,6 +9,7 @@ from open_discussions.envs import (
     get_bool,
     get_int,
     get_string,
+    get_list_of_str,
 )
 
 
@@ -100,3 +101,22 @@ def test_get_bool():
                 )
 
         assert get_int('missing', 'default') == 'default'
+
+
+def test_get_list_of_str():
+    """
+    get_list_of_str should parse a list of strings
+    """
+    with patch('open_discussions.envs.os', environ=FAKE_ENVIRONS):
+        assert get_list_of_str('list_of_str', ['noth', 'ing']) == ['x', 'y', 'z']
+
+        for key, value in FAKE_ENVIRONS.items():
+            if key != 'list_of_str':
+                with pytest.raises(EnvironmentVariableParseException) as ex:
+                    get_list_of_str(key, ['noth', 'ing'])
+                assert ex.value.args[0] == 'Expected value in {key}={value} to be a list of str'.format(
+                    key=key,
+                    value=value,
+                )
+
+        assert get_list_of_str('missing', 'default') == 'default'

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -22,6 +22,7 @@ from open_discussions.envs import (
     get_bool,
     get_int,
     get_string,
+    get_list_of_str,
 )
 
 VERSION = "0.0.0"
@@ -72,6 +73,7 @@ INSTALLED_APPS = (
     'server_status',
     'raven.contrib.django.raven_compat',
     'rest_framework',
+    'corsheaders',
     # Put our apps after this point
     'open_discussions',
     'profiles'
@@ -91,7 +93,12 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
 )
+
+# CORS
+CORS_ORIGIN_WHITELIST = get_list_of_str("OPEN_DISCUSSIONS_CORS_ORIGIN_WHITELIST", [])
+CORS_ALLOW_CREDENTIALS = True
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+django-cors-headers==2.1.0
 Django==1.10.5
 PyYAML==3.11
 betamax

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ contextlib2==0.5.5        # via raven
 decorator==4.0.11         # via ipython, traitlets
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-cors-headers==2.1.0
 django-redis==4.7.0
 django-server-status==0.3.2
 django-webpack-loader==0.4.1


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this basically copy-pastes the stuff we do in MM to have a CORS whitelist. we need to have this because we want to make a request to OD from the MM frontend app. I also copied over the `get_list_of_str` thingy too.

#### How should this be manually tested?

Open up MM and do this in the console:

```js
fetch("http://localhost:8063/api/v0/frontpage/", { credentials: "include" })
```

confirm that you get a CORS error.

Then, add a line like this to your `.env` file:

```
OPEN_DISCUSSIONS_CORS_ORIGIN_WHITELIST=['localhost:8079']
```

(replacing with your URLs for OD and MM as needed). after making that change you should be able to issue an authenticated request for the frontpage (or any other API) from the MM frontend.

other stuff should be normal.