### PR TITLE
Mark AWS environment variables as not required

### DIFF
--- a/app.json
+++ b/app.json
@@ -62,7 +62,7 @@
       "description": "E-mail to send 500 reports to."
     },
     "OPEN_DISCUSSIONS_CHANNEL_POST_LIMIT": {
-      "description": "Number of posts to display on the forntpage and channels",
+      "description": "Number of posts to display on the frontpage and channels",
       "required": false
     },
     "OPEN_DISCUSSIONS_COOKIE_NAME": {

--- a/app.json
+++ b/app.json
@@ -21,13 +21,16 @@
   "description": "open-discussions",
   "env": {
     "AWS_ACCESS_KEY_ID": {
-      "description": "AWS Access Key for S3 storage."
+      "description": "AWS Access Key for S3 storage.",
+      "required": false
     },
     "AWS_SECRET_ACCESS_KEY": {
-      "description": "AWS Secret Key for S3 storage."
+      "description": "AWS Secret Key for S3 storage.",
+      "required": false
     },
     "AWS_STORAGE_BUCKET_NAME": {
-      "description": "S3 Bucket name."
+      "description": "S3 Bucket name.",
+      "required": false
     },
     "GA_TRACKING_ID": {
       "description": "Google analytics tracking ID",


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Marks AWS environment variables as not required. We do not use AWS in this app currently, these were just copied from the cookiecutter. We need to mark it not required so that the review apps can deploy

#### How should this be manually tested?
N/A
