### PR TITLE
Added factories for reddit objects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+cassettes/* linguist-generated=true
+factory_data/* linguist-generated=true

--- a/cassettes/channels.views_test.test_get_channel.json
+++ b/cassettes/channels.views_test.test_get_channel.json
@@ -1,245 +1,254 @@
 {
   "http_interactions": [
     {
+      "recorded_at": "2017-11-06T19:47:15",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": ""
         },
         "headers": {
-          "User-Agent": [
-            "python-requests/2.18.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
-          ],
           "Connection": [
             "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BY9DYS88QQVRP81GRFV6AAGT"
       },
       "response": {
         "body": {
-          "encoding": "UTF-8",
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLUjcwrMDDxD9MtDUp29tXNKdT1DDMLMPSsKvD0VdJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2uZgZe5VmZ+UWGpVnueS4uLimGZUHBnsU53png3SkpJZlJqfGZ6aAjIVwlGoB7mx6QbQAAAA="
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0M9UN0HUt8nb0drcIryqoSKyo8EzNMTDNMkqxKI5U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5hngkleuWFeVmFXvnZvn4V+UFmpSbFlTqlpuA9KSklmUmp8ZnpoAMhnCUagExi/pWuAAAAA==",
+          "encoding": "UTF-8"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:36:15 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
           ],
           "Content-Type": [
             "text/html; charset=UTF-8"
           ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 19:32:38 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-frame-options": [
-            "SAMEORIGIN"
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=aBKVFsxc3KtdgTpdcg; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 19:32:38 GMT",
+            "loidcreated=2017-11-06T19%3A32%3A38.545Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 19:32:38 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
           "x-xss-protection": [
             "1; mode=block"
-          ],
-          "set-cookie": [
-            "loid=zxFnqz9JQzbJbEZkRD; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 25-Jul-2019 15:36:15 GMT",
-            "loidcreated=2017-07-25T15%3A36%3A15.496Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 25-Jul-2019 15:36:15 GMT"
-          ],
-          "Content-Encoding": [
-            "gzip"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
-      },
-      "recorded_at": "2017-07-25T15:36:15"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BY9DYS88QQVRP81GRFV6AAGT"
+      }
     },
     {
+      "recorded_at": "2017-11-06T19:47:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=1-D63Jukjmq2wjDlDDEf2wQSHsmKk"
+          "string": "api_type=json&link_type=any&name=1509997635_minima&public_description=Magni+officia+suscipit+corporis+quisquam.+Occaecati+nesciunt+repellendus+nam+inventore+omnis.&title=In+sed+repudiandae+deserunt.&type=public&wikimode=disabled"
         },
         "headers": {
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
+          "Authorization": [
+            "bearer 165-P-ErKAKG8WzpxaxxIel05j2d8sY"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Cookie": [
-            "loid=zxFnqz9JQzbJbEZkRD; loidcreated=2017-07-25T15%3A36%3A15.496Z"
-          ],
           "Content-Length": [
-            "68"
+            "228"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
-          "Authorization": [
-            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
+          "Cookie": [
+            "loid=aBKVFsxc3KtdgTpdcg; loidcreated=2017-11-06T19%3A32%3A38.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"1-SexozKdPTwJxdyLoMpn8FWfGpSs\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:36:15 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "Content-Length": [
-            "107"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 19:32:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-frame-options": [
-            "SAMEORIGIN"
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
-          "x-xss-protection": [
-            "1; mode=block"
+          "x-frame-options": [
+            "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298"
-          ],
-          "x-ratelimit-used": [
-            "2"
+            "299.0"
           ],
           "x-ratelimit-reset": [
-            "225"
+            "442"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/access_token"
-      },
-      "recorded_at": "2017-07-25T15:36:15"
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
     },
     {
+      "recorded_at": "2017-11-06T19:47:15",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": ""
         },
         "headers": {
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
+          "Authorization": [
+            "bearer 165-P-ErKAKG8WzpxaxxIel05j2d8sY"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Authorization": [
-            "bearer 1-SexozKdPTwJxdyLoMpn8FWfGpSs"
-          ],
           "Cookie": [
-            "loid=zxFnqz9JQzbJbEZkRD; loidcreated=2017-07-25T15%3A36%3A15.496Z"
+            "loid=aBKVFsxc3KtdgTpdcg; loidcreated=2017-11-06T19%3A32%3A38.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/subreddit_for_testing/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1509997635_minima/about/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"1\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"subreddit_for_testing\", \"header_img\": null, \"description_html\": null, \"title\": \"subreddit for tests\", \"collapse_deleted_comments\": false, \"public_description\": \"a public description goes here\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ea public description goes here\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_1\", \"created\": 1500994860.0, \"url\": \"/r/subreddit_for_testing/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1500994860.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"14\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1509997635_minima\", \"header_img\": null, \"description_html\": null, \"title\": \"In sed repudiandae deserunt.\", \"collapse_deleted_comments\": false, \"public_description\": \"Magni officia suscipit corporis quisquam. Occaecati nesciunt repellendus nam inventore omnis.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMagni officia suscipit corporis quisquam. Occaecati nesciunt repellendus nam inventore omnis.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 1, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_14\", \"created\": 1509996758.0, \"url\": \"/r/1509997635_minima/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1509996758.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:36:15 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1410"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "Content-Length": [
-            "1282"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 19:32:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
           ],
           "expires": [
             "-1"
           ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "296.0"
-          ],
-          "x-ratelimit-used": [
-            "4"
+            "298.0"
           ],
           "x-ratelimit-reset": [
-            "225"
+            "441"
+          ],
+          "x-ratelimit-used": [
+            "2"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=Y24wsl%2FYWOxxoQvMx2AEzFBBHpzHjtUkLMLrG95cZLFKmh%2BZ093km3U7%2FdCSIy9go7TDi%2Bxmu%2FfIaxEkW8KJjeeVp%2BRDHnP6"
+            "https://reddit.local/pixel/of_destiny.png?v=ZnimOtPfRudnuPuuGzXeR3SKKH2YwXyeZXCl%2FvNrROUHjlhiwxOvCS8PZduG%2Bz%2BKxgny4BbvsY1FXv1Q8zo6vpg%2FeLKA1zqC"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/subreddit_for_testing/about/?raw_json=1"
-      },
-      "recorded_at": "2017-07-25T15:36:15"
+        "url": "https://reddit.local/r/1509997635_minima/about/?raw_json=1"
+      }
     }
   ],
   "recorded_with": "betamax/0.8.0"

--- a/cassettes/channels.views_test.test_list_channels.json
+++ b/cassettes/channels.views_test.test_list_channels.json
@@ -1,181 +1,191 @@
 {
   "http_interactions": [
     {
+      "recorded_at": "2017-11-06T17:28:34",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": ""
         },
         "headers": {
-          "User-Agent": [
-            "python-requests/2.18.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
-          ],
           "Connection": [
             "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=george"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=1509989314.436939"
       },
       "response": {
         "body": {
-          "encoding": "UTF-8",
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLUTa5wdvFKz7UMyk42iYzyLc6vDE4NLvSJ9HIrV9JRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2eZW7ZfuFelR6GJa5OOebGXt4l6cUBDsG+1img3SkpJZlJqfGZ6aAjIVwlGoBsmZIpLQAAAA="
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0M9b1SMkKCgoLMwqJzLJ0dA70cPbK8MxzcTGOLI1U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5FZUWhLg4umcbJxbEp4VG+hl7eWVFpQSV6BaD9KSklmUmp8ZnpoAMhnCUagFDVtfcuAAAAA==",
+          "encoding": "UTF-8"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:16:05 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
           ],
           "Content-Type": [
             "text/html; charset=UTF-8"
           ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 17:28:34 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-frame-options": [
-            "SAMEORIGIN"
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=oE17pAqtLNDximfDlu; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:28:34 GMT",
+            "loidcreated=2017-11-06T17%3A28%3A34.494Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 06-Nov-2019 17:28:34 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
           "x-xss-protection": [
             "1; mode=block"
-          ],
-          "set-cookie": [
-            "loid=P2CV2LjYWDcKbl7AV8; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 25-Jul-2019 15:16:05 GMT",
-            "loidcreated=2017-07-25T15%3A16%3A05.341Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 25-Jul-2019 15:16:05 GMT"
-          ],
-          "Content-Encoding": [
-            "gzip"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=george"
-      },
-      "recorded_at": "2017-07-25T15:16:05"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=1509989314.436939"
+      }
     },
     {
+      "recorded_at": "2017-11-06T17:28:34",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=1-JwFkNUHyH1vDCo63HKwdpSASL9g"
+          "string": "api_type=json&link_type=any&name=1509989314_consectetu&public_description=Porro+dolore+labore+vitae+dolor+repellat.+Adipisci+ipsa+nobis+perferendis+nisi+atque+atque+aliquam.&title=Rerum+omnis+laudantium+architecto.&type=public&wikimode=disabled"
         },
         "headers": {
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
+          "Authorization": [
+            "bearer 163-HdjRRVV2TYj9ACQHCJhInDD3YuY"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Cookie": [
-            "loid=P2CV2LjYWDcKbl7AV8; loidcreated=2017-07-25T15%3A16%3A05.341Z"
-          ],
           "Content-Length": [
-            "68"
+            "244"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
-          "Authorization": [
-            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
+          "Cookie": [
+            "loid=oE17pAqtLNDximfDlu; loidcreated=2017-11-06T17%3A28%3A34.494Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"1-OozwBelgHyrMewPyGRPUrxLIxKw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:16:05 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "Content-Length": [
-            "107"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 17:28:34 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-frame-options": [
-            "SAMEORIGIN"
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
-          "x-xss-protection": [
-            "1; mode=block"
+          "x-frame-options": [
+            "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299"
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "86"
           ],
           "x-ratelimit-used": [
             "1"
           ],
-          "x-ratelimit-reset": [
-            "235"
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/access_token"
-      },
-      "recorded_at": "2017-07-25T15:16:05"
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
     },
     {
+      "recorded_at": "2017-11-06T17:28:34",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": ""
         },
         "headers": {
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+          "Accept": [
+            "*/*"
           ],
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Accept": [
-            "*/*"
+          "Authorization": [
+            "bearer 163-HdjRRVV2TYj9ACQHCJhInDD3YuY"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Authorization": [
-            "bearer 1-OozwBelgHyrMewPyGRPUrxLIxKw"
-          ],
           "Cookie": [
-            "loid=P2CV2LjYWDcKbl7AV8; loidcreated=2017-07-25T15%3A16%3A05.341Z"
+            "loid=oE17pAqtLNDximfDlu; loidcreated=2017-11-06T17%3A28%3A34.494Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
@@ -184,53 +194,53 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"1\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"subreddit_for_testing\", \"header_img\": null, \"description_html\": null, \"title\": \"subreddit for tests\", \"collapse_deleted_comments\": false, \"public_description\": \"a public description goes here\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ea public description goes here\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_1\", \"created\": 1500994860.0, \"url\": \"/r/subreddit_for_testing/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1500994860.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}], \"after\": null, \"before\": null}}"
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"12\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1509989314_consectetu\", \"header_img\": null, \"description_html\": null, \"title\": \"Rerum omnis laudantium architecto.\", \"collapse_deleted_comments\": false, \"public_description\": \"Porro dolore labore vitae dolor repellat. Adipisci ipsa nobis perferendis nisi atque atque aliquam.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPorro dolore labore vitae dolor repellat. Adipisci ipsa nobis perferendis nisi atque atque aliquam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": null, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_12\", \"created\": 1509989314.0, \"url\": \"/r/1509989314_consectetu/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1509989314.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}], \"after\": null, \"before\": null}}"
         },
         "headers": {
-          "Date": [
-            "Tue, 25 Jul 2017 15:16:05 GMT"
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1532"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "Content-Length": [
-            "1378"
-          ],
-          "Connection": [
-            "keep-alive"
+          "Date": [
+            "Mon, 06 Nov 2017 17:28:35 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
           ],
           "expires": [
             "-1"
           ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-used": [
-            "1"
+            "298.0"
           ],
           "x-ratelimit-reset": [
-            "235"
+            "86"
+          ],
+          "x-ratelimit-used": [
+            "2"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=yCLCBmuGeHtCuRCBPIK7Z0ah6hIL2wrdkTM1KOGhjXldjEDKqgnq1VJfhIt2dp3LwD3yAomFxJCihD4YHsw%2BYMFmgzNOe4nm"
+            "https://reddit.local/pixel/of_destiny.png?v=ESJffoTeaa%2BWiL9fRFu2o010tp1cstq7kj6WCMAUh3YczIpYNo1F3OG3bUn3wUULljDiwlZIduR03SXOaqyYsZzCgwJk6Ffq"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
           ]
         },
         "status": {
@@ -238,8 +248,7 @@
           "message": "OK"
         },
         "url": "https://reddit.local/subreddits/mine/subscriber/?limit=100&raw_json=1"
-      },
-      "recorded_at": "2017-07-25T15:16:05"
+      }
     }
   ],
   "recorded_with": "betamax/0.8.0"

