### PR TITLE
Use application log level for Celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program uwsgi uwsgi.ini
-worker: celery -A open_discussions worker -B
-extra_worker: celery -A open_discussions worker
+worker: celery -A open_discussions worker -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker: celery -A open_discussions worker -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/app.json
+++ b/app.json
@@ -97,6 +97,11 @@
     "OPEN_DISCUSSIONS_FROM_EMAIL": {
       "description": "E-mail to use for the from field"
     },
+    "OPEN_DISCUSSIONS_LOG_LEVEL": {
+      "description": "The log level for the application",
+      "required": true,
+      "value": "INFO"
+    },
     "OPEN_DISCUSSIONS_JWT_SECRET": {
       "description": "Shared secret for JWT auth tokens",
       "required": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions worker -B -l debug'
+      celery -A open_discussions worker -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/cookiecutter-djangoapp/pull/103

#### What's this PR do?
Uses application log level for Celery

#### How should this be manually tested?
Currently no tasks do logging and the PR build is not properly set up anyway
