### PR TITLE
add support for managing dialogs to the UI reducer

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -6,3 +6,9 @@ export const setShowDrawer = createAction(SET_SHOW_DRAWER)
 
 export const SET_SNACKBAR_MESSAGE = "SET_SNACKBAR_MESSAGE"
 export const setSnackbarMessage = createAction(SET_SNACKBAR_MESSAGE)
+
+export const SHOW_DIALOG = "SHOW_DIALOG"
+export const showDialog = createAction(SHOW_DIALOG)
+
+export const HIDE_DIALOG = "HIDE_DIALOG"
+export const hideDialog = createAction(HIDE_DIALOG)

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -7,13 +7,6 @@ import { actions } from "../actions"
 import { setChannelData } from "../actions/channel"
 import { setPostData } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { INITIAL_UI_STATE } from "./ui"
-import {
-  SET_SHOW_DRAWER,
-  SET_SNACKBAR_MESSAGE,
-  setShowDrawer,
-  setSnackbarMessage
-} from "../actions/ui"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 
 import { makePost, makeChannelPostList } from "../factories/posts"
@@ -243,46 +236,6 @@ describe("reducers", () => {
         successType
       ])
       assert.lengthOf(data.postIds, 20)
-    })
-  })
-
-  describe("ui reducer", () => {
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.ui)
-    })
-
-    it("should have some default state", () => {
-      assert.deepEqual(store.getState().ui, INITIAL_UI_STATE)
-    })
-
-    it("should let you toggle sidebar visibility", async () => {
-      let state = await dispatchThen(setShowDrawer(true), [SET_SHOW_DRAWER])
-      assert.isTrue(state.showDrawer)
-      state = await dispatchThen(setShowDrawer(false), [SET_SHOW_DRAWER])
-      assert.isFalse(state.showDrawer)
-    })
-
-    it("should set snackbar message", async () => {
-      const payload = {
-        message: "hey there!"
-      }
-      let state = await dispatchThen(setSnackbarMessage(payload), [
-        SET_SNACKBAR_MESSAGE
-      ])
-
-      assert.deepEqual(state.snackbar, {
-        id: 0,
-        ...payload
-      })
-
-      state = await dispatchThen(setSnackbarMessage(payload), [
-        SET_SNACKBAR_MESSAGE
-      ])
-
-      assert.deepEqual(state.snackbar, {
-        id: 1,
-        ...payload
-      })
     })
   })
 

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,5 +1,12 @@
 // @flow
-import { SET_SHOW_DRAWER, SET_SNACKBAR_MESSAGE } from "../actions/ui"
+import R from "ramda"
+
+import {
+  SET_SHOW_DRAWER,
+  SET_SNACKBAR_MESSAGE,
+  SHOW_DIALOG,
+  HIDE_DIALOG
+} from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
 
@@ -12,12 +19,14 @@ export type SnackbarState = {
 
 export type UIState = {
   showDrawer: boolean,
-  snackbar: ?SnackbarState
+  snackbar: ?SnackbarState,
+  dialogs: Set<string>
 }
 
 export const INITIAL_UI_STATE: UIState = {
   showDrawer: false,
-  snackbar:   null
+  snackbar:   null,
+  dialogs:    new Set()
 }
 
 // this generates a new sequential id for each snackbar state that is pushed
@@ -25,8 +34,13 @@ export const INITIAL_UI_STATE: UIState = {
 const nextSnackbarId = (snackbar: ?SnackbarState): number =>
   snackbar ? snackbar.id + 1 : 0
 
+const updateDialog = (dialogs: Set<string>, dialogKey: string, show: boolean) =>
+  show
+    ? new Set([...dialogs, dialogKey])
+    : new Set([...dialogs].filter(R.complement(R.equals)(dialogKey)))
+
 export const ui = (
-  state: Object = INITIAL_UI_STATE,
+  state: UIState = INITIAL_UI_STATE,
   action: Action<any, null>
 ): UIState => {
   switch (action.type) {
@@ -39,6 +53,16 @@ export const ui = (
         ...action.payload,
         id: nextSnackbarId(state.snackbar)
       }
+    }
+  case SHOW_DIALOG:
+    return {
+      ...state,
+      dialogs: updateDialog(state.dialogs, action.payload, true)
+    }
+  case HIDE_DIALOG:
+    return {
+      ...state,
+      dialogs: updateDialog(state.dialogs, action.payload, false)
     }
   }
   return state

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -1,0 +1,80 @@
+// @flow
+import { assert } from "chai"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { INITIAL_UI_STATE } from "./ui"
+import {
+  SET_SHOW_DRAWER,
+  SET_SNACKBAR_MESSAGE,
+  SHOW_DIALOG,
+  HIDE_DIALOG,
+  setShowDrawer,
+  setSnackbarMessage,
+  showDialog,
+  hideDialog
+} from "../actions/ui"
+
+describe("ui reducer", () => {
+  let helper, store, dispatchThen
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    store = helper.store
+    dispatchThen = store.createDispatchThen(state => state.ui)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should have some default state", () => {
+    assert.deepEqual(store.getState().ui, INITIAL_UI_STATE)
+  })
+
+  it("should let you toggle sidebar visibility", async () => {
+    let state = await dispatchThen(setShowDrawer(true), [SET_SHOW_DRAWER])
+    assert.isTrue(state.showDrawer)
+    state = await dispatchThen(setShowDrawer(false), [SET_SHOW_DRAWER])
+    assert.isFalse(state.showDrawer)
+  })
+
+  it("should set snackbar message", async () => {
+    const payload = {
+      message: "hey there!"
+    }
+    let state = await dispatchThen(setSnackbarMessage(payload), [
+      SET_SNACKBAR_MESSAGE
+    ])
+
+    assert.deepEqual(state.snackbar, {
+      id: 0,
+      ...payload
+    })
+
+    state = await dispatchThen(setSnackbarMessage(payload), [
+      SET_SNACKBAR_MESSAGE
+    ])
+
+    assert.deepEqual(state.snackbar, {
+      id: 1,
+      ...payload
+    })
+  })
+
+  it("should let you show and hide a dialog", async () => {
+    const dialogKey = "key!"
+    let state = await dispatchThen(showDialog(dialogKey), [SHOW_DIALOG])
+    assert.isTrue(state.dialogs.has(dialogKey))
+    state = await dispatchThen(hideDialog(dialogKey), [HIDE_DIALOG])
+    assert.isFalse(state.dialogs.has(dialogKey))
+  })
+
+  it("should support multiple dialogs at once", async () => {
+    const keys = ["key!", "a dialog", "my great dialog key"]
+    keys.forEach(async key => {
+      await dispatchThen(showDialog(key), [SHOW_DIALOG])
+    })
+    const dialogs = store.getState().ui.dialogs
+    assert.deepEqual(keys, [...dialogs.keys()])
+  })
+})


### PR DESCRIPTION
#### What are the relevant tickets?

working on this as part of #234 and #233 

#### What's this PR do?

this adds a new field to the UI reducer, a `Set<string>` called `dialogs` and actions to handle adding and removing keys from it. Then we can just check `dialogs.has(key)` to see if our dialog should be open or not.

#### How should this be manually tested?

It's not yet being used for anything, so just read the code and confirm the tests are passing and all that.