### PR TITLE
fix post pinning issue

### DIFF
--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -69,9 +69,7 @@ class ChannelPage extends React.Component<*, void> {
   togglePinPost = async (post: Post) => {
     const { dispatch } = this.props
 
-    await dispatch(
-      actions.posts.patch(post.id, R.evolve({ stickied: R.not }, post))
-    )
+    await dispatch(actions.posts.patch(post.id, { stickied: !post.stickied }))
     this.fetchPostsForChannel()
   }
 

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -1,16 +1,18 @@
 // @flow
+/* global SETTINGS */
 import { assert } from "chai"
 import sinon from "sinon"
 
 import PostList from "../components/PostList"
 import SubscriptionsList from "../components/SubscriptionsList"
+import CompactPostDisplay from "../components/CompactPostDisplay"
 
 import {
   makeChannel,
   makeChannelList,
   makeModerators
 } from "../factories/channels"
-import { makeChannelPostList } from "../factories/posts"
+import { makeChannelPostList, makePost } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
 import { SET_CHANNEL_DATA, CLEAR_CHANNEL_ERROR } from "../actions/channel"
@@ -64,6 +66,27 @@ describe("ChannelPage", () => {
   it("should set the document title", async () => {
     await renderPage(currentChannel)
     assert.equal(document.title, formatTitle(currentChannel.title))
+  })
+
+  it("pin post link should just post what's necessary", async () => {
+    SETTINGS.username = "username"
+    helper.getChannelModeratorsStub.returns(
+      Promise.resolve(makeModerators(SETTINGS.username))
+    )
+    const post = makePost()
+    postList[0] = post
+    const [wrapper] = await renderPage(currentChannel)
+    wrapper
+      .find(CompactPostDisplay)
+      .at(0)
+      .find(".post-links")
+      .find("a")
+      .at(1)
+      .simulate("click")
+
+    sinon.assert.calledWith(helper.editPostStub, postList[0].id, {
+      stickied: !post.stickied
+    })
   })
 
   it("should fetch postsForChannel, set post data, and render", async () => {


### PR DESCRIPTION
#### What are the relevant tickets?

#389

#### What's this PR do?

This changes the helper function in `ChannelPage` for pinning the post to just post `{stickied: true | false}` instead of the whole post object. 

#### How should this be manually tested?

You should, as a channel moderator, be able to pin a post which you did not write.