--- a/channels/factories.py
+++ b/channels/factories.py
@@ -1,14 +1,137 @@
 """Factories for making test data"""
-import pytz
+import json
+import os
+from collections import namedtuple
 
+import pytz
 import faker
 import factory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
 
 from open_discussions.factories import UserFactory
+from open_discussions.utils import now_in_utc
+from channels.api import CHANNEL_TYPE_PUBLIC, CHANNEL_TYPE_PRIVATE
 from channels.models import RedditAccessToken, RedditRefreshToken
 
 FAKE = faker.Factory.create()
+
+Channel = namedtuple('Channel', ['name', 'title', 'channel_type', 'public_description', 'api'])
+
+TextPost = namedtuple('TextPost', ['id', 'title', 'text', 'channel', 'api'])
+
+LinkPost = namedtuple('LinkPost', ['id', 'title', 'url', 'channel', 'api'])
+
+Comment = namedtuple('Comment', ['id', 'text', 'comment_id', 'children', 'post_id', 'api'])
+
+
+def _serialize_named_tuple(obj):
+    """
+    Serializes a named tuple to a dict
+
+    Args:
+        obj (namedtuple): the named tuple to serialize
+
+    Returns:
+        dict: the serialized form of the tuple
+    """
+    data = obj._asdict()
+    del data["api"]
+    return data
+
+
+class RedditFactories:
+    """
+    Factory for channels and posts
+    """
+    def __init__(self, name, api):
+        self.filename = "factory_data/{}.json".format(name)
+        self.channels = {}
+        self.posts = {}
+        self.comments = {}
+        self.api = api
+        self._dirty = False
+
+    def load(self):
+        """Loads the factory data from disk"""
+        if not os.path.exists(self.filename):
+            return
+
+        with open(self.filename, "r") as f:
+            data = json.loads(f.read())
+        self.channels = data["channels"]
+        self.posts = data["posts"]
+        self.comments = data["comments"]
+
+    def write(self):
+        """Saves the accumulated factory data to disk"""
+        if not self._dirty:
+            return
+        with open(self.filename, "w") as f:
+            json.dump({
+                "channels": self.channels,
+                "posts":  self.posts,
+                "comments":  self.comments,
+            }, f, indent=2, sort_keys=True)
+
+        self._dirty = False
+
+    def channel(self, ident, **kwargs):
+        """
+        Creates a new named channel
+
+        Args:
+            ident (str): the logical name of the channel within the test
+
+        Returns:
+            Channel: the created channel
+        """
+        if ident not in self.channels:
+            channel = ChannelFactory.create(api=self.api, **kwargs)
+            self.channels[ident] = _serialize_named_tuple(channel)
+            self._dirty = True
+        else:
+            channel = ChannelFactory.create(api=self.api, **self.channels[ident])
+
+        return channel
+
+    def post(self, ident, **kwargs):
+        """
+        Creates a new named post
+
+        Args:
+            ident (str): the logical name of the post within the test
+
+        Returns:
+            Post: the created post
+        """
+        if ident not in self.posts:
+            post = PostFactory.create(api=self.api, **kwargs)
+            self.posts[ident] = _serialize_named_tuple(post)
+            self._dirty = True
+        else:
+            post = PostFactory.create(api=self.api, **self.posts[ident])
+
+        return post
+
+    def comment(self, ident, **kwargs):
+        """
+        Creates a new named comment
+
+        Args:
+            ident (str): the logical name of the comment within the test
+
+        Returns:
+            Comment: the created comment
+        """
+        if ident not in self.comments:
+            comment = CommentFactory.create(api=self.api, **kwargs)
+            self.comments[ident] = _serialize_named_tuple(comment)
+            self._dirty = True
+        else:
+            comment = CommentFactory.create(api=self.api, **self.comments[ident])
+
+        return comment
 
 
 class RedditRefreshTokenFactory(DjangoModelFactory):
