### PR TITLE
add profile name to post and comment APIs

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -124,6 +124,7 @@ class PostSerializer(serializers.Serializer):
     num_comments = serializers.IntegerField(read_only=True)
     channel_name = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
+    author_name = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -143,6 +144,13 @@ class PostSerializer(serializers.Serializer):
     def get_url(self, instance):
         """Returns a url or null depending on if it's a self post"""
         return instance.url if not instance.is_self else None
+
+    def get_author_name(self, instance):
+        """get the authors name"""
+        user = self._get_user(instance)
+        if user and user.profile.name:
+            return user.profile.name
+        return "[deleted]"
 
     def get_profile_image(self, instance):
         """Find the Profile for the comment author"""
@@ -240,6 +248,7 @@ class CommentSerializer(serializers.Serializer):
     created = serializers.SerializerMethodField()
     replies = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
+    author_name = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -289,6 +298,15 @@ class CommentSerializer(serializers.Serializer):
         if user and user.profile.image_small:
             return user.profile.image_small
         return default_profile_image
+
+    def get_author_name(self, instance):
+        """get the author name"""
+        # this is a similar setup to the get_profile_image thingy above
+        user = self._get_user(instance)
+
+        if user and user.profile.name:
+            return user.profile.name
+        return "[deleted]"
 
     def get_downvoted(self, instance):
         """Is a comment downvoted?"""

--- a/channels/views.py
+++ b/channels/views.py
@@ -110,7 +110,7 @@ def _lookup_users_for_posts(posts):
         username__in=[
             post.author.name for post in posts if post.author
         ]
-    )
+    ).select_related('profile')
     return {user.username: user for user in users}
 
 
@@ -236,7 +236,7 @@ def _lookup_users_for_comments(comments):
     author_set = set()
     _populate_authors_for_comments(comments, author_set)
 
-    users = User.objects.filter(username__in=author_set)
+    users = User.objects.filter(username__in=author_set).select_related('profile')
     return {user.username: user for user in users}
 
 

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -1,4 +1,5 @@
 """Tests for views for REST APIs for channels"""
+# pylint: disable=too-many-lines
 import pytest
 from django.core.urlresolvers import reverse
 from rest_framework import status
@@ -7,7 +8,7 @@ from channels.serializers import default_profile_image
 from open_discussions.factories import UserFactory
 from profiles.factories import ProfileFactory
 
-# pylint: disable=redefined-outer-name, unused-argument
+# pylint: disable=redefined-outer-name, unused-argument, too-many-lines
 pytestmark = pytest.mark.django_db
 
 
@@ -153,7 +154,8 @@ def test_create_url_post(client, logged_in_profile, use_betamax, praw_settings):
         'num_comments': 0,
         'score': 1,
         'channel_name': 'unit_tests',
-        "profile_image": logged_in_profile.image_small
+        "profile_image": logged_in_profile.image_small,
+        "author_name": logged_in_profile.name,
     }
 
 
@@ -178,7 +180,8 @@ def test_create_text_post(client, logged_in_profile, use_betamax, praw_settings)
         'num_comments': 0,
         'score': 1,
         'channel_name': 'unit_tests',
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        "author_name": logged_in_profile.name,
     }
 
 
@@ -233,7 +236,8 @@ def test_get_post(client, logged_in_profile, use_betamax, praw_settings, missing
             'num_comments': 2,
             'score': 1,
             'channel_name': 'macromasters',
-            'profile_image': profile_image
+            'profile_image': profile_image,
+            "author_name": profile.name,
         }
 
 
