### PR TITLE
Change is_subscriber to return correct result if the user is a subscriber but not a contributor to a private channel

### DIFF
--- a/cassettes/channels.views_test.test_add_contributor.json
+++ b/cassettes/channels.views_test.test_add_contributor.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-06T15:00:30",
+      "recorded_at": "2017-09-25T16:27:52",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLSdQ1yNzIyLcsLMs2sSMsqKXa0MKnKTvX1cPSIVNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2GYeWlnkFh3jnuhr4BxjGlxqXVZhXOWcFJPp5gnSkpJZlJqfGZ6aAjIVwlGoBlq+ZyrQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMACF/0rsGA000Ua3rOxiSFSWXYbNJw0pbRtiRP89l6eO7+N9771JLgS05qau8CDzEZkylzIaRoxm95OXIO1KtZ8JbKvd+ZkuyGRE0DVSQXNpBS9wnJ79fG5eDezIFbmCsl0t6gGNbVIoe/H2/3bZrNbRMg7aY+IyExYURvnVwY9pZp0CrRTgsrDDQyCfLy1SmZG4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 15:00:30 GMT"
+            "Mon, 25 Sep 2017 16:27:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=0ztbHf2RNA66oPxusW; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 15:00:30 GMT",
-            "loidcreated=2017-09-06T15%3A00%3A30.511Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 15:00:30 GMT"
+            "loid=CXJbUsJgiOgVeFTSqU; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:27:52 GMT",
+            "loidcreated=2017-09-25T16%3A27%3A52.731Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:27:52 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       }
     },
     {
-      "recorded_at": "2017-09-06T15:00:30",
+      "recorded_at": "2017-09-25T16:27:52",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=2-3UuvJSTKmE0OP1_u3vx7zCjPaNI"
+          "string": "grant_type=refresh_token&refresh_token=281-ZGDEFCL6vUO18tBd-etr5kT5L-Y"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=0ztbHf2RNA66oPxusW; loidcreated=2017-09-06T15%3A00%3A30.511Z"
+            "loid=CXJbUsJgiOgVeFTSqU; loidcreated=2017-09-25T16%3A27%3A52.731Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,20 +108,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"2-zalGMrFXv0wS8sZA4HkHMfqc4u8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-E3OK4EO50e0YaW5ireZnrwfxe9c\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 15:00:30 GMT"
+            "Mon, 25 Sep 2017 16:27:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299"
+            "288"
           ],
           "x-ratelimit-reset": [
-            "570"
+            "128"
           ],
           "x-ratelimit-used": [
-            "1"
+            "12"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-06T15:00:30",
+      "recorded_at": "2017-09-25T16:27:52",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=othercontributor&type=contributor"
+          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -167,26 +167,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 2-zalGMrFXv0wS8sZA4HkHMfqc4u8"
+            "bearer 281-E3OK4EO50e0YaW5ireZnrwfxe9c"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "39"
+            "62"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=0ztbHf2RNA66oPxusW; loidcreated=2017-09-06T15%3A00%3A30.511Z"
+            "loid=CXJbUsJgiOgVeFTSqU; loidcreated=2017-09-25T16%3A27%3A52.731Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/test_channel/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -204,7 +204,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 15:00:30 GMT"
+            "Mon, 25 Sep 2017 16:27:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +222,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299.0"
+            "292.0"
           ],
           "x-ratelimit-reset": [
-            "570"
+            "128"
           ],
           "x-ratelimit-used": [
-            "1"
+            "8"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -241,7 +241,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/test_channel/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_add_contributor_again.json
+++ b/cassettes/channels.views_test.test_add_contributor_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:28:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNT1yTT3ydTNNAwJN44sinJ3KozId88yD3dJDU9X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFxReEeoanG6camCS5WzhmuUaGGuQ4pwcZB4BtS0kty0xOjc9MARkM4SjVAgBeoI+HuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:28:01 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=76r9WkWMrO2C97laDl; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:28:01 GMT",
+            "loidcreated=2017-09-25T16%3A28%3A01.944Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:28:01 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:28:02",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": "grant_type=refresh_token&refresh_token=281-Z_pUIWg3e04bG8AjEYU0lCgR3Pg"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=76r9WkWMrO2C97laDl; loidcreated=2017-09-25T16%3A28%3A01.944Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +108,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-l618lRnuH07AaTltBAGDLMBd-YI\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:28:02 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "287"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "118"
           ],
           "x-ratelimit-used": [
-            "9"
+            "13"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:28:02",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -167,44 +167,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 281-l618lRnuH07AaTltBAGDLMBd-YI"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "60"
+            "62"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=76r9WkWMrO2C97laDl; loidcreated=2017-09-25T16%3A28%3A01.944Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "uri": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:28:02 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +222,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "291.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "118"
           ],
           "x-ratelimit-used": [
-            "5"
+            "9"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -241,7 +241,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_add_moderator.json
+++ b/cassettes/channels.views_test.test_add_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-12T17:57:36",
+      "recorded_at": "2017-09-25T16:20:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA02NQQvCIBzFv8rwGAmLkUH3WHQoRtm8ibl/S2o6VKwZffdmu3R8P97vvTcSUoJz3Js7aLTO0AIPXcDYslV4nO3+wGhHot49j1pwh+YZglevLDiuUr0geT6yn8390EOauICwYFPXSTOhWUoWrqN4+//aeGfaUEaGT7WstjUlLdVFGZe0SkYDQUngqkmzU0CfL7b1F0y0AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNT1c0ssDnQJDbZ0TY73KEkOyXLMirKwyC52jwpV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5G3k6lTg6l2TkZ1dUmrlFVAQHFZVF+emGWjiC9KSklmUmp8ZnpoAMhnCUagEmgeHLuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 12 Sep 2017 17:52:50 GMT"
+            "Mon, 25 Sep 2017 16:20:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=lRlZigOcrDYPmks2zD; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 12-Sep-2019 17:52:50 GMT",
-            "loidcreated=2017-09-12T17%3A52%3A50.868Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 12-Sep-2019 17:52:50 GMT"
+            "loid=KgYw1VVKIi2s5vJAF3; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:20:36 GMT",
+            "loidcreated=2017-09-25T16%3A20%3A36.307Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:20:36 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,83 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       }
     },
     {
-      "recorded_at": "2017-09-12T17:57:36",
+      "recorded_at": "2017-09-25T16:20:36",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLUDczO98sryQnIN9Q1SfJ3szTLLDSrtPRwCzAyUdJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2BWQ5uroXJ+Z5paUbRUQYRgQZmBX7OOUn63oGgnSkpJZlJqfGZ6aAjIVwlGoBITwdALQAAAA=",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 12 Sep 2017 17:52:50 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
-      }
-    },
-    {
-      "recorded_at": "2017-09-12T17:57:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=1-PjAEGsanJfg2XX1XR06sLBoc-IQ"
+          "string": "grant_type=refresh_token&refresh_token=281-C2IBtACthokxy6FXxSRrvZN-U8A"
         },
         "headers": {
           "Accept": [
@@ -152,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic bDlkME1LUGpKcEtLWVE6bW9tcDgtZkJ6elpES3I0dEFNNllSc3dxa09F"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -176,20 +108,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"1-0wci2YhSUj9PoqHHM3uBowWHSeQ\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-IO1Fou9ea-TePPZ-NrLVsBaQtbM\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 12 Sep 2017 17:52:50 GMT"
+            "Mon, 25 Sep 2017 16:20:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -201,345 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298"
-          ],
-          "x-ratelimit-reset": [
-            "430"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-12T17:57:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 1-0wci2YhSUj9PoqHHM3uBowWHSeQ"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1504724203.0, \"mod_permissions\": [\"all\"], \"name\": \"otheruser1\", \"id\": \"t2_1\"}, {\"date\": 1505166668.0, \"mod_permissions\": [\"all\"], \"name\": \"otheruser2\", \"id\": \"t2_2\"}, {\"date\": 1505233475.0, \"mod_permissions\": [\"all\"], \"name\": \"reddit\", \"id\": \"t2_5\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
             "299"
           ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 12 Sep 2017 17:52:50 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298.0"
-          ],
           "x-ratelimit-reset": [
-            "430"
+            "564"
           ],
           "x-ratelimit-used": [
-            "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=BFmJYN0W096zFbiYzj1McR%2BXpfD6%2FGwzOOu0i2Q9CemHnQMBfG6diZrVw%2F83GCAzVlQ3S67C3BpNCuTGANkxR6xgBFKG3cpu"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-12T17:57:37",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=othermoderator&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 1-0wci2YhSUj9PoqHHM3uBowWHSeQ"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "67"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/test_channel/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 12 Sep 2017 17:52:52 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "297.0"
-          ],
-          "x-ratelimit-reset": [
-            "428"
-          ],
-          "x-ratelimit-used": [
-            "3"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-12T17:57:37",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=othermoderator"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLRrfRJt7RwtTQxLnR1NqlI98z3zg72K03NcXONVNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2WWZaJOaZORv5G1umGgQmeWeluThXuTknlXi4gnSkpJZlJqfGZ6aAjIVwlGoBRJWB8LQAAAA=",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 12 Sep 2017 17:52:52 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=othermoderator"
-      }
-    },
-    {
-      "recorded_at": "2017-09-12T17:57:37",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=4-9i8an6C2O39e0QbKjfDCzFCbtHE"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "Basic bDlkME1LUGpKcEtLWVE6bW9tcDgtZkJ6elpES3I0dEFNNllSc3dxa09F"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "68"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"access_token\": \"4-o5wjJQJu3IXtEW31Xk4fPLUjbUU\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "107"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 12 Sep 2017 17:52:52 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "297"
-          ],
-          "x-ratelimit-reset": [
-            "428"
-          ],
-          "x-ratelimit-used": [
-            "3"
+            "1"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -553,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-12T17:57:37",
+      "recorded_at": "2017-09-25T16:20:36",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -567,44 +167,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 4-o5wjJQJu3IXtEW31Xk4fPLUjbUU"
+            "bearer 281-IO1Fou9ea-TePPZ-NrLVsBaQtbM"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=lRlZigOcrDYPmks2zD; loidcreated=2017-09-12T17%3A52%3A50.868Z"
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/test_channel/api/accept_moderator_invite?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1506356020.0, \"mod_permissions\": [\"all\"], \"name\": \"admin\", \"id\": \"t2_7t\"}, {\"date\": 1506356121.0, \"mod_permissions\": [\"all\"], \"name\": \"01BTN7HXFM5MA85XBD1ZCD6XC6\", \"id\": \"t2_7q\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "24"
+            "233"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 12 Sep 2017 17:52:52 GMT"
+            "Mon, 25 Sep 2017 16:20:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -625,7 +219,345 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "428"
+            "564"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=iBWUzw6VWlQSu0tupr5u%2Fco6mqtKxc7yRO6vz9GWvhuHlq%2BQxxAfffpo1zLBRtm4MsIgHp3DRBpolLMe7cXoAqSlRfSoUI%2Bo"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:20:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 281-IO1Fou9ea-TePPZ-NrLVsBaQtbM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:20:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "562"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:20:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJoQUEkdhcmERZGgS1PbR6xVW1+JoRr/XSqT4z2559434UKAc6wzGu5kFZEkW8xSj3W7vzWcysqWO24qxEcNRaINmUYEeqsQHFNBSJdxPLCfzzpvIYycgCNg6DphRjQJCaEdxPP/m301m+tBZ9ue1r5Yl5m/uCNtmMvnwZHwVAKYkmF4DOTzBTUGmcS4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:20:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:20:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=275-pzXJlYk7Rx9VyDBM7yjsZ9X_sC4"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "70"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"275-iH149DRZnFwTAUMmRk7eTlin-KY\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:20:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "562"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:20:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-iH149DRZnFwTAUMmRk7eTlin-KY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/admin_channel/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:20:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "562"
           ],
           "x-ratelimit-used": [
             "1"
@@ -641,7 +573,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/test_channel/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/admin_channel/api/accept_moderator_invite?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_add_moderator_again.json
+++ b/cassettes/channels.views_test.test_add_moderator_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:21:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQtKPVxDAvIT8tINAuvyKkqda3IKfaJNPbLNHdU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFBvkbJOVZ+HmZGhlmZpTmF1Q6FheaFBmEGGeD9KSklmUmp8ZnpoAMhnCUagEjGJbouAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:21:02 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=ppZfySyANhkI8oiV75; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:21:02 GMT",
+            "loidcreated=2017-09-25T16%3A21%3A02.967Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:21:02 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:21:03",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": "grant_type=refresh_token&refresh_token=281-YRO0bn8NJ521ihuopyAsq4r0T3k"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=ppZfySyANhkI8oiV75; loidcreated=2017-09-25T16%3A21%3A02.967Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +108,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-jj8F7EMcYJAm0l3SyqzybWOkyr0\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:21:03 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "295"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "537"
           ],
           "x-ratelimit-used": [
-            "9"
+            "5"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:21:03",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -167,44 +167,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 281-jj8F7EMcYJAm0l3SyqzybWOkyr0"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "60"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=ppZfySyANhkI8oiV75; loidcreated=2017-09-25T16%3A21%3A02.967Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1506356020.0, \"mod_permissions\": [\"all\"], \"name\": \"admin\", \"id\": \"t2_7t\"}, {\"date\": 1506356121.0, \"mod_permissions\": [\"all\"], \"name\": \"01BTN7HXFM5MA85XBD1ZCD6XC6\", \"id\": \"t2_7q\"}, {\"date\": 1506356438.0, \"mod_permissions\": [\"all\"], \"name\": \"01BTN6G82RKTS3WF61Q33AA0ND\", \"id\": \"t2_7n\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "338"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:21:03 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +216,16 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "297.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "537"
           ],
           "x-ratelimit-used": [
-            "5"
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=oxGhm0x36%2Fj5feGpdvXKMOIYGAt0h72dmlHD2YUe%2BoLc6lwmdojChodY%2FLBnajUFv7SbWDMx7hofb6MxMir4Jc5rtAf3bUjy"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -241,7 +238,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_add_subscriber.json
+++ b/cassettes/channels.views_test.test_add_subscriber.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-13T17:51:36",
+      "recorded_at": "2017-09-25T17:04:52",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLRLXAsdjIrr9QtdLcosagssDDOzS3yL8ysKCwPVNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2eet6V4QaZTqXVeY4ZQe7+ZgmOaf4h2cFFhslg3SkpJZlJqfGZ6aAjIVwlGoBpIftfrQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQtivIuzIx3C48MN4/0SLFMzTbxdbKs9Cl2MbFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZF+PvlhcQnmhqXBAYmGxkGBFdm+mYWGBS5BKSD9KSklmUmp8ZnpoAMhnCUagHa19aDuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:51:36 GMT"
+            "Mon, 25 Sep 2017 17:04:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=VRV0M9ENcfZsB0Y6kY; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 17:51:36 GMT",
-            "loidcreated=2017-09-13T17%3A51%3A36.628Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 17:51:36 GMT"
+            "loid=NFjI9XmmYhUbYsJfnH; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Wed, 25-Sep-2019 17:04:52 GMT",
+            "loidcreated=2017-09-25T17%3A04%3A52.144Z; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Wed, 25-Sep-2019 17:04:52 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,7 +70,7 @@
       }
     },
     {
-      "recorded_at": "2017-09-13T17:51:37",
+      "recorded_at": "2017-09-25T17:04:52",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -87,18 +87,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=VRV0M9ENcfZsB0Y6kY; loidcreated=2017-09-13T17%3A51%3A36.628Z"
+            "loid=NFjI9XmmYhUbYsJfnH; loidcreated=2017-09-25T17%3A04%3A52.144Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLWDXLzcMuqCA8IT0lJ8gn1yzBxdzLSdTEK9nUrV9JRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2mZX7B4anVJk6ufllJXpbZrjoRhgGhQSlefolg3SkpJZlJqfGZ6aAjIVwlGoBiKuTl7QAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9UNy6y09IoqMK8wcHY28o2qrCiPTHP0tvRKy3dU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5ZHn6euQFmrk5ujgFGYVVpPqHl1UEVFlkh4BtS0kty0xOjc9MARkM4SjVAgDi2dM4uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -112,7 +112,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:51:37 GMT"
+            "Mon, 25 Sep 2017 17:04:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -134,15 +134,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       }
     },
     {
-      "recorded_at": "2017-09-13T17:51:37",
+      "recorded_at": "2017-09-25T17:04:52",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=3-6wOQWdz5BFNjaK9hD-X1RTRfINc"
+          "string": "grant_type=refresh_token&refresh_token=275-DjIMHnQ6FADBR2VxeOWvxPz8kTA"
         },
         "headers": {
           "Accept": [
@@ -152,19 +152,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=VRV0M9ENcfZsB0Y6kY; loidcreated=2017-09-13T17%3A51%3A36.628Z"
+            "loid=NFjI9XmmYhUbYsJfnH; loidcreated=2017-09-25T17%3A04%3A52.144Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -176,20 +176,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"3-fxcspw2ioqv8Un1BCSnFscMHKkw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-VKeZmdf-7H6VNjRjkuOcwuC-2LY\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:51:37 GMT"
+            "Mon, 25 Sep 2017 17:04:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -201,13 +201,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299"
+            "296"
           ],
           "x-ratelimit-reset": [
-            "503"
+            "308"
           ],
           "x-ratelimit-used": [
-            "1"
+            "4"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -221,11 +221,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-13T17:51:37",
+      "recorded_at": "2017-09-25T17:04:52",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=test_channel"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=admin_channel"
         },
         "headers": {
           "Accept": [
@@ -235,19 +235,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 3-fxcspw2ioqv8Un1BCSnFscMHKkw"
+            "bearer 275-VKeZmdf-7H6VNjRjkuOcwuC-2LY"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "71"
+            "72"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=VRV0M9ENcfZsB0Y6kY; loidcreated=2017-09-13T17%3A51%3A36.628Z"
+            "loid=NFjI9XmmYhUbYsJfnH; loidcreated=2017-09-25T17%3A04%3A52.144Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -272,7 +272,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:51:37 GMT"
+            "Mon, 25 Sep 2017 17:04:52 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -290,13 +290,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299.0"
+            "297.0"
           ],
           "x-ratelimit-reset": [
-            "503"
+            "308"
           ],
           "x-ratelimit-used": [
-            "1"
+            "3"
           ],
           "x-ua-compatible": [
             "IE=edge"

--- a/cassettes/channels.views_test.test_add_subscriber_again.json
+++ b/cassettes/channels.views_test.test_add_subscriber_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:31:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQ1DSxOLQyN9/TLdknPcsq0AEpnpYaUpGfkRirpKCilVhRkFqUWx2eCNBibGRgAxcD640sqC1JBhiSlJhalFoHUFifnQ4S0QLyi1DSgxgxU28xLTEO8vJ0jyzwNAt2dLXKcg/LSjIvjffN8wLalpJZlJqfGZ6aADIZwlGoBwaM0rrgAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:31:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=So5hIMGUwHUPe9UNOi; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:31:05 GMT",
+            "loidcreated=2017-09-25T16%3A31%3A05.389Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:31:05 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,79 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:31:05",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=So5hIMGUwHUPe9UNOi; loidcreated=2017-09-25T16%3A31%3A05.389Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNvQrCMBhFX6VkFAuhYoOOrR1K4iYOLiE/XzBYTUiCrYjvbmMnx3u45943EkpBjDy5GzzQvkAV2ZbtQZ31iVWqLw1tujshadeZYCU9onWBYPI2QOQ2C5sa45n9fJ5eHvKIBBEg5G5UbkGrnAKYWbz+v1E/YdPrehzYxQU2CtFGyQfSSJwdDU+rgFudh5eAPl9bYAmIuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:31:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:31:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=275-Kpx0fId6wlLZorLwaaCsb_l7Bb0"
         },
         "headers": {
           "Accept": [
@@ -96,7 +164,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=So5hIMGUwHUPe9UNOi; loidcreated=2017-09-25T16%3A31%3A05.389Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +176,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-MQbGtLHOw-clDtd0BFFqHcACkBE\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:31:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +201,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "298"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "535"
           ],
           "x-ratelimit-used": [
-            "9"
+            "2"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +221,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:31:05",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=admin_channel"
         },
         "headers": {
           "Accept": [
@@ -167,26 +235,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 275-MQbGtLHOw-clDtd0BFFqHcACkBE"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "60"
+            "72"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=So5hIMGUwHUPe9UNOi; loidcreated=2017-09-25T16%3A31%3A05.389Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
       },
       "response": {
         "body": {
@@ -204,7 +272,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:31:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +290,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "298.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "535"
           ],
           "x-ratelimit-used": [
-            "5"
+            "2"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -241,7 +309,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_add_subscriber_forbidden.json
+++ b/cassettes/channels.views_test.test_add_subscriber_forbidden.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:41:37",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQt9io1Lo40NnFO160IcE7zc/R0tqjMNM8oz/JU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFRSQFFGWZW5Y7RyT5OBlEpptmpnkkBnuZ55mA9KSklmUmp8ZnpoAMhnCUagH2uS5EuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:41:37 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=qDqXscRBHRFWdmbn68; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:41:37 GMT",
+            "loidcreated=2017-09-25T16%3A41%3A37.896Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:41:37 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,79 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:41:38",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=qDqXscRBHRFWdmbn68; loidcreated=2017-09-25T16%3A41%3A37.896Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9WNLPQKLDXO9Ao3SSvzMLT0DzfNdfRPcnM1T8tX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbFZ5kmlbqFmEXlZCUZBzqnBxR7O5ob53kGGBuA9KSklmUmp8ZnpoAMhnCUagFboIMjuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:41:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:41:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=275-_j5buFT6Zljb3QCgPsKA73nIP30"
         },
         "headers": {
           "Accept": [
@@ -96,7 +164,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=qDqXscRBHRFWdmbn68; loidcreated=2017-09-25T16%3A41%3A37.896Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +176,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-4iJZAWD-q-C8vqoMI7UDDl26wE4\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:41:38 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +201,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "295"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "502"
           ],
           "x-ratelimit-used": [
-            "9"
+            "5"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +221,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:41:38",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=admin_channel"
         },
         "headers": {
           "Accept": [
@@ -167,44 +235,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 275-4iJZAWD-q-C8vqoMI7UDDl26wE4"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "60"
+            "72"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=qDqXscRBHRFWdmbn68; loidcreated=2017-09-25T16%3A41%3A37.896Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "38"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:41:38 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -225,7 +293,7 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "502"
           ],
           "x-ratelimit-used": [
             "5"
@@ -238,10 +306,10 @@
           ]
         },
         "status": {
-          "code": 200,
-          "message": "OK"
+          "code": 403,
+          "message": "Forbidden"
         },
-        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_detail_subscriber.json
+++ b/cassettes/channels.views_test.test_detail_subscriber.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-13T17:58:20",
+      "recorded_at": "2017-09-25T17:06:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLVLU/NLjeLzMwrNfFMczHPNExLC04NqTAyCvM1UdJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2BXqbGaSaW4Z6+UclBVqkGUY55SZZZrplpqdkg3SkpJZlJqfGZ6aAjIVwlGoBsiGkMbQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNRNK3S1jKjM0DWIyiko0a3MKQg1ijT0DE4PM81X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZF5BoGFrhnOnub52emV0RmBZkYeyQ7Z6V6mgSC9KSklmUmp8ZnpoAMhnCUagFElqNYuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:58:20 GMT"
+            "Mon, 25 Sep 2017 17:06:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=3BIH10s8mLO3P1Ge74; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 17:58:20 GMT",
-            "loidcreated=2017-09-13T17%3A58%3A19.750Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 17:58:20 GMT"
+            "loid=JV22Tg6rCQU4ZnrEHn; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 17:06:08 GMT",
+            "loidcreated=2017-09-25T17%3A06%3A08.325Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 17:06:08 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,11 +66,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       }
     },
     {
-      "recorded_at": "2017-09-13T17:58:20",
+      "recorded_at": "2017-09-25T17:06:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -87,18 +87,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3BIH10s8mLO3P1Ge74; loidcreated=2017-09-13T17%3A58%3A19.750Z"
+            "loid=JV22Tg6rCQU4ZnrEHn; loidcreated=2017-09-25T17%3A06%3A08.325Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLW9dZ1dAvKMvBzMo2I8qiIyq1IzikyN84x8DDKV9JRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2hQZ4uUTlmrqkZ+mWJwe4uCWW+YQUmXs7eVmC7UpJLctMTo3PTAEZC+Eo1QIAXE6mnLQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9VNc/cK9DH1dcvWzcyuiIxM9w31zQ0qs7As9wtV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZV+VXkG+saJnpkhYTnuFiU61YEJRtlORpU+gaC9KSklmUmp8ZnpoAMhnCUagHprvlYuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -112,7 +112,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:58:20 GMT"
+            "Mon, 25 Sep 2017 17:06:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -134,15 +134,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       }
     },
     {
-      "recorded_at": "2017-09-13T17:58:20",
+      "recorded_at": "2017-09-25T17:06:08",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=3-UPJDZm5Dgj-wcPDFavLTr7KBJ9o"
+          "string": "grant_type=refresh_token&refresh_token=275-zNxo3-1aHjTWlD8w-xRc2jA0yMQ"
         },
         "headers": {
           "Accept": [
@@ -152,19 +152,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3BIH10s8mLO3P1Ge74; loidcreated=2017-09-13T17%3A58%3A19.750Z"
+            "loid=JV22Tg6rCQU4ZnrEHn; loidcreated=2017-09-25T17%3A06%3A08.325Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -176,20 +176,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"3-KZFdAE5foStBX1DH1YZQpeRTu_s\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-TM9KuxeLcf4tJ3CkeSYy05CwlqY\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:58:20 GMT"
+            "Mon, 25 Sep 2017 17:06:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -201,13 +201,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298"
+            "294"
           ],
           "x-ratelimit-reset": [
-            "100"
+            "232"
           ],
           "x-ratelimit-used": [
-            "2"
+            "6"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -221,7 +221,7 @@
       }
     },
     {
-      "recorded_at": "2017-09-13T17:58:20",
+      "recorded_at": "2017-09-25T17:06:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -235,38 +235,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 3-KZFdAE5foStBX1DH1YZQpeRTu_s"
+            "bearer 275-TM9KuxeLcf4tJ3CkeSYy05CwlqY"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3BIH10s8mLO3P1Ge74; loidcreated=2017-09-13T17%3A58%3A19.750Z"
+            "loid=JV22Tg6rCQU4ZnrEHn; loidcreated=2017-09-25T17%3A06%3A08.325Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/?raw_json=1"
+        "uri": "https://reddit.local/subreddits/mine/subscriber/?limit=100&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"1\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"test_channel\", \"header_img\": null, \"description_html\": null, \"title\": \"Test Channel\", \"collapse_deleted_comments\": false, \"public_description\": \"This is a test channel\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis is a test channel\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_1\", \"created\": 1504111173.0, \"url\": \"/r/test_channel/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1504111173.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"8\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"micromasters\", \"header_img\": null, \"description_html\": null, \"title\": \"The micromasters channel\", \"collapse_deleted_comments\": false, \"public_description\": \"It's micromasters\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt\\u0026#39;s micromasters\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 280, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_8\", \"created\": 1502389428.0, \"url\": \"/r/micromasters/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1502389428.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}, {\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"9\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"dedp\", \"header_img\": null, \"description_html\": null, \"title\": \"dedp\", \"collapse_deleted_comments\": false, \"public_description\": \"dedp\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ededp\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 279, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_9\", \"created\": 1502390775.0, \"url\": \"/r/dedp/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1502390775.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}, {\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Etest_channel\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"w\", \"user_is_contributor\": true, \"submit_text\": \"test_channel\", \"display_name\": \"admin_channel\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Etest_channel\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"test_channel\", \"collapse_deleted_comments\": false, \"public_description\": \"test_channel\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Etest_channel\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"test_channel\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_w\", \"created\": 1506356020.0, \"url\": \"/r/admin_channel/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1506356020.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}], \"after\": null, \"before\": null}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "1241"
+            "4057"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 17:58:20 GMT"
+            "Mon, 25 Sep 2017 17:06:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -284,16 +284,16 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298.0"
+            "295.0"
           ],
           "x-ratelimit-reset": [
-            "100"
+            "232"
           ],
           "x-ratelimit-used": [
-            "2"
+            "5"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=%2BpA5yDRWkNFc0cRQJCORoi6Angey%2FL61K2dc54w8EWSAtjw4%2BHAwHyy8wYoonOgjXQKnFzDU%2FNWVUH1Fv3MTfIDWUzuXz5aR"
+            "https://reddit.local/pixel/of_destiny.png?v=a1fPqcV00GXyd8TblS1ETdeb44TNDYIpKwVB19mRYTSbF%2FKhs29dxydewh32kp00gQ88BABfcaI8N%2FiDtSAh4JNRHCvh1RB2"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -306,7 +306,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/test_channel/about/?raw_json=1"
+        "url": "https://reddit.local/subreddits/mine/subscriber/?limit=100&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_detail_subscriber_missing.json
+++ b/cassettes/channels.views_test.test_detail_subscriber_missing.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-06T18:29:40",
+      "recorded_at": "2017-09-25T16:56:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLStUhOKglL964ssnCMCPSw8PEs8g5Kz8rxCCnIVtJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2OZvpZvkauRSZ57iluaZYVGT5Gxi6maYkeqQ7gnSkpJZlJqfGZ6aAjIVwlGoBisTLbLQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAlDcUE3DwVuUCZWx6Hzby0l57bCiL57W546vsf7/d4bVUKAMdwOHdzROkDRKgmZYTileZgVaV329fZmIafM0rE7oGWAYFJSg+HSAzHB2HU/ntuXAi+podKg/daIYa4WPmloHXj9f0vI8XHZjEXkpFPc7nmvduWJnxXBnmngKQVw2XjxHNDnC+HYiPW4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
+            "Mon, 25 Sep 2017 16:56:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 18:29:40 GMT",
-            "loidcreated=2017-09-06T18%3A29%3A40.688Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 18:29:40 GMT"
+            "loid=Z93IhCQPsXOy6OLuJ5; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:56:15 GMT",
+            "loidcreated=2017-09-25T16%3A56%3A15.781Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:56:15 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,83 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       }
     },
     {
-      "recorded_at": "2017-09-06T18:29:40",
+      "recorded_at": "2017-09-25T16:56:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=2-C6-jM2Dr7lFfEd8xjO01F5daHgA"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=Z93IhCQPsXOy6OLuJ5; loidcreated=2017-09-25T16%3A56%3A15.781Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9UND/cNSix2LXQsLzIMSnUqjwrxCI9PzbSocjZQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFFDubRESaVhX7RxmUBTq7+mXl5FS5BhsXO5aD9KSklmUmp8ZnpoAMhnCUagGgU5GauAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:56:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:56:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=275-TsC4XY5zsOZ0vQCENjllzES3sAw"
         },
         "headers": {
           "Accept": [
@@ -84,19 +152,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
+            "loid=Z93IhCQPsXOy6OLuJ5; loidcreated=2017-09-25T16%3A56%3A15.781Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,20 +176,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"2-h03ykHlUump1ksBLm58MW5isGNw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-CNE9V0zaCG3wYlMZpuO_syYXOMA\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
+            "Mon, 25 Sep 2017 16:56:16 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -136,7 +204,7 @@
             "299"
           ],
           "x-ratelimit-reset": [
-            "20"
+            "225"
           ],
           "x-ratelimit-used": [
             "1"
@@ -153,7 +221,7 @@
       }
     },
     {
-      "recorded_at": "2017-09-06T14:13:56",
+      "recorded_at": "2017-09-25T16:56:16",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -167,38 +235,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 2-dEIlk4h_bEjLldGr0D6F-YE3s9M"
+            "bearer 275-CNE9V0zaCG3wYlMZpuO_syYXOMA"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=hDPOYFHjnjRyV0tZPj; loidcreated=2017-09-06T14%3A13%3A55.974Z"
+            "loid=Z93IhCQPsXOy6OLuJ5; loidcreated=2017-09-25T16%3A56%3A15.781Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/contributors/?limit=100&raw_json=1"
+        "uri": "https://reddit.local/subreddits/mine/subscriber/?limit=100&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"date\": 1504641929.0, \"name\": \"othercontributor\", \"id\": \"t2_3\"}, {\"date\": 1504111173.0, \"name\": \"fooadmin\", \"id\": \"t2_2\"}], \"after\": null, \"before\": null}}"
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"8\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"micromasters\", \"header_img\": null, \"description_html\": null, \"title\": \"The micromasters channel\", \"collapse_deleted_comments\": false, \"public_description\": \"It's micromasters\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt\\u0026#39;s micromasters\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 280, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_8\", \"created\": 1502389428.0, \"url\": \"/r/micromasters/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1502389428.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}, {\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"9\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"dedp\", \"header_img\": null, \"description_html\": null, \"title\": \"dedp\", \"collapse_deleted_comments\": false, \"public_description\": \"dedp\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ededp\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 279, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_9\", \"created\": 1502390775.0, \"url\": \"/r/dedp/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1502390775.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}], \"after\": null, \"before\": null}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "202"
+            "2540"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 14:13:56 GMT"
+            "Mon, 25 Sep 2017 16:56:16 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -219,13 +287,13 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "364"
+            "224"
           ],
           "x-ratelimit-used": [
             "1"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=IpToHkGqXDH57tyS%2BLis08uq%2Bh8Obyhbx3%2BUz12uc64025lDmFzVf4gDdogxhl3uIPsU9kc90fvHwoRS42SSVSYS%2Fz%2B9R9Xq"
+            "https://reddit.local/pixel/of_destiny.png?v=kfyO4LxH7%2BARYydMGmU7W9HBq80ww%2Fr8aiRfP5oRm8lXNnzld9t2NFy4GX376BrdwceZgBt6ZYyUwjNOqCMPhVU%2F2HMU1Vop"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -238,179 +306,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/test_channel/about/contributors/?limit=100&raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-06T18:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=2-C6-jM2Dr7lFfEd8xjO01F5daHgA"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "68"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"access_token\": \"2-h03ykHlUump1ksBLm58MW5isGNw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "107"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-06T18:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 2-h03ykHlUump1ksBLm58MW5isGNw"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1504641929.0, \"name\": \"othercontributor\", \"id\": \"t2_3\"}, {\"date\": 1504111173.0, \"mod_permissions\": [\"all\"], \"name\": \"fooadmin\", \"id\": \"t2_2\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "130"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=O0XrABD8RK%2FK9m8aqh8JS%2F2zqqje%2Bjye0tyWoQMpkQ%2B3u9le20E6rZBXrE0lahnxipGAvsdtByolZ3Yb2DflsYyOvoN7vGdG"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/subreddits/mine/subscriber/?limit=100&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_remove_contributor.json
+++ b/cassettes/channels.views_test.test_remove_contributor.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-06T18:29:40",
+      "recorded_at": "2017-09-25T16:29:28",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLStUhOKglL964ssnCMCPSw8PEs8g5Kz8rxCCnIVtJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2OZvpZvkauRSZ57iluaZYVGT5Gxi6maYkeqQ7gnSkpJZlJqfGZ6aAjIVwlGoBisTLbLQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQNdDQ3Kw0qTM1wTDEpLvAKq3TMM/O00PWrMitW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZ5e5jmZbpZpsQ7FmbmBLokJlV4ZemWB7oWG5uA9KSklmUmp8ZnpoAMhnCUagEg5+M9uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
+            "Mon, 25 Sep 2017 16:29:28 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 18:29:40 GMT",
-            "loidcreated=2017-09-06T18%3A29%3A40.688Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 06-Sep-2019 18:29:40 GMT"
+            "loid=q2LXAwDsCs0ApzZeP5; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:29:28 GMT",
+            "loidcreated=2017-09-25T16%3A29%3A28.888Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:29:28 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=fooadmin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
       }
     },
     {
-      "recorded_at": "2017-09-06T18:29:40",
+      "recorded_at": "2017-09-25T16:29:29",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=2-C6-jM2Dr7lFfEd8xjO01F5daHgA"
+          "string": "grant_type=refresh_token&refresh_token=281-KH5niF9d_AqilQDabxJj-wQEs34"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
+            "loid=q2LXAwDsCs0ApzZeP5; loidcreated=2017-09-25T16%3A29%3A28.888Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,20 +108,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"2-h03ykHlUump1ksBLm58MW5isGNw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-qG-FeYME4vQ_mzLvGKDrfbCWeZo\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
+            "Mon, 25 Sep 2017 16:29:29 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299"
+            "286"
           ],
           "x-ratelimit-reset": [
-            "20"
+            "31"
           ],
           "x-ratelimit-used": [
-            "1"
+            "14"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-06T14:13:56",
+      "recorded_at": "2017-09-25T16:29:29",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -167,287 +167,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 2-dEIlk4h_bEjLldGr0D6F-YE3s9M"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=hDPOYFHjnjRyV0tZPj; loidcreated=2017-09-06T14%3A13%3A55.974Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/contributors/?limit=100&raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"date\": 1504641929.0, \"name\": \"othercontributor\", \"id\": \"t2_3\"}, {\"date\": 1504111173.0, \"name\": \"fooadmin\", \"id\": \"t2_2\"}], \"after\": null, \"before\": null}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "202"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 06 Sep 2017 14:13:56 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "364"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=IpToHkGqXDH57tyS%2BLis08uq%2Bh8Obyhbx3%2BUz12uc64025lDmFzVf4gDdogxhl3uIPsU9kc90fvHwoRS42SSVSYS%2Fz%2B9R9Xq"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/about/contributors/?limit=100&raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-06T18:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=2-C6-jM2Dr7lFfEd8xjO01F5daHgA"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "bearer 281-qG-FeYME4vQ_mzLvGKDrfbCWeZo"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "62"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
+            "loid=q2LXAwDsCs0ApzZeP5; loidcreated=2017-09-25T16%3A29%3A28.888Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"access_token\": \"2-h03ykHlUump1ksBLm58MW5isGNw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "107"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-06T18:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 2-h03ykHlUump1ksBLm58MW5isGNw"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1504111173.0, \"mod_permissions\": [\"all\"], \"name\": \"fooadmin\", \"id\": \"t2_2\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "130"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=O0XrABD8RK%2FK9m8aqh8JS%2F2zqqje%2Bjye0tyWoQMpkQ%2B3u9le20E6rZBXrE0lahnxipGAvsdtByolZ3Yb2DflsYyOvoN7vGdG"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/about/moderators/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-06T18:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=othercontributor&type=contributor"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 2-h03ykHlUump1ksBLm58MW5isGNw"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "39"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=dANVSuhCqgA6z7fZwW; loidcreated=2017-09-06T18%3A29%3A40.688Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/test_channel/api/unfriend/?raw_json=1"
+        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -465,7 +204,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 06 Sep 2017 18:29:40 GMT"
+            "Mon, 25 Sep 2017 16:29:29 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -483,13 +222,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298.0"
+            "290.0"
           ],
           "x-ratelimit-reset": [
-            "20"
+            "31"
           ],
           "x-ratelimit-used": [
-            "2"
+            "10"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -502,7 +241,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/test_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views_test.test_remove_contributor_again.json
+++ b/cassettes/channels.views_test.test_remove_contributor_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:29:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQNLA1OTS9OT/OpdClO8zR0Sg8OTw3Wza9wNvJU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVZxgalVmGFBub5lsk+4eVZpREOUfkB6V5GIeC9KSklmUmp8ZnpoAMhnCUagFVUyOruAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:29:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=uob9e4in6zOLjFWPUN; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:29:39 GMT",
+            "loidcreated=2017-09-25T16%3A29%3A39.078Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:29:39 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:29:39",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": "grant_type=refresh_token&refresh_token=281-sh12v9Ts35o8cOVuhtZCXoRfH3U"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=uob9e4in6zOLjFWPUN; loidcreated=2017-09-25T16%3A29%3A39.078Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +108,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-PQ8MO-HwPPZapJLDmysfdP1Nh-o\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:29:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "285"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "21"
           ],
           "x-ratelimit-used": [
-            "9"
+            "15"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +153,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:29:39",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -167,19 +167,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 281-PQ8MO-HwPPZapJLDmysfdP1Nh-o"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "60"
+            "62"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=uob9e4in6zOLjFWPUN; loidcreated=2017-09-25T16%3A29%3A39.078Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -204,7 +204,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:29:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +222,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "289.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "21"
           ],
           "x-ratelimit-used": [
-            "5"
+            "11"
           ],
           "x-ua-compatible": [
             "IE=edge"

--- a/cassettes/channels.views_test.test_remove_moderator_again.json
+++ b/cassettes/channels.views_test.test_remove_moderator_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:25:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNQtc/MqSPcM8q1KcorIjqwoCHYNjMoN9wg19ihW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbpGqbGeyd65VWYu7n6FSV7VgX4RVY4WTpmOlqA9KSklmUmp8ZnpoAMhnCUagG/ONuguAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:25:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=jukPADcPT26ggZgKXc; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:25:13 GMT",
+            "loidcreated=2017-09-25T16%3A25%3A13.460Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:25:13 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:25:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": "grant_type=refresh_token&refresh_token=281--1e_KaJnx7FENrcIzPNYxB9AiA8"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=jukPADcPT26ggZgKXc; loidcreated=2017-09-25T16%3A25%3A13.460Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +108,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"281-IPUqje6SPK_ky_b8ETJSqc2j0Po\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:25:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +133,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "290"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "287"
           ],
           "x-ratelimit-used": [
-            "9"
+            "10"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,7 +153,7 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:25:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -167,7 +167,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 281-IPUqje6SPK_ky_b8ETJSqc2j0Po"
           ],
           "Connection": [
             "keep-alive"
@@ -179,7 +179,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=jukPADcPT26ggZgKXc; loidcreated=2017-09-25T16%3A25%3A13.460Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -191,20 +191,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "38"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:25:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +222,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "294.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "287"
           ],
           "x-ratelimit-used": [
-            "5"
+            "6"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -238,8 +238,8 @@
           ]
         },
         "status": {
-          "code": 200,
-          "message": "OK"
+          "code": 403,
+          "message": "Forbidden"
         },
         "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
       }

--- a/cassettes/channels.views_test.test_remove_subscriber.json
+++ b/cassettes/channels.views_test.test_remove_subscriber.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-13T18:07:44",
+      "recorded_at": "2017-09-25T16:32:12",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA02NQQvCIBzFv8rwGAlGFtFtqxgeggXdxdy/qZs51I0i+u7Ndun4frzfe28kpIQQeHQtPNA+QxRbW1zzyu4UYGbYiprCdOR0UEfM0DJD8Oy1h8B1qq+3hEzsZ/P46iFN3EB48KkbpJvRIiUP90lU/18d3jSB82Zoh7FkTSmou+QQRSXOyahh1BK4rtPsHNDnC2C2sQS0AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNSNSArLNY1w9QnM9fE2C4x0Kws0908LNjQ1SzNR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblJZv455e6ula6eBt56Wb6JGdFesWbuenqGhSD9KSklmUmp8ZnpoAMhnCUagFIN+HsuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 18:07:44 GMT"
+            "Mon, 25 Sep 2017 16:32:12 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 18:07:44 GMT",
-            "loidcreated=2017-09-13T18%3A07%3A44.856Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 13-Sep-2019 18:07:44 GMT"
+            "loid=szp16zZ2qvVB31lLTW; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:32:12 GMT",
+            "loidcreated=2017-09-25T16%3A32%3A12.823Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:32:12 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,7 +70,7 @@
       }
     },
     {
-      "recorded_at": "2017-09-13T18:07:45",
+      "recorded_at": "2017-09-25T16:32:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -87,18 +87,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
+            "loid=szp16zZ2qvVB31lLTW; loidcreated=2017-09-25T16%3A32%3A12.823Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLW1S2zDEipNHTKM8gIszQONHY1tXQrdPZzTfMsVtJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2eeV4Jnr4hzpaembFG0campoZlbnkVCYmm1b5gnSkpJZlJqfGZ6aAjIVwlGoB+SJ3JbQAAAA=",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMACF/4rsGAXDKLGjIRJ50YLoNGy+3Jrk3EyU6L/n8tTxfbzvvTcpOIe1rGsUnmTnET/YrATtH02UtgM7ROckS1/1vhJxm+RQZOkRDFoaWCadsN5SOrGfz7pRw43cUBgY17W8mdHCJYP7JIr/t2Omq3wM/b0JYgzX9qJPKlQQoqbOKdFLDiZLNzwH8vkCkeKzA7gAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -112,7 +112,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
+            "Mon, 25 Sep 2017 16:32:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -134,15 +134,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
       }
     },
     {
-      "recorded_at": "2017-09-13T18:07:45",
+      "recorded_at": "2017-09-25T16:32:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=3-JlIaHOUA9Ij_3Y1562vDlyac5zM"
+          "string": "grant_type=refresh_token&refresh_token=275-KQpgRy92Cr7EexYqWpSk9kehhl0"
         },
         "headers": {
           "Accept": [
@@ -152,19 +152,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
+            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "68"
+            "70"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
+            "loid=szp16zZ2qvVB31lLTW; loidcreated=2017-09-25T16%3A32%3A12.823Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -176,328 +176,20 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"3-eZIeoJrdZm6HcXfIz5D6TnPAs8Y\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-CqgX8-cNas4yj5s13ZmvTiiztbs\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "107"
+            "109"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298"
-          ],
-          "x-ratelimit-reset": [
-            "135"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-13T18:07:45",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 3-eZIeoJrdZm6HcXfIz5D6TnPAs8Y"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/test_channel/about/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"1\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"test_channel\", \"header_img\": null, \"description_html\": null, \"title\": \"Test Channel\", \"collapse_deleted_comments\": false, \"public_description\": \"This is a test channel\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis is a test channel\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 7, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_1\", \"created\": 1504111173.0, \"url\": \"/r/test_channel/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1504111173.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "1241"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "135"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=cMBj8M9AnbBECipg8YJCmvBQL8BRfHZeIgZCxLkW3XV74F9v5ixGCOTRPkgaURbmAIDl2cnDVscu6STuO0UO0cn3anbsSM53"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/test_channel/about/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2017-09-13T18:07:45",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLRjSguL09Nzi4yKtQNKMwOdKlwLA83zXArqyzzVNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2uVZWOlUlZme4VAa4Wep6p/sW5yTp+pRXGAUGgnSkpJZlJqfGZ6aAjIVwlGoBASwnarQAAAA=",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
-      }
-    },
-    {
-      "recorded_at": "2017-09-13T18:07:45",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLW9fEzjUgqjfdP9w5NdA8riXBLNAlIdA5yzQjJVtJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2ZXlk+aZFReZFVEYWOBkURyZFmnpZhJe5BDsagHSkpJZlJqfGZ6aAjIVwlGoBPMzQS7QAAAA=",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=othersubscriber"
-      }
-    },
-    {
-      "recorded_at": "2017-09-13T18:07:45",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=3-jHjMfZYnXyYpB0sYbY5J8WvDSA0"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "Basic c2N6YUlUWVdNd0xoWEE6RnNxX2NGQW1veDBkYWhBVGdkejZaMjV2S0lv"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "68"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"access_token\": \"3-J2pPppabnACLI-XN93H36kRxhQ0\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "107"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
+            "Mon, 25 Sep 2017 16:32:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -512,7 +204,7 @@
             "297"
           ],
           "x-ratelimit-reset": [
-            "135"
+            "467"
           ],
           "x-ratelimit-used": [
             "3"
@@ -529,11 +221,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-13T18:07:45",
+      "recorded_at": "2017-09-25T16:32:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=unsub&api_type=json&sr_name=test_channel"
+          "string": "action=unsub&api_type=json&sr_name=admin_channel"
         },
         "headers": {
           "Accept": [
@@ -543,19 +235,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 3-J2pPppabnACLI-XN93H36kRxhQ0"
+            "bearer 275-CqgX8-cNas4yj5s13ZmvTiiztbs"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "47"
+            "48"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=9taHMfmDmrrUWjDJU5; loidcreated=2017-09-13T18%3A07%3A44.856Z"
+            "loid=szp16zZ2qvVB31lLTW; loidcreated=2017-09-25T16%3A32%3A12.823Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -580,7 +272,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 13 Sep 2017 18:07:45 GMT"
+            "Mon, 25 Sep 2017 16:32:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -598,13 +290,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298.0"
+            "297.0"
           ],
           "x-ratelimit-reset": [
-            "135"
+            "467"
           ],
           "x-ratelimit-used": [
-            "2"
+            "3"
           ],
           "x-ua-compatible": [
             "IE=edge"

--- a/cassettes/channels.views_test.test_remove_subscriber_again.json
+++ b/cassettes/channels.views_test.test_remove_subscriber_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:32:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -26,7 +26,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmaEto2JSNCosChzWMcX/iQUmamVKJ/z8lVy3u45943E1Ki1mDaBh9s47BV5LuwK7Ktmwc83AvO66aPDUFSjNnYs6XDcOhIoQayQrD2vIn9fDBjh3akRKFQ2a6W7YwWNim8TWL9/3ZNtM5973CRwzM830UJ8YmoiY5Vap0KXyQRqLLDc2CfL0UXGxW4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNSt0C3KiUz1zfI08Ig3KjdzzDIPDDWOLykzdjZQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFl6cFObsW6LpWmEaEhFim+BW6hIWWh5QXJ5qA9KSklmUmp8ZnpoAMhnCUagGdrSlbuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:32:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=zDebhPFlG58vMUwJDu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT",
-            "loidcreated=2017-09-25T16%3A24%3A57.328Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:24:57 GMT"
+            "loid=UzZZcQPNo6YYT98HXB; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:32:22 GMT",
+            "loidcreated=2017-09-25T16%3A32%3A22.199Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:32:22 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -70,11 +70,79 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:32:22",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-ZDssO10KTcxu4Smab_9Qiik8MdE"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=UzZZcQPNo6YYT98HXB; loidcreated=2017-09-25T16%3A32%3A22.199Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA12NywrCMBREf6VkKRaqVSNuFRVBMdkobkKb3NL4argJplb8d5t253IOc2Y+JJMSrBWuusGTLCIyptMYTrQ+7q7xgfLNxMulL+5lg3hesT0ZRgRqoxGs0EFIZ0nSss4X7m0gjOSQIWDoWln1aBASQtGK5d+bZ67ZPtCYEfI1ndtUWRDswpvuTcFLSxBaheE+kO8PF9vIYbgAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Sep 2017 16:32:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
+      }
+    },
+    {
+      "recorded_at": "2017-09-25T16:32:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=275-ewQtzHmrpp1rRF78s3dse_QZRzM"
         },
         "headers": {
           "Accept": [
@@ -96,7 +164,7 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=UzZZcQPNo6YYT98HXB; loidcreated=2017-09-25T16%3A32%3A22.199Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -108,7 +176,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-_KwRGQqk74zJ0jah2lupY0TSIT8\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"275-urGizwsL3Xc41q7INfKrXemXv0Q\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Connection": [
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:32:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -133,13 +201,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "291"
+            "296"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "458"
           ],
           "x-ratelimit-used": [
-            "9"
+            "4"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -153,11 +221,11 @@
       }
     },
     {
-      "recorded_at": "2017-09-25T16:24:57",
+      "recorded_at": "2017-09-25T16:32:22",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&type=moderator"
+          "string": "action=unsub&api_type=json&sr_name=admin_channel"
         },
         "headers": {
           "Accept": [
@@ -167,44 +235,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-_KwRGQqk74zJ0jah2lupY0TSIT8"
+            "bearer 275-urGizwsL3Xc41q7INfKrXemXv0Q"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "60"
+            "48"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=zDebhPFlG58vMUwJDu; loidcreated=2017-09-25T16%3A24%3A57.328Z"
+            "loid=UzZZcQPNo6YYT98HXB; loidcreated=2017-09-25T16%3A32%3A22.199Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "38"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:24:57 GMT"
+            "Mon, 25 Sep 2017 16:32:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -222,13 +290,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "295.0"
+            "296.0"
           ],
           "x-ratelimit-reset": [
-            "303"
+            "458"
           ],
           "x-ratelimit-used": [
-            "5"
+            "4"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -238,10 +306,10 @@
           ]
         },
         "status": {
-          "code": 200,
-          "message": "OK"
+          "code": 404,
+          "message": "Not Found"
         },
-        "url": "https://reddit.local/r/admin_channel/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
       }
     }
   ],

