### PR TITLE
Added requests for channel moderators

### DIFF
--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -69,6 +69,7 @@ class ChannelPage extends React.Component<*, void> {
       dispatch(clearChannelError())
     }
     dispatch(actions.channels.get(channelName))
+    dispatch(actions.channelModerators.get(channelName))
     dispatch(
       actions.postsForChannel.get(channelName, qs.parse(search))
     ).then(({ response }) => {

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -5,7 +5,11 @@ import sinon from "sinon"
 import PostList from "../components/PostList"
 import SubscriptionsList from "../components/SubscriptionsList"
 
-import { makeChannel, makeChannelList } from "../factories/channels"
+import {
+  makeChannel,
+  makeChannelList,
+  makeModerators
+} from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
@@ -21,16 +25,19 @@ describe("ChannelPage", () => {
     channels,
     currentChannel,
     otherChannel,
-    postList
+    postList,
+    moderators
 
   beforeEach(() => {
     channels = makeChannelList(10)
     currentChannel = channels[3]
     otherChannel = channels[4]
+    moderators = makeModerators()
     postList = makeChannelPostList()
     helper = new IntegrationTestHelper()
     helper.getChannelStub.returns(Promise.resolve(currentChannel))
     helper.getChannelsStub.returns(Promise.resolve(channels))
+    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
     helper.getPostsForChannelStub.returns(Promise.resolve({ posts: postList }))
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
@@ -48,6 +55,8 @@ describe("ChannelPage", () => {
       actions.postsForChannel.get.successType,
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
+      actions.channelModerators.get.requestType,
+      actions.channelModerators.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA
     ])
@@ -86,7 +95,9 @@ describe("ChannelPage", () => {
         actions.channels.get.requestType,
         actions.channels.get.successType,
         actions.postsForChannel.get.requestType,
-        actions.postsForChannel.get.successType
+        actions.postsForChannel.get.successType,
+        actions.channelModerators.get.requestType,
+        actions.channelModerators.get.successType
       ],
       () => {
         helper.browserHistory.push(channelURL(otherChannel.name))
@@ -108,6 +119,8 @@ describe("ChannelPage", () => {
       actions.postsForChannel.get.successType,
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
+      actions.channelModerators.get.requestType,
+      actions.channelModerators.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA,
       CLEAR_CHANNEL_ERROR

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -7,21 +7,29 @@ import CommentTree from "../components/CommentTree"
 
 import { makePost } from "../factories/posts"
 import { makeCommentTree } from "../factories/comments"
-import { makeChannel } from "../factories/channels"
+import { makeChannel, makeModerators } from "../factories/channels"
 import { actions } from "../actions"
+import { FORM_BEGIN_EDIT } from "../actions/forms"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { findComment } from "../lib/comments"
 import { postDetailURL } from "../lib/url"
 import { formatTitle } from "../lib/title"
 
 describe("PostPage", function() {
-  let helper, renderComponent, listenForActions, post, comments, channel
+  let helper,
+    renderComponent,
+    listenForActions,
+    post,
+    comments,
+    channel,
+    moderators
   this.timeout(5000)
 
   beforeEach(() => {
     post = makePost()
     comments = makeCommentTree(post, 3)
     channel = makeChannel()
+    moderators = makeModerators()
 
     helper = new IntegrationTestHelper()
     helper.getPostStub.returns(Promise.resolve(post))
@@ -33,6 +41,7 @@ describe("PostPage", function() {
         data:   comments
       })
     )
+    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
   })
@@ -50,7 +59,10 @@ describe("PostPage", function() {
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
       actions.channels.get.requestType,
-      actions.channels.get.successType
+      actions.channels.get.successType,
+      actions.channelModerators.get.requestType,
+      actions.channelModerators.get.successType,
+      FORM_BEGIN_EDIT
     ])
 
   it("should set the document title", async () => {

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -19,3 +19,12 @@ export const makeChannel = (privateChannel: boolean = false) => ({
 export const makeChannelList = (numChannels: number = 20) => {
   return R.range(0, numChannels).map(() => makeChannel(Math.random() > 0.5))
 }
+
+export const makeModerators = (username: ?string = null) =>
+  username
+    ? [
+      {
+        moderator_name: username
+      }
+    ]
+    : []

--- a/static/js/factories/channels_test.js
+++ b/static/js/factories/channels_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import { makeChannel } from "./channels"
+import { makeChannel, makeModerators } from "./channels"
 
 describe("channels factory", () => {
   it("should make a channel", () => {
@@ -11,5 +11,19 @@ describe("channels factory", () => {
     assert.equal(channel.channel_type, "public")
     assert.isString(channel.public_description)
     assert.isNumber(channel.num_users)
+  })
+
+  it("should make an empty moderators list", () => {
+    const moderators = makeModerators()
+    assert.deepEqual(moderators, [])
+  })
+
+  it("should make a moderators list with username", () => {
+    const moderators = makeModerators("username")
+    assert.deepEqual(moderators, [
+      {
+        moderator_name: "username"
+      }
+    ])
   })
 })

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -97,3 +97,9 @@ export type CommentForm = {
   comment_id?:  string,
   text:         string,
 }
+
+export type Moderator = {
+  moderator_name: string,
+}
+
+export type ChannelModerators = Array<Moderator>

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -11,6 +11,7 @@ import { getPaginationParams } from "../lib/posts"
 
 import type {
   Channel,
+  ChannelModerators,
   Comment,
   CreatePostPayload,
   PostListPaginationParams,
@@ -34,6 +35,12 @@ export function getChannel(channelName: string): Promise<Channel> {
 
 export function getChannels(): Promise<Array<Channel>> {
   return fetchWithAuthFailure("/api/v0/channels/")
+}
+
+export function getChannelModerators(
+  channelName: string
+): Promise<ChannelModerators> {
+  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/moderators/`)
 }
 
 export function createChannel(channel: Channel): Promise<Channel> {

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -1,6 +1,7 @@
 //@flow
+import R from "ramda"
 
-import type { ChannelForm } from "../flow/discussionTypes"
+import type { ChannelForm, ChannelModerators } from "../flow/discussionTypes"
 
 export const CHANNEL_TYPE_PUBLIC = "public"
 export const CHANNEL_TYPE_PRIVATE = "private"
@@ -11,3 +12,8 @@ export const newChannelForm = (): ChannelForm => ({
   public_description: "",
   channel_type:       CHANNEL_TYPE_PUBLIC
 })
+
+export const isModerator = (
+  moderators: ChannelModerators,
+  username: string
+): boolean => R.any(R.propEq("moderator_name", username), moderators)

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -1,15 +1,24 @@
 // @flow
 import { assert } from "chai"
 
-import { CHANNEL_TYPE_PUBLIC, newChannelForm } from "./channels"
+import { CHANNEL_TYPE_PUBLIC, newChannelForm, isModerator } from "./channels"
+import { makeModerators } from "../factories/channels"
 
 describe("Channel utils", () => {
-  it("should return a new channel form with empty values and public type", () => {
+  it("newChannelForm should return a new channel form with empty values and public type", () => {
     assert.deepEqual(newChannelForm(), {
       title:              "",
       name:               "",
       public_description: "",
       channel_type:       CHANNEL_TYPE_PUBLIC
     })
+  })
+
+  it("isModerator should return true for a moderator user", () => {
+    assert.isTrue(isModerator(makeModerators("username"), "username"))
+  })
+
+  it("isModerator should return false for a regular user", () => {
+    assert.isFalse(isModerator(makeModerators(), "username"))
   })
 })

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -6,11 +6,13 @@ import { postsForChannelEndpoint } from "../reducers/posts_for_channel"
 import { frontPageEndpoint } from "../reducers/frontpage"
 import { commentsEndpoint } from "../reducers/comments"
 import { postUpvotesEndpoint } from "../reducers/post_upvotes"
+import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
 
 export const endpoints = [
   postsEndpoint,
   subscribedChannelsEndpoint,
   channelsEndpoint,
+  channelModeratorsEndpoint,
   postsForChannelEndpoint,
   frontPageEndpoint,
   commentsEndpoint,

--- a/static/js/reducers/channel_moderators.js
+++ b/static/js/reducers/channel_moderators.js
@@ -1,0 +1,28 @@
+// @flow
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
+
+import type { ChannelModerators } from "../flow/discussionTypes"
+import * as api from "../lib/api"
+
+type ChannelModeratorsEndpointResponse = {
+  channelName: string,
+  response: ChannelModerators
+}
+
+export const channelModeratorsEndpoint = {
+  name:         "channelModerators",
+  verbs:        [GET],
+  initialState: { ...INITIAL_STATE, data: new Map() },
+  getFunc:      async (channelName: string) => {
+    const response = await api.getChannelModerators(channelName)
+    return { channelName, response }
+  },
+  getSuccessHandler: (
+    { channelName, response }: ChannelModeratorsEndpointResponse,
+    data: Map<string, ChannelModerators>
+  ): Map<string, ChannelModerators> => {
+    const update = new Map(data)
+    update.set(channelName, response)
+    return update
+  }
+}

--- a/static/js/reducers/channel_moderators_test.js
+++ b/static/js/reducers/channel_moderators_test.js
@@ -1,0 +1,53 @@
+// @flow
+import { assert } from "chai"
+import { INITIAL_STATE } from "redux-hammock/constants"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeModerators } from "../factories/channels"
+
+describe("channelModerators reducers", () => {
+  let helper, store, dispatchThen, moderators
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    store = helper.store
+    moderators = makeModerators("username")
+    dispatchThen = helper.store.createDispatchThen(
+      state => state.channelModerators
+    )
+    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should have some initial state", () => {
+    assert.deepEqual(store.getState().channelModerators, {
+      ...INITIAL_STATE,
+      data: new Map()
+    })
+  })
+
+  it("should handle a response with data", () => {
+    const { requestType, successType } = actions.channelModerators.get
+    return dispatchThen(actions.channelModerators.get("channelname"), [
+      requestType,
+      successType
+    ]).then(({ data }) => {
+      assert.deepEqual(moderators, data.get("channelname"))
+    })
+  })
+
+  it("should handle an empty response ok", () => {
+    const { requestType, successType } = actions.channelModerators.get
+    helper.getChannelModeratorsStub.returns(Promise.resolve(makeModerators()))
+    return dispatchThen(actions.channelModerators.get("channelname"), [
+      requestType,
+      successType
+    ]).then(({ data }) => {
+      assert.deepEqual([], data.get("channelname"))
+    })
+  })
+})


### PR DESCRIPTION
#### What are the relevant tickets?
Prerequisite to all moderator-related UI, e.g. #279, #263, etc

#### What's this PR do?
Adds a request to the channel moderators endpoint and adds some utils around it.

#### How should this be manually tested?
Go to a channel and post page and verify the pages load correctly and load the moderator list.

#### Any background context you want to provide?
To support moderator tasks in the UI, we need to have an idea if the current user is a moderator on the channel. This PR adds the api calls to retrieve that list as well as a util to see if a user is a moderator.