@@ -244,8 +248,10 @@ def test_list_posts(client, logged_in_profile, use_betamax, praw_settings, missi
         logged_in_profile.user.username = 'renamed'
         logged_in_profile.user.save()
         profile_image = default_profile_image
+        name = "[deleted]"
     else:
         profile_image = logged_in_profile.image_small
+        name = logged_in_profile.name
 
     url = reverse('post-list', kwargs={'channel_name': 'two_posts'})
     resp = client.get(url)
@@ -273,7 +279,8 @@ def test_list_posts(client, logged_in_profile, use_betamax, praw_settings, missi
                 'created': '2017-07-21T19:10:26+00:00',
                 'num_comments': 0,
                 'channel_name': 'two_posts',
-                "profile_image": profile_image
+                "profile_image": profile_image,
+                "author_name": name
             },
             {
                 'url': 'http://micromasters.mit.edu',
@@ -286,7 +293,8 @@ def test_list_posts(client, logged_in_profile, use_betamax, praw_settings, missi
                 'created': '2017-07-21T19:09:37+00:00',
                 'num_comments': 0,
                 'channel_name': 'two_posts',
-                "profile_image": profile_image
+                "profile_image": profile_image,
+                "author_name": name
             }
         ]
 
@@ -308,7 +316,8 @@ def test_update_post_text(client, logged_in_profile, use_betamax, praw_settings)
         'created': '2017-07-21T19:10:26+00:00',
         'num_comments': 0,
         'channel_name': 'two_posts',
-        "profile_image": logged_in_profile.image_small
+        "profile_image": logged_in_profile.image_small,
+        "author_name": logged_in_profile.name,
     }
 
 
@@ -330,6 +339,7 @@ def test_update_post_clear_vote(client, logged_in_profile, use_betamax, praw_set
         'num_comments': 0,
         'channel_name': 'two_posts',
         "profile_image": logged_in_profile.image_small,
+        "author_name": logged_in_profile.name,
     }
 
 
@@ -350,7 +360,8 @@ def test_update_post_upvote(client, logged_in_profile, use_betamax, praw_setting
         'created': '2017-07-21T19:10:26+00:00',
         'num_comments': 0,
         'channel_name': 'two_posts',
-        "profile_image": logged_in_profile.image_small
+        "profile_image": logged_in_profile.image_small,
+        "author_name": logged_in_profile.name,
     }
 
 
@@ -374,7 +385,8 @@ def test_create_post_without_upvote(client, logged_in_profile, use_betamax, praw
         'num_comments': 0,
         'score': 1,
         'channel_name': 'subreddit_for_testing',
-        "profile_image": logged_in_profile.image_small
+        "profile_image": logged_in_profile.image_small,
+        "author_name": logged_in_profile.name
     }
 
 
@@ -385,10 +397,12 @@ def test_list_comments(client, logged_in_profile, use_betamax, praw_settings, mi
         logged_in_profile.user.username = 'renamed'
         logged_in_profile.user.save()
         profile_image = default_profile_image
+        name = "[deleted]"
         author_id = '[deleted]'
     else:
         profile_image = logged_in_profile.image_small
         author_id = logged_in_profile.user.username
+        name = logged_in_profile.name
 
     url = reverse('comment-list', kwargs={'post_id': '2'})
     resp = client.get(url)
@@ -404,6 +418,7 @@ def test_list_comments(client, logged_in_profile, use_betamax, praw_settings, mi
             "downvoted": False,
             "created": "2017-07-25T17:09:45+00:00",
             'profile_image': profile_image,
+            'author_name': name,
             "replies": [
                 {
                     "id": "2",
@@ -416,6 +431,7 @@ def test_list_comments(client, logged_in_profile, use_betamax, praw_settings, mi
                     "created": "2017-07-25T17:15:57+00:00",
                     "replies": [],
                     'profile_image': profile_image,
+                    'author_name': name,
                 },
                 {
                     "id": "3",
@@ -428,6 +444,7 @@ def test_list_comments(client, logged_in_profile, use_betamax, praw_settings, mi
                     "created": "2017-07-25T17:16:10+00:00",
                     "replies": [],
                     'profile_image': profile_image,
+                    'author_name': name,
                 }
             ]
         }
@@ -458,12 +475,14 @@ def test_list_deleted_comments(client, logged_in_profile, use_betamax, praw_sett
                 'replies': [],
                 'score': 1,
                 'text': 'reply to parent which is not deleted',
-                'upvoted': False
+                'upvoted': False,
+                "author_name": user.profile.name
             }],
             'score': 1,
             'text': '[deleted]',
             'upvoted': False,
             'id': '1s',
+            "author_name": "[deleted]"
         }]
 
 
