### PR TITLE
Make public_description not required when creating a channel

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -27,7 +27,7 @@ class ChannelSerializer(serializers.Serializer):
 
     title = serializers.CharField()
     name = serializers.CharField(source='display_name')
-    public_description = serializers.CharField()
+    public_description = serializers.CharField(required=False, allow_blank=True)
     channel_type = serializers.ChoiceField(
         source="subreddit_type",
         choices=VALID_CHANNEL_TYPES,


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/issues/3581

#### What's this PR do?
Make `public_description` not required

#### How should this be manually tested?
Should be able to create a channel with empty description.

