### PR TITLE
This fixes a layout problem where long URLs are causing the page layout to break.

### DIFF
--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -75,6 +75,10 @@ $replyPaddingLeft: 8px;
         color: rgba(0,0,0,.77);
         line-height: 1.3;
         font-size: 15px;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        word-break: break-word;
+        hyphens: auto;
 
         &:not(:last-child) {
           margin: 0 0 15px 0;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -16,7 +16,7 @@
 
   &:not(.expanded) {
     flex-direction: row;
-    padding: 22px 0;
+    padding: 16px 0;
   }
 
   &.sticky {
@@ -24,7 +24,7 @@
   }
 
   .post-title {
-    font-size: 16px;
+    font-size: 17px;
     font-weight: 400;
     margin: 0 0 7px;
   }
@@ -72,6 +72,11 @@
   .text-content {
     color: rgba(0,0,0,.77);
     line-height: 1.4;
+    font-size: 15px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
   }
 
   .post-actions {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #395

#### What's this PR do?
This PR fixes layout problem where long URLs are causing the page layout to break. (see screenshot below).

#### How should this be manually tested?
See that a long URL will not cause the URL to break as shown.

#### Screenshots (if appropriate)
Broken:
![image](https://user-images.githubusercontent.com/20047260/33904775-9127a1b0-df4a-11e7-9cf2-7765a31a721b.png)

Fixed: 
![image](https://user-images.githubusercontent.com/20047260/33904700-550fe6a6-df4a-11e7-8b6c-6e8267c162ea.png)
