### PR TITLE
Use ExtractTextPlugin to split CSS into separate file

### DIFF
--- a/app.json
+++ b/app.json
@@ -62,7 +62,7 @@
       "description": "E-mail to send 500 reports to."
     },
     "OPEN_DISCUSSIONS_CHANNEL_POST_LIMIT": {
-      "description": "Number of posts to display on the forntpage and channels",
+      "description": "Number of posts to display on the frontpage and channels",
       "required": false
     },
     "OPEN_DISCUSSIONS_COOKIE_NAME": {

--- a/app.json
+++ b/app.json
@@ -21,13 +21,16 @@
   "description": "open-discussions",
   "env": {
     "AWS_ACCESS_KEY_ID": {
-      "description": "AWS Access Key for S3 storage."
+      "description": "AWS Access Key for S3 storage.",
+      "required": false
     },
     "AWS_SECRET_ACCESS_KEY": {
-      "description": "AWS Secret Key for S3 storage."
+      "description": "AWS Secret Key for S3 storage.",
+      "required": false
     },
     "AWS_STORAGE_BUCKET_NAME": {
-      "description": "S3 Bucket name."
+      "description": "S3 Bucket name.",
+      "required": false
     },
     "GA_TRACKING_ID": {
       "description": "Google analytics tracking ID",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0",
     "express": "^4.15.3",
+    "extract-text-webpack-plugin": "2",
     "fetch-mock": "^5.12.1",
     "flow-bin": "^0.50.0",
     "history": "^4.6.3",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,7 +37,17 @@ const devConfig = Object.assign({}, config, {
 });
 
 devConfig.module.rules = [
-  babelSharedLoader, ...config.module.rules
+  babelSharedLoader,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use: [
+      { loader: 'style-loader' },
+      { loader: 'css-loader' },
+      { loader: 'postcss-loader' },
+      { loader: 'sass-loader' },
+    ]
+  },
 ];
 
 const makeDevConfig = (host, port) => (

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,6 +1,7 @@
 var webpack = require('webpack');
 var path = require("path");
 var BundleTracker = require('webpack-bundle-tracker');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { config, babelSharedLoader } = require(path.resolve("./webpack.config.shared.js"));
 
 const prodBabelConfig = Object.assign({}, babelSharedLoader);
@@ -11,14 +12,24 @@ prodBabelConfig.query.plugins.push(
 );
 
 const prodConfig = Object.assign({}, config);
-prodConfig.module.rules = [prodBabelConfig, ...config.module.rules];
+prodConfig.module.rules = [
+  prodBabelConfig,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use:  ExtractTextPlugin.extract({
+      fallback: 'style-loader',
+      use:      ['css-loader', 'postcss-loader', 'sass-loader'],
+    })
+  }
+];
 
 module.exports = Object.assign(prodConfig, {
   context: __dirname,
-  output: {
-    path: path.resolve('./static/bundles/'),
-    filename: "[name]-[chunkhash].js",
-    chunkFilename: "[id]-[chunkhash].js",
+  output:  {
+    path:               path.resolve('./static/bundles/'),
+    filename:           "[name]-[chunkhash].js",
+    chunkFilename:      "[id]-[chunkhash].js",
     crossOriginLoading: "anonymous",
   },
 
@@ -35,7 +46,7 @@ module.exports = Object.assign(prodConfig, {
       sourceMap: true,
     }),
     new webpack.optimize.CommonsChunkPlugin({
-      name: 'common',
+      name:      'common',
       minChunks: 2,
     }),
     new BundleTracker({
@@ -45,6 +56,11 @@ module.exports = Object.assign(prodConfig, {
       minimize: true
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
+    new ExtractTextPlugin({
+      filename:    "[name]-[contenthash].css",
+      allChunks:   true,
+      ignoreOrder: false,
+    })
   ],
   devtool: 'source-map'
 });

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -13,24 +13,6 @@ module.exports = {
           test: /\.(svg|ttf|woff|woff2|eot|gif)$/,
           use: 'url-loader'
         },
-        {
-          test: /\.scss$/,
-          exclude: /node_modules/,
-          use: [
-            { loader: 'style-loader' },
-            { loader: 'css-loader' },
-            { loader: 'postcss-loader' },
-            { loader: 'sass-loader' },
-          ]
-        },
-        {
-          test: /\.css$/,
-          exclude: /node_modules/,
-          use: [
-            { loader: 'style-loader' },
-            { loader: 'css-loader' }
-          ]
-        },
       ]
     },
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,6 +2432,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-text-webpack-plugin@2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz#756ef4efa8155c3681833fbc34da53b941746d6c"
+  dependencies:
+    async "^2.1.2"
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+    webpack-sources "^1.0.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/pull/3637

#### What's this PR do?
Splits off CSS for production instances into separate file. This lets the browser cache the CSS and load it in parallel to the JS

#### How should this be manually tested?
Go to PR build's page, verify that CSS loads correctly. You should also see no changes locally.
