### PR TITLE
Switched factories to class-based model and added created field

### DIFF
--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -16,16 +16,14 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture()
-def reddit_factories(request, cassette_exists):
+def reddit_factories(request):
     """RedditFactories fixture"""
     # use betamax's _casette_name to determine filename
     store = FactoryStore(_casette_name(request, parametrized=True))
     ctx = RedditFactories(store)
-    if cassette_exists:
-        store.load()
+    store.load()
     yield ctx
-    if not cassette_exists:
-        store.write()
+    store.write()
 
 
 @pytest.fixture()

--- a/factory_data/channels.views_test.test_add_contributor.json
+++ b/factory_data/channels.views_test.test_add_contributor.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKVXTEW4Z9CCZ2Z2FGVKB"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_contributor_again.json
+++ b/factory_data/channels.views_test.test_add_contributor_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKVYT658QG36A03FC5SFC"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_moderator.json
+++ b/factory_data/channels.views_test.test_add_moderator.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW00TWQ74CZE1J38HZB6"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_moderator_again.json
+++ b/factory_data/channels.views_test.test_add_moderator_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW1KGTC7K86AAHB8QYPQ"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_subscriber.json
+++ b/factory_data/channels.views_test.test_add_subscriber.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW30Y9AY335MMFEE8E0Y"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_subscriber_again.json
+++ b/factory_data/channels.views_test.test_add_subscriber_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW4B2641RJX8BH91KC9Q"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_add_subscriber_forbidden.json
+++ b/factory_data/channels.views_test.test_add_subscriber_forbidden.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW5W94R11K75P2JFX2S4"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_create_channel.json
+++ b/factory_data/channels.views_test.test_create_channel.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKSQKT3DJS0YKNDSNWHMC"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_create_channel_already_exists.json
+++ b/factory_data/channels.views_test.test_create_channel_already_exists.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKSS5RB5PRAZE81PKMH56"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_detail_subscriber.json
+++ b/factory_data/channels.views_test.test_detail_subscriber.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKW9P46FSG7E3F8PWX11A"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_patch_channel.json
+++ b/factory_data/channels.views_test.test_patch_channel.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKSYHPZR0AXZDP3W237JT"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_patch_channel_forbidden.json
+++ b/factory_data/channels.views_test.test_patch_channel_forbidden.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKSZQWB81GW6W36W5FB7W"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_patch_channel_not_found.json
+++ b/factory_data/channels.views_test.test_patch_channel_not_found.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKT0YZB6AVZX64DK1TFGJ"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_contributor.json
+++ b/factory_data/channels.views_test.test_remove_contributor.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWC3N60W873Y5EJSYH6S"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_contributor_again.json
+++ b/factory_data/channels.views_test.test_remove_contributor_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWD3PPNG7FSG9J3HKGSE"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_moderator.json
+++ b/factory_data/channels.views_test.test_remove_moderator.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWE7STJSR6EWEZGF6KB8"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_moderator_again.json
+++ b/factory_data/channels.views_test.test_remove_moderator_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWF95G9QBQN5DHV26GZW"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_subscriber.json
+++ b/factory_data/channels.views_test.test_remove_subscriber.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWGE32QAWMK1DM73FZ83"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_remove_subscriber_again.json
+++ b/factory_data/channels.views_test.test_remove_subscriber_again.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01BYXNKWHVY9GRCNY7P1YJDMRA"
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Refactors the factory models into classes so we can move the creation of posts into a `post_generation` hook and posthumously set both `id` and `created`. It also modifies the `FactoryStore` to only write the `factory_data` 

#### How should this be manually tested?
Delete `cassettes/channels.views_test.test_list_channels.json` and rerun tests. Ensure the cassette is recreated and the `factory_data` file updated.

Also, if you run this you should see an ISO formatted `created` date:

```python
from channels.factories import *
from django.contrib.auth.models import User
from channels.api import Api
u = User.objects.first()
api = Api(u)
p = TextPostFactory.create(api=api)
p.created  # -> '2017-11-14T16:20:14+00:00'
```

#### What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/3oKHWuaHwQXPs2CvV6/giphy.gif)