@@ -39,3 +162,137 @@ class RedditAccessTokenFactory(DjangoModelFactory):
                 lambda: FAKE.date_time_this_year(before_now=True, after_now=False, tzinfo=pytz.utc)
             )
         )
+
+
+class ChannelFactory(factory.Factory):
+    """Factory for channels"""
+    api = None
+    title = factory.Faker('text', max_nb_chars=50)
+    public_description = factory.Faker('text', max_nb_chars=100)
+    channel_type = FuzzyChoice([CHANNEL_TYPE_PUBLIC, CHANNEL_TYPE_PRIVATE])
+
+    @factory.lazy_attribute
+    def name(self):
+        """Lazily determine a unique channel name"""
+        now = now_in_utc().timestamp()
+        return "{}_{}".format(int(now), FAKE.word())[:21]  # maximum of 21-char channel names
+
+    @factory.post_generation
+    def _api(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """Lazily create the channel"""
+        if not self.api:
+            raise ValueError("ChannelFactory requires an api instance")
+
+        self.api.create_channel(
+            self.name,
+            self.title,
+            channel_type=self.channel_type,
+            public_description=self.public_description
+        )
+
+    class Meta:
+        model = Channel
+
+
+class PostFactory(factory.Factory):
+    """Abstract factory for posts"""
+    api = None
+    title = factory.Faker('text', max_nb_chars=50)
+
+    @factory.lazy_attribute
+    def channel(self):
+        """Lazily create a channel"""
+        if not self.api:
+            raise ValueError("PostFactory requires an api instance")
+
+        return ChannelFactory.create(api=self.api)
+
+    class Meta:
+        abstract = True
+
+
+class TextPostFactory(PostFactory):
+    """Factory for text posts"""
+    text = factory.Faker('text', max_nb_chars=100)
+
+    @factory.lazy_attribute
+    def id(self):
+        """Lazily create the post"""
+        if not self.api:
+            raise ValueError("TextPostFactory requires an api instance")
+
+        return self.api.create_post(self.channel.name, self.title, text=self.text).id
+
+    class Meta:
+        model = TextPost
+
+
+class LinkPostFactory(PostFactory):
+    """Factory for link posts"""
+    url = factory.Faker('uri')
+
+    @factory.lazy_attribute
+    def id(self):
+        """Lazily create the post"""
+        if not self.api:
+            raise ValueError("LinkPostFactory requires an api instance")
+
+        return self.api.create_post(self.channel.name, self.title, url=self.url).id
+
+    class Meta:
+        model = LinkPost
+
+
+class CommentFactory(factory.Factory):
+    """Factory for comments"""
+    api = None
+    comment_id = None
+    text = factory.Faker('text', max_nb_chars=100)
+    children = factory.LazyFunction(lambda: [])
+
+    @factory.lazy_attribute
+    def post_id(self):
+        """Lazily create the post"""
+        if not self.api:
+            raise ValueError("CommentFactory requires an api instance")
+
+        return TextPostFactory.create(api=self.api).id
+
+    @factory.lazy_attribute
+    def id(self):
+        """Lazily create the comment"""
+        if not self.api:
+            raise ValueError("CommentFactory requires an api instance")
+
+        return self.api.create_comment(
+            self.text,
+            post_id=self.post_id if not self.comment_id else None,  # only use post_id if top-level comment
+            comment_id=self.comment_id
+        ).id
+
+    @factory.post_generation
+    def comment_tree(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """Create nested comments"""
+        # NOTE: we need to do this in post_generation because we need to parent comment to be created first
+        max_children = kwargs.get('max', 3)
+
+        if max_children == 0:
+            return
+
+        if 'count' in kwargs:
+            count = kwargs['count']
+        else:
+            count = factory.fuzzy.random.randrange(1, max_children + 1, 1)
+
+        for _ in range(count):
+            self.children.append(
+                CommentFactory.create(
+                    api=self.api,
+                    post_id=self.post_id,
+                    comment_id=self.id,
+                    comment_tree__max=count - 1,
+                )
+            )
+
+    class Meta:
+        model = Comment

--- a/channels/models.py
+++ b/channels/models.py
@@ -12,7 +12,7 @@ class RedditRefreshToken(models.Model):
     token_value = models.CharField(null=True, max_length=255)
 
     def __str__(self):
-        return self.token_value
+        return "{}".format(self.token_value)
 
 
 class RedditAccessToken(models.Model):

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,16 @@
 """Configuration for pytest fixtures"""
 # pylint: disable=unused-argument, redefined-outer-name
+import factory
 import pytest
 from rest_framework_jwt.settings import api_settings
 
 from open_discussions.factories import UserFactory
+
+
+@pytest.fixture(scope="function")
+def randomness():
+    """Ensure a fixed seed for factoryboy"""
+    factory.fuzzy.reseed_random("happy little clouds")
 
 
 @pytest.fixture
@@ -13,12 +20,18 @@ def user(db):
 
 
 @pytest.fixture
-def staff_jwt_token(admin_user):
+def staff_user(db):
+    """Create a staff user"""
+    return UserFactory.create()
+
+
+@pytest.fixture
+def staff_jwt_token(staff_user):
     """Creates a JWT token for a staff user"""
     jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
     jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
 
-    payload = jwt_payload_handler(admin_user)
+    payload = jwt_payload_handler(staff_user)
     payload['roles'] = ['staff']
     return jwt_encode_handler(payload)
 

--- a/factory_data/channels.views_test.test_get_channel.json
+++ b/factory_data/channels.views_test.test_get_channel.json
@@ -1,0 +1,12 @@
+{
+  "channels": {
+    "one": {
+      "channel_type": "public",
+      "name": "1509997635_minima",
+      "public_description": "Magni officia suscipit corporis quisquam. Occaecati nesciunt repellendus nam inventore omnis.",
+      "title": "In sed repudiandae deserunt."
+    }
+  },
+  "comments": {},
+  "posts": {}
+}

--- a/factory_data/channels.views_test.test_list_channels.json
+++ b/factory_data/channels.views_test.test_list_channels.json
@@ -1,0 +1,12 @@
+{
+  "channels": {
+    "one": {
+      "channel_type": "public",
+      "name": "1509989314_consectetu",
+      "public_description": "Porro dolore labore vitae dolor repellat. Adipisci ipsa nobis perferendis nisi atque atque aliquam.",
+      "title": "Rerum omnis laudantium architecto."
+    }
+  },
+  "comments": {},
+  "posts": {}
+}

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -1,15 +1,16 @@
 """
 Factory for Users
 """
+import ulid
 from django.contrib.auth.models import User
-from factory import Sequence
+from factory import LazyFunction
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
 
 class UserFactory(DjangoModelFactory):
     """Factory for Users"""
-    username = Sequence(lambda n: "user_%d" % n)
+    username = LazyFunction(lambda: ulid.new().str)
     email = FuzzyText(suffix='@example.com')
 
     class Meta:

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -14,3 +14,6 @@ class Profile(models.Model):
     image = models.CharField(null=True, max_length=MAX_IMAGE_FIELD_LENGTH)
     image_small = models.CharField(null=True, max_length=MAX_IMAGE_FIELD_LENGTH)
     image_medium = models.CharField(null=True, max_length=MAX_IMAGE_FIELD_LENGTH)
+
+    def __str__(self):
+        return "{}".format(self.name)

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -14,18 +14,18 @@ pytestmark = pytest.mark.django_db
 API_KWARGS = dict(content_type='application/json', format='json')
 
 
-def test_list_users(client, admin_user, staff_jwt_header):
+def test_list_users(client, staff_user, staff_jwt_header):
     """
     List users
     """
-    profile = ProfileFactory.create(user=admin_user)
+    profile = ProfileFactory.create(user=staff_user)
     url = reverse('user_api-list')
     resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == 200
     assert resp.json() == [
         {
-            'id': admin_user.id,
-            'username': admin_user.username,
+            'id': staff_user.id,
+            'username': staff_user.username,
             'profile': {
                 'name': profile.name,
                 'image': profile.image,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #317

Adds factories for reddit objects and utilities to store and use generated factory data.

#### How should this be manually tested?
Run the factories and be sure that they create matching objects in reddit.

Example:
```python
from channels.api import Api
from django.contrib.auth.models import User
from channels.factories import *

u = User.objects.first()
api = Api(u)

channel = ChannelFactory.create(channel_type='public', api=api)
post = TextPostFactory.create(channel=channel, api=api)
comment = CommentFactory.create(post_id=post.id, api=api)
```

Then go over to `reddit.local//comments/{post.id}` and ensure it is in the expected channel with comments.

Also, delete the cassette and factory_data for one of the updated tests and be sure you can run the tests and it generates new files and a second run of the tests passes too.