### PR TITLE
Fix logging configuration

### DIFF
--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -226,10 +226,6 @@ LOG_HOST = get_string('OPEN_DISCUSSIONS_LOG_HOST', 'localhost')
 LOG_HOST_PORT = get_int('OPEN_DISCUSSIONS_LOG_HOST_PORT', 514)
 
 HOSTNAME = platform.node().split('.')[0]
-DEFAULT_LOG_STANZA = {
-    'handlers': ['console', 'syslog'],
-    'level': LOG_LEVEL,
-}
 
 # nplusone profiler logger configuration
 NPLUSONE_LOGGER = logging.getLogger('nplusone')
@@ -237,7 +233,7 @@ NPLUSONE_LOG_LEVEL = logging.ERROR
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse',
@@ -278,8 +274,10 @@ LOGGING = {
         },
     },
     'loggers': {
-        'root': DEFAULT_LOG_STANZA,
-        'open_discussions': DEFAULT_LOG_STANZA,
+        'root': {
+            'handlers': ['console', 'syslog'],
+            'level': LOG_LEVEL,
+        },
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,
@@ -289,9 +287,6 @@ LOGGING = {
             'handlers': ['mail_admins'],
             'level': DJANGO_LOG_LEVEL,
             'propagate': True,
-        },
-        'urllib3': {
-            'level': 'INFO',
         },
         'raven': {
             'level': 'DEBUG',


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/pull/3591

#### What's this PR do?
Turns off `disable_existing_loggers` which allows celery exceptions to be displayed on the console

#### How should this be manually tested?
At the bottom of `open_discussions/celery.py` add:

    @app.task
    def faketask():
        raise Exception("message")

Check out master, restart open-discussions. In a Django shell run `faketask.delay()` and verify that you do not see an exception in the console. You will see information about the task being executed but no exception message.

Check out this branch, restart open-discussions. In a Django shell run `faketask.delay)(` and verify that you do see the exception in the console now.

#### Any background context you want to provide?
See this PR where the logging was originally added: https://github.com/mitodl/lore/pull/58
