### PR TITLE
Update URL in place instead of adding a new URL when new channel is selected

### DIFF
--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -98,7 +98,7 @@ class CreatePostPage extends React.Component {
 
     e.preventDefault()
     if (e.target.value) {
-      history.push(e.target.value)
+      history.replace(e.target.value)
     }
   }
 

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -215,6 +215,14 @@ describe("CreatePostPage", () => {
     assert.equal(select.props().value, channels[6].name)
   })
 
+  it("should not add to history when the new subreddit is selected", async () => {
+    const [wrapper] = await renderPage()
+    const select = wrapper.find("select")
+    assert.equal(helper.browserHistory.entries.length, 2)
+    select.simulate("change", { target: { value: channels[6].name } })
+    assert.equal(helper.browserHistory.entries.length, 2)
+  })
+
   it("should not change URL if you select the placeholder entry", async () => {
     const [wrapper] = await renderPage()
     const select = wrapper.find("select")


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #223 

#### What's this PR do?
Uses `history.replace` to preserve the history stack

#### How should this be manually tested?
Open the create post page. Change the channel a few times. Click the cancel button and you should be back where you were before.
