### PR TITLE
add edited to comments, posts

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -131,6 +131,7 @@ class PostSerializer(serializers.Serializer):
     channel_title = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
     author_name = serializers.SerializerMethodField()
+    edited = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -184,6 +185,10 @@ class PostSerializer(serializers.Serializer):
     def get_channel_title(self, instance):
         """The title of the channel"""
         return instance.subreddit.title
+
+    def get_edited(self, instance):
+        """Return a Boolean signifying if the post has been edited or not"""
+        return instance.edited if instance.edited is False else True
 
     def validate_upvoted(self, value):
         """Validate that upvoted is a bool"""
@@ -275,6 +280,7 @@ class CommentSerializer(serializers.Serializer):
     replies = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
     author_name = serializers.SerializerMethodField()
+    edited = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -345,6 +351,10 @@ class CommentSerializer(serializers.Serializer):
     def get_created(self, instance):
         """The ISO-8601 formatted datetime for the creation time"""
         return datetime.fromtimestamp(instance.created, tz=timezone.utc).isoformat()
+
+    def get_edited(self, instance):
+        """Return a Boolean signifying if the comment has been edited or not"""
+        return instance.edited if instance.edited is False else True
 
     def validate_upvoted(self, value):
         """Validate that upvoted is a bool"""

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -275,6 +275,7 @@ def test_create_url_post(client, private_channel_and_contributor):
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        'edited': False,
     }
 
 
@@ -305,6 +306,7 @@ def test_create_text_post(client, private_channel_and_contributor):
         'channel_title': channel.title,
         'profile_image': user.profile.image_small,
         "author_name": user.profile.name,
+        'edited': False,
     }
 
 
@@ -384,7 +386,8 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         "channel_name": channel.name,
         "channel_title": channel.title,
         'author_name': user.profile.name,
-        "profile_image": profile_image
+        "profile_image": profile_image,
+        'edited': False,
     }
 
 
@@ -446,7 +449,8 @@ def test_list_posts(client, missing_user, private_channel_and_contributor, reddi
                     "channel_name": channel.name,
                     "channel_title": channel.title,
                     'author_name': user.profile.name,
-                    "profile_image": user.profile.image_small
+                    "profile_image": user.profile.image_small,
+                    "edited": False,
                 } for post in posts
             ],
             'pagination': {}
@@ -560,6 +564,7 @@ def test_update_post_text(client, private_channel_and_contributor, reddit_factor
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        'edited': False
     }
 
 
@@ -586,6 +591,7 @@ def test_update_post_clear_vote(client, private_channel_and_contributor, reddit_
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        'edited': False
     }
 
 
@@ -612,6 +618,7 @@ def test_update_post_upvote(client, private_channel_and_contributor, reddit_fact
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        "edited": False,
     }
 
 
@@ -638,6 +645,7 @@ def test_update_post_removed(client, staff_user, private_channel_and_contributor
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        "edited": False,
     }
 
 
@@ -665,6 +673,7 @@ def test_update_post_clear_removed(client, staff_user, staff_api, private_channe
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
         "author_name": user.profile.name,
+        'edited': False
     }
 
 
@@ -720,7 +729,8 @@ def test_create_post_without_upvote(client, private_channel_and_contributor):
         'channel_name': channel.name,
         'channel_title': channel.title,
         "profile_image": user.profile.image_small,
-        "author_name": user.profile.name
+        "author_name": user.profile.name,
+        'edited': False
     }
 
 
@@ -761,6 +771,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
             "created": "2017-07-25T17:09:45+00:00",
             'profile_image': profile_image,
             'author_name': name,
+            'edited': False,
             "replies": [
                 {
                     "id": "2",
@@ -774,6 +785,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
                     "replies": [],
                     'profile_image': profile_image,
                     'author_name': name,
+                    'edited': True,
                 },
                 {
                     "id": "3",
@@ -787,6 +799,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
                     "replies": [],
                     'profile_image': profile_image,
                     'author_name': name,
+                    'edited': False,
                 }
             ]
         }
@@ -832,13 +845,15 @@ def test_list_deleted_comments(client, logged_in_profile):
                 'score': 1,
                 'text': 'reply to parent which is not deleted',
                 'upvoted': False,
