### PR TITLE
add pin post api

### DIFF
--- a/cassettes/channels.views_test.test_get_post_stickied.json
+++ b/cassettes/channels.views_test.test_get_post_stickied.json
@@ -1,0 +1,869 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-30T17:31:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C06ZQZBTXT8RQVCRBBT1TDWK"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9L18nAzKww2cHSL1DVKCYj3dvMxDckKKi4oDzdQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFpTmW5efklkZ5F3qU+1oWu/mHp7iGuqVZ+hWD9KSklmUmp8ZnpoAMhnCUagFJqvZruAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:31:49 GMT",
+            "loidcreated=2017-11-30T17%3A31%3A49.528Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:31:49 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C06ZQZBTXT8RQVCRBBT1TDWK"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Ratione+provident+delectus+optio+maiores+dolorum+aliquid.+Laudantium+aut+reiciendis+eveniet+dolorem+officia+maiores+cumque.+Recusandae+possimus+accusamus+veritatis+soluta+officiis+labore.%0APerferendis+atque+enim+voluptas+explicabo+eius+rem+molestiae+atque.+Assumenda+iusto+quia+iure+consectetur+at.%0AAutem+veniam+inventore+occaecati+veniam+eius+dolore.+Asperiores+voluptatem+non+dolorum+quo+aut.+Debitis+vel+illo+molestias+incidunt.&link_type=any&name=1512063109_tempora&public_description=Ut+porro+facilis+nemo.+Repellendus+sunt+qui+error+quos.&title=Animi+sed+autem+dolorum.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 272-JHF6qS0AFY-2dP_KFL5TjRspwW0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "635"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "491"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C06ZR5X0TW164JT70S8K1CKW"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WN0QqCMBiFX0V2GQniykGXaVC3NdB2M/TfP1yS2mZiRO+ey6suz8f5znmTEgCdk0PXYEt2AYkZDQ/bqU5jxtWej+zWMB0ds0e4qS7jiawDglNvLDppvECTKJrZz5fDq0c/UmFp0fqug25BK58s6lms/98KYXP1bPP0DPciq0HQRF8Fp5B03lE4GkBplB9eAvl8ARGq3Aq4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:56 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C06ZR5X0TW164JT70S8K1CKW"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C06ZR5X0TW164JT70S8K1CKW&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 272-JHF6qS0AFY-2dP_KFL5TjRspwW0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1512063109_tempora/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:56 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "484"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063109_tempora/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1512063109_tempora"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 273-E5xhC27TdBTv7jk7f0HDq-4bSvI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "77"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:56 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "484"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512063109_tempora&text=Sunt+ea+quis+non+esse+ipsam+distinctio.+At+modi+perferendis+nesciunt+fugit.&title=Accusamus+fuga+similique+possimus+ullam+quod+ut."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 273-E5xhC27TdBTv7jk7f0HDq-4bSvI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "212"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512063109_tempora/comments/4o/accusamus_fuga_similique_possimus_ullam_quod_ut/\", \"id\": \"4o\", \"name\": \"t3_4o\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "176"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:56 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "484"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:31:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 273-E5xhC27TdBTv7jk7f0HDq-4bSvI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4o/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063109_tempora\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESunt ea quis non esse ipsam distinctio. At modi perferendis nesciunt fugit.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Sunt ea quis non esse ipsam distinctio. At modi perferendis nesciunt fugit.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4o\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C06ZR5X0TW164JT70S8K1CKW\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063109_tempora\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3y\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063109_tempora/comments/4o/accusamus_fuga_similique_possimus_ullam_quod_ut/\", \"locked\": false, \"name\": \"t3_4o\", \"created\": 1512063116.0, \"url\": \"http://reddit.local/r/1512063109_tempora/comments/4o/accusamus_fuga_similique_possimus_ullam_quod_ut/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Accusamus fuga similique possimus ullam quod ut.\", \"created_utc\": 1512063116.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1766"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:31:56 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "484"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=jve3HhiB2LeAULlgCZ8R6dkL0bQkWUvYlbQym8Kwhd%2FNRakZRs5VwyDhwNxZ%2BylfWXzJWSvafjiAO5QXonettKV8PjqZgXJs"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4o/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:32:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_4o&state=True"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 272-JHF6qS0AFY-2dP_KFL5TjRspwW0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:32:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "480"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:32:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 273-E5xhC27TdBTv7jk7f0HDq-4bSvI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4o/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063109_tempora\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESunt ea quis non esse ipsam distinctio. At modi perferendis nesciunt fugit.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Sunt ea quis non esse ipsam distinctio. At modi perferendis nesciunt fugit.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4o\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C06ZR5X0TW164JT70S8K1CKW\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063109_tempora\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3y\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": true, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063109_tempora/comments/4o/accusamus_fuga_similique_possimus_ullam_quod_ut/\", \"locked\": false, \"name\": \"t3_4o\", \"created\": 1512063116.0, \"url\": \"http://reddit.local/r/1512063109_tempora/comments/4o/accusamus_fuga_similique_possimus_ullam_quod_ut/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Accusamus fuga similique possimus ullam quod ut.\", \"created_utc\": 1512063116.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1765"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:32:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "480"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=p1s7AB6dVFf%2FpDLq3X3sdPD4vykXguh20T5PYqWK1PQR3k5%2FFg5kyxf%2FHqDGL%2BvuTu%2BfWyCNcfPpIVijvMI7RHfcwQFGwA7U"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4o/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:32:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 273-E5xhC27TdBTv7jk7f0HDq-4bSvI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1FvAt7FP97rNgMKsgi; loidcreated=2017-11-30T17%3A31%3A49.528Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063109_tempora/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3y\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512063109_tempora\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ERatione provident delectus optio maiores dolorum aliquid. Laudantium aut reiciendis eveniet dolorem officia maiores cumque. Recusandae possimus accusamus veritatis soluta officiis labore.\\nPerferendis atque enim voluptas explicabo eius rem molestiae atque. Assumenda iusto quia iure consectetur at.\\nAutem veniam inventore occaecati veniam eius dolore. Asperiores voluptatem non dolorum quo aut. Debitis vel illo molestias incidunt.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Animi sed autem dolorum.\", \"collapse_deleted_comments\": false, \"public_description\": \"Ut porro facilis nemo. Repellendus sunt qui error quos.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EUt porro facilis nemo. Repellendus sunt qui error quos.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Ratione provident delectus optio maiores dolorum aliquid. Laudantium aut reiciendis eveniet dolorem officia maiores cumque. Recusandae possimus accusamus veritatis soluta officiis labore.\\nPerferendis atque enim voluptas explicabo eius rem molestiae atque. Assumenda iusto quia iure consectetur at.\\nAutem veniam inventore occaecati veniam eius dolore. Asperiores voluptatem non dolorum quo aut. Debitis vel illo molestias incidunt.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 6, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3y\", \"created\": 1512063109.0, \"url\": \"/r/1512063109_tempora/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512063109.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2318"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:32:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "480"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=CiVV2nkQf9ZfuC3p%2FUcM4GCRKPDaP8ZLTW7gKCPZZz32e5k37ONHk1czulzGTDvLECTqJEWGUuXralxr2ipjY7l12nWdXbi%2F"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063109_tempora/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_list_posts_stickied.json
+++ b/cassettes/channels.views_test.test_list_posts_stickied.json
@@ -1,0 +1,1679 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-30T17:36:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C0700R3F544AS6Z0GMNHZKY2"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9H1skxND0rMjDDwMfF3s3B19Eur8kz0CzIucDdR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYlBlomRbqY5pobubilx2dE+KSFJQWYGFYkpruC9KSklmUmp8ZnpoAMhnCUagGSPBu8uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:37 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:36:37 GMT",
+            "loidcreated=2017-11-30T17%3A36%3A37.013Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:36:37 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C0700R3F544AS6Z0GMNHZKY2"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Minus+perspiciatis+voluptate+temporibus+repudiandae+nisi+natus+animi.+Magnam+sapiente+excepturi+id+eos+at+nihil+autem.+Necessitatibus+dolor+fugiat+rem+magni.+At+harum+similique+sunt+saepe.%0AAperiam+exercitationem+tenetur+dolor+nam+ab.+Ipsum+facere+qui+doloremque+voluptas+harum+cumque.+Omnis+soluta+pariatur+nobis+vel+eius+quos+assumenda.+Laborum+perspiciatis+dignissimos+aspernatur+accusantium+odit+sequi+illo+magnam.&link_type=any&name=1512063397_mollitia&public_description=Error+dolor+natus+architecto+amet+sequi.+Hic+corrupti+eligendi+eius+hic+quo+odio.&title=Pariatur+cum+maxime+quas+corporis+quas.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 274-J9egRaiX0L4OF8EANfzIaNR3pG4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "662"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:37 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "203"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C0700YNYZ3N088B499ZWWKFC"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyN9U1DjQOdzFytDS0LElyM/AJ8Sj2dwl2dK809khX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZpQSUp3tlO5V4uuXm5mYHObobmOeb+aRE5fuC9KSklmUmp8ZnpoAMhnCUagE6s+9SuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C0700YNYZ3N088B499ZWWKFC"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C0700YNYZ3N088B499ZWWKFC&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 274-J9egRaiX0L4OF8EANfzIaNR3pG4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1512063397_mollitia/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "196"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1512063397_mollitia"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "196"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512063397_mollitia&text=Eius+nisi+error+eius+enim+dignissimos+vitae.+Architecto+amet+explicabo+autem+magnam.&title=Dolore+soluta+deserunt+minima."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "204"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512063397_mollitia/comments/4p/dolore_soluta_deserunt_minima/\", \"id\": \"4p\", \"name\": \"t3_4p\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "159"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "196"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4p/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EEius nisi error eius enim dignissimos vitae. Architecto amet explicabo autem magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Eius nisi error eius enim dignissimos vitae. Architecto amet explicabo autem magnam.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4p\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063397_mollitia\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4p/dolore_soluta_deserunt_minima/\", \"locked\": false, \"name\": \"t3_4p\", \"created\": 1512063404.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4p/dolore_soluta_deserunt_minima/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Dolore soluta deserunt minima.\", \"created_utc\": 1512063404.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1734"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "196"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=Myvs52O6gs5Lbhek8%2BX%2Bby8h5gtabCKmyZ3u4dkFgT56njXc81OpV4Fiw7%2F7IFLoDdluUUzA9yXMaubnaJIaoRnRDPSqUzYg"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4p/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512063397_mollitia&text=Voluptate+neque+maiores+non+officia+accusantium.+Veniam+aspernatur+a+tempore+praesentium+impedit.&title=Odit+laudantium+incidunt+aspernatur."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "223"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512063397_mollitia/comments/4q/odit_laudantium_incidunt_aspernatur/\", \"id\": \"4q\", \"name\": \"t3_4q\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "165"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "193"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4q/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EVoluptate neque maiores non officia accusantium. Veniam aspernatur a tempore praesentium impedit.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Voluptate neque maiores non officia accusantium. Veniam aspernatur a tempore praesentium impedit.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4q\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063397_mollitia\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4q/odit_laudantium_incidunt_aspernatur/\", \"locked\": false, \"name\": \"t3_4q\", \"created\": 1512063407.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4q/odit_laudantium_incidunt_aspernatur/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Odit laudantium incidunt aspernatur.\", \"created_utc\": 1512063407.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1778"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "193"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=C2QGfL4gsAzNqBpHhlL8Q5fULTOSLb8T8LVX5LJ2T5B5N%2BQJzEb19PxnV5ETfwVDEJd5wdEYHnL2bKHzyIhF0Yc82mhzR%2BSD"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4q/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512063397_mollitia&text=Magni+cumque+temporibus+alias+placeat.+Natus+quos+veniam+cupiditate+occaecati+ipsum+quia.&title=Fugit+quam+molestiae+in+corporis+aliquam."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "220"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512063397_mollitia/comments/4r/fugit_quam_molestiae_in_corporis_aliquam/\", \"id\": \"4r\", \"name\": \"t3_4r\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "170"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "190"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4r/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMagni cumque temporibus alias placeat. Natus quos veniam cupiditate occaecati ipsum quia.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Magni cumque temporibus alias placeat. Natus quos veniam cupiditate occaecati ipsum quia.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4r\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063397_mollitia\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4r/fugit_quam_molestiae_in_corporis_aliquam/\", \"locked\": false, \"name\": \"t3_4r\", \"created\": 1512063410.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4r/fugit_quam_molestiae_in_corporis_aliquam/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Fugit quam molestiae in corporis aliquam.\", \"created_utc\": 1512063410.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1777"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "190"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=H1JQdoakXfAHHh5xuN8CEfL8FFoUJxYcu2qR45SAMATtDTZPVW%2FguBcWJR8AMjPsN2mcmdaoRYMgvrpd6D0CZdTYH2jI7S9F"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4r/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512063397_mollitia&text=Facilis+nostrum+voluptatem+aliquam+quos+minima+illo+quisquam.+Aspernatur+recusandae+aperiam+odio.&title=Sunt+quos+quae+quos+provident+quod."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "222"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512063397_mollitia/comments/4s/sunt_quos_quae_quos_provident_quod/\", \"id\": \"4s\", \"name\": \"t3_4s\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "164"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "292.0"
+          ],
+          "x-ratelimit-reset": [
+            "187"
+          ],
+          "x-ratelimit-used": [
+            "8"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4s/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFacilis nostrum voluptatem aliquam quos minima illo quisquam. Aspernatur recusandae aperiam odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Facilis nostrum voluptatem aliquam quos minima illo quisquam. Aspernatur recusandae aperiam odio.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4s\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512063397_mollitia\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4s/sunt_quos_quae_quos_provident_quod/\", \"locked\": false, \"name\": \"t3_4s\", \"created\": 1512063413.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4s/sunt_quos_quae_quos_provident_quod/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Sunt quos quae quos provident quod.\", \"created_utc\": 1512063413.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1775"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "291.0"
+          ],
+          "x-ratelimit-reset": [
+            "186"
+          ],
+          "x-ratelimit-used": [
+            "9"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=90sAKm1l21PlycFJKHeUCbgh2%2FTl%2BFefhBX5QZqA8ZZhBoJNJM5y6lzooTN8bRDUzaxAW6ZGme%2FOYh7wSME7ZUs%2BJOOs5Tn5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4s/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_4r&state=True"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 274-J9egRaiX0L4OF8EANfzIaNR3pG4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063397_mollitia/hot?count=0&limit=25&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"domain\": \"self.1512063397_mollitia\", \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMagni cumque temporibus alias placeat. Natus quos veniam cupiditate occaecati ipsum quia.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Magni cumque temporibus alias placeat. Natus quos veniam cupiditate occaecati ipsum quia.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4r\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"name\": \"t3_4r\", \"score\": 1, \"approved_by\": null, \"over_18\": false, \"removal_reason\": null, \"hidden\": false, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"mod_reports\": [], \"archived\": false, \"media_embed\": {}, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4r/fugit_quam_molestiae_in_corporis_aliquam/\", \"locked\": false, \"stickied\": true, \"created\": 1512063410.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4r/fugit_quam_molestiae_in_corporis_aliquam/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Fugit quam molestiae in corporis aliquam.\", \"created_utc\": 1512063410.0, \"link_flair_text\": null, \"distinguished\": null, \"num_comments\": 0, \"visited\": false, \"num_reports\": null, \"ups\": 1}}, {\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"domain\": \"self.1512063397_mollitia\", \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFacilis nostrum voluptatem aliquam quos minima illo quisquam. Aspernatur recusandae aperiam odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Facilis nostrum voluptatem aliquam quos minima illo quisquam. Aspernatur recusandae aperiam odio.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4s\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"name\": \"t3_4s\", \"score\": 1, \"approved_by\": null, \"over_18\": false, \"removal_reason\": null, \"hidden\": false, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"mod_reports\": [], \"archived\": false, \"media_embed\": {}, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4s/sunt_quos_quae_quos_provident_quod/\", \"locked\": false, \"stickied\": false, \"created\": 1512063413.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4s/sunt_quos_quae_quos_provident_quod/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Sunt quos quae quos provident quod.\", \"created_utc\": 1512063413.0, \"link_flair_text\": null, \"distinguished\": null, \"num_comments\": 0, \"visited\": false, \"num_reports\": null, \"ups\": 1}}, {\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"domain\": \"self.1512063397_mollitia\", \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EVoluptate neque maiores non officia accusantium. Veniam aspernatur a tempore praesentium impedit.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Voluptate neque maiores non officia accusantium. Veniam aspernatur a tempore praesentium impedit.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4q\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"name\": \"t3_4q\", \"score\": 1, \"approved_by\": null, \"over_18\": false, \"removal_reason\": null, \"hidden\": false, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"mod_reports\": [], \"archived\": false, \"media_embed\": {}, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4q/odit_laudantium_incidunt_aspernatur/\", \"locked\": false, \"stickied\": false, \"created\": 1512063407.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4q/odit_laudantium_incidunt_aspernatur/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Odit laudantium incidunt aspernatur.\", \"created_utc\": 1512063407.0, \"link_flair_text\": null, \"distinguished\": null, \"num_comments\": 0, \"visited\": false, \"num_reports\": null, \"ups\": 1}}, {\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"domain\": \"self.1512063397_mollitia\", \"subreddit\": \"1512063397_mollitia\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EEius nisi error eius enim dignissimos vitae. Architecto amet explicabo autem magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Eius nisi error eius enim dignissimos vitae. Architecto amet explicabo autem magnam.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4p\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C0700YNYZ3N088B499ZWWKFC\", \"media\": null, \"name\": \"t3_4p\", \"score\": 1, \"approved_by\": null, \"over_18\": false, \"removal_reason\": null, \"hidden\": false, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3z\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"mod_reports\": [], \"archived\": false, \"media_embed\": {}, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512063397_mollitia/comments/4p/dolore_soluta_deserunt_minima/\", \"locked\": false, \"stickied\": false, \"created\": 1512063404.0, \"url\": \"http://reddit.local/r/1512063397_mollitia/comments/4p/dolore_soluta_deserunt_minima/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Dolore soluta deserunt minima.\", \"created_utc\": 1512063404.0, \"link_flair_text\": null, \"distinguished\": null, \"num_comments\": 0, \"visited\": false, \"num_reports\": null, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "6318"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "290.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "10"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=teTz94387M6bE4SrOjNKKf9LcdJZbGCDx5MuunSt5YYSGUI9SEJx8ME%2FasZCEYr9fHnFea%2B10f%2BC8sniRzQ8IcMAoa4QryzS"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/hot?count=0&limit=25&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3z\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512063397_mollitia\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMinus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Pariatur cum maxime quas corporis quas.\", \"collapse_deleted_comments\": false, \"public_description\": \"Error dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EError dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Minus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3z\", \"created\": 1512063397.0, \"url\": \"/r/1512063397_mollitia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512063397.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2359"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "289.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "11"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=faZ009ourncqwbUL96LKtLUVGuIS4W196ajjxRWiC%2BPzMYxDjHs1dZJKM80JlRJlJd5mPfTEdvA4aEm3RAB03sFC9Lxs32Ah"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3z\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512063397_mollitia\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMinus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Pariatur cum maxime quas corporis quas.\", \"collapse_deleted_comments\": false, \"public_description\": \"Error dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EError dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Minus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3z\", \"created\": 1512063397.0, \"url\": \"/r/1512063397_mollitia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512063397.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2359"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "288.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "12"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=NvxVdx2qEo6xZx78SU6kLWqYhnRF7KIzYvzfPtabPgJt5UnhPaYBFuUnrUdBSBJrU7k8uRB4aHV%2FMeSoojTAdZf1WpC2Ig5R"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3z\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512063397_mollitia\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMinus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Pariatur cum maxime quas corporis quas.\", \"collapse_deleted_comments\": false, \"public_description\": \"Error dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EError dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Minus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3z\", \"created\": 1512063397.0, \"url\": \"/r/1512063397_mollitia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512063397.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2359"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "287.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "13"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=l8fnNbCvZcMxlVHltnpqEztAqAcHKNgd074I9IWNhj5SN%2BJsomoQaOS73XEJYACEb4%2F7EqPaKkfKZockdnmLYMzUuQICoyeL"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:36:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 275-3Q3WD2A919tbF0LTHsODSAGy3Hg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=8xMK97vnHqyWcGMlkK; loidcreated=2017-11-30T17%3A36%3A37.013Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3z\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512063397_mollitia\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMinus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Pariatur cum maxime quas corporis quas.\", \"collapse_deleted_comments\": false, \"public_description\": \"Error dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EError dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Minus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3z\", \"created\": 1512063397.0, \"url\": \"/r/1512063397_mollitia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512063397.0, \"banner_size\": null, \"user_is_moderator\": false, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2359"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:36:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "286.0"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "14"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=9Nk4eUmsh%2FMVtcscR3GnPTmTs%2F3gqDFvWmjqWNgg5b0GD4Jn%2FtF9I0%2FaNaMwARede6OsnMrIXUZ%2FFBgkQ2Yu%2B0lJfxW4ZFGM"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512063397_mollitia/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_post_nonmoderator_cant_sticky.json
+++ b/cassettes/channels.views_test.test_update_post_nonmoderator_cant_sticky.json
@@ -1,0 +1,691 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-30T16:37:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C06WN463F529CZXV3QMRDNC9"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyM9L1KfA0c0s3Ms829An2zawoTw+IiggPCclzDi9X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFu6fmuseHReVVmYWEJUbkBhf4h8S7u5eWRqaD9KSklmUmp8ZnpoAMhnCUagH0B0UuuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 16:37:50 GMT",
+            "loidcreated=2017-11-30T16%3A37%3A50.388Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 16:37:50 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C06WN463F529CZXV3QMRDNC9"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Quis+cum+quia+corporis+praesentium.+Deserunt+odio+soluta+distinctio+totam+voluptates.+Sit+qui+occaecati+incidunt+id.%0AAccusamus+esse+velit+illum+nam+totam+illum.+Eaque+laborum+illum+alias+at.+Facilis+distinctio+et+eligendi+atque+eveniet.+Aliquid+dolores+tempora+molestias+reiciendis+architecto+cupiditate.%0AConsectetur+sunt+quaerat+atque+ducimus+porro+a.+Voluptate+modi+commodi+sapiente+eligendi+alias+nulla.+Rem+libero+rem+nostrum+voluptas+earum+quam+ea.+Placeat+ex+corporis+distinctio+quisquam+quam.&link_type=any&name=1512059870_suscipit&public_description=Velit+quod+error+labore.+Quas+quam+rem+illo+eos+necessitatibus+consequatur.&title=Ipsa+id+at+eveniet+doloremque+aperiam.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 262-LpI6Fg27k1LSMixwgPZXWTTnCWw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "739"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "130"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C06WNAMD3EX5R82W25MWP7XM"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyM9b1STX1NCouTyo1KSqoSqkwyAnPcA5xsqgMygpU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZlVWa5Jue6ZTl5hxp6GjlGRlb5REXF52WblkaC9KSklmUmp8ZnpoAMhnCUagHcCCjPuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C06WNAMD3EX5R82W25MWP7XM"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C06WNAMD3EX5R82W25MWP7XM&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 262-LpI6Fg27k1LSMixwgPZXWTTnCWw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1512059870_suscipit/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "123"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512059870_suscipit/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1512059870_suscipit"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 263-Le5I2swbu4rpzdx0lWhCTB8yRjQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "123"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512059870_suscipit&text=Placeat+doloremque+nisi+amet+quo+eaque.+Atque+laborum+enim+corporis+accusamus+deserunt.&title=Unde+nisi+ipsum+veniam+molestias+unde+facilis."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 263-Le5I2swbu4rpzdx0lWhCTB8yRjQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "223"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512059870_suscipit/comments/4g/unde_nisi_ipsum_veniam_molestias_unde_facilis/\", \"id\": \"4g\", \"name\": \"t3_4g\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "175"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "123"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:37:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 263-Le5I2swbu4rpzdx0lWhCTB8yRjQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4g/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512059870_suscipit\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPlaceat doloremque nisi amet quo eaque. Atque laborum enim corporis accusamus deserunt.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Placeat doloremque nisi amet quo eaque. Atque laborum enim corporis accusamus deserunt.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4g\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C06WNAMD3EX5R82W25MWP7XM\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512059870_suscipit\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3t\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512059870_suscipit/comments/4g/unde_nisi_ipsum_veniam_molestias_unde_facilis/\", \"locked\": false, \"name\": \"t3_4g\", \"created\": 1512059877.0, \"url\": \"http://reddit.local/r/1512059870_suscipit/comments/4g/unde_nisi_ipsum_veniam_molestias_unde_facilis/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Unde nisi ipsum veniam molestias unde facilis.\", \"created_utc\": 1512059877.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1788"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:37:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "123"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=DMeEtO8%2BKbxxGlohyNYVdT9HUsokfQ%2BLM0ha7vXFP6hIkzpRmlIpKcuDUlUl9z0vjqU3zHPPoz%2BWMJF8mYpfoCVqPAC98BjI"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4g/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T16:38:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_4g&state=True"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 263-Le5I2swbu4rpzdx0lWhCTB8yRjQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4T2Fxu8EmzsmXDxtyZ; loidcreated=2017-11-30T16%3A37%3A50.388Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 16:38:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "120"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_post_stickied.json
+++ b/cassettes/channels.views_test.test_update_post_stickied.json
@@ -1,0 +1,958 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-29T20:27:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C04QDSA01V17M2RW96VF1WKM"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIysdANCU/PdzfOd/E2N8grCQywiIryzgosSsktzPBV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbpZpVn5/ilV4Vnepi5eiQnVpbnO1vmlBaa+HqC9KSklmUmp8ZnpoAMhnCUagHcQnaRuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:27:58 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 29-Nov-2019 20:27:58 GMT",
+            "loidcreated=2017-11-29T20%3A27%3A58.153Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 29-Nov-2019 20:27:58 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C04QDSA01V17M2RW96VF1WKM"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:27:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Eligendi+earum+odio+veritatis+animi+ipsam+illum+error+saepe.+Eum+iste+adipisci+modi+facilis+incidunt+labore.+Facilis+necessitatibus+ducimus+facilis+inventore+assumenda+at.+Veritatis+necessitatibus+iusto+quidem+et+enim+nostrum.%0AIpsa+sit+perspiciatis+fugiat+consectetur+modi+aliquam+possimus.+Saepe+quos+earum+reprehenderit+quia+ex+expedita.+Quis+fugiat+vel+quo+ex.+Amet+mollitia+et+voluptatem.+Natus+molestias+magnam+sequi+eveniet+earum.&link_type=any&name=1511987278_quasi&public_description=Et+occaecati+error+adipisci+accusamus+sapiente+natus+unde.+A+aperiam+ex+cumque+harum+itaque+ullam.&title=Ipsa+nisi+blanditiis+consequuntur+consequatur.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "702"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:27:58 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "122"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C04QDZRWSYDCZ7HEFRHJMTKK"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIysdTN8HdyjbBwKywvD6rwTkv3izdKr/IIjw9yTMpW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblO5WV5gdapJS6mnmkeOa4RGWFGeble+aHFSeD9KSklmUmp8ZnpoAMhnCUagFV+WD4uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C04QDZRWSYDCZ7HEFRHJMTKK"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C04QDZRWSYDCZ7HEFRHJMTKK&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1511987278_quasi/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "115"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1511987278_quasi/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1511987278_quasi"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 249-hOBEX8FqwwRxKfgN_2gzHW_RAbk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "115"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1511987278_quasi&text=Nisi+recusandae+deleniti+eaque+magnam+quaerat+eaque+voluptate.+Vitae+doloremque+voluptatem+ducimus.&title=Aliquid+velit+nostrum+ducimus."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 249-hOBEX8FqwwRxKfgN_2gzHW_RAbk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "216"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"id\": \"49\", \"name\": \"t3_49\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "156"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "115"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 249-hOBEX8FqwwRxKfgN_2gzHW_RAbk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1511987278_quasi\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Nisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"49\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C04QDZRWSYDCZ7HEFRHJMTKK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1511987278_quasi\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3m\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"locked\": false, \"name\": \"t3_49\", \"created\": 1511987285.0, \"url\": \"http://reddit.local/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Aliquid velit nostrum ducimus.\", \"created_utc\": 1511987285.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1752"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "115"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=K7FoB9u3iyQ1DrCQCVftcy3IQ7WIBGtnzhLlYpiCHKuXBvasQPO0D%2Fse3ljBfoNNUic%2Bru8n91hgmnbsxo8S2Y8cBR83qCcs"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_49&state=True"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "112"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1511987278_quasi\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Nisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"49\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C04QDZRWSYDCZ7HEFRHJMTKK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1511987278_quasi\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3m\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": true, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"locked\": false, \"name\": \"t3_49\", \"created\": 1511987285.0, \"url\": \"http://reddit.local/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Aliquid velit nostrum ducimus.\", \"created_utc\": 1511987285.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1746"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "112"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=JExyRXqLCQY2UkFjg%2BwJNpWjNkpqoJm4heWKHZ1ldlKTdBcDdpTkOmUTZMij35r4aLoAewtpA6uvMZt989bJUQTmOiPxo%2Bqb"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1511987278_quasi\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Nisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"49\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C04QDZRWSYDCZ7HEFRHJMTKK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1511987278_quasi\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_3m\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": true, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"locked\": false, \"name\": \"t3_49\", \"created\": 1511987285.0, \"url\": \"http://reddit.local/r/1511987278_quasi/comments/49/aliquid_velit_nostrum_ducimus/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Aliquid velit nostrum ducimus.\", \"created_utc\": 1511987285.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1746"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "112"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=X192VwIruKVSSlTbcOeKekT1lFyx8RHY7V8SZ8aYdi%2B%2BXb%2FpaG7lDbvrrpkALO37OUYxj6CHTK91ZKhGbkbVAIkWKGNps5MU"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/49/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-29T20:28:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 248-TWgoG3oDK70ntQP8ZZKjQrdmqhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4XXyNetTaEgBBA4tOl; loidcreated=2017-11-29T20%3A27%3A58.153Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.4.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1511987278_quasi/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"3m\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1511987278_quasi\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EEligendi earum odio veritatis animi ipsam illum error saepe. Eum iste adipisci modi facilis incidunt labore. Facilis necessitatibus ducimus facilis inventore assumenda at. Veritatis necessitatibus iusto quidem et enim nostrum.\\nIpsa sit perspiciatis fugiat consectetur modi aliquam possimus. Saepe quos earum reprehenderit quia ex expedita. Quis fugiat vel quo ex. Amet mollitia et voluptatem. Natus molestias magnam sequi eveniet earum.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Ipsa nisi blanditiis consequuntur consequatur.\", \"collapse_deleted_comments\": false, \"public_description\": \"Et occaecati error adipisci accusamus sapiente natus unde. A aperiam ex cumque harum itaque ullam.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EEt occaecati error adipisci accusamus sapiente natus unde. A aperiam ex cumque harum itaque ullam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Eligendi earum odio veritatis animi ipsam illum error saepe. Eum iste adipisci modi facilis incidunt labore. Facilis necessitatibus ducimus facilis inventore assumenda at. Veritatis necessitatibus iusto quidem et enim nostrum.\\nIpsa sit perspiciatis fugiat consectetur modi aliquam possimus. Saepe quos earum reprehenderit quia ex expedita. Quis fugiat vel quo ex. Amet mollitia et voluptatem. Natus molestias magnam sequi eveniet earum.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 6, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_3m\", \"created\": 1511987278.0, \"url\": \"/r/1511987278_quasi/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1511987278.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2431"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Nov 2017 20:28:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "112"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=3lGke%2F%2FTbofYY0Sw%2FSxE8CgcwHgAwMBWejTHff%2BMO8%2FQOGhFz6xlxrQv8ZOB%2FPqszrkZajRDZo3htA8wddAKftOTurz2TWle"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1511987278_quasi/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views_test.test_update_post_unsticky.json
+++ b/cassettes/channels.views_test.test_update_post_unsticky.json
@@ -1,0 +1,1050 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-30T17:52:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C070YNE6DFN2ZMFTT9ZEJFTH"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNSwuCQBSF/4rMMhoQDZXWgaDVohfUZrDxqpdB52X2ov+ek6uW5+N857xJwTlYy3opoCNLjwRxQve7ll70KlO1PsiUsk2d0C0O8T08k7lH4KHQgGXohDDy/ZH9fNY/FbiRKxQGjOtaLic0c8lANYrN/1u+NioVrMPTLQls+1p0Udbovs2PwjklDMiBYemGp0A+XxQkfHm4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:52:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:52:57 GMT",
+            "loidcreated=2017-11-30T17%3A52%3A57.317Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 30-Nov-2019 17:52:57 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C070YNE6DFN2ZMFTT9ZEJFTH"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:52:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Neque+id+mollitia+iusto+commodi.+Libero+nisi+consectetur+illum+quidem+odit+at+incidunt.+Vitae+expedita+distinctio+id+fugiat.+Sequi+esse+sapiente+culpa+repudiandae.%0ANihil+in+modi+omnis+fugiat+aut+odio.+Soluta+earum+recusandae+culpa+accusantium+minima.+Repellat+sequi+inventore+vero+accusantium+explicabo+eaque.%0ASoluta+consequatur+eligendi+consequuntur+veritatis+quisquam+facere+illo.+Ipsam+dolor+sit+ullam+nam+dicta.+A+sint+quae+atque+facilis+exercitationem+at.&link_type=any&name=1512064377_repellat&public_description=Velit+maiores+adipisci+autem+delectus+id+maxime.+Suscipit+est+in+explicabo.&title=Exercitationem+voluptatibus+fugiat+ratione.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "705"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:52:58 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "423"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C070YW6Z31ZS69DC1MJKWGKY"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQmmMVa7WghBNIsYiNkM9nzlIKi9J6ZE/56Tq5b3cM+9b5EDILPtmgprsQtEnG5DuSLTZydF583QXaoY9FMZflGdslgGAofWEbJ1XkhkFE3s59tubNGP3DAnJN9laGa08InwPonl/1tfOiP1ADkkOjOuCvl4aNV6P14f3imwd4DWFX54DuLzBVH199O4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C070YW6Z31ZS69DC1MJKWGKY"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C070YW6Z31ZS69DC1MJKWGKY&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1512064377_repellat/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "416"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512064377_repellat/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1512064377_repellat"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 279-61rZvFLOrN8xtSk2cUqOZswrn7s"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "416"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1512064377_repellat&text=Aspernatur+tenetur+numquam+qui+vel.+Totam+minima+earum+atque.+Earum+eum+distinctio+optio+quo+iste.&title=Dolor+iusto+quasi+iusto+ad."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 279-61rZvFLOrN8xtSk2cUqOZswrn7s"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "215"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"id\": \"4u\", \"name\": \"t3_4u\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "156"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "416"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 279-61rZvFLOrN8xtSk2cUqOZswrn7s"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512064377_repellat\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EAspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Aspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4u\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C070YW6Z31ZS69DC1MJKWGKY\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512064377_repellat\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_41\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"locked\": false, \"name\": \"t3_4u\", \"created\": 1512064384.0, \"url\": \"http://reddit.local/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Dolor iusto quasi iusto ad.\", \"created_utc\": 1512064384.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1753"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "416"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=myvF9Po5mYvGZFibMk1FzStFmZjPpdW%2FK%2BpfA4VYMZfWO0eyDiCOBEaW2AcY9%2BcQZXZ7OlaEujURxdAH3EUYJEOUl6LMx9Zn"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_4u&state=True"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "413"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_4u&state=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "34"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/set_subreddit_sticky/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512064377_repellat\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EAspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Aspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4u\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C070YW6Z31ZS69DC1MJKWGKY\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512064377_repellat\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_41\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"locked\": false, \"name\": \"t3_4u\", \"created\": 1512064384.0, \"url\": \"http://reddit.local/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Dolor iusto quasi iusto ad.\", \"created_utc\": 1512064384.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1748"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=strBsQdr8ZfYmpZKkXuX%2FM1gz0%2BiCHRFrFULI8J%2B%2FB2jzWPqpkst2bGIBEytvAHPm%2Bz%2FfEbwkm9ZsDBAKs9aYrL9cJ4C%2B6C0"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1512064377_repellat\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EAspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Aspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"4u\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C070YW6Z31ZS69DC1MJKWGKY\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1512064377_repellat\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_41\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"locked\": false, \"name\": \"t3_4u\", \"created\": 1512064384.0, \"url\": \"http://reddit.local/r/1512064377_repellat/comments/4u/dolor_iusto_quasi_iusto_ad/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Dolor iusto quasi iusto ad.\", \"created_utc\": 1512064384.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1748"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=oI%2BLqVt4D9zBFiNRyLi%2BvBucSyxNozPPdNxkOgO1Sk7naLfeNWymuRzUug%2F1461reaySEUGyxSBWMWKmIgGz40oUolFz1oKB"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/4u/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-30T17:53:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 278-SRm-ZqDJpgqToG-_Mg8-Niv7w3Y"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=1ZO4O4bzAlashxJWt4; loidcreated=2017-11-30T17%3A52%3A57.317Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.5.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1512064377_repellat/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"41\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1512064377_repellat\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENeque id mollitia iusto commodi. Libero nisi consectetur illum quidem odit at incidunt. Vitae expedita distinctio id fugiat. Sequi esse sapiente culpa repudiandae.\\nNihil in modi omnis fugiat aut odio. Soluta earum recusandae culpa accusantium minima. Repellat sequi inventore vero accusantium explicabo eaque.\\nSoluta consequatur eligendi consequuntur veritatis quisquam facere illo. Ipsam dolor sit ullam nam dicta. A sint quae atque facilis exercitationem at.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Exercitationem voluptatibus fugiat ratione.\", \"collapse_deleted_comments\": false, \"public_description\": \"Velit maiores adipisci autem delectus id maxime. Suscipit est in explicabo.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EVelit maiores adipisci autem delectus id maxime. Suscipit est in explicabo.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Neque id mollitia iusto commodi. Libero nisi consectetur illum quidem odit at incidunt. Vitae expedita distinctio id fugiat. Sequi esse sapiente culpa repudiandae.\\nNihil in modi omnis fugiat aut odio. Soluta earum recusandae culpa accusantium minima. Repellat sequi inventore vero accusantium explicabo eaque.\\nSoluta consequatur eligendi consequuntur veritatis quisquam facere illo. Ipsam dolor sit ullam nam dicta. A sint quae atque facilis exercitationem at.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_41\", \"created\": 1512064377.0, \"url\": \"/r/1512064377_repellat/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1512064377.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2438"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 30 Nov 2017 17:53:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=o4zbgZbMHK01JjCjkj4A%2BKO65nQeIKG9uoRKnqivRg2we3HEf49lO1aDFrsuqZSlE8ERdwmgQ9c%2B6ivNJwg%2B%2FULhsE3SCDX9"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1512064377_repellat/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/api.py
+++ b/channels/api.py
@@ -443,6 +443,17 @@ class Api:
 
         return post.edit(text)
 
+    def pin_post(self, post_id, pinned):
+        """
+        Pin the Post!
+
+        Args:
+            post_id(str): the base36 id for the post
+            pinned(bool): the value for the 'stickied' field
+        """
+        post = self.get_post(post_id)
+        post.mod.sticky(pinned)
+
     def remove_post(self, post_id):
         """
         Removes the post, opposite of approve_post

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -124,6 +124,7 @@ class PostSerializer(serializers.Serializer):
     title = serializers.CharField()
     upvoted = WriteableSerializerMethodField()
     removed = WriteableSerializerMethodField()
+    stickied = serializers.BooleanField()
     score = serializers.IntegerField(source='ups', read_only=True)
     author_id = serializers.CharField(read_only=True, source='author')
     id = serializers.CharField(read_only=True)
@@ -263,6 +264,10 @@ class PostSerializer(serializers.Serializer):
 
         if "text" in validated_data:
             instance = api.update_post(post_id=post_id, text=validated_data['text'])
+
+        if "stickied" in validated_data:
+            sticky = validated_data["stickied"]
+            api.pin_post(post_id, sticky)
 
         _apply_vote(instance, validated_data, False)
         return api.get_post(post_id=post_id)

--- a/factory_data/channels.views_test.test_get_post_stickied.json
+++ b/factory_data/channels.views_test.test_get_post_stickied.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Ratione provident delectus optio maiores dolorum aliquid. Laudantium aut reiciendis eveniet dolorem officia maiores cumque. Recusandae possimus accusamus veritatis soluta officiis labore.\nPerferendis atque enim voluptas explicabo eius rem molestiae atque. Assumenda iusto quia iure consectetur at.\nAutem veniam inventore occaecati veniam eius dolore. Asperiores voluptatem non dolorum quo aut. Debitis vel illo molestias incidunt.",
+      "name": "1512063109_tempora",
+      "public_description": "Ut porro facilis nemo. Repellendus sunt qui error quos.",
+      "title": "Animi sed autem dolorum."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "4o",
+      "text": "Sunt ea quis non esse ipsam distinctio. At modi perferendis nesciunt fugit.",
+      "title": "Accusamus fuga similique possimus ullam quod ut."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C06ZR5X0TW164JT70S8K1CKW"
+    },
+    "staff_user": {
+      "username": "01C06ZQZBTXT8RQVCRBBT1TDWK"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_list_posts_stickied.json
+++ b/factory_data/channels.views_test.test_list_posts_stickied.json
@@ -1,0 +1,41 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Minus perspiciatis voluptate temporibus repudiandae nisi natus animi. Magnam sapiente excepturi id eos at nihil autem. Necessitatibus dolor fugiat rem magni. At harum similique sunt saepe.\nAperiam exercitationem tenetur dolor nam ab. Ipsum facere qui doloremque voluptas harum cumque. Omnis soluta pariatur nobis vel eius quos assumenda. Laborum perspiciatis dignissimos aspernatur accusantium odit sequi illo magnam.",
+      "name": "1512063397_mollitia",
+      "public_description": "Error dolor natus architecto amet sequi. Hic corrupti eligendi eius hic quo odio.",
+      "title": "Pariatur cum maxime quas corporis quas."
+    }
+  },
+  "posts": {
+    "great post!0": {
+      "id": "4p",
+      "text": "Eius nisi error eius enim dignissimos vitae. Architecto amet explicabo autem magnam.",
+      "title": "Dolore soluta deserunt minima."
+    },
+    "great post!1": {
+      "id": "4q",
+      "text": "Voluptate neque maiores non officia accusantium. Veniam aspernatur a tempore praesentium impedit.",
+      "title": "Odit laudantium incidunt aspernatur."
+    },
+    "great post!2": {
+      "id": "4r",
+      "text": "Magni cumque temporibus alias placeat. Natus quos veniam cupiditate occaecati ipsum quia.",
+      "title": "Fugit quam molestiae in corporis aliquam."
+    },
+    "great post!3": {
+      "id": "4s",
+      "text": "Facilis nostrum voluptatem aliquam quos minima illo quisquam. Aspernatur recusandae aperiam odio.",
+      "title": "Sunt quos quae quos provident quod."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C0700YNYZ3N088B499ZWWKFC"
+    },
+    "staff_user": {
+      "username": "01C0700R3F544AS6Z0GMNHZKY2"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_update_post_nonmoderator_cant_sticky.json
+++ b/factory_data/channels.views_test.test_update_post_nonmoderator_cant_sticky.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Quis cum quia corporis praesentium. Deserunt odio soluta distinctio totam voluptates. Sit qui occaecati incidunt id.\nAccusamus esse velit illum nam totam illum. Eaque laborum illum alias at. Facilis distinctio et eligendi atque eveniet. Aliquid dolores tempora molestias reiciendis architecto cupiditate.\nConsectetur sunt quaerat atque ducimus porro a. Voluptate modi commodi sapiente eligendi alias nulla. Rem libero rem nostrum voluptas earum quam ea. Placeat ex corporis distinctio quisquam quam.",
+      "name": "1512059870_suscipit",
+      "public_description": "Velit quod error labore. Quas quam rem illo eos necessitatibus consequatur.",
+      "title": "Ipsa id at eveniet doloremque aperiam."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "4g",
+      "text": "Placeat doloremque nisi amet quo eaque. Atque laborum enim corporis accusamus deserunt.",
+      "title": "Unde nisi ipsum veniam molestias unde facilis."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C06WNAMD3EX5R82W25MWP7XM"
+    },
+    "staff_user": {
+      "username": "01C06WN463F529CZXV3QMRDNC9"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_update_post_stickied.json
+++ b/factory_data/channels.views_test.test_update_post_stickied.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Eligendi earum odio veritatis animi ipsam illum error saepe. Eum iste adipisci modi facilis incidunt labore. Facilis necessitatibus ducimus facilis inventore assumenda at. Veritatis necessitatibus iusto quidem et enim nostrum.\nIpsa sit perspiciatis fugiat consectetur modi aliquam possimus. Saepe quos earum reprehenderit quia ex expedita. Quis fugiat vel quo ex. Amet mollitia et voluptatem. Natus molestias magnam sequi eveniet earum.",
+      "name": "1511987278_quasi",
+      "public_description": "Et occaecati error adipisci accusamus sapiente natus unde. A aperiam ex cumque harum itaque ullam.",
+      "title": "Ipsa nisi blanditiis consequuntur consequatur."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "49",
+      "text": "Nisi recusandae deleniti eaque magnam quaerat eaque voluptate. Vitae doloremque voluptatem ducimus.",
+      "title": "Aliquid velit nostrum ducimus."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C04QDZRWSYDCZ7HEFRHJMTKK"
+    },
+    "staff_user": {
+      "username": "01C04QDSA01V17M2RW96VF1WKM"
+    }
+  }
+}

--- a/factory_data/channels.views_test.test_update_post_unsticky.json
+++ b/factory_data/channels.views_test.test_update_post_unsticky.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Neque id mollitia iusto commodi. Libero nisi consectetur illum quidem odit at incidunt. Vitae expedita distinctio id fugiat. Sequi esse sapiente culpa repudiandae.\nNihil in modi omnis fugiat aut odio. Soluta earum recusandae culpa accusantium minima. Repellat sequi inventore vero accusantium explicabo eaque.\nSoluta consequatur eligendi consequuntur veritatis quisquam facere illo. Ipsam dolor sit ullam nam dicta. A sint quae atque facilis exercitationem at.",
+      "name": "1512064377_repellat",
+      "public_description": "Velit maiores adipisci autem delectus id maxime. Suscipit est in explicabo.",
+      "title": "Exercitationem voluptatibus fugiat ratione."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "4u",
+      "text": "Aspernatur tenetur numquam qui vel. Totam minima earum atque. Earum eum distinctio optio quo iste.",
+      "title": "Dolor iusto quasi iusto ad."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C070YW6Z31ZS69DC1MJKWGKY"
+    },
+    "staff_user": {
+      "username": "01C070YNE6DFN2ZMFTT9ZEJFTH"
+    }
+  }
+}

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -25,7 +25,8 @@ export const makePost = (
   channel_title: casual.string,
   profile_image: casual.url,
   author_name:   casual.name,
-  edited:        casual.boolean
+  edited:        casual.boolean,
+  stickied:      casual.boolean
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -19,6 +19,7 @@ describe("posts factories", () => {
       assert.isString(post.profile_image)
       assert.isString(post.author_name)
       assert.isBoolean(post.edited)
+      assert.isBoolean(post.stickied)
     })
 
     it("should make a URL post", () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -25,6 +25,7 @@ export type AuthoredContent = {
   created:       string,
   profile_image: string,
   author_name:   string,
+  edited:        boolean,
 }
 
 export type Post = AuthoredContent & {
@@ -34,7 +35,7 @@ export type Post = AuthoredContent & {
   num_comments:  number,
   channel_name:  string,
   channel_title: string,
-  edited:        boolean,
+  stickied:      boolean,
 }
 
 export type PostForm = {
@@ -94,7 +95,6 @@ export type CommentFromAPI = AuthoredContent & HasParentId & {
   post_id:       string,
   text:          string,
   downvoted:     boolean,
-  edited:        boolean,
   comment_type:  "comment",
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #194 

#### What's this PR do?

this adds a field ('stickied') to the Post API which can be toggled to make a post 'pinned' / 'sticky'.

#### How should this be manually tested?

You should be a moderator on your channels, so you should be able to toggle the boolean using the DRF web interface (just type `{"stickied": true}` and make sure it saves).