@@ -490,7 +509,8 @@ def test_get_comment(client, logged_in_profile, use_betamax, praw_settings, miss
             "downvoted": False,
             "created": "2017-07-25T21:18:47+00:00",
             "replies": [],
-            'profile_image': logged_in_profile.image_small
+            'profile_image': logged_in_profile.image_small,
+            'author_name': logged_in_profile.name,
         }
 
 
@@ -511,7 +531,8 @@ def test_get_comment_no_image(client, logged_in_profile, use_betamax, praw_setti
         "downvoted": False,
         "created": "2017-07-25T21:18:47+00:00",
         "replies": [],
-        'profile_image': default_profile_image
+        'profile_image': default_profile_image,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -542,7 +563,8 @@ def test_create_comment(client, logged_in_profile, use_betamax, praw_settings):
         'text': 'reply_to_post 2',
         'upvoted': True,
         "downvoted": False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -565,7 +587,8 @@ def test_create_comment_no_upvote(client, logged_in_profile, use_betamax, praw_s
         'text': 'no upvoted',
         'upvoted': False,
         "downvoted": False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -588,7 +611,8 @@ def test_create_comment_downvote(client, logged_in_profile, use_betamax, praw_se
         'text': 'downvoted',
         'upvoted': False,
         'downvoted': True,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -611,7 +635,8 @@ def test_create_comment_reply_to_comment(client, logged_in_profile, use_betamax,
         'text': 'reply_to_comment 3',
         'upvoted': True,
         "downvoted": False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -632,7 +657,8 @@ def test_update_comment_text(client, logged_in_profile, use_betamax, praw_settin
         'text': 'updated text',
         'upvoted': False,
         'downvoted': False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -654,7 +680,8 @@ def test_update_comment_upvote(client, logged_in_profile, use_betamax, praw_sett
         'text': 'downvoted',
         'upvoted': True,
         'downvoted': False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -676,7 +703,8 @@ def test_update_comment_downvote(client, logged_in_profile, use_betamax, praw_se
         'text': 'downvoted',
         'upvoted': False,
         'downvoted': True,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -697,7 +725,8 @@ def test_update_comment_clear_upvote(client, logged_in_profile, use_betamax, pra
         'text': 'reply_to_comment 3',
         'upvoted': False,
         'downvoted': False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -719,7 +748,8 @@ def test_update_comment_clear_downvote(client, logged_in_profile, use_betamax, p
         'text': 'downvoted',
         'upvoted': False,
         'downvoted': False,
-        'profile_image': logged_in_profile.image_small
+        'profile_image': logged_in_profile.image_small,
+        'author_name': logged_in_profile.name,
     }
 
 
@@ -755,6 +785,7 @@ def test_frontpage(client, logged_in_profile, use_betamax, praw_settings, missin
                 "created": "2017-07-25T22:05:44+00:00",
                 "num_comments": 0,
                 "channel_name": "subreddit_for_testing",
+                'author_name': logged_in_profile.name,
                 "profile_image": logged_in_profile.image_small
             },
             {
@@ -768,6 +799,7 @@ def test_frontpage(client, logged_in_profile, use_betamax, praw_settings, missin
                 "created": "2017-07-25T17:57:07+00:00",
                 "num_comments": 0,
                 "channel_name": "a_channel",
+                'author_name': logged_in_profile.name,
                 "profile_image": logged_in_profile.image_small
             },
             {
@@ -781,6 +813,7 @@ def test_frontpage(client, logged_in_profile, use_betamax, praw_settings, missin
                 "created": "2017-07-25T22:02:40+00:00",
                 "num_comments": 0,
                 "channel_name": "subreddit_for_testing",
+                'author_name': logged_in_profile.name,
                 "profile_image": logged_in_profile.image_small
             },
             {
@@ -794,6 +827,7 @@ def test_frontpage(client, logged_in_profile, use_betamax, praw_settings, missin
                 "created": "2017-07-25T15:31:44+00:00",
                 "num_comments": 6,
                 "channel_name": "subreddit_for_testing",
+                'author_name': logged_in_profile.name,
                 "profile_image": logged_in_profile.image_small
             },
             {
@@ -807,6 +841,7 @@ def test_frontpage(client, logged_in_profile, use_betamax, praw_settings, missin
                 "created": "2017-07-25T15:07:30+00:00",
                 "num_comments": 0,
                 "channel_name": "subreddit_for_testing",
+                'author_name': logged_in_profile.name,
                 "profile_image": logged_in_profile.image_small
             }
         ]

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -62,7 +62,7 @@ const renderComment = R.curry(
         <div className="comment-contents">
           <div className="author-info">
             <a className="author-name">
-              {comment.author_id}
+              {comment.author_name}
             </a>
             <div>
               {moment(comment.created).fromNow()}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -94,4 +94,15 @@ describe("CommentTree", () => {
     assert.ok(beginReplyStub.called)
     assert.ok(beginReplyStub.calledWith(replyToCommentKey(comments[0])))
   })
+
+  it("should show the author name", () => {
+    const wrapper = renderCommentTree()
+    const authorName = wrapper
+      .find(".comment")
+      .at(0)
+      .find(".author-name")
+      .at(0)
+      .text()
+    assert.equal(authorName, comments[0].author_name)
+  })
 })

--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -115,8 +115,7 @@ class PostDisplay extends React.Component {
             {postTitle(post)}
           </div>
           <div className="authored-by">
-            <a>{post.author_id || "someone"}</a> {formattedDate}{" "}
-            {this.showChannelLink()}
+            <a>{post.author_name}</a> {formattedDate} {this.showChannelLink()}
           </div>
           <div className="num-comments">
             {expanded

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -46,8 +46,8 @@ describe("PostDisplay", () => {
       formatCommentsCount(post)
     )
     const authoredBy = wrapper.find(".authored-by").text()
-    assert(authoredBy.startsWith(post.author_id))
-    assert.isNotEmpty(authoredBy.substring(post.author_id.length))
+    assert(authoredBy.startsWith(post.author_name))
+    assert.isNotEmpty(authoredBy.substring(post.author_name.length))
   })
 
   it("should link to the subreddit, if told to", () => {

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -18,7 +18,8 @@ export const makeComment = (post: Post): Comment => {
     downvoted:     casual.coin_flip,
     created:       casual.moment.format(),
     replies:       [],
-    profile_image: casual.url
+    profile_image: casual.url,
+    author_name:   casual.name
   }
 
   if (comment.upvoted && comment.downvoted) {

--- a/static/js/factories/comments_test.js
+++ b/static/js/factories/comments_test.js
@@ -19,6 +19,7 @@ describe("comment factories", () => {
       assert(moment(comment.created).isValid())
       assert.isArray(comment.replies)
       assert.isString(comment.profile_image)
+      assert.isString(comment.author_name)
     })
   })
 

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -22,7 +22,8 @@ export const makePost = (
   created:       casual.moment.format(),
   num_comments:  Math.round(Math.random() * 10),
   channel_name:  channelName,
-  profile_image: casual.url
+  profile_image: casual.url,
+  author_name:   casual.name
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -17,6 +17,7 @@ describe("posts factories", () => {
       assert.isString(post.created)
       assert.isNumber(post.num_comments)
       assert.isString(post.profile_image)
+      assert.isString(post.author_name)
     })
 
     it("should make a URL post", () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -29,6 +29,7 @@ export type Post = {
   num_comments:  number,
   channel_name:  string,
   profile_image: string,
+  author_name:   string,
 }
 
 export type PostForm = {
@@ -55,6 +56,7 @@ export type Comment = {
   replies:       Array<Comment>,
   author_id:     string,
   profile_image: string,
+  author_name:   string,
 }
 
 export type CommentForm = {


### PR DESCRIPTION
#### What are the relevant tickets?

#188 

#### What's this PR do?

this adds the `.name` from the user's profile to the results returned by both the comment and post APIs, and makes the changes in the UI to display that information.

#### How should this be manually tested?

If you look at a post or a channel you should see names instead of usernames, same with comments on a post.