### PR TITLE
set focus on comment reply things, add key combo to submit form

### DIFF
--- a/static/js/components/CreateCommentForm.js
+++ b/static/js/components/CreateCommentForm.js
@@ -47,10 +47,19 @@ const commentForm = (
   onUpdate: (e: any) => void,
   cancelReply: () => void,
   isComment: boolean,
-  disabled: boolean
+  disabled: boolean,
+  autoFocus: boolean
 ) =>
   <div className="reply-form">
-    <form onSubmit={onSubmit} className="form">
+    <form
+      onSubmit={onSubmit}
+      className="form"
+      onKeyDown={e => {
+        if (e.key === "Enter" && e.ctrlKey && !disabled && !isEmptyText(text)) {
+          onSubmit(e)
+        }
+      }}
+    >
       <div className="form-item">
         <textarea
           name="text"
@@ -59,6 +68,7 @@ const commentForm = (
           placeholder="Write a reply here..."
           value={text || ""}
           onChange={onUpdate}
+          autoFocus={autoFocus}
         />
       </div>
       <button
@@ -183,7 +193,8 @@ export const ReplyToCommentForm = connect(mapStateToProps, mapDispatchToProps)(
           onUpdate,
           cancelReply,
           true,
-          replying
+          replying,
+          true
         )
         : null
     }
@@ -255,7 +266,8 @@ export const ReplyToPostForm = connect(mapStateToProps, mapDispatchToProps)(
         onUpdate,
         cancelReply,
         false,
-        replying
+        replying,
+        false
       )
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #237 

#### What's this PR do?

this sets the `autoFocus` prop on the textarea for replying to comments, so that we you click the 'reply' button the focus automatically goes into the text box (and you can compose your comment without having to click or tab into it first).

I also added an `onKeyDown` to the reply form, which listens for the ctrl-enter key combo and submits the form when you press that (for that power user life).

#### How should this be manually tested?

go to a post. the focus should not be automatically into the 'top level' reply box. click 'reply' to a comment, the focus should automatically go to that text box. in both a comment and a post reply you should be able to submit your comment by pressing ctrl+enter.