### PR TITLE
show link post domain after the link

### DIFF
--- a/static/js/components/PostDisplay.js
+++ b/static/js/components/PostDisplay.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 import ReactMarkdown from "react-markdown"
 
-import { channelURL, postDetailURL } from "../lib/url"
+import { channelURL, postDetailURL, urlHostname } from "../lib/url"
 import { formatCommentsCount } from "../lib/posts"
 
 import type { Post } from "../flow/discussionTypes"
@@ -26,9 +26,19 @@ const postTitle = (post: Post) =>
     >
       {post.title}
     </Link>
-    : <a className="post-title" href={post.url} target="_blank">
-      {post.title}
-    </a>
+    : <div>
+      <a
+        className="post-title"
+        href={post.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {post.title}
+      </a>
+      <span className="url-hostname">
+        {`(${urlHostname(post.url)})`}
+      </span>
+    </div>
 
 class PostDisplay extends React.Component {
   props: {

--- a/static/js/components/PostDisplay_test.js
+++ b/static/js/components/PostDisplay_test.js
@@ -9,12 +9,14 @@ import PostDisplay from "./PostDisplay"
 import Router from "../Router"
 
 import { wait } from "../lib/util"
+import { urlHostname } from "../lib/url"
 import { formatCommentsCount } from "../lib/posts"
 import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("PostDisplay", () => {
-  let helper
+  let helper, post
+
   const renderPostDisplay = props => {
     props = {
       toggleUpvote: () => {},
@@ -29,6 +31,7 @@ describe("PostDisplay", () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
+    post = makePost()
   })
 
   afterEach(() => {
@@ -36,7 +39,6 @@ describe("PostDisplay", () => {
   })
 
   it("should render a post correctly", () => {
-    const post = makePost()
     const wrapper = renderPostDisplay({ post })
     const summary = wrapper.find(".summary")
     assert.equal(wrapper.find(".votes").text(), post.score.toString())
@@ -51,14 +53,12 @@ describe("PostDisplay", () => {
   })
 
   it("should link to the subreddit, if told to", () => {
-    const post = makePost()
     post.channel_name = "channel_name"
     const wrapper = renderPostDisplay({ post: post, showChannelLink: true })
     assert.equal(wrapper.find(Link).at(1).props().to, "/channel/channel_name")
   })
 
   it("should display text, if given a text post and the 'expanded' flag", () => {
-    const post = makePost()
     const string = "JUST SOME GREAT TEXT!"
     post.text = string
     const wrapper = renderPostDisplay({ post: post, expanded: true })
@@ -66,14 +66,12 @@ describe("PostDisplay", () => {
   })
 
   it("should display profile image, if expanded", () => {
-    const post = makePost()
     const wrapper = renderPostDisplay({ post: post, expanded: true })
     const { src } = wrapper.find(".summary img").props()
     assert.equal(src, post.profile_image)
   })
 
   it("should not display images from markdown", () => {
-    const post = makePost()
     post.text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
     const wrapper = renderPostDisplay({ post: post, expanded: true })
     assert.equal(wrapper.find(ReactMarkdown).props().source, post.text)
@@ -81,7 +79,6 @@ describe("PostDisplay", () => {
   })
 
   it("should not display text, if given a text post but lacking the 'expanded' flag", () => {
-    const post = makePost()
     const string = "JUST SOME GREAT TEXT!"
     post.text = string
     const wrapper = renderPostDisplay({ post: post })
@@ -97,8 +94,13 @@ describe("PostDisplay", () => {
     assert.equal(children, post.title)
   })
 
+  it("should display the domain, for a url post", () => {
+    const post = makePost(true)
+    const wrapper = renderPostDisplay({ post: post })
+    assert.include(wrapper.find(".url-hostname").text(), urlHostname(post.url))
+  })
+
   it("should link to the detail view, if a text post", () => {
-    const post = makePost()
     const wrapper = renderPostDisplay({ post: post })
     const { to, children } = wrapper.find(Link).at(0).props()
     assert.equal(children, post.title)
@@ -124,7 +126,6 @@ describe("PostDisplay", () => {
   ;[true, false].forEach(prevUpvote => {
     it(`should show the correct UI when the upvote 
     button is clicked when prev state was ${String(prevUpvote)}`, async () => {
-      const post = makePost()
       post.upvoted = prevUpvote
       // setting to a function so Flow doesn't complain
       let resolveUpvote = () => null

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -26,5 +26,8 @@ export const AUTH_REQUIRED_URL = "/auth_required/"
 const QS_OPTIONS = {
   sort: (a, b) => a.localeCompare(b)
 }
+
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params, QS_OPTIONS)}`
+
+export const urlHostname = (url: ?string) => (url ? new URL(url).hostname : "")

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -8,7 +8,8 @@ import {
   newPostURL,
   postDetailURL,
   getChannelNameFromPathname,
-  toQueryString
+  toQueryString,
+  urlHostname
 } from "./url"
 
 describe("url helper functions", () => {
@@ -77,6 +78,29 @@ describe("url helper functions", () => {
         }),
         "?abc=10&def=1"
       )
+    })
+  })
+
+  describe("urlHostname", () => {
+    it("should pull out the hostname", () => {
+      [
+        [
+          "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "developer.mozilla.org"
+        ],
+        ["https://github.com/mitodl/open-discussions", "github.com"],
+        [
+          "https://mobile.github.com/mitodl/open-discussions",
+          "mobile.github.com"
+        ],
+        ["https://mail.google.com/", "mail.google.com"],
+        [
+          "https://www.nytimes.com/2017/10/16/us/politics/trump-mcconnell-bannon.html",
+          "www.nytimes.com"
+        ]
+      ].forEach(([url, expectation]) => {
+        assert.equal(urlHostname(url), expectation)
+      })
     })
   })
 })

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -25,6 +25,12 @@
     margin: 0 0 7px;
   }
 
+  .url-hostname {
+    color: $font-grey;
+    font-size: 13px;
+    margin-left: 4px;
+  }
+
   .authored-by {
     font-size: 13px;
     color: $font-grey;


### PR DESCRIPTION
#### What are the relevant tickets?

#270 

#### What's this PR do?

this adds a little display next to the title link for a URL post which just shows what domain the link is from.

#### How should this be manually tested?

if you look at the frontpage or a channel page with link posts you should see something like:

![fjfjasdf](https://user-images.githubusercontent.com/6207644/31676566-09f316f6-b336-11e7-9266-1c8959163fb8.png)

the same thing should show up if you look at the comments for the post.