### PR TITLE
Default to empty description for new channel if not provided (#349)

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -40,7 +40,7 @@ class ChannelSerializer(serializers.Serializer):
             name=validated_data['display_name'],
             title=validated_data['title'],
             channel_type=validated_data['subreddit_type'],
-            description=validated_data['description'],
+            description=validated_data.get('description', ''),
             public_description=validated_data['public_description'],
         )
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #349

#### What's this PR do?
Makes the `description` field on creating a channel optional.

#### How should this be manually tested?
Following the instructions in the README to get a token and create a channel: https://github.com/mitodl/open-discussions#5b-set-up-initial-channelpost-data

#### What GIF best describes this PR or how it makes you feel?
(Optional)
