### PR TITLE
fix a bug where the MDC drawer was obliterating onclick handlers

### DIFF
--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -14,6 +14,22 @@ import type { Dispatch } from "redux"
 import type { Channel } from "../flow/discussionTypes"
 import type { Location } from "react-router"
 
+// see https://github.com/mitodl/open-discussions/issues/295
+if (!MDCTemporaryDrawer.prototype.getDefaultFoundation_) {
+  MDCTemporaryDrawer.prototype.getDefaultFoundation_ =
+    MDCTemporaryDrawer.prototype.getDefaultFoundation
+  MDCTemporaryDrawer.prototype.getDefaultFoundation = function() {
+    const foundation = this.getDefaultFoundation_()
+
+    foundation.drawerClickHandler_ = e => {
+      if (e.target.tagName !== "A") {
+        e.stopPropagation()
+      }
+    }
+    return foundation
+  }
+}
+
 class Drawer extends React.Component {
   // the ref for the rendered DOM element, which MDCTemporaryDrawer needs
   // access to in order to manage it's animations and so on


### PR DESCRIPTION
#### What are the relevant tickets?

closes #295

#### What's this PR do?

this adds a little hacky thing (see the linked issue) which works around a bug with the MDC Drawer. Basically, the drawer component was blowing away all `onclick` handlers inside of it, so our react-router `<Link />` components we working as normal `<a>` tags and not as SPA links. This fixes that.

#### How should this be manually tested?

Check out master and confirm that the navigation links in the mobile navigation drawer are always causing full-page refreshes. Then check out this and confirm that they are SPA links, as they should be. In both cases the links in the desktop sidebar should be unaffected.