--- a/channels/views.py
+++ b/channels/views.py
@@ -4,11 +4,11 @@ from functools import lru_cache
 from django.contrib.auth import get_user_model
 from praw.models.reddit.redditor import Redditor
 from rest_framework import status
+from rest_framework.views import APIView
 from rest_framework.generics import (
     CreateAPIView,
     ListAPIView,
     ListCreateAPIView,
-    RetrieveDestroyAPIView,
     RetrieveUpdateAPIView,
     RetrieveUpdateDestroyAPIView,
 )
@@ -17,7 +17,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from channels.api import Api
-from channels.exceptions import RemoveUserException
 from channels.serializers import (
     ChannelSerializer,
     CommentSerializer,
@@ -71,25 +70,35 @@ class ModeratorListView(ListCreateAPIView):
         return api.list_moderators(channel_name)
 
 
-class ModeratorDetailView(RetrieveDestroyAPIView):
+class ModeratorDetailView(APIView):
     """
     View to retrieve and remove moderators
     """
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission,)
-    serializer_class = ModeratorSerializer
 
-    def get_object(self):
+    def get(self, request, *args, **kwargs):
         """Get moderator for the channel"""
-        api = Api(user=self.request.user)
+        api = Api(user=request.user)
+        moderator_name = self.kwargs['moderator_name']
+        channel_name = self.kwargs['channel_name']
+        if moderator_name not in api.list_moderators(channel_name):
+            raise NotFound('User {} is not a moderator of {}'.format(moderator_name, channel_name))
+        return Response(
+            ModeratorSerializer(
+                Redditor(api.reddit, name=moderator_name)
+            ).data
+        )
+
+    def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Removes a contributor from a channel
+        """
+        api = Api(user=request.user)
+        channel_name = self.kwargs['channel_name']
         moderator_name = self.kwargs['moderator_name']
 
-        return Redditor(api.reddit, name=moderator_name)
-
-    def perform_destroy(self, moderator):
-        """Remove moderator in a channel"""
-        api = Api(user=self.request.user)
-        channel_name = self.kwargs['channel_name']
-        api.remove_moderator(moderator.name, channel_name)
+        api.remove_moderator(moderator_name, channel_name)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class PostListView(ListCreateAPIView):
@@ -184,38 +193,35 @@ class ContributorListView(ListCreateAPIView):
         return api.list_contributors(self.kwargs['channel_name'])
 
 
-class ContributorDetailView(RetrieveDestroyAPIView):
+class ContributorDetailView(APIView):
     """
     View to retrieve and remove contributors in channels
     """
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
-    serializer_class = ContributorSerializer
 
-    def get_object(self):
+    def get(self, request, *args, **kwargs):
         """Get contributor in channel"""
-        api = Api(user=self.request.user)
+        api = Api(user=request.user)
         contributor_name = self.kwargs['contributor_name']
         channel_name = self.kwargs['channel_name']
         if contributor_name not in api.list_contributors(channel_name):
             raise NotFound('User {} is not a contributor of {}'.format(contributor_name, channel_name))
-        return Redditor(api.reddit, name=contributor_name)
+        return Response(
+            ContributorSerializer(
+                Redditor(api.reddit, name=contributor_name)
+            ).data
+        )
 
-    def perform_destroy(self, contributor):
+    def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Removes a contributor from a channel
         """
