### PR TITLE
highlight current channel in the navbar

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -26,7 +26,10 @@ const Navigation = (props: NavigationProps) => {
       >
         Submit a New Post
       </Link>
-      <SubscriptionsList subscribedChannels={subscribedChannels} />
+      <SubscriptionsList
+        currentChannel={channelName}
+        subscribedChannels={subscribedChannels}
+      />
     </div>
   )
 }

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -45,5 +45,16 @@ describe("Navigation", () => {
         channels
       )
     })
+
+    it("should pass the current channel down to the SubscriptionsList", () => {
+      const wrapper = renderComponent({
+        ...defaultProps,
+        pathname: "/channel/foobar"
+      })
+      assert.equal(
+        wrapper.find(SubscriptionsList).props().currentChannel,
+        "foobar"
+      )
+    })
   })
 })

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -6,19 +6,28 @@ import { channelURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type SubscriptionsListProps = {
-  subscribedChannels: Array<Channel>
+  subscribedChannels: Array<Channel>,
+  currentChannel: ?string
 }
+
+const channelClassName = (channelName, currentChannel) =>
+  currentChannel === channelName
+    ? "channelname current-location"
+    : "channelname"
 
 export default class SubscriptionsList extends React.Component {
   props: SubscriptionsListProps
 
   render() {
-    const { subscribedChannels } = this.props
+    const { subscribedChannels, currentChannel } = this.props
 
     return (
       <div className="subscriptions">
         {subscribedChannels.map(channel =>
-          <div className="channelname" key={channel.name}>
+          <div
+            className={channelClassName(channel.name, currentChannel)}
+            key={channel.name}
+          >
             <Link to={channelURL(channel.name)}>
               {channel.title}
             </Link>

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -11,8 +11,9 @@ import { makeChannelList } from "../factories/channels"
 
 describe("SubscriptionsList", function() {
   let channels
-  const renderSubscriptionsList = (props = { subscribedChannels: channels }) =>
-    shallow(<SubscriptionsList {...props} />)
+  const renderSubscriptionsList = (
+    props = { subscribedChannels: channels, currentChannel: channels[0].name }
+  ) => shallow(<SubscriptionsList {...props} />)
 
   beforeEach(() => {
     channels = makeChannelList()
@@ -25,5 +26,20 @@ describe("SubscriptionsList", function() {
       assert.equal(link.props().to, channelURL(channels[index].name))
       assert.equal(link.props().children, channels[index].title)
     })
+  })
+
+  it("should highlight the current channel", () => {
+    const wrapper = renderSubscriptionsList()
+    const currentLocation = wrapper.find(".current-location")
+    assert.lengthOf(currentLocation, 1)
+    assert.equal(
+      currentLocation.props().className,
+      "channelname current-location"
+    )
+    assert.equal(currentLocation.children().props().children, channels[0].title)
+    assert.equal(
+      currentLocation.children().props().to,
+      channelURL(channels[0].name)
+    )
   })
 })

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -11,3 +11,4 @@ $bg-blue: #c8e8f7;
 $voted-blue: #2573d7;
 $validation-bg: #ffe8ec;
 $validation-text: #f07183;
+$bg-grey: #dad9d9;

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -78,6 +78,10 @@
     a:hover {
       background: rgba(0,0,0,.05);
     }
+
+    &.current-location {
+      background-color: $bg-grey;
+    }
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #214 

#### What's this PR do?

this highlights the current channel in the navigation sidebar, following the mocks.

#### How should this be manually tested?

check that, for both the mobile sidenav and the desktop sidenav, the following are true:

- on the homepage no channel is highlighted
- navigating to a channel causes that channel to be highlighted
- changing channels switches which one is highlighted

and that it looks reasonable, etc