### PR TITLE
fix channel error issue

### DIFF
--- a/static/js/actions/channel.js
+++ b/static/js/actions/channel.js
@@ -3,3 +3,6 @@ import { createAction } from "redux-actions"
 
 export const SET_CHANNEL_DATA = "SET_CHANNEL_DATA"
 export const setChannelData = createAction(SET_CHANNEL_DATA)
+
+export const CLEAR_CHANNEL_ERROR = "CLEAR_CHANNEL_ERROR"
+export const clearChannelError = createAction(CLEAR_CHANNEL_ERROR)

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -22,6 +22,7 @@ import { toggleUpvote } from "../util/api_actions"
 import { anyError } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { formatTitle } from "../lib/title"
+import { clearChannelError } from "../actions/channel"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -36,7 +37,8 @@ type ChannelPageProps = {
   postsForChannel: ?Array<string>,
   posts: ?Array<Post>,
   subscribedChannels: ?Array<Channel>,
-  pagination: PostListPagination
+  pagination: PostListPagination,
+  errored: boolean
 }
 
 const shouldLoadData = R.complement(
@@ -62,7 +64,10 @@ class ChannelPage extends React.Component<*, void> {
   }
 
   loadData = () => {
-    const { dispatch, channelName, location: { search } } = this.props
+    const { dispatch, errored, channelName, location: { search } } = this.props
+    if (errored) {
+      dispatch(clearChannelError())
+    }
     dispatch(actions.channels.get(channelName))
     dispatch(
       actions.postsForChannel.get(channelName, qs.parse(search))

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -9,7 +9,7 @@ import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
-import { SET_CHANNEL_DATA } from "../actions/channel"
+import { SET_CHANNEL_DATA, CLEAR_CHANNEL_ERROR } from "../actions/channel"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { channelURL } from "../lib/url"
 import { formatTitle } from "../lib/title"
@@ -93,5 +93,25 @@ describe("ChannelPage", () => {
       }
     )
     sinon.assert.calledWith(helper.getChannelStub, otherChannel.name)
+  })
+
+  it("should clear the error if present on load", async () => {
+    helper.store.dispatch({
+      type:    actions.channels.get.failureType,
+      payload: { error: "some error" }
+    })
+
+    await renderComponent(channelURL(currentChannel.name), [
+      actions.channels.get.requestType,
+      actions.channels.get.successType,
+      actions.postsForChannel.get.requestType,
+      actions.postsForChannel.get.successType,
+      actions.subscribedChannels.get.requestType,
+      actions.subscribedChannels.get.successType,
+      SET_POST_DATA,
+      SET_CHANNEL_DATA,
+      CLEAR_CHANNEL_ERROR
+    ])
+    assert.isUndefined(helper.store.getState().channels.error)
   })
 })

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -1,7 +1,8 @@
 // @flow
 import { GET, POST, INITIAL_STATE } from "redux-hammock/constants"
+import R from "ramda"
 
-import { SET_CHANNEL_DATA } from "../actions/channel"
+import { SET_CHANNEL_DATA, CLEAR_CHANNEL_ERROR } from "../actions/channel"
 import type { Channel } from "../flow/discussionTypes"
 import * as api from "../lib/api"
 
@@ -38,6 +39,7 @@ export const channelsEndpoint = {
         ...state,
         data: updatedData
       }
-    }
+    },
+    [CLEAR_CHANNEL_ERROR]: R.dissoc("error")
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #323

#### What's this PR do?

This PR will basically clear the `channels` error object when trying to load data on the `ChannelPage`. This fixes the bug that was occurring in the linked issue, which was happening becuase the error from visiting a non-existant subreddit was sticking around even after the URL had been changed to an existing one. Since the UI just looks for the presence of the `error` property to see if it should show UI or not this was preventing the actually existing subreddit from showing up.

#### How should this be manually tested?

Go to `/channel/not-found`, ensure you see an error page. Then navigate to one of the channels in the sidebar by clicking on it. Ensure you can navigate there and you see the posts, instead of just continuing to see the error page.

Also probably confirm you can repro the bug on master.