-        api = Api(user=self.request.user)
+        api = Api(user=request.user)
         channel_name = self.kwargs['channel_name']
-        api.remove_contributor(contributor.name, channel_name)
+        contributor_name = self.kwargs['contributor_name']
 
-    def delete(self, request, *args, **kwargs):
-        try:
-            return super().delete(self, request, *args, **kwargs)
-        except RemoveUserException as exc:
-            return Response(
-                data={'error': str(exc)},
-                status=status.HTTP_409_CONFLICT
-            )
+        api.remove_contributor(contributor_name, channel_name)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class SubscriberListView(CreateAPIView):
@@ -226,26 +232,32 @@ class SubscriberListView(CreateAPIView):
     serializer_class = SubscriberSerializer
 
 
-class SubscriberDetailView(RetrieveDestroyAPIView):
+class SubscriberDetailView(APIView):
     """
     View to retrieve and remove subscribers in channels
     """
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
-    serializer_class = SubscriberSerializer
 
-    def get_object(self):
-        """Get subscriber in channel"""
-        api = Api(user=self.request.user)
+    def get(self, request, *args, **kwargs):
+        """Get moderator for the channel"""
+        api = Api(user=request.user)
         subscriber_name = self.kwargs['subscriber_name']
         channel_name = self.kwargs['channel_name']
         if not api.is_subscriber(subscriber_name, channel_name):
             raise NotFound('User {} is not a subscriber of {}'.format(subscriber_name, channel_name))
