### PR TITLE
Handle Forbidden exception

### DIFF
--- a/cassettes/channels.views_test.test_api_exception.json
+++ b/cassettes/channels.views_test.test_api_exception.json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T17:32:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdcNqyooqfQrdPcJzknMqMwONg5Ks3Qx9XAJyE5W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFRXlllQWl+RaUeAZUZpb4W5YEJTm7uef4mwSC9KSklmUmp8ZnpoAMhnCUagFMBEGquAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:32:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=VhoGLKgWOSbKoMIz9G; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:38 GMT",
+            "loidcreated=2017-11-06T17%3A32%3A38.978Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:38 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_create_channel_already_exists.json
+++ b/cassettes/channels.views_test.test_create_channel_already_exists.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T15:35:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNd19c0qcjXODg0w9HDyN8ipcilLdi+KN3RJCQxU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFmIelhbslhhaE++WVZHu5J6d5lYaWZjk7B0eC9KSklmUmp8ZnpoAMhnCUagHtVU1nuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:35:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=PXrRkXBU3o3Viz60HB; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:35:53 GMT",
+            "loidcreated=2017-11-06T15%3A35%3A53.731Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:35:53 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T15:35:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&link_type=any&name=a_channel&public_description=public&title=Channel+title&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 187-EMjrE3kUP1HBO0lzDvcGr_1DdQQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "119"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=PXrRkXBU3o3Viz60HB; loidcreated=2017-11-06T15%3A35%3A53.731Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"SUBREDDIT_EXISTS\", \"that subreddit already exists\", \"name\"]]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "85"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:35:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "247"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_create_comment_forbidden.json
+++ b/cassettes/channels.views_test.test_create_comment_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T15:12:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdcNt0jzMdb1Nshxcc9LccmKNKoMMsssDvR3yTBR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblurnnBgWX+rhYBjmHVPmlRyUnGQcG6laVFUaC9KSklmUmp8ZnpoAMhnCUagHj3sxeuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:12:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=ogwDJdj1Kx4VGi0BKr; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:12:33 GMT",
+            "loidcreated=2017-11-06T15%3A12%3A33.466Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:12:33 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T15:12:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=reply_to_post+2&thing_id=t3_adc"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-W8fL3-K0lDGndDjY2yR6isQODh4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "50"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ogwDJdj1Kx4VGi0BKr; loidcreated=2017-11-06T15%3A12%3A33.466Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:12:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "447"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_create_comment_not_found.json
+++ b/cassettes/channels.views_test.test_create_comment_not_found.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T15:13:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdctLA0Myi42ychPcYrUDSkPjXKuKM6s8o0MdLNQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFV5Ukx8cXpbr4ensW6XoXO1pYlKZERka5ZfuC9KSklmUmp8ZnpoAMhnCUagFt0nwcuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:13:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=rXFDV9gg2KCEWJ8YPn; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:13:27 GMT",
+            "loidcreated=2017-11-06T15%3A13%3A27.787Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:13:27 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T15:13:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=reply_to_post+2&thing_id=t3_missing"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-quQRks4hodBY-TwUZCxsizMYQF8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=rXFDV9gg2KCEWJ8YPn; loidcreated=2017-11-06T15%3A13%3A27.787Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:13:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "393"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_create_post_forbidden.json
+++ b/cassettes/channels.views_test.test_create_post_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:15:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0Nde1cPLzyUrPz/A0qjL0qCz1KCk38/EOrUiOyo1U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZF6VXeeWbGBtWGHiXOht7llbo5lvmuoc4+biC9KSklmUmp8ZnpoAMhnCUagEwJNuhuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:15:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=okopi11VYLIVkj6ddd; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:15:27 GMT",
+            "loidcreated=2017-11-06T16%3A15%3A27.251Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:15:27 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:15:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=my_channel2&text=tests+are+great&title=parameterized+testing"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-8BNLjgohI2z1HyuHtw6LKUxcZmY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=okopi11VYLIVkj6ddd; loidcreated=2017-11-06T16%3A15%3A27.251Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"SUBREDDIT_NOTALLOWED\", \"you aren't allowed to post there.\", \"sr\"]]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "91"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:15:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "273"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_create_post_not_found.json
+++ b/cassettes/channels.views_test.test_create_post_not_found.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T15:31:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NddNNM9KcjHJqQpKLE8pikxyCspx8UrJTHO1DMtW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZZJBYWRWXnuRWam5tmWxrpxjv5RzjrBqcnBziC9KSklmUmp8ZnpoAMhnCUagE3+3tAuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:31:52 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=6TbC9xp5ztbcd54Pfe; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:31:52 GMT",
+            "loidcreated=2017-11-06T15%3A31%3A52.585Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 15:31:52 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T15:31:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=doesnt_exist&text=tests+are+great&title=parameterized+testing"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-a7jbD4lzRawdrYbBRlDJdifE9Vk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "119"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=6TbC9xp5ztbcd54Pfe; loidcreated=2017-11-06T15%3A31%3A52.585Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"SUBREDDIT_NOEXIST\", \"that subreddit doesn't exist\", \"sr\"]]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "83"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 15:31:52 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "488"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_delete_post.json
+++ b/cassettes/channels.views_test.test_delete_post.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:41:55",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdcNT801LcsIr0g2SwtzNywtSHQzMSiriIqK8CpX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbllpUaZlrkR2ZZBpq7e4QWhpQbR+UaOZZlBIFtS0kty0xOjc9MARkM4SjVAgClp6KMuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:41:55 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=thhEyPwQzDtiJTx4Xj; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:41:55 GMT",
+            "loidcreated=2017-11-06T16%3A41%3A55.314Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:41:55 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:41:55",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_2"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-Wem5vhWxc6fVG1upaF40vxZZXJw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "21"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=thhEyPwQzDtiJTx4Xj; loidcreated=2017-11-06T16%3A41%3A55.314Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/del/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:41:55 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "485"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/del/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_get_channel_forbidden.json
+++ b/cassettes/channels.views_test.test_get_channel_forbidden.json
@@ -1,0 +1,151 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-30T19:15:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=user_4"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA12NywrCMBREf6VkKQaibUXcRqnRTUUFXYUmvbVB+iCJ0Vb8dxu7cznDnDNvlEkJxnDb3KFGqwCFURxh5ijb964mZd89IBSb2zYtzjbJigZNAwSvVmkwXHkiXBAydD8Bt10L3iIg06D91shmrCY+aSgGsPy7E8wxup5VF0hSejzx9orj5e6J59XBQzk4JYGr3JvHgD5fJNfGELoAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 30 Oct 2017 19:15:21 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=jgFr5OJnAydCS5r4XK; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 30-Oct-2019 19:15:21 GMT",
+            "loidcreated=2017-10-30T19%3A15%3A20.319Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 30-Oct-2019 19:15:21 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=user_4"
+      }
+    },
+    {
+      "recorded_at": "2017-10-30T19:15:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 3454-IvCIKzvn0hzyue3bEgHPfUtGafo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=jgFr5OJnAydCS5r4XK; loidcreated=2017-10-30T19%3A15%3A20.319Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/xavier2/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 30 Oct 2017 19:15:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=st%2BO6OqN50IgAvp8aRHCVY3WBVc91yiAic5eUzyPYiyr0jaRXVzOO3ePWeMDC8do24aPo1wiaa4%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/r/xavier2/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_get_channel_not_found.json
+++ b/cassettes/channels.views_test.test_get_channel_not_found.json
@@ -1,0 +1,148 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-30T19:15:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=user_5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA12NwQqCQBRFf0VmGQmC2aJdLcQKhCioZjPY84nPbEbeSGrRv+fkruW93HPuW2QAaK1qzR21WHkiXESRr+WravW1ehRdGR+3NaUVrTnNTXAQc09g3xCjVeSIcBkEY/cTqHZo0FlumDGy21owUzVzibEYwfLvDi+bQfa7094mnazPRhJzDBD7CTgoxycBKsqdeQri8wUeHSQ4ugAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 30 Oct 2017 19:15:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=jMQz4H1IzXMQ9TakZ6; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 30-Oct-2019 19:15:26 GMT",
+            "loidcreated=2017-10-30T19%3A15%3A24.839Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 30-Oct-2019 19:15:26 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=user_5"
+      }
+    },
+    {
+      "recorded_at": "2017-10-30T19:15:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 3455-nZzjtnYjmfwhFSIliNjiArNdo0Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=jMQz4H1IzXMQ9TakZ6; loidcreated=2017-10-30T19%3A15%3A24.839Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/not_a_real_channel_name/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+1d648bx5H/nr+izSCWFGlI7pL71C4NSV4pSmRFsdd5eGETw5kmZ7TDGXoe5FKyAOcBBAhiHPLB8R0QHOJAfiSwdYmdh+w8/EHJV2P1QbGD+7IBLrnD4e5/uF919wxnyBmuJFLA3WFjREvOdFdVV1dXV1VXNTceMz0jHPY4s8Ku09igf9le13GDzZIVhr31SmUwGJQHtbLndyoLa2trlT1qU2KO7nY2S9wtUfP15BtAcN1sbIR26PCGz03TDsuG111nPb3DmeuFrO1FrrlRkS02ujzUmat3+WZplw8Hnm8GJWZ4bsjdcLPEJIRT6i9BOsX6XshPoU23izanWBC1unbISqzSSEMzeWD4di+0PdCYAPR63GWBF/kGZ3bA9AEPvC4f7+vzNvd97qc7+nbHdksKBfFG4y9Gdn+zdE4Sq22DjakOId8LK8Sr08ywdD/g4eaz2+e1VYHLsd1dRnzfLOm9nmMbOtFZIeoCrvuGlaL+JBhMjHA2S/JdiVkgcLNUCUJ0M1K9ytQUbBDgRQ9Ddz0X4AFBdiLKAzWtanocD+8rGLDnVyAOEbG18kSXBwGmbPOyF548T1P2uN7tnTY8k2/Wq3Xxhe/1MPGC9M1ti5/0wUzi7EnDixzzJCb7ZIufFPNdHmdx3+aDnueHKY4NbDO0Nheqi3WwORnCMRuTd2xsyPSs3HM7T/Q3F5aq1Xp1bXWpVq7WSiywr3EI7+LS8h7+X1JMtrsYSgUdRtwn9hwLLJBgRCHLQ9LW+wIP/pnEIydPwt3TqN0YaJpXroVeZFjitdbzOWS25wXczBuObJo/qMyUBuHQ4YHFeVjBX6wWSYqQN4O+Z6UDjyrxRKP55Ei63LR1yKHjpNleegg0utm13Zbul4muMUSLJZZB9Jim7dht1gk5u7jF1p5vbOBJY0Ou2fSQrup9XT7F5PrGSOyvBhXHblWuvhhxf6gtlhfw39VxtDWMqSK7PwxwHixpgWV35w64i3Xku/Y1f+6Qrwaeuzh3qFj/3A8Mz+faQrleruPfCV7Tsp2B10EI6HOHepWbkzBnlIqW54VB6Ou9MqZRdx4hfCBxA5v2hkeJxPOc0O7NHYPUOprh2NhQNKzVSQwzioxc+7AKvF07R3RmnGbeJ7oxBcYun/86tbq6Ad2iY5ea5MsMlJueho1Xkj1XwCOpD5XAwMKBvTJv4WzpwXznMorsHB0wg+hZkLdgrryFdRjlLMAZaOzaHV8PudZxvJbuaMoCmKfO1q/qe/Nlgt7m2vx3AdhdjqfPVwIcrwNvoDM5/BlmTOlJYYdrhGDOSgdu07xJjuz8xToDF+yF1fnudVFoOzmLdQYS4fI4QzheOVBn0Ntit5kvSN0wYIhPCukMVKo93XbtUCM1OAl8Bsaq7bxIV81ANnnK3G4P50puX3dsU4fVOleoMCy52wktDZGRPA0wA39DKBW4ZnMlt2iyZiAz8DU9Cj1ylh3wYK7kBj0vdOyOFR4CFc7oxmM73DXt9vPklyp31Qljb/XBHVWKBS3BmexPop5BslMuMBzg/1M+sHSu9SPn+si5pjCmiueM3Iwj51oEsPPDXmojPnKuc4OCR851gejk2+sz7D9HzvWRc33kXFeOnOv0OdwMxv+Rc60dOdcwBY+cazDh/6tznXKsp/rRDTpIZpvsOnf76+yYiRiZ4/UoP+HYjdOznDUSXHGQOdtJqW1ulnDy37Y7pYZfFkH849dLFBhvml5XR77IOiupSRRZFqVTrIQMgLCJQz1OL+lBx3NMfG7rToC8Fry3cYSLUG3T55Qh0cRBEV67kePgrRu0B01xkt7EuZTrDRxudni6P8W6ghR+QtHWDQ7HareJrISmTa0FZjtoIiDiBp6fwh8F3JdtYopEaFKdgzUj36HulZ69x52K126aXAZUKLsiQz5yT3R/OCJdxLTTlHp9YFpYTeO2i9HYOH5GhyGlSBAiuIeWHlip3gHiNU1gCfAs9CNipmMHFPVuTqISiTBN9AC/3RA9BEeSIy08UBw3Ij8zXcUUcsIl6EPyg6dfCPsDr727tR1e63z9svOlLdP94nPnhl/n5+tfC9ya3X6x+6VquLi18uKVy9HXzl69Em15z35u8bw1+Go4tIZLZ3pnBvjqPve5xbPPXdlaqrU7vcFXnjW+8YXnnjnbby3X1178BjECaTi6a3pNHHQgbYm7BkmWIt7kragzYgcY1kS+FC26VlZouE+TEdpIhlpn2MvXamvVtcXVchUI4GQau+PDFg/FhANt0yX0XltHXJhmXHGfWFe8ENpcDyOfN10+iEUdmSiYPwDIiF7QNDzH4QZCrbH4EWI5g20PGUdpqZLy64qxeBHNbAwM4t7Wd2mAij4wi9IaKKEGDwEQ6VPEUDr4TSMNuOHzREZ0c5wXo7Xged1YPiegIL+NsBAGQzcs3ux5YKx4JpcGqG0i3Y4aiGOwZt+GniBpjkdA2VzNQ5ajjYlEt2SdEHsHNgRkkAJEstJsIfcu9SxyKeSKJC5kKH3xGbxQXKLMvYtu28MTKDeDshEuI2EPX0visKp8YWsb0ywTx4h4EGC3VU4btaqvLNZaC2vt6lK1tsiNdn11raabS7Vl3Vxb5JBro77IV6r10g107g54q9lyoNxo7TYh3EQRcBIfdkovVIj0oPIEIXoBGUB9Lj9XVMJahV5UBvauHT8XT16oQO6lKg4qmE2cB4iGMntQAvMrOy9Unj9Z0VuYCdVLKGeBSjcxrhAzItUPEeJ1kYpoqs4RNhX5sRWFIdH7PA2HsqumLAKZw9f0kVJCrIpz+ghQvD6wWjk2QCTMyalPCwStMKXjqHvbRzIizRf159iBnKacjMwKIZxR0OwGtNKuA09oWDQqAqA+M5GeWS6XCRAdn6r36qN6IZlHCpb6jr7Ra5pLuRUFSBx0eJOOo6nZQunGidTeTYsvne9FKWyNyufZuQhroMvwdZ1hSbPQQr5mC7soEic9ZiNP0g9Z0OMGVAYkFXkyjshE1EyOLEoTK5j6oiF6cpl9Sqmp3GefrwA9oUW6ksxWbXnmkBmOHiBzsMQaG6bdZ7S3i4Q2DRltyFKUb6U+VU3UM8lO0Qw5ZtDFcWNDl+mnDdkCWPEy2wTrkhaK5zMJeewtpRVSUhX1Ew0YJY5NBwRlBa2KbmlSRIJiDEm2mA4FthbO4im/FNNRDCplkjHV/BC4dqC3YLNMA6qbATNVu9mh0SwgA3eOEEmSHZuSjqdRibkLfc8ZZx+2WKyXQJNKYowNxEJMnaZGrdrm8cCyTZ7AoC9xIyVkFciwFGQlpQleSHPmhTQfElgnN/K6Yrwu1FumIxkL9Bi6Qn7QWr43wLpEs0IYo8ZoCN2UtJU9JvohQ3eQ0KbAykZTPYfcqHALm0rLcymFsYr/JpJhakSMBAuRFxHUtGaalomquDsJc5ZQSJxOO53QWFlJ7YZMcc9BWnlLd13BXZ2Fegtqhu9tQvWq5ODPknBCRZaEmrsadXvb3jn1qEFfSceqNhsVfaQRcTYr8Wg69tCsPIj8bUr362Wfm77Xg/WBvHufPpaY5wrjcbNE+e5wZtzoOGn3E+iW1lkBJ5uPm3IvKjW6Q8r1V3t4Iu7jck4oNMPybOQ+xBgbG/pY+nvaKUtbBomib3nYw7uaJzQ4MvgJHrYG7ObYdaQFLV4Fgj2TYusj4TEIMaLIibeDNjYo8RRk0W7BLPJKaL9xbNXmWDzmY4eQnNCZUCa2fkmMYwuQ49zs6VBccPUS9TKdK36FUsJj4hM8eDhfLNi64SNUEkzy+4jl8vsIZyVCoUpWTpKRPe62gt7pl+SfWEQOnwHs9cfknIDvAr6c0PuXGrIWAKFLCdJUuoBZpc/scV9/MfIQq8AakjBHokJ91GJS0ubwNolMjBY8SbWxu6heSMyQth45SMERFg1KAKjcBrZLXHEjgg2EVHEizS4yD6nghsWyVmqM1+ZQ85jerHrRFKWohrGI1DRgcrxKja/psLygPa7CrX7i8c/WFk8n44lrTzKLD64P4iTxwMQ3ZCuitAatwMVLXodsOBhIgd1xWdQToyKweApDxnPNoBzPdJqagCdS8VL8Pk8S0otwxPqRrl/ve7Z5vHoiIZH8D40KnhIRTfQZnMTIB1nYs6jB8ROnMYIttwNVYI0JcFoY4gKoWCmD9UrlqumOXyjdLiJLI50sGg014YslVMZdGhuQm+xuKNmPIh6eU22yVGK6g8orUc1iLUyIBh4J81hRJpCS+CBdSdQLQSZ6jcTiHnoRKpdQoRGQHjc9qGQqAeN70I0blV7jM5/JrAq155LQUxEUfDtT63m9CHtGqsgl5PAnhJ2UpgRBHHLlkSyPYic5akVj+o0mKnbGjtQnG2B3k+hzOIQiI8GhuAn2VE6rAdvrUrXEZBWT+JzhVAaJYhbrmhpNFCKFYq+mtaaI7pKFbNUa2+T2UKWay2KEjCKIZfYN8HaA0qiQtTgjm5pWHdXG0WKBJ09hUqwMwMCMXEGXQKxG7NvyL1KsumTfQ6EP1Rs5ZvmlDXaKT8vi3y7ItGil9WLFMFJkiuTY7R2topFSN7RWCL+I/kUhFCYBgcHGBYjCRcjBmG5MTLAJDG14ydzXsLDJdpHsbQ21a9yHtSIdNNkEC4WSaoiHKZ4iioQHY0qAnPqcnbgkdmvxUijXUkNEBTYQcVCba6ylc7UaHNVOavSx+UCPR4oA235Wg6Z0VqyyxrEIKspKg2KWc5AoQomrCbEFmrEIS0ZDU81fDhpVRUlvZxtSBlkqypKDM347T4xXvVaQg4oej8aVMgrmJlAWd7CbJVM0PtMZtvgUXcqhks4RmHg5ovVhxEohu0aRk2CX6mxHO0ksvOfPfGUuSGS9qYjQTSKhx/PGIgaHTSgM8+Q49XbeiEVYSmgrY5gzeenXc0QtdhQDAcxYJya2u3qDeNoI3aOQbJwyBUyUCGNPQghkipTbYYTAQllUy5LYVaKggi/q6FODJaF5bQSTsatr9Nw2F6rL9cWF5dXF1Se64SbqqZXmT0b5tKg6R525z+wrFvz90WAfZmnA1hiWO56H1GlBoAjNE41BxUQAHdUFT8BgAemxVh4FYaeRdsaFp2qjEH4WPZ3gzF2wXa9lwyxAQJ3UxGyYlIKQa1ft9DkSpt6McD0K8XrcCU/XpshUhlYK4McR/Xg+WtGQHicGvHKbGD0ckf6gwoKqeom5Y7fDIF+HphqMEKV4JE2exzQNFzKI6xdoe40Fi5bHpYvnti4/swXXh7OtPctuIR5xllGK+vj+QRc3KE5QR7WLi8D3ZomqxTXUL3TcdQO2FPdPI5RJkr4uQuwwkxK3IbZvglpZ7+rXPFcfiMEh0JiG3/MGOHw0m60hDvPEtQ+i3F6YylfkO9Yaxhc5wAKnCPxmSZjL6wv1am/vtDKk1+sr9AU2IjxD5XCus6XeHl1tQMull8yjCNJQAKnUeBZnBF5bHhOIXRHKjtyBKITTQZUwvVDH0Si1wSUFwqadYJkiXAo5bc/QRtzXOzh/IWsazhyw+OxM/ICokdYyrkc43NUVEGH99nVjqM7+4pFEPVSSCIf3inzPrnh0OMiOqzc4MtEbZfa44fWGp9lidWFFsRLesVFmZxyHCZ88wGMRWTWlrZ7Lq6e3nnzy4jZ8CsTWcDhy5tLFrcsMnrYHHwPmBO/APaPJpHMVE8dI/m5AfJPsEQhTfoAKmPYR0Dq7tX2m+YUvP7ONnI1jdLqYEpBjpxnq/Y8Tb0U9swWPhG1ubo46nWDXmY9lQ/kUZSF1yfE8wYvl8Bg7Oepzmt2ADStCtTClZciW3EfY2ZCdqb6jVRPRFZFUoNFZWDwXIu9cU1Y/eVkuJ1Z4TAClD6YHvumxdxVHSMTrrMeBJYVCKURTOHkeKcsx9UJDFIM4gsOspLGGpojpU3TcqufSJY8wGUIHfEDiDX8HnpRVb2xg3+uKkcXzqNETun4htDywhrxHuLACp7zlhe4DyYg+NcGTEUsIgtZfJLXg9nBdhvTGceyAc7aSur6FIrvI2oqwqKlrZriGoEHrwC3rMbxy9BZ3aIfeLNEKg8YY4cIs4rgT0WWMX/NcB44itaGQ1TqUPvWMyVDoYgqomQyZTQBVBJABhPh4OpwAxuh7jii5wrUhcOBH4XLcWQGVaHAL2wIHqbAwcHsHeB7TU2JYtbqmctW4htwY3E+h9+wKjveN3WbcDscCdD9ItjGOgTZLFExI1TohJN5uQ82kRSVLutaGMNJBhjbABQQ9aCOwM+3dFTSH7y0mUXFgBCa0fK/VEqKWcz5Z0KsQmgpCicVD8cjYwZyFwiASdYwjYOnYWWpNKVrzhKyHo92BeZiYiVa4gWhczEih5EDI8iYWQtkwlrAY5DSxGrXJCghJ07GUNMXthDQhUD059InJPZKRsVPQQ2Vk8TAhQUgIhaRIKIBE5cgKqalYWqA/RqKTBTwuO1KhxkCnScsYfqyKIzkYabM56AqZNnPIjiQarTN1vGI3jsuDQt2BnYYA4dRtSvSVojGJK18wyFyfJhQCDhsRMb7XjG9Mon3uruRhU0K2hIvL2lpORAbIkXg9jHgJA6Dl7YGBaZMpeayMJp/DMiMlgQ9S86TNj4yhFLeAs9rlXezYsOgSQZsIlRs4A4cJcjgFsB8DlFnD3h9lhkqS8t+k6RuzaB5eysYADWxcBCfz18gYSlmLuTQ1OhwmKRyZFs6ZUo6KkHJputNBFI7pyHgbcL5bznprlRFYWmU+4G2WKAkRB7nIQddxpkenucpjlxZoHsepadveg3Ukc+GkwQsRyDF/Ju0uGTtRtrUEkPgkOecnwNJDTrgmj2IzZmsjOSuVMKGQsIrFUh5bz7pDxx8GQgH4q5m07mnNy+ZpqoVhx54+s7116eJT8B3bNndMLcmESvz5OIyARFXKQcsxKfMh9ZFGrg8PASPJqpAhG9OY0k5p/0n5VKCgwH+CswZHdsxjkl4jgX9wd0l6f7GvJmzt+3eYclzHKZaK8G6y+ObmNGXBTtuNCt0m+DQZtyn2gmgpJ3IYM2rKMIU1JBL6UwkCOQONraYpZvv0UaVtNqx/cS1nDDS9644PbNRmbFXle1pHxviEMX6fe1Rml1RzOdqHKG0vtUXQPinb5O6UcZi0Mpq9+AAhrU/RF/U8iZkvVX+sREfCa/zvUPlgAYYsFNpMGj9HwcpHSRhRcBbhqQBMQ9onNouzSMtDHBlJrcjOOcVopxURUwqUPWykFScLjW3ud8U5VRxhFTE3Ad/S+xSm1M0HQZAJvBKCbKT1YWK55G8jLixjuQTynHyggrciZJuKlOYGKrHlTo9TkjK5j3Bd5GJqUAnWlJ5IML6DKSFH9lIYDkUsiPKUsOkL3yJrpWYDe5GVBPZEVhBWHk6V4kWjRkxZUeIFFmPo4/9WQ2S8UOWZuCw6QpIQbn228AoHLzJZgzolmWQi21PYwpQ7FYdTxOfGhsrDjFPWkK6nkkOPxTFHBCLjVCuG+sLnN3AvMoVVk74qWKi3S40zwLqro2SA7ejt59nxz8NrK2gNAf/0rb9859MPPv3Fp2//5Xuf/hRd/KldWrB79n+w/6v93+7//O7Ld79995v7H+LTP7D93+3/Yf+9/Z+znRafDgHR0/1f3P0eILwvYBCE2wwgf7N/e/9D9O8UDq/lahcvlxoHb75z8OYfDt781sGb7+EDutDz6Vhx1oKEmbyeLXN6TySGn/UC8HPXBqZgamMDWcM4AtCdOz9mO4ZeOBCqO/jjK0hGGKJZUNwM4eFzw66v8w7aDaeiNoEaJm6wy3bMYsQm5u9JHoWBYaEdL8RMIf2PX/34t/jvNx///uMPPv7w43cgeU5xBxf3Wo2E9PgZVLj4OIPTT5DA4t20nsQ2lUnIjp9DZSXKilzZcQoTAbbTSnW8QIVP7KxvU8qZ7N1pTUMbYRZitERkVDwT3ENTFOQgXxeaf4d7U+eCigk4HIw7v/AcNJ4CNkAyXrYtHhTTHCADfay5MWVOAq0LHx10J5TgQTF0ZJ1xKvNkuxwHGDs8nD5Imu4o2EXiNdoWz28bk/uXb376FnTM+//6fbbTLpbOtl1qBJHXxUJr24V0tm3w4LyNVHzbxVzg61Q622BwG/N25y0dqYY77WL2tn2NJPF8ujGeFBMy1C5fovZDWnVt+jaVko6u2Vh/F3RuOwhB7Yjv03tAZ12482PbtHCajQ5mIS0d8OQCHF0cc+50pjPEAg2f/OSTH3zy9if/9MnP2I41XWFbmJSDm7cObv7h4ObbBzdfZQc3Pzi4+RF9eeOVg5tvHrzxMmDYU8dhYQ4sv4/abVKiVvEUWBCqp/TOEOetO1axTFlQjPdevvf6vV/de+PPL997496v2b138OfNe7f//C30HBbyCfXhjbM6SoV1dhGp+UjPsSG+9vQ9wMZ6vvMuIklQr9S6eEHbWEPQP9B7EM3jF/FpCE1kh4X0XIXA/f21N/7+o3f+42f/zHauFkvbrtsUm997rx689/bB+6/Qv++9znbE80L4u1Bc//3qj/7zV+/+1w9/icZeYUsHlFzC8bXLdhx96mw6uJ6/1Fio1VbQFJ+LQVJO6qUvX0Izr1hNOQCGa7TDqG//6X22qzst8NiZrnycPvroIepG//R6RFYS7ipHp34hKV1MoZr3pygYE7Gd7vS9vBtqT22TNOL+cDSmb4XQXYzzMsc5Kiw61PftuMWjdWHKXR66nk86wy025VxM3GXVqnjSejZW1hlf/e8xtoMHU+euB0ph0ot12Cumsoc5ofsZok5052cYUG/6dPSQBzDRA48KGdYLm2efzqBo+XqAhC4b2c7AhreFfX1wBtXJd37i/vHbbMcvZo4PZSKNVGGm3t7/AM2LlUqAeGjgoGzJ/eMrtgtxCnYLaQjARtn2T6/Hradr3QATdfebd1/e/0gSw+7+48jmDYo1IgpvaGU+4/fEnImvxWRhWTyDAQg1FRSvBpTGNw5u3Ty4devg1kcHt3558C+vsJ2wWPeEFtrf/vHB7fcObv+U/v3gOwe3Xzu4/RP0sgqpCTHk7Tu/83fvvIXdLiweYwTO3/32/ofgzs/vvrb/e/Dp++RXpLyKqHgu+tigtu2/fvgRnPSv2n/97XdDttMvNh+uYSz/dvvdv//wu2znWjHx1yzNwFL991sv/+37P/zbu69RYzxJDbYi3TSZJJWJgqvUSZV534ALRnlF6spXlg3Px5k/YxltfoUui5al/ojYi3s+UEDrUx5Vo+85yIjhOCWBMSoSbalkRIZxKK6NUGSI3ymqCF+V/FV8SR/UjMXfUbeQOMEBRR9iL5tS0hJAFeEB4wn57PgjE5IAGCU4dMhjoQijKS6LiCtQsnk3soJaXq0irpHIzXWTpeI23ciQPVmQRd6P92y6G4fGmFP9pUIWpcbT4u4LnI4gKe/KxSfZ4spyvYozkjjLC34CZZlpC1WtVmULa+sLS+uLK+W1xYW1+uLJanW9WkXiuSviPgtVvmjW2gwpZ4q3qBKRg08X7oyKquLhqwFnfsqljGOkyTraGsaa8PPBQT/C0l9DXFSgiVs55ko3LHLUCc0VJJ0bmpWCK9FnYLGEKyRb/vIEooGPgHDoB8rD1AS6ucKX+d1aqHe0LpxrnIJVOuF8byZORJDud5sr8Y+i+DwussuRv/rDL0UsXNzkI1Na53ttOt1BQJHMScbOQG5kzxWcSEedK0QRjZ8rRHE6mzPpMyiHDjZeGeKepHQGsMgk3s37cacZ5puECFf/5Ax/BqBx2eZcBz9KWJgEOwOtKHq0c9blDLMk77CbK5HiXAFBOPqluelXYzyYnSBu25qzRFE52ySRM8wQ1R1NApxhgqjmZa4Au7iYYL5jRvgS6UlzJVL8FiNsCcQjJuHOMj0irV4cr813muZv8lCSP/0AmZ9rq83AA3Uf4SRfZ5BS8rlyxHQGKsUVfNiW1GWbuDYslHUYc6VbFfrnyMIMpMtajfn//g5dXEL396C4AB6zsTtvwRggkQ4VHRodVc92ZzhuW8VBU9eWFwOiOqhZFjd3msezL156iV3HRXTX6dY0cfkN7rsjlYw/qV/YXUfZ0eXm8ZK0/EUmITUS9VHyN5REEAEJhvS4dOKUKG+Ie8lnN07JlodCpmuBRDWVSNa3ka6BCKZAJa5sMitdVKyZosQkGEclUZRO3DhFV/vloxJpEVTZhZ3XGRLhyeBR6YJzoTHy5bMbp0AO6q7yYcpbj2SIJcAvLqM0CZsvfoM5wDdxowb+Es4zGM1TMa/pAim6GncMYfz0xinSQLjdL28qkDMm5gHbnY9wI/0AdFf8RXwBPwGN/BMK90S4V0UipmtxmUx9meCaQENME9ZNPj419ZSqxkSzU4xWQ/yZxiYes8QvGh+WeA0smJuYAU0btzaGHBiPZC6zZI5kLqVu5iFzqRs1PzM98NaQV8GWfSjN5KNQk6f9sgok4NXOdbq8Ez/PnboMGMG/lYUVuljUpft2k0uC8XxtuYbn6oJbsbOWcclU/AFXWAubMPRw2EcXg+YAx03D1aXFSeD0fGWpEDhy9O4DeBHl48BJ11DZZQDqPfwiblysSkXNNuzuwwawspw7gIXq7NypLa3lwa4trxDTZuN8bW05l/Pq+czAafRjMrNaBvA5cGVNDD8H+MpcgNfzKV+h57OyRQDJo7xY2nHKcR/SvlquL+cvpfpKndZvhnLUknj2NZ6s1UOEvI5LwfOYUl+rpZhCsZnmQEecU4EvXPXoR+Od4ANuIE/Bk9Q9IKkAkbse1fMMFx5YWwFIjipcLS8t1KazGBrrEBavri7lyh2ekw7I0C1vME8m776kAxe75+oS9TwD/wH5slau1moLk/OJ5/XFifl8cOLXyrXlpRy+4/mqUL4Z4h8G/gpyNvLoX1kWOrIQ/n1vRIs5qhb7U72aEhtYoX3cNyqusC/j+payiMpm7lkvo3wclreD29R4weJKoI4tLnq+TCtDDeZ+sNHvhtGvclpTcAmY88KVVBYFD45xuUoq6kFHN5WREuTY4NbKK6v11PZ7P4yU9y4UjCkBmINo9QHHRF5PARoIQJ4UEvaUgrmf0SiDCCf+MtSKM1q6Sx1/6LcUGv8DrW5J4V+IAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 30 Oct 2017 19:15:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://reddit.local/r/not_a_real_channel_name/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_get_post_forbidden.json
+++ b/cassettes/channels.views_test.test_get_post_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:45:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0Ndc1yA7wz/QOySkN9AtySwyILMh1cjfzdTLN9HFV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0Z6Lbll/v5Zqck5oSbulvEhydXOFk4upuaFBgXg/SkpJZlJqfGZ6aADIZwlGoB636mvrgAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:45:07 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=INk7O30YNHf90sh1gA; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:45:07 GMT",
+            "loidcreated=2017-11-06T16%3A45%3A07.751Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:45:07 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:45:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-0kPOiKTluQNRFaPYpmBG6MB5iLE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=INk7O30YNHf90sh1gA; loidcreated=2017-11-06T16%3A45%3A07.751Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/adc/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:45:07 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "293"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=lJSbRYCMVqiMnEjkOqfe0orFh4nVOe4Cqad9vR2hUDegmdiC9QAeMp28cgLvS%2FghBQ6pU7Ho4722bMSjGiGfr6oIzq%2BNRLTU"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/comments/adc/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_get_post_not_found.json
+++ b/cassettes/channels.views_test.test_get_post_not_found.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:45:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdetSHHNCnMz9oq0TMlKjncJTQ7KMskyj8jIifRV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYlmee7WiSV+hm7l5gZOVoURzmZRBTlZLlbFGSD9KSklmUmp8ZnpoAMhnCUagFv0sxBuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:45:34 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=mFBD4YTg3MRuHBD8ll; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:45:34 GMT",
+            "loidcreated=2017-11-06T16%3A45%3A34.382Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:45:34 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:45:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-xdEjVF3JY9djc_DUcRj4j7XhlYM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=mFBD4YTg3MRuHBD8ll; loidcreated=2017-11-06T16%3A45%3A34.382Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:45:34 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "266"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=LuKDCcV2BjfjgnDUd%2F20TuxZB56VNiHiLT%2BHWL79JZNu6FimV0%2B3fxC3FzHnXtppLF%2FnljXjudjE6u5ANQiCIM4b0uBu69LB"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_list_comments_forbidden.json
+++ b/cassettes/channels.views_test.test_list_comments_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:47:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0Ndf1dM5NDMyLzK+KyPH2ccpwMbCICM/3Ly4MNwlV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblBxsa+pt6pHlVWpZkmDoWF/mVuQb4GpUFxfuC9KSklmUmp8ZnpoAMhnCUagH3vmCxuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:47:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=mMLNEhhA195wlB1sMb; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:47:12 GMT",
+            "loidcreated=2017-11-06T16%3A47%3A12.646Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:47:12 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:47:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-ICmaQnYozXlKLBhD08XWoOsqW4U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=mMLNEhhA195wlB1sMb; loidcreated=2017-11-06T16%3A47%3A12.646Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/adc/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:47:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "168"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=5CcIu3p3UFhYpo761VZms9lXcE05GXXkbBr3Ns4q8eQkDMrT%2BYg5sceTqtqu1XZJ%2BNSqb3KuCRWmhbH1TWJdeJR0J1MwHbTL"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/comments/adc/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_list_comments_not_found.json
+++ b/cassettes/channels.views_test.test_list_comments_not_found.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:47:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NddN8jHwNQ/xNSw09wgsME/1KwwPcS/zzs11czNQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFmOiGO4YnO6b4VBU4Jvn7pxUEBZeHZlgaBiaD9KSklmUmp8ZnpoAMhnCUagEE77OMuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:47:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=wV4vNb1dPzrFfIOgco; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:47:24 GMT",
+            "loidcreated=2017-11-06T16%3A47%3A24.442Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:47:24 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:47:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-bL0M7TM1q7HQp7eNqWTGvKmmFF0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=wV4vNb1dPzrFfIOgco; loidcreated=2017-11-06T16%3A47%3A24.442Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:47:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "156"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=aRvOB%2Fq0nd00RM6uh9fpVeGT2HDhTCrz8eIzLcShRyLl3xm4PFbHJh3G5v7JZSE9mwcoOpcguUe4sjsKZ8nHHVKqTKLHakHE"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_list_posts_forbidden.json
+++ b/cassettes/channels.views_test.test_list_posts_forbidden.json
@@ -1,0 +1,151 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:48:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NdfNME4N9C/yrgxyzSzM8vFJiTc188xxy3B3y81X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5VXpa6AYmp3iFuGSnx4cnGhlHpoWWRnlUBoaC9KSklmUmp8ZnpoAMhnCUagEOblduuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:48:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=BByRu5IdZi6EvtND32; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:48:31 GMT",
+            "loidcreated=2017-11-06T16%3A48%3A31.297Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:48:31 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:48:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-h3eQOrKyREiqjLLd_56IlFhGFmo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=BByRu5IdZi6EvtND32; loidcreated=2017-11-06T16%3A48%3A31.297Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/my_channel2/hot?count=0&limit=25&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:48:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=sFuXWBx5l9yaVXE%2BWpF8H2ST6uAWvWk4WNwCjNwnXl1axDj91rZrRbSKvrPY7Q3TwSfGyHZTh19Kz%2BeFXOTSY3XJ%2B8ZGgEzY"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/r/my_channel2/hot?count=0&limit=25&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_list_posts_not_found.json
+++ b/cassettes/channels.views_test.test_list_posts_not_found.json
@@ -1,0 +1,136 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T16:48:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAlarqBbF3E7BIFQt6Hz75xhG5ubSfTdc3nq+H6833tvVHEO1rJRPeCJThFK8TGOfZ45wpWoMizqCdOh3DVSd9fyjLYRgpeWBiyTQdgfkmRhP5+Ns4YwUkNlwISu5WpFm5AMtIvY/b9Nc0rorfduuOcU27aITSIujvQqC04DXnJgsgnDa0CfL9WSZAK4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:48:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=BJnPadlIuEBQCWLokB; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:48:42 GMT",
+            "loidcreated=2017-11-06T16%3A48%3A42.231Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 16:48:42 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T16:48:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157--vF4uIcoga45gbw5JmT2diphQTA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=BJnPadlIuEBQCWLokB; loidcreated=2017-11-06T16%3A48%3A42.231Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/missing/hot?count=0&limit=25&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "<html>\n <head>\n  <title>302 Found</title>\n </head>\n <body>\n  <h1>302 Found</h1>\n  The resource was found at <a href=\"https://reddit.local/subreddits/search?q=missing\">https://reddit.local/subreddits/search?q=missing</a>;\nyou should be redirected automatically.\n\n\n </body>\n</html>"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "279"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 16:48:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "location": [
+            "https://reddit.local/subreddits/search?q=missing"
+          ]
+        },
+        "status": {
+          "code": 302,
+          "message": "Found"
+        },
+        "url": "https://reddit.local/r/missing/hot?count=0&limit=25&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_patch_channel_forbidden.json
+++ b/cassettes/channels.views_test.test_patch_channel_forbidden.json
@@ -1,0 +1,151 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T17:02:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNfNyfVNSk2OLDA1jvDx8Ygvyvb2SYsPLjNxLAtU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5exd4Zlf5GGYWW/gGVYWXB8cnueebZ5pnhxmA9KSklmUmp8ZnpoAMhnCUagGV3Xv6uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:02:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=oyWucpNcyHuGPkXSDG; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:02:27 GMT",
+            "loidcreated=2017-11-06T17%3A02%3A27.094Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:02:27 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T17:02:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 187-lmMbecYp53XLLH_rkKLf_Sv4AvQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=oyWucpNcyHuGPkXSDG; loidcreated=2017-11-06T17%3A02%3A27.094Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/dedp2/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:02:27 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=nP17LWXh883tUtF5%2B90PU%2FK9BOt4%2Fi6JEc7Ffqvj3naHib9VYU7AgrWnhdJANvaBe6%2FgnRzE1QQ%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/r/dedp2/about/edit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_patch_channel_not_found.json
+++ b/cassettes/channels.views_test.test_patch_channel_not_found.json
@@ -1,0 +1,136 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T17:02:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNf1yQzNMLHIdXeOyI80cnMxjc+2CHE3TEnLLihW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5ZJTm6FYGF+t6p/ubJeVkVBYU+Romu7q457uC9KSklmUmp8ZnpoAMhnCUagHkEXBxuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:02:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=4aAggNlcpJGkm9sXEZ; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:02:57 GMT",
+            "loidcreated=2017-11-06T17%3A02%3A57.358Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:02:57 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T17:02:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 187-LiUh48mGCXoY2FD5_k8TG1dfkps"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4aAggNlcpJGkm9sXEZ; loidcreated=2017-11-06T17%3A02%3A57.358Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/missing/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "<html>\n <head>\n  <title>302 Found</title>\n </head>\n <body>\n  <h1>302 Found</h1>\n  The resource was found at <a href=\"https://reddit.local/subreddits/search?q=missing\">https://reddit.local/subreddits/search?q=missing</a>;\nyou should be redirected automatically.\n\n\n </body>\n</html>"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "279"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:02:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "location": [
+            "https://reddit.local/subreddits/search?q=missing"
+          ]
+        },
+        "status": {
+          "code": 302,
+          "message": "Found"
+        },
+        "url": "https://reddit.local/r/missing/about/edit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_comment_forbidden.json
+++ b/cassettes/channels.views_test.test_update_comment_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T20:36:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNSwuCQBSF/4rMMhKM0qhlDWXQQgJzOczjlkMP5Y6KU/Tf8+aq5fk43zlvJrUG50RT3eDJ1gGbxcuw3e1NlpcG1WKzjSUif93TU3/kuWPTgEFfWwQnLAnzJIoG9vNF42ugEQUSAanrdDWiCSWEyyCW/28JT7MWMn+tfGdVoYv8vApjVOZxIMdAZzUIa2h4DOzzBc3dKWy4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 20:36:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=foxSy878meZtWNV0PQ; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 20:36:54 GMT",
+            "loidcreated=2017-11-06T20%3A36%3A54.418Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 20:36:54 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T20:40:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=updated+text&thing_id=t1_e8h"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-uFGdPUhdrb4BC5arrDzlHRxLDUs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "47"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=foxSy878meZtWNV0PQ; loidcreated=2017-11-06T20%3A36%3A54.418Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/editusertext/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"NOT_AUTHOR\", \"you can't do that\", \"thing_id\"]]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "71"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 20:40:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "574"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/editusertext/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_post_forbidden.json
+++ b/cassettes/channels.views_test.test_update_post_forbidden.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T17:32:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0Ndf18Y1IN3M18PEuN4tMibeIDzEu8PKw9AowcypX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbFm6cUJZWk5gbnGQbmBkVkBESmpvn5GQVaVriC9KSklmUmp8ZnpoAMhnCUagGFeRKxuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:32:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=4W3j3Eq6Tf0PSfVas1; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:24 GMT",
+            "loidcreated=2017-11-06T17%3A32%3A24.335Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:24 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T17:32:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-LMXg6E0LKw6Yd_8_T3pJH9JP6Bw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4W3j3Eq6Tf0PSfVas1; loidcreated=2017-11-06T17%3A32%3A24.335Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/acd/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:32:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "456"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=0FfWfpzDtseJwQrLa1NGNYic41k3xi76%2F0rmjkakmEl7sC9Eoq4IIWiafiY5abNJWfWfgkyntDm09OqvkuEIbWzUft487J3n"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/comments/acd/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_post_not_found.json
+++ b/cassettes/channels.views_test.test_update_post_not_found.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-06T17:32:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WN0QqCMBiFX0V2GQmWLc270CBSiqj7ofNXxyB1GzoXvXsur7o8H+c7541ySkFKoloOLxQ5aIMD179dkl2ac3xIwkpneHRVptP6brYntHYQ6I4JkIRZwd973sx+PlFTB3akgFyAsF1J2wWtbBJQzWLz/2aqKTybGB+v/Nk3qh+Lh9H1YOKAWqeEgVEgrLTDS0CfLyrIzsa4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:32:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=ADscWoBzmGRTbaGQgp; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:24 GMT",
+            "loidcreated=2017-11-06T17%3A32%3A24.429Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:32:24 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+      }
+    },
+    {
+      "recorded_at": "2017-11-06T17:32:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 157-3OJD4Kak59D8fxL5w-tLxKgQz2E"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=ADscWoBzmGRTbaGQgp; loidcreated=2017-11-06T17%3A32%3A24.429Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 06 Nov 2017 17:32:24 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "456"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=7L4XSLnwgaj0lhXupWOFXq3NhTIc4xPTX6qm47eFj8eQWVxB2uQ3DGEyikCLwp93QCJIN4n048wnj8vQWpqnqu56ShIHUqHi"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://reddit.local/comments/missing/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/conftest.py
+++ b/channels/conftest.py
@@ -7,8 +7,8 @@ from betamax.fixtures.pytest import _casette_name as cassette_name
 from rest_framework.test import APIClient
 
 from channels.test_utils import no_ssl_verification
-from profiles.factories import ProfileFactory
 from open_discussions.betamax_config import setup_betamax
+from profiles.factories import ProfileFactory
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def use_betamax(mocker, cassette_exists, praw_settings, configure_betamax, betam
         mocker.patch('channels.api._get_refresh_token', return_value={
             'refresh_token': 'fake',
             'access_token': 'fake',
-            'expires_in': 123,
+            'expires_in': 1234,
         })
 
     # always ignore SSL verification

--- a/channels/exceptions.py
+++ b/channels/exceptions.py
@@ -1,9 +1,20 @@
 """
 Exceptions for the channels app
 """
+from rest_framework import status
+from rest_framework.exceptions import APIException
 
 
 class RemoveUserException(Exception):
     """
     To be raised in case the provided user or username cannot be removed
     """
+
+
+class ConflictException(APIException):
+    """
+    An action would cause a conflict with an existing resource
+    """
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = 'Resource conflict.'
+    default_code = 'resource_conflict'

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -16,6 +16,7 @@ import { formatTitle } from "../lib/title"
 
 describe("PostPage", function() {
   let helper, renderComponent, listenForActions, post, comments, channel
+  this.timeout(5000)
 
   beforeEach(() => {
     post = makePost()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #319 

#### What's this PR do?
Converts PRAW exceptions to DRF exceptions so that we get the 403 or 404 responses. This PR will only handle this for the cases where we are relying on reddit to do these permission checks.

#### How should this be manually tested?
Open up the network tab in your browser and make sure these return these results:
 - Go to `/channel/missing` and verify that the API errors are all 404s
 - For a channel you are subscribed to go to `/channel/channel_name/missing/` and verify the API errors are 404s
 - Create a private channel your user is not subscribed to. Go to `/channel/<channel_name>/` and verify the API errors are all 403s

There are many other cases which may not be worth testing manually, but in general you should never see a 500 error from an API call.