### PR TITLE
edit comments

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -29,9 +29,11 @@ def index(request):
         )
         auth_url = payload.get("auth_url", None)
         session_url = payload.get("session_url", None)
+        username = payload.get("username", None)
     except jwt.InvalidTokenError:
         auth_url = None
         session_url = None
+        username = None
 
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
@@ -41,6 +43,7 @@ def index(request):
         "max_comment_depth": settings.OPEN_DISCUSSIONS_MAX_COMMENT_DEPTH,
         "micromasters_external_login_url": settings.MICROMASTERS_EXTERNAL_LOGIN_URL,
         "micromasters_base_url": settings.MICROMASTERS_BASE_URL,
+        "username": username,
     }
 
     return render(request, "index.html", context={

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -35,4 +35,5 @@ class ViewsTest(TestCase):
             'micromasters_external_login_url': 'http://other.fake.site/discussions/',
             'micromasters_base_url': 'http://other.fake.site/',
             'max_comment_depth': 6,
+            'username': None,
         }

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -9,7 +9,7 @@ import withLoading from "../components/Loading"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 import ExpandedPostDisplay from "../components/ExpandedPostDisplay"
 import CommentTree from "../components/CommentTree"
-import { ReplyToPostForm } from "../components/CreateCommentForm"
+import { ReplyToPostForm } from "../components/CommentForms"
 import withNavSidebar from "../hoc/withNavSidebar"
 
 import { formatCommentsCount } from "../lib/posts"
@@ -18,7 +18,7 @@ import { toggleUpvote } from "../util/api_actions"
 import { getChannelName, getPostID } from "../lib/util"
 import { anyError } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
-import { beginReply } from "../components/CreateCommentForm"
+import { beginEditing } from "../components/CommentForms"
 import { formatTitle } from "../lib/title"
 
 import type { Dispatch } from "redux"
@@ -127,7 +127,7 @@ class PostPage extends React.Component<*, void> {
           forms={forms}
           upvote={this.upvote}
           downvote={this.downvote}
-          beginReply={beginReply(dispatch)}
+          beginEditing={beginEditing(dispatch)}
           processing={commentInFlight}
         />
       </div>

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -12,6 +12,7 @@ declare var SETTINGS: {
   FEATURES: {
     [key: string]: boolean,
   },
+  username: string,
 }
 
 // mocha

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -53,10 +53,14 @@
       justify-content: space-between;
       align-items: center;
 
-      &.vote-reply {
+      &.comment-actions {
         width: 110px;
         margin: 4px 0 5px;
         display: flex;
+
+        > div {
+          margin-right: 10px;
+        }
       }
 
       p {
@@ -122,7 +126,7 @@
     }
   }
 
-  .reply-button {
+  .comment-action-button {
     font-size: .9em;
     font-weight: 400;
   }


### PR DESCRIPTION
#### What are the relevant tickets?

#232 

#### What's this PR do?

This adds UI to be able to edit a comment. 

#### How should this be manually tested?

If you look at comments that you wrote you should see an 'Edit' button right next to where the 'Reply' button currently is. Clicking on this button should replace the comment text display with a form containing the current text for the comment. Saving this form should update the comment with your changes. Canceling should return you to the normal UI.