### PR TITLE
set up google analytics

### DIFF
--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -6,7 +6,6 @@ import { Route, Router as ReactRouter } from "react-router-dom"
 import App from "./containers/App"
 import withTracker from "./util/withTracker"
 import ScrollToTop from "./components/ScrollToTop"
-import Analytics from "./components/Analytics"
 
 import type { Store } from "redux"
 

--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -6,6 +6,7 @@ import { Route, Router as ReactRouter } from "react-router-dom"
 import App from "./containers/App"
 import withTracker from "./util/withTracker"
 import ScrollToTop from "./components/ScrollToTop"
+import Analytics from "./components/Analytics"
 
 import type { Store } from "redux"
 

--- a/static/js/components/Analytics.js
+++ b/static/js/components/Analytics.js
@@ -3,12 +3,21 @@ import React from "react"
 import { withRouter } from "react-router"
 import ReactGA from 'react-ga'
 
+if (SETTINGS.gaTrackingID) {
+  console.log(SETTINGS.gaTrackingID);
+  ReactGA.initialize(SETTINGS.gaTrackingID, { debug: true })
+  console.log('initializing');
+}
+
 class Analytics extends React.Component {
   componentDidUpdate(prevProps) {
     const { location } = this.props
 
+    console.log('potato');
+
     if (location !== prevProps.location) {
-      ga.pageview(window.location.pathname)
+      console.log(window.location.pathname);
+      ReactGA.pageview(window.location.pathname)
     }
   }
 

--- a/static/js/components/Analytics.js
+++ b/static/js/components/Analytics.js
@@ -1,22 +1,19 @@
+/* global SETTINGS:false */
 // @flow
 import React from "react"
 import { withRouter } from "react-router"
 import ReactGA from 'react-ga'
 
+const debug = SETTINGS.reactGaDebug === "true"
 if (SETTINGS.gaTrackingID) {
-  console.log(SETTINGS.gaTrackingID);
-  ReactGA.initialize(SETTINGS.gaTrackingID, { debug: true })
-  console.log('initializing');
+  ReactGA.initialize(SETTINGS.gaTrackingID, { debug: debug })
 }
 
 class Analytics extends React.Component {
   componentDidUpdate(prevProps) {
     const { location } = this.props
 
-    console.log('potato');
-
     if (location !== prevProps.location) {
-      console.log(window.location.pathname);
       ReactGA.pageview(window.location.pathname)
     }
   }

--- a/static/js/components/Analytics.js
+++ b/static/js/components/Analytics.js
@@ -2,7 +2,7 @@
 // @flow
 import React from "react"
 import { withRouter } from "react-router"
-import ReactGA from 'react-ga'
+import ReactGA from "react-ga"
 
 const debug = SETTINGS.reactGaDebug === "true"
 if (SETTINGS.gaTrackingID) {

--- a/static/js/components/Analytics.js
+++ b/static/js/components/Analytics.js
@@ -1,0 +1,20 @@
+// @flow
+import React from "react"
+import { withRouter } from "react-router"
+import ReactGA from 'react-ga'
+
+class Analytics extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { location } = this.props
+
+    if (location !== prevProps.location) {
+      ga.pageview(window.location.pathname)
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default withRouter(Analytics)

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -13,6 +13,7 @@ import AuthRequiredPage from "./AuthRequiredPage"
 import CreatePostPage from "./CreatePostPage"
 import Toolbar from "../components/Toolbar"
 import Drawer from "../containers/Drawer"
+import Analytics from "../components/Analytics"
 
 import { actions } from "../actions"
 import { setShowDrawer } from "../actions/ui"
@@ -63,6 +64,7 @@ class App extends React.Component {
 
     return (
       <div className="app">
+        <Analytics />
         <DocumentTitle title="MIT Open Discussions" />
         <Toolbar toggleShowSidebar={this.toggleShowSidebar} />
         <Drawer />


### PR DESCRIPTION
#### What are the relevant tickets?

#80 

#### What's this PR do?

This sets up very basic google analytics for logging page views.

#### How should this be manually tested?

Set up a google analytics account and make a new account / app combo. Call it whatever you like, but get that google analytics code and set it as the value of the `GA_TRACKING_ID` env var (in your `.env`). Then just do a few page-loads and you should see some pageviews show up in the GA 'realtime' web dashboard. 

NOTE: make sure that you have any extensions which might interfere with GA disabled. Or, better yet, use either incognito mode or a different browser than your day-to-day browser to test.