### PR TITLE
Monkey patch prawcore's rate limit to not limit

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -12,6 +12,7 @@ import praw
 from praw.exceptions import APIException
 from praw.models.reddit import more
 from praw.models.reddit.redditor import Redditor
+import prawcore
 from prawcore.exceptions import (
     Forbidden as PrawForbidden,
     NotFound as PrawNotFound,
@@ -53,6 +54,9 @@ FULL_ACCESS_SCOPE = '*'
 EXPIRES_IN_OFFSET = 30  # offsets the reddit refresh_token expirations by 30 seconds
 
 User = get_user_model()
+
+# monkey patch praw's rate limiter to not limit us
+prawcore.rate_limit.RateLimiter.delay = lambda *args: None
 
 
 def _get_refresh_token(username):


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Makes everything go faster by having praw ignore the rate limiting headers coming back from reddit. It does so by monkey patching [this method](https://github.com/praw-dev/prawcore/blob/master/prawcore/rate_limit.py#L37-L44) in `prawcore` to be a no-op instead of sleeping.

#### How should this be manually tested?
Use the app, create a post, etc.

#### What GIF best describes this PR or how it makes you feel?
![faster](https://media.giphy.com/media/HdcimOKferlkI/giphy.gif)