### PR TITLE
refactor create post form

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -16,13 +16,20 @@ type CreatePostFormProps = {
   postForm: ?PostForm,
   channel: Channel,
   history: Object,
-  processing: boolean
+  processing: boolean,
+  channels: Map<string, Channel>,
+  updateChannelSelection: Function
 }
 
 const goBackAndHandleEvent = R.curry((history, e) => {
   e.preventDefault()
   history.goBack()
 })
+
+const channelOptions = (channels: Map<string, Channel>) =>
+  Array.from(channels).map(([key, value], index) =>
+    <option label={value.title} value={key} key={index} />
+  )
 
 export default class CreatePostForm extends React.Component {
   props: CreatePostFormProps
@@ -35,7 +42,9 @@ export default class CreatePostForm extends React.Component {
       onSubmit,
       updateIsText,
       history,
-      processing
+      processing,
+      channels,
+      updateChannelSelection
     } = this.props
     if (!postForm) {
       return null
@@ -49,7 +58,7 @@ export default class CreatePostForm extends React.Component {
 
     return (
       <div>
-        <ChannelBreadcrumbs channel={channel} />
+        {channel ? <ChannelBreadcrumbs channel={channel} /> : null}
         <Card className="new-post-card">
           <form onSubmit={onSubmit}>
             <div className="post-types row">
@@ -96,6 +105,17 @@ export default class CreatePostForm extends React.Component {
                   onChange={onUpdate}
                 />
               </div>}
+            <div className="row channel-select">
+              <label>Channel</label>
+              <select
+                onChange={updateChannelSelection}
+                name="channel"
+                value={channel ? channel.name : ""}
+              >
+                <option label="Select a channel" value="" />
+                {channelOptions(channels)}
+              </select>
+            </div>
             <div className="posting-policy row">
               <span>
                 Please be mindful of{" "}

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -8,14 +8,6 @@ import { newPostURL, getChannelNameFromPathname } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
-const submitPostButton = channelName =>
-  <Link
-    className="mdc-button mdc-button--raised blue-button"
-    to={newPostURL(channelName)}
-  >
-    Submit a New Post
-  </Link>
-
 type NavigationProps = {
   pathname: string,
   subscribedChannels: Array<Channel>
@@ -28,7 +20,12 @@ const Navigation = (props: NavigationProps) => {
 
   return (
     <div className="navigation">
-      {channelName ? submitPostButton(channelName) : null}
+      <Link
+        className="mdc-button mdc-button--raised blue-button"
+        to={newPostURL(channelName)}
+      >
+        Submit a New Post
+      </Link>
       <SubscriptionsList subscribedChannels={subscribedChannels} />
     </div>
   )

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -16,24 +16,27 @@ describe("Navigation", () => {
     const renderComponent = (props = defaultProps) =>
       shallow(<Navigation {...props} />)
 
-    it("should not show a create post link if channelName is not in URL", () => {
-      let wrapper = renderComponent()
-      assert.lengthOf(wrapper.find(Link), 0)
+    it("create post link should not have channel name if channelName is not in URL", () => {
+      const wrapper = renderComponent()
+      assert.lengthOf(wrapper.find(Link), 1)
+      const props = wrapper.find(Link).props()
+      assert.equal(props.to, "/create_post/")
+      assert.equal(props.children, "Submit a New Post")
     })
 
-    it("should show create post link if channelName is in URL", () => {
-      let wrapper = renderComponent({
+    it("create post link should have channel name if channelName is in URL", () => {
+      const wrapper = renderComponent({
         ...defaultProps,
         pathname: "/channel/foobar"
       })
-      let link = wrapper.find(Link)
+      const link = wrapper.find(Link)
       assert.equal(link.props().to, newPostURL("foobar"))
       assert.equal(link.props().children, "Submit a New Post")
     })
 
     it("should show a SubscriptionsList", () => {
-      let channels = makeChannelList(10)
-      let wrapper = renderComponent({
+      const channels = makeChannelList(10)
+      const wrapper = renderComponent({
         ...defaultProps,
         subscribedChannels: channels
       })

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -58,7 +58,7 @@ class App extends React.Component {
         />
         <Route path={`${match.url}manage/`} component={AdminPage} />
         <Route
-          path={`${match.url}create_post/:channelName`}
+          path={`${match.url}create_post/:channelName?`}
           component={CreatePostPage}
         />
       </div>

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux"
 import R from "ramda"
 
 import CreatePostForm from "../components/CreatePostForm"
+
 import { actions } from "../actions"
 import { newPostForm } from "../lib/posts"
 import { postDetailURL } from "../lib/url"
@@ -20,7 +21,7 @@ type CreatePostPageProps = {
   dispatch: Dispatch,
   postForm: ?FormValue,
   channel: Channel,
-  channels: RestState<Array<Channel>>,
+  channels: RestState<Map<string, Channel>>,
   history: Object,
   processing: boolean
 }
@@ -35,7 +36,7 @@ class CreatePostPage extends React.Component {
   componentWillMount() {
     const { dispatch, channels } = this.props
     const channelName = getChannelName(this.props)
-    if (!channels.loaded && !channels.processing) {
+    if (!channels.loaded && !channels.processing && channelName) {
       dispatch(actions.channels.get(channelName))
     }
     dispatch(
@@ -90,10 +91,19 @@ class CreatePostPage extends React.Component {
     })
   }
 
-  render() {
-    const { channel, postForm, history, processing } = this.props
+  updateChannelSelection = (e: Object) => {
+    const { history } = this.props
 
-    if (!postForm || R.isNil(channel)) {
+    e.preventDefault()
+    if (e.target.value) {
+      history.push(e.target.value)
+    }
+  }
+
+  render() {
+    const { channel, channels, postForm, history, processing } = this.props
+
+    if (!postForm) {
       return null
     }
 
@@ -104,10 +114,12 @@ class CreatePostPage extends React.Component {
             onSubmit={this.onSubmit}
             onUpdate={this.onUpdate}
             updateIsText={this.updateIsText}
+            updateChannelSelection={this.updateChannelSelection}
             postForm={postForm.value}
             channel={channel}
             history={history}
             processing={processing}
+            channels={channels.data}
           />
         </div>
       </div>

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -6,7 +6,8 @@ export const channelURL = (channelName: string) => `/channel/${channelName}`
 export const postDetailURL = (channelName: string, postID: string) =>
   `/channel/${channelName}/${postID}`
 
-export const newPostURL = (channelName: string) => `/create_post/${channelName}`
+export const newPostURL = (channelName: ?string) =>
+  channelName ? `/create_post/${channelName}` : "/create_post/"
 
 export const frontPageURL = () => "/"
 

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -29,6 +29,10 @@ describe("url helper functions", () => {
     it("should return a url for creating a new post", () => {
       assert.equal(newPostURL("channel_name"), "/create_post/channel_name")
     })
+
+    it("should return a non-specific URL if not passed a channel name", () => {
+      assert.equal(newPostURL(undefined), "/create_post/")
+    })
   })
 
   describe("frontPageURL", () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #126 

#### What's this PR do?

this refactors some aspects of the create post page so that we can put a link to it on any page.

#### How should this be manually tested?

You should be able to see the 'create post' link on any page. If you click on it from the home page it should not have a subreddit pre-selected, and if you click on it from a subreddit it should have the right subreddit pre-selected.

You should be able to submit a post to a subreddit. You shouldn't be able to submit a post until you've selected a subreddit.