### PR TITLE
Move collectstatic into docker-compose to match cookiecutter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,13 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 # Install project packages
 COPY requirements.txt /tmp/requirements.txt
 COPY test_requirements.txt /tmp/test_requirements.txt
-RUN pip install -r requirements.txt && pip install -r test_requirements.txt
+RUN pip install -r requirements.txt -r test_requirements.txt
 
 # Add project
 COPY . /src
 WORKDIR /src
 RUN chown -R mitodl:mitodl /src
 
-# Gather static
-RUN ./manage.py collectstatic --noinput
 RUN apt-get clean && apt-get purge
 USER mitodl
 

--- a/app.json
+++ b/app.json
@@ -151,7 +151,7 @@
   "name": "open_discussions",
   "repository": "https://github.com/mitodl/mit-open",
   "scripts": {
-    "postdeploy": "./manage.py migrate"
+    "postdeploy": "./manage.py migrate --noinput"
   },
   "success_url": "/",
   "website": "https://github.com/mitodl/mit-open"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - "8063:8063"
     links:
       - web
-      - watch
 
   python:
     build: .
@@ -54,6 +53,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3 &&
+      python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --no-input &&
       uwsgi uwsgi.ini'
     ports:

--- a/travis-docker-compose.yml
+++ b/travis-docker-compose.yml
@@ -35,6 +35,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3 &&
+      python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate &&
       ./with_host.sh python3 manage.py runserver 0.0.0.0:8063'
     ports:

--- a/travis/Dockerfile-travis-web
+++ b/travis/Dockerfile-travis-web
@@ -6,7 +6,7 @@ USER root
 
 COPY requirements.txt /tmp/requirements.txt
 COPY test_requirements.txt /tmp/test_requirements.txt
-RUN pip install -r requirements.txt && pip install -r test_requirements.txt
+RUN pip install -r requirements.txt -r test_requirements.txt
 
 # open_discussions_web_travis comes with a copy of the source which may not match the current copy, so we need to copy it again
 RUN rm -rf /src


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/cookiecutter-djangoapp/pull/92

#### What's this PR do?
Moves the `./manage.py collectstatic` command to docker-compose to match the cookiecutter and to allow validation of `settings.py` at runtime

#### How should this be manually tested?
Nothing should break
