### PR TITLE
set eslint pefer-const rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
       "plugin:react/recommended"
   ],
   "rules": {
+    "prefer-const": [2],
     "key-spacing": [2, {
       "beforeColon": false,
       "afterColon": true,

--- a/static/js/components/Card_test.js
+++ b/static/js/components/Card_test.js
@@ -6,7 +6,7 @@ import { assert } from "chai"
 import Card from "./Card"
 
 describe("Card component", () => {
-  let mountCard = (children, props = {}) =>
+  const mountCard = (children, props = {}) =>
     shallow(
       <Card {...props}>
         {children}
@@ -14,18 +14,18 @@ describe("Card component", () => {
     )
 
   it("should render children", () => {
-    let wrapper = mountCard(<div className="child">HEY</div>)
+    const wrapper = mountCard(<div className="child">HEY</div>)
     assert.lengthOf(wrapper.find(".child"), 1)
     assert.equal(wrapper.text(), "HEY")
   })
 
   it("should put className, if passed one", () => {
-    let wrapper = mountCard(<div />, { className: "HEY THERE" })
+    const wrapper = mountCard(<div />, { className: "HEY THERE" })
     assert.equal(wrapper.props().className, "card HEY THERE")
   })
 
   it("should display a title, if passed one", () => {
-    let wrapper = mountCard(<div />, { title: "HEY THERE" })
+    const wrapper = mountCard(<div />, { title: "HEY THERE" })
     assert.equal(wrapper.text(), "HEY THERE")
   })
 })

--- a/static/js/components/ChannelBreadcrumbs_test.js
+++ b/static/js/components/ChannelBreadcrumbs_test.js
@@ -13,9 +13,9 @@ describe("ChannelBreadcrumbs", () => {
     shallow(<ChannelBreadcrumbs channel={channel} />)
 
   it("should render breadcrumbs", () => {
-    let channel = makeChannel()
-    let wrapper = renderBreadcrumbs(channel)
-    let [first, second] = wrapper.find(Link)
+    const channel = makeChannel()
+    const wrapper = renderBreadcrumbs(channel)
+    const [first, second] = wrapper.find(Link)
     assert.equal(first.props.to, "/")
     assert.equal(first.props.children, "Discussions")
     assert.equal(second.props.to, `/channel/${channel.name}`)

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -46,14 +46,14 @@ describe("CommentTree", () => {
     )
 
   it("should render all top-level comments as separate cards", () => {
-    let wrapper = renderCommentTree()
+    const wrapper = renderCommentTree()
     assert.equal(wrapper.find(Card).length, comments.length)
   })
 
   it("should render all replies to a top-level comment", () => {
-    let wrapper = renderCommentTree()
-    let firstComment = wrapper.find(".top-level-comment").at(0)
-    let replies = firstComment.find(".comment")
+    const wrapper = renderCommentTree()
+    const firstComment = wrapper.find(".top-level-comment").at(0)
+    const replies = firstComment.find(".comment")
     const countReplies = R.compose(
       R.reduce((acc, val) => acc + countReplies(val), 1),
       R.prop("replies")
@@ -63,8 +63,8 @@ describe("CommentTree", () => {
 
   it("should use markdown to render comments, should skip images", () => {
     comments[0].text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
-    let wrapper = renderCommentTree()
-    let firstComment = wrapper.find(".top-level-comment").at(0)
+    const wrapper = renderCommentTree()
+    const firstComment = wrapper.find(".top-level-comment").at(0)
     assert.equal(
       firstComment.find(ReactMarkdown).first().props().source,
       comments[0].text
@@ -73,14 +73,14 @@ describe("CommentTree", () => {
   })
 
   it("should render a profile image", () => {
-    let wrapper = renderCommentTree()
-    let { src } = wrapper.find(".profile-image").at(0).props()
+    const wrapper = renderCommentTree()
+    const { src } = wrapper.find(".profile-image").at(0).props()
     assert.equal(src, comments[0].profile_image)
   })
 
   it("should put a className on replies, to allow for indentation", () => {
-    let wrapper = renderCommentTree()
-    let firstComment = wrapper.find(".top-level-comment").at(0)
+    const wrapper = renderCommentTree()
+    const firstComment = wrapper.find(".top-level-comment").at(0)
     assert.equal(
       firstComment.find(".comment").at(0).props().className,
       "comment"
@@ -89,7 +89,7 @@ describe("CommentTree", () => {
   })
 
   it('should include a "reply" button', () => {
-    let wrapper = renderCommentTree()
+    const wrapper = renderCommentTree()
     wrapper.find(".reply-button").at(0).simulate("click")
     assert.ok(beginReplyStub.called)
     assert.ok(beginReplyStub.calledWith(replyToCommentKey(comments[0])))

--- a/static/js/components/CommentVoteForm_test.js
+++ b/static/js/components/CommentVoteForm_test.js
@@ -34,7 +34,7 @@ describe("CommentVoteForm", () => {
     sandbox.restore()
   })
 
-  let renderForm = (props = {}) =>
+  const renderForm = (props = {}) =>
     mount(
       <CommentVoteForm
         comment={comment}
@@ -84,7 +84,7 @@ describe("CommentVoteForm", () => {
   ;[true, false].forEach(isUpvote => {
     describe(`clicks the ${isUpvote ? "upvote" : "downvote"} button`, () => {
       it("when the previous state was clear", async () => {
-        let wrapper = renderForm()
+        const wrapper = renderForm()
         const voteStub = isUpvote ? upvoteStub : downvoteStub
 
         wrapper
@@ -119,7 +119,7 @@ describe("CommentVoteForm", () => {
           } else {
             comment.downvoted = true
           }
-          let wrapper = renderForm()
+          const wrapper = renderForm()
 
           assertButtons(wrapper, wasUpvote, false, false)
 

--- a/static/js/components/CreateCommentForm_test.js
+++ b/static/js/components/CreateCommentForm_test.js
@@ -99,7 +99,7 @@ describe("CreateCommentForm", () => {
           }
         })
       })
-      let btnProps = wrapper.find("button").props()
+      const btnProps = wrapper.find("button").props()
       assert.isTrue(btnProps.disabled)
       assert.equal(btnProps.className, "blue-button disabled")
     })
@@ -119,7 +119,7 @@ describe("CreateCommentForm", () => {
     })
 
     it("should trigger an update in state when text is input", async () => {
-      let state = await helper.listenForActions([forms.FORM_UPDATE], () => {
+      const state = await helper.listenForActions([forms.FORM_UPDATE], () => {
         wrapper.find("textarea[name='text']").simulate("change", {
           target: {
             name:  "text",
@@ -146,7 +146,7 @@ describe("CreateCommentForm", () => {
         })
       })
 
-      let state = await helper.listenForActions(
+      const state = await helper.listenForActions(
         [
           requestType,
           successType,
@@ -215,7 +215,7 @@ describe("CreateCommentForm", () => {
           }
         })
       })
-      let btnProps = wrapper.find("button").props()
+      const btnProps = wrapper.find("button").props()
       assert.isTrue(btnProps.disabled)
       assert.equal(btnProps.className, "blue-button disabled")
     })
@@ -242,7 +242,7 @@ describe("CreateCommentForm", () => {
     })
 
     it("should cancel and hide the form", async () => {
-      let mockPreventDefault = helper.sandbox.stub()
+      const mockPreventDefault = helper.sandbox.stub()
       const state = await helper.listenForActions([forms.FORM_END_EDIT], () => {
         wrapper.find(".cancel-button").simulate("click", {
           preventDefault: mockPreventDefault

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -59,7 +59,7 @@ describe("PostDisplay", () => {
 
   it("should display text, if given a text post and the 'expanded' flag", () => {
     const post = makePost()
-    let string = "JUST SOME GREAT TEXT!"
+    const string = "JUST SOME GREAT TEXT!"
     post.text = string
     const wrapper = renderPostDisplay({ post: post, expanded: true })
     assert.equal(wrapper.find(ReactMarkdown).props().source, string)
@@ -82,14 +82,14 @@ describe("PostDisplay", () => {
 
   it("should not display text, if given a text post but lacking the 'expanded' flag", () => {
     const post = makePost()
-    let string = "JUST SOME GREAT TEXT!"
+    const string = "JUST SOME GREAT TEXT!"
     post.text = string
     const wrapper = renderPostDisplay({ post: post })
     assert.notInclude(wrapper.text(), string)
   })
 
   it("should include an external link, if a url post", () => {
-    let post = makePost(true)
+    const post = makePost(true)
     const wrapper = renderPostDisplay({ post: post })
     const { href, target, children } = wrapper.find("a").at(0).props()
     assert.equal(href, post.url)
@@ -98,7 +98,7 @@ describe("PostDisplay", () => {
   })
 
   it("should link to the detail view, if a text post", () => {
-    let post = makePost()
+    const post = makePost()
     const wrapper = renderPostDisplay({ post: post })
     const { to, children } = wrapper.find(Link).at(0).props()
     assert.equal(children, post.title)
@@ -124,7 +124,7 @@ describe("PostDisplay", () => {
   ;[true, false].forEach(prevUpvote => {
     it(`should show the correct UI when the upvote 
     button is clicked when prev state was ${String(prevUpvote)}`, async () => {
-      let post = makePost()
+      const post = makePost()
       post.upvoted = prevUpvote
       // setting to a function so Flow doesn't complain
       let resolveUpvote = () => null

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -12,18 +12,18 @@ describe("PostList", () => {
     shallow(<PostList toggleUpvote={() => {}} {...props} />)
 
   it("should render a list of posts", () => {
-    let wrapper = renderPostList()
+    const wrapper = renderPostList()
     assert.lengthOf(wrapper.find(PostDisplay), 20)
   })
 
   it("should behave well if handed an empty list", () => {
-    let wrapper = renderPostList({ posts: [] })
+    const wrapper = renderPostList({ posts: [] })
     assert.lengthOf(wrapper.find(PostDisplay), 0)
     assert.equal(wrapper.text(), "There are no posts to display.")
   })
 
   it("should pass the showChannelLinks prop to PostDisplay", () => {
-    let wrapper = renderPostList({
+    const wrapper = renderPostList({
       posts:            makeChannelPostList(),
       showChannelLinks: true
     })

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -19,7 +19,7 @@ describe("SubscriptionsList", function() {
   })
 
   it("should show each channel", () => {
-    let wrapper = renderSubscriptionsList()
+    const wrapper = renderSubscriptionsList()
     assert.equal(wrapper.find(Link).length, channels.length)
     wrapper.find(Link).forEach((link, index) => {
       assert.equal(link.props().to, channelURL(channels[index].name))

--- a/static/js/components/admin/ChannelEditForm_test.js
+++ b/static/js/components/admin/ChannelEditForm_test.js
@@ -33,10 +33,10 @@ describe("ChannelEditForm", () => {
   })
 
   it("should render a blank form", () => {
-    let wrapper = renderForm(form)
-    let [title, name] = wrapper.find('input[type="text"]')
-    let [description] = wrapper.find("textarea")
-    let [radioPublic, radioPrivate] = wrapper.find('input[type="radio"]')
+    const wrapper = renderForm(form)
+    const [title, name] = wrapper.find('input[type="text"]')
+    const [description] = wrapper.find("textarea")
+    const [radioPublic, radioPrivate] = wrapper.find('input[type="radio"]')
     assert.equal(title.props.value, "")
     assert.equal(name.props.value, "")
     assert.equal(description.props.value, "")
@@ -63,18 +63,18 @@ describe("ChannelEditForm", () => {
     })
 
     describe("onUpdate", () => {
-      for (let inputName of ["title", "name", "public_description"]) {
+      for (const inputName of ["title", "name", "public_description"]) {
         it(`should be called when ${inputName} input is modified`, () => {
-          let event = { target: { value: "text" } }
+          const event = { target: { value: "text" } }
           assert.isNotOk(onSubmit.called)
           wrapper.find(`[name="${inputName}"]`).simulate("change", event)
           assert.isOk(onUpdate.calledWith(event))
         })
       }
 
-      for (let channelType of [CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC]) {
+      for (const channelType of [CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC]) {
         it(`should be called when ${channelType} channel_type is clicked`, () => {
-          let event = { target: { value: channelType } }
+          const event = { target: { value: channelType } }
           assert.isNotOk(onSubmit.called)
           wrapper.find(`#channel_${channelType}`).simulate("change", event)
           assert.isOk(onUpdate.calledWith(event))

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -52,15 +52,15 @@ describe("ChannelPage", () => {
     ])
 
   it("should fetch postsForChannel, set post data, and render", async () => {
-    let [wrapper] = await renderPage(currentChannel)
+    const [wrapper] = await renderPage(currentChannel)
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
   })
 
   it("should handle missing data gracefully", async () => {
-    let otherChannel = makeChannel()
+    const otherChannel = makeChannel()
     otherChannel.name =
       "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
-    let [wrapper] = await renderPage(otherChannel)
+    const [wrapper] = await renderPage(otherChannel)
     assert.lengthOf(wrapper.find(".loading").find(".sk-three-bounce"), 1)
   })
 

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -38,7 +38,7 @@ describe("HomePage", () => {
     ])
 
   it("should fetch frontpage, set post data, render", async () => {
-    let [wrapper] = await renderPage()
+    const [wrapper] = await renderPage()
     assert.deepEqual(wrapper.find(PostList).props().posts, postList)
   })
 

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -52,7 +52,7 @@ describe("PostPage", function() {
     ])
 
   it("should fetch post, comments, channel, and render", async () => {
-    let [wrapper] = await renderPage()
+    const [wrapper] = await renderPage()
     assert.deepEqual(wrapper.find(CommentTree).props().comments, comments)
   })
   ;[
@@ -65,7 +65,7 @@ describe("PostPage", function() {
       const comment = comments[0].replies[2]
       assert(comment, "comment not found")
       // set initial state for upvoted or downvoted so we can flip it the other way
-      let expectedPayload = {}
+      const expectedPayload = {}
       if (isUpvote) {
         comment.upvoted = wasClear
         expectedPayload.upvoted = !wasClear
@@ -81,21 +81,21 @@ describe("PostPage", function() {
       }
       helper.updateCommentStub.returns(Promise.resolve(expectedComment))
 
-      let newState = await listenForActions(
+      const newState = await listenForActions(
         [
           actions.comments.patch.requestType,
           actions.comments.patch.successType
         ],
         () => {
-          let props = wrapper.find("CommentTree").props()
-          let voteFunc = isUpvote ? props.upvote : props.downvote
+          const props = wrapper.find("CommentTree").props()
+          const voteFunc = isUpvote ? props.upvote : props.downvote
           voteFunc(comment)
         }
       )
 
-      let commentTree = newState.comments.data.get(post.id)
-      let lens = findComment(commentTree, comment.id)
-      let updatedComment = R.view(lens, commentTree)
+      const commentTree = newState.comments.data.get(post.id)
+      const lens = findComment(commentTree, comment.id)
+      const updatedComment = R.view(lens, commentTree)
       if (isUpvote) {
         assert.equal(comment.upvoted, !updatedComment.upvoted)
       } else {
@@ -113,8 +113,8 @@ describe("PostPage", function() {
 
   it("passed props to each CommentVoteForm", async () => {
     const [wrapper] = await renderPage()
-    let commentTree = wrapper.find("CommentTree")
-    let commentTreeProps = commentTree.props()
+    const commentTree = wrapper.find("CommentTree")
+    const commentTreeProps = commentTree.props()
     for (const form of wrapper.find("CommentVoteForm")) {
       const fromProps = form.props
       assert.equal(fromProps.downvote, commentTreeProps.downvote)

--- a/static/js/factories/channels_test.js
+++ b/static/js/factories/channels_test.js
@@ -5,7 +5,7 @@ import { makeChannel } from "./channels"
 
 describe("channels factory", () => {
   it("should make a channel", () => {
-    let channel = makeChannel()
+    const channel = makeChannel()
     assert.isString(channel.name)
     assert.isString(channel.title)
     assert.equal(channel.channel_type, "public")

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -31,7 +31,7 @@ export const makeCommentTree = (
   post: Post,
   minComments: number = 1
 ): Array<Comment> => {
-  let topLevelComments = arrayN(minComments, 10).map(() => makeComment(post))
+  const topLevelComments = arrayN(minComments, 10).map(() => makeComment(post))
 
   topLevelComments.forEach((comment, index) => {
     if (casual.coin_flip || index === 0) {

--- a/static/js/factories/comments_test.js
+++ b/static/js/factories/comments_test.js
@@ -7,7 +7,7 @@ import { makeCommentTree } from "./comments"
 
 describe("comment factories", () => {
   it("should make a tree of comments", () => {
-    let post = makePost()
+    const post = makePost()
     makeCommentTree(post).forEach(comment => {
       assert.isString(comment.id)
       assert.equal(comment.post_id, post.id)
@@ -23,12 +23,12 @@ describe("comment factories", () => {
   })
 
   it("should always put replies on the first comment", () => {
-    let [firstComment] = makeCommentTree(makePost())
+    const [firstComment] = makeCommentTree(makePost())
     assert.isNotEmpty(firstComment.replies)
   })
 
   it("should have unique IDs", () => {
-    let ids = makeCommentTree(makePost()).map(comment => comment.id)
+    const ids = makeCommentTree(makePost()).map(comment => comment.id)
     assert.equal(ids.length, new Set(ids).size)
   })
 })

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -7,7 +7,7 @@ import { makePost, makeChannelPostList } from "./posts"
 describe("posts factories", () => {
   describe("makePost", () => {
     it("should make a text post", () => {
-      let post = makePost()
+      const post = makePost()
       assert.isString(post.id)
       assert.isString(post.title)
       assert.isBoolean(post.upvoted)
@@ -20,19 +20,19 @@ describe("posts factories", () => {
     })
 
     it("should make a URL post", () => {
-      let post = makePost(true)
+      const post = makePost(true)
       assert.isNull(post.text)
       assert.isString(post.url)
     })
 
     it("should randomly generate username", () => {
-      let firstPost = makePost()
-      let secondPost = makePost()
+      const firstPost = makePost()
+      const secondPost = makePost()
       assert.notEqual(firstPost.author_id, secondPost.author_id)
     })
 
     it("should randomly generate upvotes", () => {
-      let upvoteScores = R.range(1, 20).map(makePost).map(R.prop("score"))
+      const upvoteScores = R.range(1, 20).map(makePost).map(R.prop("score"))
       assert.isAbove(new Set(upvoteScores).size, 1)
     })
   })

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -17,7 +17,7 @@ if (!Object.entries) {
 // cleanup after each test run
 // eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(function() {
-  let node = document.querySelector("#integration_test_div")
+  const node = document.querySelector("#integration_test_div")
   if (node) {
     ReactDOM.unmountComponentAtNode(node)
   }

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -63,7 +63,7 @@ export function getPost(postId: string): Promise<Post> {
 }
 
 export async function getComments(postID: string): Promise<CommentResponse> {
-  let response = await fetchWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
+  const response = await fetchWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
   return { postID, data: response }
 }
 
@@ -72,7 +72,7 @@ export function createComment(
   comment: string,
   commentId: ?string
 ) {
-  let body =
+  const body =
     commentId === undefined
       ? { text: comment }
       : { text: comment, comment_id: commentId }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -30,8 +30,8 @@ describe("api", function() {
   afterEach(function() {
     sandbox.restore()
 
-    for (let cookie of document.cookie.split(";")) {
-      let key = cookie.split("=")[0].trim()
+    for (const cookie of document.cookie.split(";")) {
+      const key = cookie.split("=")[0].trim()
       document.cookie = `${key}=`
     }
   })

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -23,8 +23,8 @@ describe("auth", function() {
   afterEach(function() {
     sandbox.restore()
     fetchMock.restore()
-    for (let cookie of document.cookie.split(";")) {
-      let key = cookie.split("=")[0].trim()
+    for (const cookie of document.cookie.split(";")) {
+      const key = cookie.split("=")[0].trim()
       document.cookie = `${key}=`
     }
   })
@@ -38,14 +38,14 @@ describe("auth", function() {
     assert.equal(window.location.pathname, "/") // no redirect happened
   })
 
-  for (let [message, error] of [
+  for (const [message, error] of [
     ["a 500 error", error500],
     ["an unexpected exception", typeError]
   ]) {
     it(`does not renew auth for ${message}`, async () => {
       fetchStub.returns(Promise.reject(error))
 
-      let response = await assert.isRejected(auth.fetchWithAuthFailure("/url"))
+      const response = await assert.isRejected(auth.fetchWithAuthFailure("/url"))
 
       sinon.assert.calledWith(fetchStub, "/url")
       assert.equal(fetchStub.callCount, 1)

--- a/static/js/lib/comments_test.js
+++ b/static/js/lib/comments_test.js
@@ -14,23 +14,23 @@ describe("comments lib functions", () => {
   })
 
   it("finds a root comment", () => {
-    let root = comments[1]
+    const root = comments[1]
     assert(root, "missing comment")
-    let lens = findComment(comments, root.id)
+    const lens = findComment(comments, root.id)
     assert.deepEqual(R.view(lens, comments), root)
   })
 
   it("finds a nested comment", () => {
-    let root = comments[0]
-    let firstChild = root.replies[0]
-    let secondChild = firstChild.replies[2]
+    const root = comments[0]
+    const firstChild = root.replies[0]
+    const secondChild = firstChild.replies[2]
     assert(secondChild, "missing comment")
-    let lens = findComment(comments, secondChild.id)
+    const lens = findComment(comments, secondChild.id)
     assert.deepEqual(R.view(lens, comments), secondChild)
   })
 
   it("can't find the comment", () => {
-    let lens = findComment(comments, "not_a_comment_id")
+    const lens = findComment(comments, "not_a_comment_id")
     assert.isNull(lens)
   })
 })

--- a/static/js/lib/maps_test.js
+++ b/static/js/lib/maps_test.js
@@ -6,10 +6,10 @@ import { safeBulkGet } from "./maps"
 
 describe("Map helper utils", () => {
   describe("safeBulkGet", () => {
-    let keys = ["just", "write", "more", "tests"]
+    const keys = ["just", "write", "more", "tests"]
 
     it("should accept a list of IDs and a Map, and return the right entries", () => {
-      let map = new Map()
+      const map = new Map()
       keys.forEach(key => {
         map.set(key, R.toUpper(key))
       })
@@ -21,7 +21,7 @@ describe("Map helper utils", () => {
     })
 
     it("should return an empty list, given no keys", () => {
-      let map = new Map()
+      const map = new Map()
       keys.forEach(key => {
         map.set(key, R.toUpper(key))
       })

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -15,7 +15,7 @@ describe("Post utils", () => {
   })
 
   it("should correctly format comments", () => {
-    let post = makePost()
+    const post = makePost()
     ;[
       [0, "0 Comments"],
       [1, "1 Comment"],

--- a/static/js/lib/sanctuary_test.js
+++ b/static/js/lib/sanctuary_test.js
@@ -32,10 +32,10 @@ const assertIsRight = (e, val) => {
 
 describe("sanctuary util functions", () => {
   describe("allJust", () => {
-    let maybes = [Just(2), Just("maybe?")]
+    const maybes = [Just(2), Just("maybe?")]
 
     it("should return Just(values) if passed an array of Just values", () => {
-      let checked = allJust(maybes)
+      const checked = allJust(maybes)
       assert(S.isJust(checked))
       checked.value.forEach((m, i) => assertMaybeEquality(m, maybes[i]))
     })
@@ -66,14 +66,14 @@ describe("sanctuary util functions", () => {
     })
 
     it("return func(input) if the input is not nil", () => {
-      let result = ifNil(x => x)("test input")
+      const result = ifNil(x => x)("test input")
       assert.equal("test input", result)
     })
   })
 
   describe("guard", () => {
-    let wrappedFunc = guard(x => x + 2)
-    let wrappedRestFunc = guard((x, y, z) => [x, y, z])
+    const wrappedFunc = guard(x => x + 2)
+    const wrappedRestFunc = guard((x, y, z) => [x, y, z])
 
     it("takes a function and returns a function", () => {
       assert.isFunction(wrappedFunc)
@@ -94,7 +94,7 @@ describe("sanctuary util functions", () => {
     })
 
     it("returns Nothing if any rest parameter arg is undefined", () => {
-      let args = [1, 2, 3]
+      const args = [1, 2, 3]
       ;[null, undefined].forEach(nilVal => {
         for (let i = 0; i < 3; i++) {
           assertIsNothing(wrappedRestFunc(...R.update(i, nilVal, args)))
@@ -127,7 +127,7 @@ describe("sanctuary util functions", () => {
     })
 
     it("returns Right(Object) if handed good JSON", () => {
-      let testObj = {
+      const testObj = {
         foo: ["bar", "baz"]
       }
       assertIsRight(parseJSON(JSON.stringify(testObj)), testObj)
@@ -135,8 +135,8 @@ describe("sanctuary util functions", () => {
   })
 
   describe("filterE", () => {
-    let left = S.Left(2)
-    let right = S.Right(4)
+    const left = S.Left(2)
+    const right = S.Right(4)
     it("returns a Left if passed one, regardless of predicate", () => {
       assertIsLeft(filterE(x => x === 2, left), 2)
       assertIsLeft(filterE(x => x !== 2, left), 2)

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -26,7 +26,7 @@ describe("utility functions", () => {
       yield* [6, 7, 8, 9, 10]
     }
 
-    let list = []
+    const list = []
     for (const item of enumerate(someNums())) {
       list.push(item)
     }

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -11,13 +11,13 @@ export const channelsEndpoint = {
   initialState:      { ...INITIAL_STATE, data: new Map() },
   getFunc:           (name: string) => api.getChannel(name),
   getSuccessHandler: (payload: Channel, data: Map<string, Channel>) => {
-    let update = new Map(data)
+    const update = new Map(data)
     update.set(payload.name, payload)
     return update
   },
   postFunc:           (channel: Channel) => api.createChannel(channel),
   postSuccessHandler: (payload: Channel, data: Map<string, Channel>) => {
-    let update = new Map(data)
+    const update = new Map(data)
     update.set(payload.name, payload)
     return update
   },

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -27,7 +27,7 @@ const appendCommentToTree = (
     return R.prepend(comment, tree)
   }
 
-  let lens = findComment(tree, commentId)
+  const lens = findComment(tree, commentId)
   if (!lens) {
     // should probably not get to this point, the original comment should still be present
     // if the API returned a message saying that the reply was successful
@@ -35,7 +35,7 @@ const appendCommentToTree = (
   }
 
   let treeComment = R.view(lens, tree)
-  let replies = [...treeComment.replies, comment]
+  const replies = [...treeComment.replies, comment]
   treeComment = { ...treeComment, replies }
   return R.set(lens, treeComment, tree)
 }
@@ -44,13 +44,13 @@ const updateCommentTree = (
   tree: Array<Comment>,
   updatedComment: Comment
 ): Array<Comment> => {
-  let lens = findComment(tree, updatedComment.id)
+  const lens = findComment(tree, updatedComment.id)
   if (lens === null) {
     return tree
   }
 
-  let original = R.view(lens, tree)
-  let replies = original.replies
+  const original = R.view(lens, tree)
+  const replies = original.replies
   updatedComment = { ...updatedComment, replies }
 
   return R.set(lens, updatedComment, tree)
@@ -65,7 +65,7 @@ export const commentsEndpoint = {
     response: CommentResponse,
     data: Map<string, Array<Comment>>
   ) => {
-    let update = new Map(data)
+    const update = new Map(data)
     update.set(response.postID, response.data)
     return update
   },
@@ -77,8 +77,8 @@ export const commentsEndpoint = {
     { commentId, postId, comment }: CommentPayload,
     data: Map<string, Array<Comment>>
   ) => {
-    let update = new Map(data)
-    let oldTree = data.get(postId)
+    const update = new Map(data)
+    const oldTree = data.get(postId)
     if (oldTree) {
       update.set(postId, appendCommentToTree(oldTree, comment, commentId))
     }
@@ -90,9 +90,9 @@ export const commentsEndpoint = {
     response: Comment,
     data: Map<string, Array<Comment>>
   ) => {
-    let update = new Map(data)
-    let postId = response.post_id
-    let oldTree = data.get(postId)
+    const update = new Map(data)
+    const postId = response.post_id
+    const oldTree = data.get(postId)
     if (oldTree) {
       update.set(postId, updateCommentTree(oldTree, response))
     }

--- a/static/js/reducers/comments_test.js
+++ b/static/js/reducers/comments_test.js
@@ -49,7 +49,7 @@ describe("comments reducers", () => {
       requestType,
       successType
     ]).then(({ data }) => {
-      let comments = data.get(post.id)
+      const comments = data.get(post.id)
       assert.isArray(comments)
       assert.isNotEmpty(comments[0].replies)
     })
@@ -121,7 +121,7 @@ describe("comments reducers", () => {
   })
 
   it("should let you update a comment", async () => {
-    let comment = tree[0].replies[0]
+    const comment = tree[0].replies[0]
     comment.upvoted = false
     helper.updateCommentStub.returns(
       Promise.resolve({
@@ -129,7 +129,7 @@ describe("comments reducers", () => {
         upvoted: true
       })
     )
-    let state = await listenForActions(
+    const state = await listenForActions(
       [
         actions.comments.get.requestType,
         actions.comments.get.successType,

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -31,7 +31,7 @@ describe("reducers", () => {
       dispatchThen = store.createDispatchThen(state => state.posts)
       helper.getPostStub.resetBehavior() // needed because ``callsFake`` doesn't override the ``throws``
       helper.getPostStub.callsFake(async id => {
-        let post = makePost()
+        const post = makePost()
         post.id = id
         return post
       })
@@ -50,7 +50,7 @@ describe("reducers", () => {
         requestType,
         successType
       ]).then(posts => {
-        let post = posts.data.get("mypostid")
+        const post = posts.data.get("mypostid")
         assert.equal(post.id, "mypostid")
         assert.isString(post.title)
       })
@@ -61,7 +61,7 @@ describe("reducers", () => {
         store.dispatch(actions.posts.get("first")),
         store.dispatch(actions.posts.get("second"))
       ]).then(() => {
-        let { posts: { data } } = store.getState()
+        const { posts: { data } } = store.getState()
         assert.equal(data.get("first").id, "first")
         assert.equal(data.get("second").id, "second")
         assert.equal(data.size, 2)
@@ -69,7 +69,7 @@ describe("reducers", () => {
     })
 
     it("should allow setting a post record separately", () => {
-      let post = makePost()
+      const post = makePost()
       post.id = "my great post wow"
       store.dispatch(setPostData(post))
       const { posts } = store.getState()
@@ -78,7 +78,7 @@ describe("reducers", () => {
     })
 
     it("should let you set a list of posts separately", () => {
-      let posts = makeChannelPostList()
+      const posts = makeChannelPostList()
       store.dispatch(setPostData(posts))
       const { posts: { data } } = store.getState()
       assert.equal(data.size, 20)
@@ -90,7 +90,7 @@ describe("reducers", () => {
       dispatchThen = store.createDispatchThen(state => state.channels)
       helper.getChannelStub.resetBehavior() // needed because ``callsFake`` doesn't override the ``throws``
       helper.getChannelStub.callsFake(async name => {
-        let channel = makeChannel()
+        const channel = makeChannel()
         channel.name = name
         return channel
       })
@@ -111,7 +111,7 @@ describe("reducers", () => {
         requestType,
         successType
       ]).then(channels => {
-        let channel = channels.data.get("wowowowow")
+        const channel = channels.data.get("wowowowow")
         assert.isString(channel.name)
         assert.equal(channel.channel_type, "public")
       })
@@ -122,7 +122,7 @@ describe("reducers", () => {
         store.dispatch(actions.channels.get("first")),
         store.dispatch(actions.channels.get("second"))
       ]).then(() => {
-        let { channels: { data } } = store.getState()
+        const { channels: { data } } = store.getState()
         assert.equal(data.get("first").name, "first")
         assert.equal(data.get("second").name, "second")
         assert.equal(data.size, 2)
@@ -131,8 +131,8 @@ describe("reducers", () => {
 
     it("should let you create a channel", async () => {
       const { requestType, successType } = actions.channels.post
-      let channel = makeChannel()
-      let channels = await dispatchThen(actions.channels.post(channel), [
+      const channel = makeChannel()
+      const channels = await dispatchThen(actions.channels.post(channel), [
         requestType,
         successType
       ])
@@ -141,7 +141,7 @@ describe("reducers", () => {
 
     it("should let you set a list of channels separately", () => {
       const numChannels = 9
-      let channels = makeChannelList(numChannels)
+      const channels = makeChannelList(numChannels)
       store.dispatch(setChannelData(channels))
       let data = store.getState().channels.data
       assert.equal(data.size, numChannels)
@@ -187,7 +187,7 @@ describe("reducers", () => {
         actions.postsForChannel.get("channel"),
         [requestType, successType]
       )
-      let channel = data.get("channel")
+      const channel = data.get("channel")
       assert.isArray(channel)
       assert.lengthOf(channel, 20)
     })
@@ -197,7 +197,7 @@ describe("reducers", () => {
         store.dispatch(actions.postsForChannel.get("first")),
         store.dispatch(actions.postsForChannel.get("second"))
       ])
-      let { postsForChannel: { data } } = store.getState()
+      const { postsForChannel: { data } } = store.getState()
       assert.isArray(data.get("first"))
       assert.isArray(data.get("second"))
       assert.equal(data.size, 2)

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -10,7 +10,7 @@ const mergePostData = (
   post: Post,
   data: Map<string, Post>
 ): Map<string, Post> => {
-  let update = new Map(data)
+  const update = new Map(data)
   update.set(post.id, post)
   return update
 }
@@ -19,7 +19,7 @@ const mergeMultiplePosts = (
   posts: Array<Post>,
   data: Map<string, Post>
 ): Map<string, Post> => {
-  let update = new Map(data)
+  const update = new Map(data)
   posts.forEach(post => {
     update.set(post.id, post)
   })
@@ -37,7 +37,7 @@ export const postsEndpoint = {
   getSuccessHandler:  mergePostData,
   extraActions:       {
     [SET_POST_DATA]: (state, action) => {
-      let update =
+      const update =
         action.payload instanceof Array
           ? mergeMultiplePosts(action.payload, state.data)
           : mergePostData(action.payload, state.data)

--- a/static/js/reducers/posts_for_channel.js
+++ b/static/js/reducers/posts_for_channel.js
@@ -22,7 +22,7 @@ export const postsForChannelEndpoint = {
     data: Map<string, Array<string>>
   ) => {
     const { channelName, posts } = payload
-    let update = new Map(data)
+    const update = new Map(data)
     update.set(channelName, posts.map(post => post.id))
     return update
   }

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -35,9 +35,9 @@ export default class IntegrationTestHelper {
     // stub all the api functions
     // NOTE: due to a regression in sinon 2.x, if you use `callsFake` you must
     //       call `resetBehavior()` on the stub first or the error still raises
-    for (let methodName in api) {
+    for (const methodName in api) {
       if (typeof api[methodName] === "function") {
-        let stubName = `${methodName}Stub`
+        const stubName = `${methodName}Stub`
         this[stubName] = this.sandbox
           .stub(api, methodName)
           .throws(new Error(`${stubName} not implemented`))

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -19,7 +19,7 @@ export function createAssertReducerResultState<State>(
     const getState = () => stateLookup(getReducerState(store.getState()))
 
     assert.deepEqual(defaultValue, getState())
-    for (let value of [
+    for (const value of [
       true,
       null,
       false,


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

just sets the 'prefer-const' rule, which tells us to use `const` to declare variables whenever we don't need to reassign them. this rule can be enforced automatically with `eslint --fix` so the code changes are all as a result of `npm run fmt`.

I wanted to add this because I have a real tendency to use `let` when I probably shouldn't :laughing: 

#### How should this be manually tested?

tests should pass, functionality should be all good