-        return Redditor(api.reddit, name=subscriber_name)
+        return Response(
+            SubscriberSerializer(
+                Redditor(api.reddit, name=subscriber_name)
+            ).data
+        )
 
-    def perform_destroy(self, subscriber):
+    def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
-        Removes a subscriber from a channel
+        Removes a contributor from a channel
         """
-        api = Api(user=self.request.user)
+        api = Api(user=request.user)
         channel_name = self.kwargs['channel_name']
-        api.remove_subscriber(subscriber.name, channel_name)
+        subscriber_name = self.kwargs['subscriber_name']
+
+        api.remove_subscriber(subscriber_name, channel_name)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/channels/views.py
+++ b/channels/views.py
@@ -91,7 +91,7 @@ class ModeratorDetailView(APIView):
 
     def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
-        Removes a contributor from a channel
+        Removes a moderator from a channel
         """
         api = Api(user=request.user)
         channel_name = self.kwargs['channel_name']
@@ -239,7 +239,7 @@ class SubscriberDetailView(APIView):
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
 
     def get(self, request, *args, **kwargs):
-        """Get moderator for the channel"""
+        """Get subscriber for the channel"""
         api = Api(user=request.user)
         subscriber_name = self.kwargs['subscriber_name']
         channel_name = self.kwargs['channel_name']
@@ -253,7 +253,7 @@ class SubscriberDetailView(APIView):
 
     def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
-        Removes a contributor from a channel
+        Removes a subscriber from a channel
         """
         api = Api(user=request.user)
         channel_name = self.kwargs['channel_name']


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #187 

#### What's this PR do?
- Changes is_subscriber to look through the list of subscribed channels to see if a user is a subscriber. The channel info API will return 403 if the user is not a contributor so this is unreliable.
 - Handles double adds and deletes for moderator, subscriber and contributor. The status code should be 201 for an add and a 204 for a delete.

#### How should this be manually tested?
Make a private channel and have a user who is not on the list of contributors for that channel. Go to `/api/v0/channels/<channel>/subscribers/<username>/` and verify that it returns a 404. A DELETE to that API should return a 204, though it may not make a change since this is inaccessable in the reddit API.
