### PR TITLE
set page title

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ramda": "^0.24.1",
     "react": "^15.6.1",
     "react-addons-shallow-compare": "^15.6.0",
+    "react-document-title": "^2.0.3",
     "react-dom": "^15.6.1",
     "react-ga": "^2.2.0",
     "react-hot-loader": "next",

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { Route } from "react-router-dom"
 import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
 
 import HomePage from "./HomePage"
 import ChannelPage from "./ChannelPage"
@@ -44,6 +45,7 @@ class App extends React.Component {
     const { match } = this.props
     return (
       <div className="app">
+        <DocumentTitle title="MIT Open Discussions" />
         <Toolbar toggleShowSidebar={this.toggleShowSidebar} />
         <Drawer />
         <Route exact path={match.url} component={HomePage} />

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -2,6 +2,7 @@
 import React from "react"
 import R from "ramda"
 import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
 
 import Card from "../components/Card"
 import PostList from "../components/PostList"
@@ -16,6 +17,7 @@ import { getChannelName } from "../lib/util"
 import { toggleUpvote } from "../util/api_actions"
 import { anyError } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
+import { formatTitle } from "../lib/title"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
@@ -64,6 +66,7 @@ class ChannelPage extends React.Component {
     } else {
       return (
         <div>
+          <DocumentTitle title={formatTitle(channel.title)} />
           <ChannelBreadcrumbs channel={channel} />
           <Card title={channel.title}>
             <PostList

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -12,6 +12,7 @@ import { SET_POST_DATA } from "../actions/post"
 import { SET_CHANNEL_DATA } from "../actions/channel"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { channelURL } from "../lib/url"
+import { formatTitle } from "../lib/title"
 
 describe("ChannelPage", () => {
   let helper,
@@ -50,6 +51,11 @@ describe("ChannelPage", () => {
       SET_POST_DATA,
       SET_CHANNEL_DATA
     ])
+
+  it("should set the document title", async () => {
+    await renderPage(currentChannel)
+    assert.equal(document.title, formatTitle(currentChannel.title))
+  })
 
   it("should fetch postsForChannel, set post data, and render", async () => {
     const [wrapper] = await renderPage(currentChannel)

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
+import DocumentTitle from "react-document-title"
 
 import CreatePostForm from "../components/CreatePostForm"
 
@@ -9,6 +10,7 @@ import { actions } from "../actions"
 import { newPostForm } from "../lib/posts"
 import { postDetailURL } from "../lib/url"
 import { getChannelName } from "../lib/util"
+import { formatTitle } from "../lib/title"
 
 import type { FormValue } from "../flow/formTypes"
 import type { Channel, CreatePostPayload } from "../flow/discussionTypes"
@@ -109,6 +111,7 @@ class CreatePostPage extends React.Component {
 
     return (
       <div className="content">
+        <DocumentTitle title={formatTitle("Submit a Post")} />
         <div className="main-content">
           <CreatePostForm
             onSubmit={this.onSubmit}

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -7,6 +7,7 @@ import { makePost, makeChannelPostList } from "../factories/posts"
 import { newPostURL } from "../lib/url"
 import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
+import { formatTitle } from "../lib/title"
 
 import type { CreatePostPayload } from "../flow/discussionTypes"
 
@@ -61,6 +62,11 @@ describe("CreatePostPage", () => {
         ]
     )
   }
+
+  it("should set the document title", async () => {
+    await renderPage()
+    assert.equal(document.title, formatTitle("Submit a Post"))
+  })
 
   it("attempts to clear form and load channels on mount", async () => {
     const [wrapper] = await renderPage()

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
+import DocumentTitle from "react-document-title"
 
 import Card from "../components/Card"
 import withLoading from "../components/Loading"
@@ -18,6 +19,7 @@ import { getChannelName, getPostID } from "../lib/util"
 import { anyError } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { beginReply } from "../components/CreateCommentForm"
+import { formatTitle } from "../lib/title"
 
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
@@ -103,6 +105,7 @@ class PostPage extends React.Component {
     return (
       <div>
         <ChannelBreadcrumbs channel={channel} />
+        <DocumentTitle title={formatTitle(post.title)} />
         <Card>
           <div className="post-card">
             <PostDisplay

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -12,6 +12,7 @@ import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { findComment } from "../lib/comments"
 import { postDetailURL } from "../lib/url"
+import { formatTitle } from "../lib/title"
 
 describe("PostPage", function() {
   let helper, renderComponent, listenForActions, post, comments, channel
@@ -50,6 +51,11 @@ describe("PostPage", function() {
       actions.channels.get.requestType,
       actions.channels.get.successType
     ])
+
+  it("should set the document title", async () => {
+    await renderPage()
+    assert.equal(document.title, formatTitle(post.title))
+  })
 
   it("should fetch post, comments, channel, and render", async () => {
     const [wrapper] = await renderPage()

--- a/static/js/containers/admin/CreateChannelPage.js
+++ b/static/js/containers/admin/CreateChannelPage.js
@@ -2,11 +2,13 @@
 import React from "react"
 import R from "ramda"
 import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
 
 import ChannelEditForm from "../../components/admin/ChannelEditForm"
 import { actions } from "../../actions"
 import { channelURL } from "../../lib/url"
 import { newChannelForm } from "../../lib/channels"
+import { formatTitle } from "../../lib/title"
 
 import type { Dispatch } from "redux"
 import type { FormValue } from "../../flow/formTypes"
@@ -70,6 +72,7 @@ class CreateChannelPage extends React.Component {
 
     return (
       <div>
+        <DocumentTitle title={formatTitle("Create a Channel")} />
         <ChannelEditForm
           onSubmit={this.onSubmit}
           onUpdate={this.onUpdate}

--- a/static/js/lib/title.js
+++ b/static/js/lib/title.js
@@ -1,0 +1,3 @@
+// @flow
+
+export const formatTitle = (text: string) => `${text} | MIT Open Discussions`

--- a/static/js/lib/title_test.js
+++ b/static/js/lib/title_test.js
@@ -1,0 +1,13 @@
+// @flow
+import { assert } from "chai"
+
+import { formatTitle } from "./title"
+
+describe("title lib", () => {
+  it("should format the thing correctly", () => {
+    assert.equal(
+      "Create Channel | MIT Open Discussions",
+      formatTitle("Create Channel")
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,10 @@ execa@^0.5.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -5004,6 +5008,13 @@ react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
 
+react-document-title@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-document-title/-/react-document-title-2.0.3.tgz#bbf922a0d71412fc948245e4283b2412df70f2b9"
+  dependencies:
+    prop-types "^15.5.6"
+    react-side-effect "^1.0.2"
+
 react-dom@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
@@ -5079,6 +5090,13 @@ react-router@^4.1.1:
     path-to-regexp "^1.5.3"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-side-effect@^1.0.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-test-renderer@^15.6.1:
   version "15.6.1"
@@ -5644,6 +5662,10 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
+
+shallowequal@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shelljs@^0.6.0:
   version "0.6.1"


### PR DESCRIPTION
#### What are the relevant tickets?

#174 

#### What's this PR do?

this uses the [react-document-title](https://github.com/gaearon/react-document-title) lib to set `document.title` for the various pages in OD.

#### How should this be manually tested?

There should be a sensible title set on every page. In particular, they should correspond to what is laid out in the linked issue:

```
Home Page:
MIT Open Discussions

Create a channel:
Create a Channel | MIT Open Discussions

Submit a Post:
Submit a Post | MIT Open Discussions

Channel:
[Channel Name] | MIT Open Discussions

Post
[Post Title] | MIT Open Discussions
```