### PR TITLE
s/self/text/ on guidelines

### DIFF
--- a/static/js/containers/ContentPolicyPage.js
+++ b/static/js/containers/ContentPolicyPage.js
@@ -67,7 +67,7 @@ export default class ContentPolicyPage extends React.Component<*, void> {
               <li>
                 Read over your submission for mistakes before submitting,
                 especially the title of the submission. Comments and the content
-                of self posts can be edited after being submitted, however, the
+                of text posts can be edited after being submitted, however, the
                 title of a post can't be. Make sure the facts you provide are
                 accurate to avoid any confusion down the line.
               </li>


### PR DESCRIPTION
#### What are the relevant tickets?

closes #354

#### What's this PR do?

changes `self` to `text` so that the guidelines match up with the 'create post' UI.

#### How should this be manually tested?

you can visit the guidelines and make sure it doesn't say 'self post' anywhere.