### PR TITLE
add validation for create post, make title a textarea

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -5,15 +5,14 @@ import R from "ramda"
 import Card from "../components/Card"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 
-import { isEmptyText } from "../lib/util"
-
-import type { Channel, PostForm } from "../flow/discussionTypes"
+import type { Channel, PostForm, PostValidation } from "../flow/discussionTypes"
 
 type CreatePostFormProps = {
   onSubmit: Function,
   onUpdate: Function,
   updateIsText: (isText: boolean) => void,
   postForm: ?PostForm,
+  validation: PostValidation,
   channel: Channel,
   history: Object,
   processing: boolean,
@@ -33,6 +32,13 @@ const channelOptions = (channels: Map<string, Channel>) =>
     </option>
   )
 
+const validationMessage = message =>
+  R.isEmpty(message) || R.isNil(message)
+    ? null
+    : <div className="validation-message">
+      {message}
+    </div>
+
 export default class CreatePostForm extends React.Component {
   props: CreatePostFormProps
 
@@ -46,17 +52,14 @@ export default class CreatePostForm extends React.Component {
       history,
       processing,
       channels,
-      updateChannelSelection
+      updateChannelSelection,
+      validation
     } = this.props
     if (!postForm) {
       return null
     }
 
     const { isText, text, url, title } = postForm
-
-    const shouldDisableSubmit = isText
-      ? isEmptyText(text) || isEmptyText(title)
-      : isEmptyText(url) || isEmptyText(title)
 
     return (
       <div>
@@ -79,13 +82,16 @@ export default class CreatePostForm extends React.Component {
             </div>
             <div className="titlefield row">
               <label>Title</label>
-              <input
+              <textarea
                 type="text"
                 placeholder=""
                 name="title"
                 value={title}
                 onChange={onUpdate}
+                rows="1"
+                className="no-height"
               />
+              {validationMessage(validation.title)}
             </div>
             {isText
               ? <div className="text row">
@@ -96,6 +102,7 @@ export default class CreatePostForm extends React.Component {
                   value={text}
                   onChange={onUpdate}
                 />
+                {validationMessage(validation.text)}
               </div>
               : <div className="url row">
                 <label>Link URL</label>
@@ -106,6 +113,7 @@ export default class CreatePostForm extends React.Component {
                   value={url}
                   onChange={onUpdate}
                 />
+                {validationMessage(validation.url)}
               </div>}
             <div className="row channel-select">
               <label>Channel</label>
@@ -119,6 +127,7 @@ export default class CreatePostForm extends React.Component {
                 </option>
                 {channelOptions(channels)}
               </select>
+              {validationMessage(validation.channel)}
             </div>
             <div className="posting-policy row">
               <span>
@@ -131,7 +140,7 @@ export default class CreatePostForm extends React.Component {
               <button
                 className={`submit-post ${processing ? "disabled" : ""}`}
                 type="submit"
-                disabled={processing || shouldDisableSubmit}
+                disabled={processing}
               >
                 Submit Post
               </button>

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -42,6 +42,13 @@ export type PostForm = {
   title:  string,
 }
 
+export type PostValidation = {
+  text:   string,
+  url:    string,
+  title:  string,
+  channel:string,
+}
+
 export type CreatePostPayload = {
   url?:  string,
   text?: string,

--- a/static/js/flow/formTypes.js
+++ b/static/js/flow/formTypes.js
@@ -2,7 +2,7 @@
 
 
 export type FormValue = {
-  value: Object,
+  value:  Object,
   errors: Object,
 }
 
@@ -12,5 +12,6 @@ export type FormsState = {
 
 export type FormActionPayload = {
   formKey: string,
-  value?: Object
+  value?:  Object,
+  errors?: Object,
 }

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -16,3 +16,7 @@ export const assertIsJust = (m: Maybe, val: any) => {
   assert(m.isJust, `should be Just(${val}), is ${m}`)
   assert.deepEqual(m.value, val)
 }
+
+export const assertIsJustNoVal = (m: Maybe) => {
+  assert(m.isJust, "should be a Just")
+}

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -1,0 +1,67 @@
+// @flow
+import R from "ramda"
+
+import { S } from "./sanctuary"
+import type { PostForm } from "../flow/discussionTypes"
+
+// this function checks that a given object passes or fails validation.
+// if it fails, it returns a setter (R.set) which which set the appropirate
+// validation message in an object. Else, it returns nothing.
+//
+// The use pattern is to bind the first three arguments, so that the
+// validate function (below) can call that bound function with the object
+// to validate.
+export const validation = R.curry(
+  (validator: Function, lens: Function, message: string, toValidate: Object) =>
+    validator(R.view(lens, toValidate))
+      ? S.Just(R.set(lens, message))
+      : S.Nothing
+)
+
+// validate takes an array of validations and an object to validate.  A
+// validation is a validation function, e.g. as defined above with its first
+// three arguments bound (so a validator function, a lens, and a message).
+//
+// however, any function that takes `toValidate` and returns a setter function
+// wrapped in a Just will do.
+export const validate = R.curry((validations, toValidate) =>
+  R.converge(
+    R.compose(R.reduce((acc, setter) => setter(acc), {}), S.justs, Array),
+    validations
+  )(toValidate)
+)
+
+const emptyOrNil = R.either(R.isEmpty, R.isNil)
+
+// POST CREATE VALIDATION
+export const postUrlOrTextPresent = (postForm: { value: PostForm }) => {
+  if (R.isEmpty(postForm)) {
+    return S.Nothing
+  }
+
+  const post = postForm.value
+
+  if (post.isText && emptyOrNil(post.text)) {
+    return S.Just(
+      R.set(R.lensPath(["value", "text"]), "Post text cannot be empty")
+    )
+  }
+
+  if (!post.isText && emptyOrNil(post.url)) {
+    return S.Just(
+      R.set(R.lensPath(["value", "url"]), "Post url cannot be empty")
+    )
+  }
+
+  return S.Nothing
+}
+
+export const validatePostCreateForm = validate([
+  validation(
+    R.compose(R.lte(300), R.length),
+    R.lensPath(["value", "title"]),
+    "Title length is limited to 300 characters"
+  ),
+  validation(emptyOrNil, R.lensPath(["value", "title"]), "Title is required"),
+  postUrlOrTextPresent
+])

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -1,0 +1,137 @@
+// @flow
+import { assert } from "chai"
+import R from "ramda"
+
+import { assertIsNothing, assertIsJustNoVal } from "./test_utils"
+import { validation, validate, validatePostCreateForm } from "./validation"
+
+describe("validation library", () => {
+  describe("validation", () => {
+    it("returns a Just if the validation passes", () => {
+      const result = validation(
+        R.equals("potato"),
+        R.lensPath(["foo", "bar", "baz"]),
+        "SHUD BE POTATO YUP!",
+        { foo: { bar: { baz: "potato" } } }
+      )
+      assertIsJustNoVal(result)
+    })
+
+    it("the returned setter puts the validation message in the right place", () => {
+      const result = validation(
+        R.equals("potato"),
+        R.lensPath(["foo", "bar", "baz"]),
+        "SHUD BE POTATO YUP!",
+        { foo: { bar: { baz: "potato" } } }
+      )
+      assert.deepEqual(result.value({}), {
+        foo: { bar: { baz: "SHUD BE POTATO YUP!" } }
+      })
+    })
+
+    it("returns Nothing if the validation doesnt pass", () => {
+      assertIsNothing(
+        validation(
+          R.equals("not equal"),
+          R.lensPath(["wait", "up"]),
+          "These should be not equal",
+          { wait: { up: "equal!" } }
+        )
+      )
+    })
+  })
+
+  describe("validate", () => {
+    let validations
+    beforeEach(() => {
+      validations = [
+        validation(
+          R.equals("beep"),
+          R.lensProp("topLevel"),
+          "top-level validation failed"
+        ),
+        validation(
+          R.isEmpty,
+          R.lensPath(["nested", "prop"]),
+          "simple nested validation failed"
+        ),
+        validation(
+          R.equals("blippy boop doop"),
+          R.lensPath(["nested", "array", 2]),
+          "nested array validation failed"
+        )
+      ]
+    })
+
+    it("should take an array of validations and return Just if they apply", () => {
+      const curriedValidate = validate([
+        validation(R.equals("hey"), R.lensProp("topLevel"), "validation failed")
+      ])
+      assert.deepEqual(curriedValidate({ topLevel: "hey" }), {
+        topLevel: "validation failed"
+      })
+    })
+
+    it("should return Nothing if they dont apply", () => {
+      const perfectObject = { nested: { prop: "should be defined" } }
+      assert.deepEqual(validate(validations, perfectObject), {})
+    })
+
+    it("should support checking for a variety of errors", () => {
+      const failingObject = {
+        nested: { array: ["just", "stuff", "blippy boop doop"] }
+      }
+      assert.deepEqual(validate(validations, failingObject), {
+        nested: {
+          array: [undefined, undefined, "nested array validation failed"]
+        }
+      })
+    })
+  })
+
+  describe("validatePostCreateForm", () => {
+    it("should complain about no title", () => {
+      const post = { value: { isText: true, text: "foobar" } }
+      assert.deepEqual(validatePostCreateForm(post), {
+        value: {
+          title: "Title is required"
+        }
+      })
+    })
+
+    it("should complain about no text on a text post", () => {
+      const post = { value: { isText: true, title: "potato" } }
+      assert.deepEqual(validatePostCreateForm(post), {
+        value: {
+          text: "Post text cannot be empty"
+        }
+      })
+    })
+
+    it("should complain about no url on a url post", () => {
+      const post = { value: { isText: false, title: "potato" } }
+      assert.deepEqual(validatePostCreateForm(post), {
+        value: {
+          url: "Post url cannot be empty"
+        }
+      })
+    })
+
+    it("should complain about too long of a title", () => {
+      const post = {
+        value: {
+          isText: true,
+          title:  "a".repeat(300),
+          text:   "a great post! really"
+        }
+      }
+      assert.deepEqual(validatePostCreateForm(post), {
+        value: {
+          title: "Title length is limited to 300 characters"
+        }
+      })
+      post.value.title = "a".repeat(299)
+      assert.deepEqual(validatePostCreateForm(post), {})
+    })
+  })
+})

--- a/static/js/reducers/forms.js
+++ b/static/js/reducers/forms.js
@@ -1,7 +1,12 @@
 //@flow
 import R from "ramda"
 
-import { FORM_BEGIN_EDIT, FORM_UPDATE, FORM_END_EDIT } from "../actions/forms"
+import {
+  FORM_BEGIN_EDIT,
+  FORM_UPDATE,
+  FORM_VALIDATE,
+  FORM_END_EDIT
+} from "../actions/forms"
 
 import type { Action } from "../flow/reduxTypes"
 import type { FormsState, FormActionPayload } from "../flow/formTypes"
@@ -25,6 +30,15 @@ export const forms = (
         value: action.payload.value
       }
     })
+  case FORM_VALIDATE:
+    return R.mergeDeepRight(
+      R.dissocPath([action.payload.formKey, "errors"], state),
+      {
+        [action.payload.formKey]: {
+          errors: action.payload.errors
+        }
+      }
+    )
   case FORM_END_EDIT:
     return R.omit(action.payload.formKey, state)
   }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -9,3 +9,5 @@ $card-shadow: #cccaca;
 $app-background: #f1f1f1;
 $bg-blue: #c8e8f7;
 $voted-blue: #2573d7;
+$validation-bg: #ffe8ec;
+$validation-text: #f07183;

--- a/static/scss/createPost.scss
+++ b/static/scss/createPost.scss
@@ -6,6 +6,13 @@
       &.post-types>div {
         cursor: pointer;
       }
+
+      .validation-message {
+        background-color: $validation-bg;
+        color: $validation-text;
+        font-size: 14px;
+        padding: 5px;
+      }
     }
 
     .post-types {

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -40,6 +40,10 @@ textarea {
   resize: auto;
   font-size: 15px;
   font-family: inherit;
+
+  &.no-height {
+    height: auto;
+  }
 }
 
 label {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #251 
closes #243 

#### What's this PR do?

This makes the title input for a Post into a `<textarea />` (instead of `<input type="text" />`), and also writes some code for validation the form inputs on the post create page. I wrote some general, somewhat abstract validation code which should be useful for validating other things as well.

#### How should this be manually tested?

1. Go to the create post page.
2. try to submit an empty text post. it should show validation messages.
3. fill in the fields one at a time, and re-submit. the validation messages should go away, until it finally lets you submit the post when they are all resolved.
4. do the same for the URL post
5. also confirm that you can write a really long title for your post, and that if you do more than 300 character you get a validation message for that.