### PR TITLE
Add post editing

### DIFF
--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -10,6 +10,7 @@ import {
   ReplyToCommentForm,
   ReplyToPostForm,
   EditCommentForm,
+  EditPostForm,
   replyToPostKey,
   replyToCommentKey,
   beginEditing,
@@ -44,6 +45,13 @@ describe("CommentForms", () => {
     mount(
       <Provider store={helper.store}>
         <EditCommentForm comment={comment} {...props} />
+      </Provider>
+    )
+
+  const renderEditPostForm = (props = {}) =>
+    mount(
+      <Provider store={helper.store}>
+        <EditPostForm comment={post} {...props} />
       </Provider>
     )
 
@@ -431,6 +439,44 @@ describe("CommentForms", () => {
       assert.equal(R.keys(state.forms).length, 1)
       assert.deepInclude(state.forms[R.keys(state.forms)[0]], {
         value: { text: "comment text" }
+      })
+    })
+
+    it("should cancel and go away", async () => {
+      const mockPreventDefault = helper.sandbox.stub()
+      const state = await helper.listenForActions([forms.FORM_END_EDIT], () => {
+        wrapper.find(".cancel-button").simulate("click", {
+          preventDefault: mockPreventDefault
+        })
+      })
+      assert.deepEqual(state.forms, {})
+      sinon.assert.calledWith(mockPreventDefault)
+    })
+  })
+
+  describe("EditPostForm", () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = renderEditPostForm()
+    })
+
+    it("should have the autofocus prop", () => {
+      assert.isTrue(wrapper.find("textarea").props().autoFocus)
+    })
+
+    it("should trigger an update when text is input", async () => {
+      const state = await helper.listenForActions([forms.FORM_UPDATE], () => {
+        wrapper.find("textarea[name='text']").simulate("change", {
+          target: {
+            name:  "text",
+            value: "new post text"
+          }
+        })
+      })
+      assert.equal(R.keys(state.forms).length, 1)
+      assert.deepInclude(state.forms[R.keys(state.forms)[0]], {
+        value: { text: "new post text" }
       })
     })
 

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -111,6 +111,8 @@ class PostPage extends React.Component<*, void> {
             <ExpandedPostDisplay
               post={post}
               toggleUpvote={toggleUpvote(dispatch)}
+              forms={forms}
+              beginEditing={beginEditing(dispatch)}
             />
             <ReplyToPostForm
               forms={forms}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -106,6 +106,13 @@ export function updateUpvote(postId: string, upvoted: boolean): Promise<Post> {
   })
 }
 
+export function editPost(postId: string, post: Post): Promise<Post> {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: "PATCH",
+    body:   JSON.stringify(R.dissoc("url", post))
+  })
+}
+
 export function updateComment(
   commentId: string,
   commentPayload: Object

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 import sinon from "sinon"
 import { PATCH, POST } from "redux-hammock/constants"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import R from "ramda"
 
 import {
   createChannel,
@@ -14,7 +15,8 @@ import {
   getComments,
   createComment,
   createPost,
-  updateComment
+  updateComment,
+  editPost
 } from "./api"
 import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
@@ -232,6 +234,22 @@ describe("api", function() {
           method: PATCH,
           body:   JSON.stringify(payload)
         })
+      })
+    })
+
+    it("updates a post", async () => {
+      const post = makePost()
+
+      fetchStub.returns(Promise.resolve())
+
+      post.text = "updated!"
+
+      await editPost(post.id, post)
+
+      assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
+      assert.deepEqual(fetchStub.args[0][1], {
+        method: PATCH,
+        body:   JSON.stringify(R.dissoc("url", post))
       })
     })
   })

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -1,6 +1,6 @@
 // @flow
 import * as api from "../lib/api"
-import { GET, POST, INITIAL_STATE } from "redux-hammock/constants"
+import { GET, POST, PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
 import { SET_POST_DATA } from "../actions/post"
 
@@ -28,14 +28,16 @@ const mergeMultiplePosts = (
 
 export const postsEndpoint = {
   name:     "posts",
-  verbs:    [GET, POST],
+  verbs:    [GET, POST, PATCH],
   getFunc:  (id: string) => api.getPost(id),
   postFunc: (name: string, payload: CreatePostPayload) =>
     api.createPost(name, payload),
-  postSuccessHandler: mergePostData,
-  initialState:       { ...INITIAL_STATE, data: new Map() },
-  getSuccessHandler:  mergePostData,
-  extraActions:       {
+  patchFunc:           (id: string, post: Post) => api.editPost(id, post),
+  postSuccessHandler:  mergePostData,
+  initialState:        { ...INITIAL_STATE, data: new Map() },
+  getSuccessHandler:   mergePostData,
+  patchSuccessHandler: mergePostData,
+  extraActions:        {
     [SET_POST_DATA]: (state, action) => {
       const update =
         action.payload instanceof Array

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -62,7 +62,14 @@
   .text-content {
     color: rgba(0,0,0,.77);
     line-height: 1.4;
+  }
 
+  .post-actions {
+    display: flex;
+
+    a {
+      margin-left: 10px;
+    }
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

#231 

#### What's this PR do?

This adds UI for editing discussions posts (text posts). If the user is viewing the detail page for their own post there should be a an 'edit' button that opens a text box for editing the post.

#### How should this be manually tested?

You should be able to edit your own post, and you shouldn't be able to edit others! The edit button shouldn't show up on a url post.