### PR TITLE
Added UI to remove posts as a moderator

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@material/list": "^0.2.14",
     "@material/menu": "^0.4.3",
     "@material/rtl": "^0.1.7",
+    "@material/snackbar": "^0.25.0",
     "@material/toolbar": "^0.4.4",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.25.0",

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -3,3 +3,6 @@ import { createAction } from "redux-actions"
 
 export const SET_SHOW_DRAWER = "SET_SHOW_DRAWER"
 export const setShowDrawer = createAction(SET_SHOW_DRAWER)
+
+export const SET_SNACKBAR_MESSAGE = "SET_SNACKBAR_MESSAGE"
+export const setSnackbarMessage = createAction(SET_SNACKBAR_MESSAGE)

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -26,7 +26,10 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
   props: {
     post: Post,
     toggleUpvote: Post => void,
+    approvePost: Post => void,
+    removePost: Post => void,
     forms: FormsState,
+    isModerator: boolean,
     beginEditing: (key: string, initialValue: Object, e: ?Event) => void
   }
 
@@ -38,8 +41,24 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
       : textContent(post)
   }
 
+  approvePost = (e: Event) => {
+    const { post, approvePost } = this.props
+
+    e.preventDefault()
+
+    approvePost(post)
+  }
+
+  removePost = (e: Event) => {
+    const { post, removePost } = this.props
+
+    e.preventDefault()
+
+    removePost(post)
+  }
+
   postActionButtons = () => {
-    const { toggleUpvote, post, beginEditing } = this.props
+    const { toggleUpvote, post, beginEditing, isModerator } = this.props
 
     return (
       <div className="post-actions">
@@ -50,10 +69,26 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
         />
         {SETTINGS.username === post.author_id && post.text
           ? <div
-            className="comment-action-button"
+            className="comment-action-button edit-post"
             onClick={beginEditing(editPostKey(post), post)}
           >
             <a href="#">edit</a>
+          </div>
+          : null}
+        {isModerator && !post.removed
+          ? <div
+            className="comment-action-button remove-post"
+            onClick={this.removePost.bind(this)}
+          >
+            <a href="#">remove</a>
+          </div>
+          : null}
+        {isModerator && post.removed
+          ? <div
+            className="comment-action-button approve-post"
+            onClick={this.approvePost.bind(this)}
+          >
+            <a href="#">approve</a>
           </div>
           : null}
       </div>

--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -1,0 +1,53 @@
+// @flow
+import React from "react"
+import R from "ramda"
+
+import { MDCSnackbar } from "@material/snackbar/dist/mdc.snackbar"
+
+import type { SnackbarState } from "../../reducers/ui"
+
+type SnackbarProps = {
+  snackbar: ?SnackbarState
+}
+
+export default class Snackbar extends React.Component<*, *> {
+  snackbar = null
+  snackbarRoot = null
+
+  props: SnackbarProps
+
+  componentDidMount() {
+    this.snackbar = new MDCSnackbar(this.snackbarRoot)
+  }
+
+  componentWillReceiveProps(nextProps: SnackbarProps) {
+    if (!R.equals(this.props.snackbar, nextProps.snackbar)) {
+      this.showSnackbar(nextProps.snackbar)
+    }
+  }
+
+  showSnackbar(snackbar: ?SnackbarState) {
+    if (this.snackbar && snackbar) {
+      this.snackbar.show(R.omit("id", snackbar))
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <div
+          className="mdc-snackbar"
+          aria-live="assertive"
+          aria-atomic="true"
+          aria-hidden="true"
+          ref={node => (this.snackbarRoot = node)}
+        >
+          <div className="mdc-snackbar__text" />
+          <div className="mdc-snackbar__action-wrapper">
+            <button type="button" className="mdc-snackbar__action-button" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -13,6 +13,7 @@ import AdminPage from "./admin/AdminPage"
 import AuthRequiredPage from "./AuthRequiredPage"
 import CreatePostPage from "./CreatePostPage"
 import Toolbar from "../components/Toolbar"
+import Snackbar from "../components/material/Snackbar"
 import Drawer from "../containers/Drawer"
 
 import { actions } from "../actions"
@@ -22,12 +23,14 @@ import { AUTH_REQUIRED_URL } from "../lib/url"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
+import type { SnackbarState } from "../reducers/ui"
 
 class App extends React.Component<*, void> {
   props: {
     match: Match,
     location: Location,
     showDrawer: boolean,
+    snackbar: SnackbarState,
     dispatch: Dispatch
   }
 
@@ -55,7 +58,7 @@ class App extends React.Component<*, void> {
   }
 
   render() {
-    const { match, location: { pathname } } = this.props
+    const { match, location: { pathname }, snackbar } = this.props
 
     if (!SETTINGS.session_url && pathname !== AUTH_REQUIRED_URL) {
       // user does not have the jwt cookie, they must go through login workflow first
@@ -65,6 +68,7 @@ class App extends React.Component<*, void> {
     return (
       <div className="app">
         <DocumentTitle title="MIT Open Discussions" />
+        <Snackbar snackbar={snackbar} />
         <Toolbar toggleShowSidebar={this.toggleShowSidebar} />
         <Drawer />
         <Route exact path={match.url} component={HomePage} />
@@ -96,6 +100,6 @@ class App extends React.Component<*, void> {
 }
 
 export default connect(state => {
-  const { ui: { showDrawer } } = state
-  return { showDrawer }
+  const { ui: { showDrawer, snackbar } } = state
+  return { showDrawer, snackbar }
 })(App)

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -26,7 +26,8 @@ export const makePost = (
   profile_image: casual.url,
   author_name:   casual.name,
   edited:        casual.boolean,
-  stickied:      casual.boolean
+  stickied:      casual.boolean,
+  removed:       casual.boolean
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -20,6 +20,7 @@ describe("posts factories", () => {
       assert.isString(post.author_name)
       assert.isBoolean(post.edited)
       assert.isBoolean(post.stickied)
+      assert.isBoolean(post.removed)
     })
 
     it("should make a URL post", () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -44,6 +44,7 @@ export type Post = AuthoredContent & {
   channel_name:  string,
   channel_title: string,
   stickied:      boolean,
+  removed:       boolean
 }
 
 export type PostForm = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -124,6 +124,13 @@ export function updateUpvote(postId: string, upvoted: boolean): Promise<Post> {
   })
 }
 
+export function updateRemoved(postId: string, removed: boolean): Promise<Post> {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: "PATCH",
+    body:   JSON.stringify({ removed })
+  })
+}
+
 export function editPost(postId: string, post: Post): Promise<Post> {
   return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
     method: "PATCH",

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -19,7 +19,8 @@ import {
   updateComment,
   editPost,
   getMoreComments,
-  updateChannel
+  updateChannel,
+  updateRemoved
 } from "./api"
 import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
@@ -285,6 +286,23 @@ describe("api", function() {
       assert.deepEqual(fetchStub.args[0][1], {
         method: PATCH,
         body:   JSON.stringify(R.dissoc("url", post))
+      })
+    })
+    ;[true, false].forEach(status => {
+      it(`updates post removed: ${status}`, async () => {
+        const post = makePost()
+
+        fetchStub.returns(Promise.resolve())
+
+        await updateRemoved(post.id, status)
+
+        assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
+        assert.deepEqual(fetchStub.args[0][1], {
+          method: PATCH,
+          body:   JSON.stringify({
+            removed: status
+          })
+        })
       })
     })
 

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -27,4 +27,4 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
 export const isModerator = (
   moderators: ChannelModerators,
   username: string
-): boolean => R.any(R.propEq("moderator_name", username), moderators)
+): boolean => R.any(R.propEq("moderator_name", username), moderators || [])

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -7,6 +7,7 @@ import { frontPageEndpoint } from "../reducers/frontpage"
 import { commentsEndpoint, moreCommentsEndpoint } from "../reducers/comments"
 import { postUpvotesEndpoint } from "../reducers/post_upvotes"
 import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
+import { postRemoved } from "../reducers/post_removed"
 
 export const endpoints = [
   postsEndpoint,
@@ -17,5 +18,6 @@ export const endpoints = [
   frontPageEndpoint,
   commentsEndpoint,
   moreCommentsEndpoint,
-  postUpvotesEndpoint
+  postUpvotesEndpoint,
+  postRemoved
 ]

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -8,7 +8,12 @@ import { setChannelData } from "../actions/channel"
 import { setPostData } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { INITIAL_UI_STATE } from "./ui"
-import { SET_SHOW_DRAWER, setShowDrawer } from "../actions/ui"
+import {
+  SET_SHOW_DRAWER,
+  SET_SNACKBAR_MESSAGE,
+  setShowDrawer,
+  setSnackbarMessage
+} from "../actions/ui"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 
 import { makePost, makeChannelPostList } from "../factories/posts"
@@ -256,9 +261,32 @@ describe("reducers", () => {
       state = await dispatchThen(setShowDrawer(false), [SET_SHOW_DRAWER])
       assert.isFalse(state.showDrawer)
     })
+
+    it("should set snackbar message", async () => {
+      const payload = {
+        message: "hey there!"
+      }
+      let state = await dispatchThen(setSnackbarMessage(payload), [
+        SET_SNACKBAR_MESSAGE
+      ])
+
+      assert.deepEqual(state.snackbar, {
+        id: 0,
+        ...payload
+      })
+
+      state = await dispatchThen(setSnackbarMessage(payload), [
+        SET_SNACKBAR_MESSAGE
+      ])
+
+      assert.deepEqual(state.snackbar, {
+        id: 1,
+        ...payload
+      })
+    })
   })
 
-  describe("subsribed channels (getChannels) reducer", () => {
+  describe("subscribed channels (getChannels) reducer", () => {
     let channels
 
     beforeEach(() => {

--- a/static/js/reducers/post_removed.js
+++ b/static/js/reducers/post_removed.js
@@ -1,0 +1,10 @@
+// @flow
+import * as api from "../lib/api"
+import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
+
+export const postRemoved = {
+  name:         "postRemoved",
+  verbs:        [PATCH],
+  patchFunc:    (id: string, removed: boolean) => api.updateRemoved(id, removed),
+  initialState: { ...INITIAL_STATE }
+}

--- a/static/js/reducers/post_removed_test.js
+++ b/static/js/reducers/post_removed_test.js
@@ -1,0 +1,32 @@
+// @flow
+import { assert } from "chai"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+describe("post_removed reducer", () => {
+  let helper
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.updateRemovedStub.returns(Promise.resolve())
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  for (const value of [true, false]) {
+    it(`should let you update the post removed value with ${value.toString()}`, () => {
+      const { requestType, successType } = actions.postRemoved.patch
+      return helper
+        .dispatchThen(actions.postRemoved.patch("id", value), [
+          requestType,
+          successType
+        ])
+        .then(() => {
+          assert.isOk(helper.updateRemovedStub.calledWith("id", value))
+        })
+    })
+  }
+})

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,23 +1,45 @@
 // @flow
-import { SET_SHOW_DRAWER } from "../actions/ui"
+import { SET_SHOW_DRAWER, SET_SNACKBAR_MESSAGE } from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
 
+export type SnackbarState = {
+  id: number,
+  message: string,
+  actionText: ?string,
+  timeout: ?number
+}
+
 export type UIState = {
-  showDrawer: boolean
+  showDrawer: boolean,
+  snackbar: ?SnackbarState
 }
 
 export const INITIAL_UI_STATE: UIState = {
-  showDrawer: false
+  showDrawer: false,
+  snackbar:   null
 }
+
+// this generates a new sequential id for each snackbar state that is pushed
+// this ensures the snack will display for each message even if they repeat
+const nextSnackbarId = (snackbar: ?SnackbarState): number =>
+  snackbar ? snackbar.id + 1 : 0
 
 export const ui = (
   state: Object = INITIAL_UI_STATE,
-  action: Action<boolean, null>
+  action: Action<any, null>
 ): UIState => {
   switch (action.type) {
   case SET_SHOW_DRAWER:
     return { ...state, showDrawer: action.payload }
+  case SET_SNACKBAR_MESSAGE:
+    return {
+      ...state,
+      snackbar: {
+        ...action.payload,
+        id: nextSnackbarId(state.snackbar)
+      }
+    }
   }
   return state
 }

--- a/static/js/util/api_actions.js
+++ b/static/js/util/api_actions.js
@@ -13,3 +13,13 @@ export const toggleUpvote = R.curry(async (dispatch: Dispatch, post: Post) => {
   )
   return dispatch(setPostData(result))
 })
+
+export const approvePost = R.curry(async (dispatch: Dispatch, post: Post) => {
+  const result = await dispatch(actions.postRemoved.patch(post.id, false))
+  return dispatch(setPostData(result))
+})
+
+export const removePost = R.curry(async (dispatch: Dispatch, post: Post) => {
+  const result = await dispatch(actions.postRemoved.patch(post.id, true))
+  return dispatch(setPostData(result))
+})

--- a/static/js/util/api_actions_test.js
+++ b/static/js/util/api_actions_test.js
@@ -2,7 +2,8 @@
 import { assert } from "chai"
 
 import { actions } from "../actions"
-import { toggleUpvote } from "../util/api_actions"
+import { SET_POST_DATA } from "../actions/post"
+import { toggleUpvote, approvePost, removePost } from "../util/api_actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 import { makePost } from "../factories/posts"
@@ -24,18 +25,61 @@ describe("api_actions util", () => {
     })
 
     for (const value of [true, false]) {
-      it(`should set invert the upvoted value for upvoted:${value.toString()}`, () => {
+      it(`should set invert the upvoted value for upvoted:${value.toString()}`, async () => {
         const { requestType, successType } = actions.postUpvotes.patch
         const post = makePost()
         post.upvoted = value
-        return helper
-          .listenForActions([requestType, successType], () => {
-            toggleUpvote(helper.store.dispatch, post)
-          })
-          .then(() => {
-            assert.isOk(helper.updateUpvoteStub.calledWith(post.id, !value))
-          })
+        await helper.listenForActions([requestType, successType], () => {
+          toggleUpvote(helper.store.dispatch, post)
+        })
+
+        assert.isOk(helper.updateUpvoteStub.calledWith(post.id, !value))
       })
     }
+  })
+
+  describe("approvePost", () => {
+    let post
+    beforeEach(() => {
+      post = makePost()
+      helper.updateRemovedStub.returns(Promise.resolve(post))
+    })
+
+    it("should patch the post and set the updated value", async () => {
+      const postToApprove = makePost()
+      postToApprove.id = post.id
+      const { requestType, successType } = actions.postRemoved.patch
+      const state = await helper.listenForActions(
+        [requestType, successType, SET_POST_DATA],
+        () => {
+          approvePost(helper.store.dispatch, postToApprove)
+        }
+      )
+      assert.deepEqual(state.posts.data.get(post.id), post)
+      assert.isOk(helper.updateRemovedStub.calledWith(post.id, false))
+    })
+  })
+
+  describe("removePost", () => {
+    let post
+    beforeEach(() => {
+      post = makePost()
+      helper.updateRemovedStub.returns(Promise.resolve(post))
+    })
+
+    it("should patch the post and set the updated value", async () => {
+      const postToRemove = makePost()
+      postToRemove.id = post.id
+      const { requestType, successType } = actions.postRemoved.patch
+      const state = await helper.listenForActions(
+        [requestType, successType, SET_POST_DATA],
+        () => {
+          removePost(helper.store.dispatch, postToRemove)
+        }
+      )
+
+      assert.deepEqual(state.posts.data.get(post.id), post)
+      assert.isOk(helper.updateRemovedStub.calledWith(post.id, true))
+    })
   })
 })

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -2,6 +2,7 @@
 @import "node_modules/@material/toolbar/dist/mdc.toolbar";
 @import "node_modules/@material/list/dist/mdc.list";
 @import "node_modules/@material/button/dist/mdc.button";
+@import "node_modules/@material/snackbar/dist/mdc.snackbar";
 @import "node_modules/spinkit/scss/spinners/7-three-bounce";
 @import "node_modules/spinkit/scss/spinners/10-fading-circle";
 @import "breakpoints";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@material/animation@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.25.0.tgz#b252ac3d0b628e79a79f0c406d7470fb56352a80"
+
 "@material/animation@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.3.1.tgz#229de6927d0590d6d6b20157d778d264ef02229a"
@@ -9,6 +13,10 @@
 "@material/base@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.2.3.tgz#c4eb26b6d6e5840c254ad487588dc4f69b971f3e"
+
+"@material/base@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.24.0.tgz#888a61e5b6580e35a66384a9f8823091b4fe7c55"
 
 "@material/button@^0.3.11":
   version "0.3.11"
@@ -66,9 +74,27 @@
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.7.tgz#b38b771af183bcf34d643f600f17fc433698535a"
 
+"@material/rtl@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.8.tgz#2462db15e2d4e041666485559c028382872b01fb"
+
+"@material/snackbar@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-0.25.0.tgz#73169dbf51d6c3f23b7c84654a540e1b3c5a88a6"
+  dependencies:
+    "@material/animation" "^0.25.0"
+    "@material/base" "^0.24.0"
+    "@material/rtl" "^0.1.8"
+    "@material/theme" "^0.25.0"
+    "@material/typography" "^0.3.0"
+
 "@material/theme@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.1.7.tgz#d94a7c5099feae9dc318c639802327c7ae82e872"
+
+"@material/theme@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.25.0.tgz#707b4c61ebc62e662d36164c8dd45fcf98bb1444"
 
 "@material/toolbar@^0.4.4":
   version "0.4.4"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #279 

#### What's this PR do?
Adds the UI for a moderator to remove posts

#### How should this be manually tested?
- As a regular user, verify you see no option to remove posts
- As a moderator verify you see the option to remove posts
- Remove a post, it should no longer show up in the listing
- As a moderator, you should be able to see the post content
- As a regular user you should see a message that the post has been removed
- As a moderator, you should be able to re-approve the post and it should return to a non-removed state  (shows up in channel listing and regular users can see the content)