-                "author_name": user.profile.name
+                "author_name": user.profile.name,
+                'edited': False,
             }],
             'score': 1,
             'text': '[deleted]',
             'upvoted': False,
             'id': '1s',
-            "author_name": "[deleted]"
+            "author_name": "[deleted]",
+            'edited': False,
         }]
 
 
@@ -862,6 +877,7 @@ def test_create_comment(client, logged_in_profile):
         "downvoted": False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -906,6 +922,7 @@ def test_create_comment_no_upvote(client, logged_in_profile):
         "downvoted": False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False
     }
 
 
@@ -930,6 +947,7 @@ def test_create_comment_downvote(client, logged_in_profile):
         'downvoted': True,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -954,6 +972,7 @@ def test_create_comment_reply_to_comment(client, logged_in_profile):
         "downvoted": False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False
     }
 
 
@@ -976,6 +995,7 @@ def test_update_comment_text(client, logged_in_profile):
         'downvoted': False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': True
     }
 
 
@@ -1010,6 +1030,7 @@ def test_update_comment_upvote(client, logged_in_profile):
         'downvoted': False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -1033,6 +1054,7 @@ def test_update_comment_downvote(client, logged_in_profile):
         'downvoted': True,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -1055,6 +1077,7 @@ def test_update_comment_clear_upvote(client, logged_in_profile):
         'downvoted': False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -1078,6 +1101,7 @@ def test_update_comment_clear_downvote(client, logged_in_profile):
         'downvoted': False,
         'profile_image': logged_in_profile.image_small,
         'author_name': logged_in_profile.name,
+        'edited': False,
     }
 
 
@@ -1130,7 +1154,8 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
                 "channel_name": channel.name,
                 "channel_title": channel.title,
                 'author_name': user.profile.name,
-                "profile_image": user.profile.image_small
+                "profile_image": user.profile.image_small,
+                "edited": False,
             },
             {
                 "url": None,
@@ -1146,7 +1171,8 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
                 "channel_name": channel.name,
                 "channel_title": channel.title,
                 'author_name': user.profile.name,
-                "profile_image": user.profile.image_small
+                "profile_image": user.profile.image_small,
+                "edited": False,
             },
             {
                 "url": None,
@@ -1162,7 +1188,8 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
                 "channel_name": channel.name,
                 "channel_title": channel.title,
                 'author_name': user.profile.name,
-                "profile_image": user.profile.image_small
+                "profile_image": user.profile.image_small,
+                "edited": False,
             },
             {
                 "url": None,
@@ -1178,7 +1205,8 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
                 "channel_name": channel.name,
                 "channel_title": channel.title,
                 'author_name': user.profile.name,
-                "profile_image": user.profile.image_small
+                "profile_image": user.profile.image_small,
+                "edited": False,
             },
         ],
         'pagination': {},

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -15,6 +15,7 @@ import {
   editCommentKey,
   getCommentReplyInitialValue
 } from "../components/CommentForms"
+import { addEditedMarker } from "../lib/reddit_objects"
 
 import type { Comment } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
