### PR TITLE
add pinning ui

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -17,7 +17,10 @@ class CompactPostDisplay extends React.Component<*, void> {
   props: {
     post: Post,
     showChannelLink: boolean,
-    toggleUpvote: Post => void
+    toggleUpvote: Post => void,
+    togglePinPost: Post => void,
+    showPinUI: boolean,
+    isModerator: boolean
   }
 
   showChannelLink = () => {
@@ -32,10 +35,19 @@ class CompactPostDisplay extends React.Component<*, void> {
   }
 
   render() {
-    const { post, toggleUpvote } = this.props
+    const {
+      post,
+      toggleUpvote,
+      showPinUI,
+      togglePinPost,
+      isModerator
+    } = this.props
     const formattedDate = moment(post.created).fromNow()
+
     return (
-      <div className="post-summary">
+      <div
+        className={`post-summary ${post.stickied && showPinUI ? "sticky" : ""}`}
+      >
         <PostVotingButtons post={post} toggleUpvote={toggleUpvote} />
         <div className="summary">
           <div className="post-title">
@@ -45,10 +57,15 @@ class CompactPostDisplay extends React.Component<*, void> {
             by <span className="author-name">{post.author_name}</span>,{" "}
             {formattedDate} {this.showChannelLink()}
           </div>
-          <div className="num-comments">
+          <div className="post-links">
             <Link to={postDetailURL(post.channel_name, post.id)}>
               {formatCommentsCount(post)}
             </Link>
+            {showPinUI && post.text && isModerator
+              ? <a onClick={() => togglePinPost(post)}>
+                {post.stickied ? "unpin" : "pin"}
+              </a>
+              : null}
           </div>
         </div>
       </div>

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -43,7 +43,7 @@ describe("CompactPostDisplay", () => {
     assert.equal(wrapper.find(".votes").text(), post.score.toString())
     assert.equal(summary.find(Link).at(0).props().children, post.title)
     assert.deepEqual(
-      wrapper.find(".num-comments").find(Link).props().children,
+      wrapper.find(".post-links").find(Link).props().children,
       formatCommentsCount(post)
     )
     const authoredBy = wrapper.find(".authored-by").text()
@@ -66,6 +66,56 @@ describe("CompactPostDisplay", () => {
     assert.equal(href, post.url)
     assert.equal(target, "_blank")
     assert.equal(children, post.title)
+  })
+
+  it('should include a "pinning" link, if isModerator and showPinUI', () => {
+    [[true, "unpin"], [false, "pin"]].forEach(([pinned, linkText]) => {
+      const post = makePost()
+      post.stickied = pinned
+      const wrapper = renderPostDisplay({
+        post:        post,
+        showPinUI:   true,
+        isModerator: true
+      })
+      assert.equal(linkText, wrapper.find("a").at(2).text())
+    })
+  })
+
+  it("should not show a pin link otherwise", () => {
+    [true, false].forEach(showPinUI => {
+      const wrapper = renderPostDisplay({ post, showPinUI })
+      assert.lengthOf(wrapper.find(".post-links").find("a"), 1)
+    })
+  })
+
+  it("should set a class if stickied and showing pin ui", () => {
+    [
+      [true, true],
+      [true, false],
+      [false, true],
+      [false, false]
+    ].forEach(([showPinUI, stickied]) => {
+      post.stickied = stickied
+      const wrapper = renderPostDisplay({ post, showPinUI })
+      assert.equal(
+        wrapper.find(".post-summary").props().className,
+        showPinUI && stickied ? "post-summary sticky" : "post-summary "
+      )
+    })
+  })
+
+  it("pin link should call togglePinPost", () => {
+    const togglePinPostStub = helper.sandbox.stub()
+    const post = makePost()
+    post.stickied = true
+    const wrapper = renderPostDisplay({
+      post:          post,
+      showPinUI:     true,
+      isModerator:   true,
+      togglePinPost: togglePinPostStub
+    })
+    wrapper.find("a").at(2).simulate("click")
+    assert.ok(togglePinPostStub.calledWith(post))
   })
 
   it("should display the domain, for a url post", () => {

--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -5,29 +5,39 @@ import CompactPostDisplay from "./CompactPostDisplay"
 
 import type { Post } from "../flow/discussionTypes"
 
-const renderPosts = (posts, showChannelLinks, toggleUpvote) =>
-  posts.map((post, index) =>
-    <CompactPostDisplay
-      post={post}
-      key={index}
-      showChannelLink={showChannelLinks}
-      toggleUpvote={toggleUpvote}
-    />
-  )
-
 type PostListProps = {
   posts: Array<Post>,
   showChannelLinks?: boolean,
-  toggleUpvote: Post => void
+  showPinUI?: boolean,
+  toggleUpvote: Post => void,
+  togglePinPost?: Post => Promise<*>,
+  isModerator?: boolean
 }
 
 const PostList = (props: PostListProps) => {
-  const { posts, showChannelLinks, toggleUpvote } = props
+  const {
+    posts,
+    showChannelLinks,
+    showPinUI,
+    isModerator,
+    toggleUpvote,
+    togglePinPost
+  } = props
 
   return (
     <div className="post-list">
       {posts.length > 0
-        ? renderPosts(posts, showChannelLinks, toggleUpvote)
+        ? posts.map((post, index) =>
+          <CompactPostDisplay
+            post={post}
+            key={index}
+            showChannelLink={showChannelLinks}
+            toggleUpvote={toggleUpvote}
+            showPinUI={showPinUI}
+            isModerator={isModerator}
+            togglePinPost={togglePinPost}
+          />
+        )
         : <div className="empty-list-msg">There are no posts to display.</div>}
     </div>
   )

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
+import sinon from "sinon"
 
 import PostList from "./PostList"
 import CompactPostDisplay from "./CompactPostDisplay"
@@ -29,6 +30,41 @@ describe("PostList", () => {
     })
     wrapper.find(CompactPostDisplay).forEach(postSummary => {
       assert.isTrue(postSummary.props().showChannelLink)
+    })
+  })
+
+  it("should pass the showPinUI prop to CompactPostDisplay", () => {
+    [true, false].forEach(showPinUI => {
+      const wrapper = renderPostList({
+        posts: makeChannelPostList(),
+        showPinUI
+      })
+      wrapper.find(CompactPostDisplay).forEach(postSummary => {
+        assert.equal(postSummary.props().showPinUI, showPinUI)
+      })
+    })
+  })
+
+  it("should pass the isModerator prop to CompactPostDisplay", () => {
+    [true, false].forEach(isModerator => {
+      const wrapper = renderPostList({
+        posts: makeChannelPostList(),
+        isModerator
+      })
+      wrapper.find(CompactPostDisplay).forEach(postSummary => {
+        assert.equal(postSummary.props().isModerator, isModerator)
+      })
+    })
+  })
+
+  it("should pass thesinon.stub() showChannelLinks prop to CompactPostDisplay", () => {
+    const pinStub = sinon.stub()
+    const wrapper = renderPostList({
+      posts:         makeChannelPostList(),
+      togglePinPost: pinStub
+    })
+    wrapper.find(CompactPostDisplay).forEach(postSummary => {
+      assert.equal(postSummary.props().togglePinPost, pinStub)
     })
   })
 })

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -20,7 +20,7 @@ export const newPostForm = (): PostForm => ({
 })
 
 export const formatCommentsCount = (post: Post): string =>
-  post.num_comments === 1 ? "1 Comment" : `${post.num_comments || 0} Comments`
+  post.num_comments === 1 ? "1 comment" : `${post.num_comments || 0} comments`
 
 export const mapPostListResponse = (
   response: PostListResponse

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -17,9 +17,9 @@ describe("Post utils", () => {
   it("should correctly format comments", () => {
     const post = makePost()
     ;[
-      [0, "0 Comments"],
-      [1, "1 Comment"],
-      [10, "10 Comments"]
+      [0, "0 comments"],
+      [1, "1 comment"],
+      [10, "10 comments"]
     ].forEach(([num, expectation]) => {
       post.num_comments = num
       assert.equal(formatCommentsCount(post), expectation)

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -8,7 +8,7 @@ $border-grey: #d3d3d3;
 $card-background: #fff;
 $card-shadow: #cccaca;
 $app-background: #f1f1f1;
-$bg-blue: #c8e8f7;
+$bg-blue: #e1f0f6;
 $voted-blue: #2573d7;
 $validation-bg: #ffe8ec;
 $validation-text: #f07183;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -10,13 +10,17 @@
   display: flex;
   flex-direction: column;
 
-  &:not(:last-child):not(.expanded) {
+  &:not(:last-child):not(.expanded):not(.sticky) {
     border-bottom: 1px solid $border-grey;
   }
 
   &:not(.expanded) {
     flex-direction: row;
     padding: 22px 0;
+  }
+
+  &.sticky {
+    background-color: $bg-blue;
   }
 
   .post-title {
@@ -41,11 +45,17 @@
     }
   }
 
-  .num-comments {
-    display: block;
-    margin: 0;
-    font-size: 13px;
-    font-weight: 400;
+  .post-links {
+    display: flex;
+
+    a {
+      cursor: pointer;
+      display: block;
+      margin: 0;
+      font-size: 13px;
+      font-weight: 400;
+      margin-right: 10px;
+    }
   }
 
   .summary {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #236 

#### What's this PR do?

This adds UI for pinning posts on a channel. There's a special display for the 'pinned' post, and then also a little button for pinning / unpinning a post. This button should only show up for moderators.

#### How should this be manually tested?

The frontpage should look the same as it does on master. On a subreddit, if your user is a moderator you should see an option (on text posts only) to 'pin' a post. When you select this option the pinned post should change it's display, and after a quick refresh of the post data it should appear at the top of the list. Unpinning it should reverse this.

These buttons shouldn't show up for a non-moderator, but a non-moderator should still see pinned posts on the channel page. A post which is pinned on a subreddit shouldn't look any different on the homepage.