### PR TITLE
Add check for presence of mailgun variables

### DIFF
--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -202,8 +202,12 @@ EMAIL_USE_TLS = get_bool('OPEN_DISCUSSIONS_EMAIL_TLS', False)
 EMAIL_SUPPORT = get_string('OPEN_DISCUSSIONS_SUPPORT_EMAIL', 'support@example.com')
 DEFAULT_FROM_EMAIL = get_string('OPEN_DISCUSSIONS_FROM_EMAIL', 'webmaster@localhost')
 
-MAILGUN_URL = get_string('MAILGUN_URL', '')
+MAILGUN_URL = get_string('MAILGUN_URL', None)
+if not MAILGUN_URL:
+    raise ImproperlyConfigured("MAILGUN_URL not set")
 MAILGUN_KEY = get_string('MAILGUN_KEY', None)
+if not MAILGUN_KEY:
+    raise ImproperlyConfigured("MAILGUN_KEY not set")
 MAILGUN_BATCH_CHUNK_SIZE = get_int('MAILGUN_BATCH_CHUNK_SIZE', 1000)
 MAILGUN_RECIPIENT_OVERRIDE = get_string('MAILGUN_RECIPIENT_OVERRIDE', None)
 MAILGUN_FROM_EMAIL = get_string('MAILGUN_FROM_EMAIL', 'no-reply@example.com')

--- a/open_discussions/settings_test.py
+++ b/open_discussions/settings_test.py
@@ -15,6 +15,8 @@ import semantic_version
 
 REQUIRED_SETTINGS = {
     'MICROMASTERS_EXTERNAL_LOGIN_URL': 'http://fake/',
+    'MAILGUN_URL': 'http://mailgun.url',
+    'MAILGUN_KEY': 'fake_mailgun_key',
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,5 +29,7 @@ setenv =
     DISABLE_WEBPACK_LOADER_STATS=True
     OPEN_DISCUSSIONS_DB_DISABLE_SSL=True
     OPEN_DISCUSSIONS_SECURE_SSL_REDIRECT=False
+    MAILGUN_URL=http://fake.mailgun.url
+    MAILGUN_KEY=fake_mailgun_key
     USE_WEBPACK_DEV_SERVER=False
     MICROMASTERS_EXTERNAL_LOGIN_URL=http://other.fake.site/


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/issues/3599

#### What's this PR do?
Validates the presence of `MAILGUN_KEY` and `MAILGUN_URL` (currently unused)

#### How should this be manually tested?
N/A