@@ -82,7 +83,7 @@ const renderComment = R.curry(
               />
               : <ReactMarkdown
                 disallowedTypes={["Image"]}
-                source={comment.text}
+                source={addEditedMarker(comment)}
                 escapeHtml
               />}
           </div>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -63,6 +63,7 @@ describe("CommentTree", () => {
 
   it("should use markdown to render comments, should skip images", () => {
     comments[0].text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
+    comments[0].edited = false
     const wrapper = renderCommentTree()
     const firstComment = wrapper.find(".top-level-comment").at(0)
     assert.equal(

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -5,13 +5,14 @@ import { connect } from "react-redux"
 import ReactMarkdown from "react-markdown"
 
 import { formatPostTitle, PostVotingButtons } from "../lib/posts"
+import { addEditedMarker } from "../lib/reddit_objects"
 
 import type { Post } from "../flow/discussionTypes"
 
 const textContent = post =>
   <ReactMarkdown
     disallowedTypes={["Image"]}
-    source={post.text}
+    source={addEditedMarker(post)}
     escapeHtml
     className="text-content"
   />

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -38,6 +38,7 @@ describe("ExpandedPostDisplay", () => {
   })
 
   it("should render a post correctly", () => {
+    post.edited = false
     const wrapper = renderPostDisplay({ post })
     const summary = wrapper.find(".summary")
     assert.equal(wrapper.find(".votes").text(), post.score.toString())
@@ -50,6 +51,7 @@ describe("ExpandedPostDisplay", () => {
   it("should display post text", () => {
     const string = "JUST SOME GREAT TEXT!"
     post.text = string
+    post.edited = false
     const wrapper = renderPostDisplay({ post: post })
     assert.equal(wrapper.find(ReactMarkdown).props().source, string)
   })
@@ -61,6 +63,7 @@ describe("ExpandedPostDisplay", () => {
   })
 
   it("should not display images from markdown", () => {
+    post.edited = false
     post.text = "# MARKDOWN!\n![](https://images.example.com/potato.jpg)"
     const wrapper = renderPostDisplay({ post: post })
     assert.equal(wrapper.find(ReactMarkdown).props().source, post.text)

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -19,7 +19,8 @@ export const makeComment = (post: Post): Comment => {
     created:       casual.moment.format(),
     replies:       [],
     profile_image: casual.url,
-    author_name:   casual.name
+    author_name:   casual.name,
+    edited:        casual.boolean
   }
 
   if (comment.upvoted && comment.downvoted) {

--- a/static/js/factories/comments_test.js
+++ b/static/js/factories/comments_test.js
@@ -20,6 +20,7 @@ describe("comment factories", () => {
       assert.isArray(comment.replies)
       assert.isString(comment.profile_image)
       assert.isString(comment.author_name)
+      assert.isBoolean(comment.edited)
     })
   })
 

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -24,7 +24,8 @@ export const makePost = (
   channel_name:  channelName,
   channel_title: casual.string,
   profile_image: casual.url,
-  author_name:   casual.name
+  author_name:   casual.name,
+  edited:        casual.boolean
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -18,6 +18,7 @@ describe("posts factories", () => {
       assert.isNumber(post.num_comments)
       assert.isString(post.profile_image)
       assert.isString(post.author_name)
+      assert.isBoolean(post.edited)
     })
 
     it("should make a URL post", () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -31,6 +31,7 @@ export type Post = {
   num_comments:  number,
   channel_name:  string,
   channel_title: string,
+  edited:        boolean,
 }
 
 export type PostForm = {
@@ -88,6 +89,7 @@ export type Comment = {
   text:          string,
   downvoted:     boolean,
   replies:       Array<Comment>,
+  edited:        boolean,
 }
 
 export type CommentForm = {

--- a/static/js/lib/reddit_objects.js
+++ b/static/js/lib/reddit_objects.js
@@ -1,0 +1,14 @@
+// @flow
+import R from "ramda"
+
+// a place for functions that work with Posts or Comments to live
+
+export const addEditedMarker = R.compose(
+  R.prop("text"),
+  R.when(
+    R.propEq("edited", true),
+    R.evolve({
+      text: str => str.concat(" _[edited by author]_")
+    })
+  )
+)

--- a/static/js/lib/reddit_objects_test.js
+++ b/static/js/lib/reddit_objects_test.js
@@ -1,0 +1,26 @@
+// @flow
+/* global SETTINGS */
+import { assert } from "chai"
+
+import { addEditedMarker } from "./reddit_objects"
+import { makeCommentTree } from "../factories/comments"
+import { makePost } from "../factories/posts"
+
+describe("addEditedMarker", () => {
+  let comment, post
+
+  beforeEach(() => {
+    post = makePost()
+    comment = makeCommentTree(post)[0]
+  })
+
+  it("should leave things alone if not edited", () => {
+    comment.edited = false
+    assert.equal(comment.text, addEditedMarker(comment))
+  })
+
+  it("should add a marker if edited", () => {
+    comment.edited = true
+    assert.ok(addEditedMarker(comment).endsWith(" _[edited by author]_"))
+  })
+})


### PR DESCRIPTION
#### What are the relevant tickets?

#232  and #231 

#### What's this PR do?

this adds an 'edited' field to the post and comment APIs, based on what Reddit returns. this also adds some logic to display a little _[edited by author]_ message in the UI when `.edited === true`.

#### How should this be manually tested?

Use the API or the UI to edit a post or comment. Afterwards, you should see the message appear after it.