### PR TITLE
add https to placeholder for create post form

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -108,7 +108,7 @@ export default class CreatePostForm extends React.Component {
                 <label>Link URL</label>
                 <input
                   type="url"
-                  placeholder="www.example.com"
+                  placeholder="https://www.example.com"
                   name="url"
                   value={url}
                   onChange={onUpdate}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #297

#### What's this PR do?

this just fixes the little placeholder text for the link post creation form

#### How should this be manually tested?

go to create a post, you should see `https://www.example.com` instead of `www.example.com`.