### PR TITLE
fixed styling of channel page

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -3,6 +3,7 @@ $link-blue: #0b51bf;
 $button-blue: #0085df;
 $font-black: rgba(0,0,0,.87);
 $font-grey: #888;
+$font-darkgrey: #666;
 $border-grey: #d3d3d3;
 $card-background: #fff;
 $card-shadow: #cccaca;

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -5,12 +5,18 @@
     margin-top: 52px; // margin to align with top of main-content card on desktop
   }
 
+  .card-contents {
+    padding: 15px 26px;
+  }
+
   .title {
     margin-left: 0;
   }
 
   .description {
-    font-size: 14px;
+    font-size: 15px;
+    line-height: 1.4;
+    color: $font-darkgrey;
   }
 
   .edit-button {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -78,9 +78,9 @@ body {
     &.has-left-sidebar, &.has-right-sidebar {
       .main-content {
         @include breakpoint(desktop) {
-          margin-left: 40px;
-          margin-right: 40px;
-          width: 72%;
+          margin-left: 1.5%;
+          margin-right: 1.5%;
+          width: 70%;
         }
       }
     }
@@ -89,7 +89,7 @@ body {
     &.has-left-sidebar.has-right-sidebar {
       .main-content {
         @include breakpoint(desktop) {
-          width: 48%;
+          width: 49.5%;
         }
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?
#359

#### What's this PR do?
This PR fixes spacing and margin issues with the About this Channel card. The card needs to have margins to the right of it. Also, decrease the margins between columns. There will also be subtle changes with the font in the card, and increased padding inside the card.

#### How should this be manually tested?
See that the channel page matches the screenshot below. Less margins between columns, and the right column should always have margin to the right of it.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/20047260/33339101-0e8ede94-d446-11e7-8a8e-8c019fe8c403.png)

