### PR TITLE
Refactored User/Profile factories to be UserFactory-centric

### DIFF
--- a/channels/conftest.py
+++ b/channels/conftest.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 
 from channels.test_utils import no_ssl_verification
 from open_discussions.betamax_config import setup_betamax
-from profiles.factories import ProfileFactory
+from open_discussions.factories import UserFactory
 
 
 @pytest.fixture
@@ -63,6 +63,6 @@ def client():
 @pytest.fixture()
 def logged_in_profile(client):
     """Add a Profile and logged-in User"""
-    profile = ProfileFactory.create(user__username='george')
-    client.force_login(profile.user)
-    return profile
+    user = UserFactory.create(username='george')
+    client.force_login(user)
+    return user.profile

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -3,7 +3,7 @@ Factory for Users
 """
 import ulid
 from django.contrib.auth.models import User
-from factory import LazyFunction
+from factory import LazyFunction, RelatedFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
@@ -12,6 +12,8 @@ class UserFactory(DjangoModelFactory):
     """Factory for Users"""
     username = LazyFunction(lambda: ulid.new().str)
     email = FuzzyText(suffix='@example.com')
+
+    profile = RelatedFactory('profiles.factories.ProfileFactory', 'user')
 
     class Meta:
         model = User

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -1,15 +1,12 @@
 """Factories for making test data"""
-from factory import SubFactory, Faker
+from factory import Faker
 from factory.django import DjangoModelFactory
 
-from open_discussions.factories import UserFactory
 from profiles.models import Profile
 
 
 class ProfileFactory(DjangoModelFactory):
     """Factory for Profiles"""
-    user = SubFactory(UserFactory)
-
     name = Faker('name')
 
     image = Faker('file_path', extension='jpg')

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -4,7 +4,6 @@ Tests for serializers for profiles REST APIS
 """
 import pytest
 
-from profiles.factories import ProfileFactory
 from profiles.models import Profile
 from profiles.serializers import UserSerializer
 
@@ -13,7 +12,7 @@ def test_serialize_user(user):
     """
     Test serializing a user
     """
-    profile = ProfileFactory.create(user=user)
+    profile = user.profile
 
     assert UserSerializer(user).data == {
         'id': user.id,
@@ -61,7 +60,7 @@ def test_update_user_profile(user, key, value):
     """
     Test creating a user
     """
-    profile = ProfileFactory.create(user=user)
+    profile = user.profile
     expected_profile = {
         'name': profile.name,
         'image': profile.image,

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -5,8 +5,6 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 import pytest
 
-from profiles.factories import ProfileFactory
-
 
 # pylint: disable=redefined-outer-name, unused-argument
 pytestmark = pytest.mark.django_db
@@ -18,7 +16,7 @@ def test_list_users(client, staff_user, staff_jwt_header):
     """
     List users
     """
-    profile = ProfileFactory.create(user=staff_user)
+    profile = staff_user.profile
     url = reverse('user_api-list')
     resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == 200
@@ -60,7 +58,7 @@ def test_get_user(client, user, staff_jwt_header):
     """
     Get a user
     """
-    profile = ProfileFactory.create(user=user)
+    profile = user.profile
     url = reverse('user_api-detail', kwargs={'username': user.username})
     resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == 200
@@ -80,7 +78,7 @@ def test_patch_user(client, user, staff_jwt_header):
     """
     Update a users' profile
     """
-    profile = ProfileFactory.create(user=user)
+    profile = user.profile
     url = reverse('user_api-detail', kwargs={'username': user.username})
     resp = client.patch(url, data=json.dumps({
         'profile': {
@@ -104,7 +102,6 @@ def test_patch_username(client, user, staff_jwt_header):
     """
     Trying to update a users's username does not change anything
     """
-    ProfileFactory.create(user=user)
     url = reverse('user_api-detail', kwargs={'username': user.username})
     resp = client.patch(url, data=json.dumps({
         'username': 'notallowed'


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR makes `ProfileFactory` a `RelatedFactory` of `UserFactory` and removes the reverse relationship. This aligns better with how these records actually get created (your can't have a `Profile` without a `User` and simplifies some test code.

#### How should this be manually tested?
Travis tests should pass.
