### PR TITLE
add user post deletion

### DIFF
--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -30,7 +30,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     removePost: Post => void,
     forms: FormsState,
     isModerator: boolean,
-    beginEditing: (key: string, initialValue: Object, e: ?Event) => void
+    beginEditing: (key: string, initialValue: Object, e: ?Event) => void,
+    showPostDeleteDialog: () => void
   }
 
   renderTextContent = () => {
@@ -58,7 +59,13 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
   }
 
   postActionButtons = () => {
-    const { toggleUpvote, post, beginEditing, isModerator } = this.props
+    const {
+      toggleUpvote,
+      post,
+      beginEditing,
+      isModerator,
+      showPostDeleteDialog
+    } = this.props
 
     return (
       <div className="post-actions">
@@ -73,6 +80,14 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             onClick={beginEditing(editPostKey(post), post)}
           >
             <a href="#">edit</a>
+          </div>
+          : null}
+        {SETTINGS.username === post.author_id
+          ? <div
+            className="comment-action-button delete-post"
+            onClick={showPostDeleteDialog}
+          >
+            <a href="#">delete</a>
           </div>
           : null}
         {isModerator && !post.removed

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -4,9 +4,9 @@
 import R from "ramda"
 import "isomorphic-fetch"
 import qs from "query-string"
-import { PATCH, POST } from "redux-hammock/constants"
+import { PATCH, POST, DELETE } from "redux-hammock/constants"
 
-import { fetchWithAuthFailure } from "./auth"
+import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./auth"
 import { toQueryString } from "../lib/url"
 import { getPaginationParams } from "../lib/posts"
 
@@ -28,25 +28,27 @@ const getPaginationQS = R.compose(
 )
 
 export function getFrontpage(params: PostListPaginationParams): Promise<Post> {
-  return fetchWithAuthFailure(`/api/v0/frontpage/${getPaginationQS(params)}`)
+  return fetchJSONWithAuthFailure(
+    `/api/v0/frontpage/${getPaginationQS(params)}`
+  )
 }
 
 export function getChannel(channelName: string): Promise<Channel> {
-  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/`)
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/`)
 }
 
 export function getChannels(): Promise<Array<Channel>> {
-  return fetchWithAuthFailure("/api/v0/channels/")
+  return fetchJSONWithAuthFailure("/api/v0/channels/")
 }
 
 export function getChannelModerators(
   channelName: string
 ): Promise<ChannelModerators> {
-  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/moderators/`)
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/moderators/`)
 }
 
 export function createChannel(channel: Channel): Promise<Channel> {
-  return fetchWithAuthFailure(`/api/v0/channels/`, {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/`, {
     method: POST,
     body:   JSON.stringify(
       R.pickAll(
@@ -58,7 +60,7 @@ export function createChannel(channel: Channel): Promise<Channel> {
 }
 
 export function updateChannel(channel: Channel): Promise<Channel> {
-  return fetchWithAuthFailure(`/api/v0/channels/${channel.name}/`, {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channel.name}/`, {
     method: PATCH,
     body:   JSON.stringify(
       R.pickAll(
@@ -73,7 +75,7 @@ export function getPostsForChannel(
   channelName: string,
   params: PostListPaginationParams
 ): Promise<Array<Post>> {
-  return fetchWithAuthFailure(
+  return fetchJSONWithAuthFailure(
     `/api/v0/channels/${channelName}/posts/${getPaginationQS(params)}`
   )
 }
@@ -83,7 +85,7 @@ export function createPost(
   payload: CreatePostPayload
 ): Promise<Post> {
   const { text, url, title } = payload
-  return fetchWithAuthFailure(`/api/v0/channels/${channelName}/posts/`, {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/posts/`, {
     method: "POST",
     body:   JSON.stringify({
       url:   url,
@@ -94,13 +96,13 @@ export function createPost(
 }
 
 export function getPost(postId: string): Promise<Post> {
-  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`)
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`)
 }
 
 export function getComments(
   postID: string
 ): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> {
-  return fetchWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
 }
 
 export const createComment = (
@@ -111,30 +113,36 @@ export const createComment = (
   const body =
     commentId === undefined ? { text } : { text, comment_id: commentId }
 
-  return fetchWithAuthFailure(`/api/v0/posts/${postId}/comments/`, {
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/comments/`, {
     method: POST,
     body:   JSON.stringify(body)
   })
 }
 
 export function updateUpvote(postId: string, upvoted: boolean): Promise<Post> {
-  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
-    method: "PATCH",
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
     body:   JSON.stringify({ upvoted })
   })
 }
 
 export function updateRemoved(postId: string, removed: boolean): Promise<Post> {
-  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
-    method: "PATCH",
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
     body:   JSON.stringify({ removed })
   })
 }
 
 export function editPost(postId: string, post: Post): Promise<Post> {
-  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
-    method: "PATCH",
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
     body:   JSON.stringify(R.dissoc("url", post))
+  })
+}
+
+export function deletePost(postId: string): Promise<Post> {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: DELETE
   })
 }
 
@@ -142,7 +150,7 @@ export function updateComment(
   commentId: string,
   commentPayload: Object
 ): Promise<GenericComment> {
-  return fetchWithAuthFailure(`/api/v0/comments/${commentId}/`, {
+  return fetchJSONWithAuthFailure(`/api/v0/comments/${commentId}/`, {
     method: PATCH,
     body:   JSON.stringify(commentPayload)
   })
@@ -161,5 +169,7 @@ export function getMoreComments(
     // $FlowFixMe: Flow doesn't know that we're still constructing payload
     payload.parent_id = parentId
   }
-  return fetchWithAuthFailure(`/api/v0/morecomments/?${qs.stringify(payload)}`)
+  return fetchJSONWithAuthFailure(
+    `/api/v0/morecomments/?${qs.stringify(payload)}`
+  )
 }

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 import sinon from "sinon"
 import fetchMock from "fetch-mock/src/server"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+
 import * as auth from "./auth"
 
 describe("auth", function() {
@@ -13,86 +14,90 @@ describe("auth", function() {
   const typeError = new TypeError()
 
   let sandbox, fetchStub
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create()
-    fetchStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+  ;[
+    [auth.fetchJSONWithAuthFailure, "fetchJSONWithCSRF"],
+    [auth.fetchWithAuthFailure, "fetchWithCSRF"]
+  ].forEach(([authFunc, djangoCSRFFunc]) => {
+    describe(authFunc.name, () => {
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create()
+        fetchStub = sandbox.stub(fetchFuncs, djangoCSRFFunc)
 
-    SETTINGS.session_url = "/session/url"
-  })
-  afterEach(function() {
-    sandbox.restore()
-    fetchMock.restore()
-    for (const cookie of document.cookie.split(";")) {
-      const key = cookie.split("=")[0].trim()
-      document.cookie = `${key}=`
-    }
-  })
+        SETTINGS.session_url = "/session/url"
+      })
+      afterEach(function() {
+        sandbox.restore()
+        fetchMock.restore()
+        for (const cookie of document.cookie.split(";")) {
+          const key = cookie.split("=")[0].trim()
+          document.cookie = `${key}=`
+        }
+      })
 
-  it("does not renew if request returned ok", async () => {
-    fetchStub.returns(Promise.resolve())
+      it("does not renew if request returned ok", async () => {
+        fetchStub.returns(Promise.resolve())
 
-    await assert.isFulfilled(auth.fetchWithAuthFailure("/url"))
+        await assert.isFulfilled(authFunc("/url"))
 
-    assert.ok(fetchStub.calledWith("/url"))
-    assert.equal(window.location.pathname, "/") // no redirect happened
-  })
+        assert.ok(fetchStub.calledWith("/url"))
+        assert.equal(window.location.pathname, "/") // no redirect happened
+      })
 
-  for (const [message, error] of [
-    ["a 500 error", error500],
-    ["an unexpected exception", typeError]
-  ]) {
-    it(`does not renew auth for ${message}`, async () => {
-      fetchStub.returns(Promise.reject(error))
+      for (const [message, error] of [
+        ["a 500 error", error500],
+        ["an unexpected exception", typeError]
+      ]) {
+        it(`does not renew auth for ${message}`, async () => {
+          fetchStub.returns(Promise.reject(error))
 
-      const response = await assert.isRejected(
-        auth.fetchWithAuthFailure("/url")
-      )
+          const response = await assert.isRejected(authFunc("/url"))
+          sinon.assert.calledWith(fetchStub, "/url")
+          assert.equal(fetchStub.callCount, 1)
+          assert.deepEqual(response, error)
+        })
+      }
 
-      sinon.assert.calledWith(fetchStub, "/url")
-      assert.equal(fetchStub.callCount, 1)
-      assert.deepEqual(response, error)
+      it("renews and retries if the request failed", async () => {
+        fetchStub.onFirstCall().returns(Promise.reject(error401)) // original api call
+        fetchStub.onSecondCall().returns(Promise.resolve()) // original api call again
+        fetchMock.mock(SETTINGS.session_url, {
+          has_token: true
+        })
+
+        await assert.isFulfilled(authFunc("/url"))
+
+        assert.ok(fetchMock.called)
+        assert.ok(fetchStub.calledTwice)
+        assert.ok(fetchStub.firstCall.calledWith("/url"))
+        assert.ok(fetchStub.secondCall.calledWith("/url"))
+        assert.equal(window.location.pathname, "/") // no redirect happened
+      })
+
+      it("redirects and rejects if no token", async () => {
+        fetchStub.onFirstCall().returns(Promise.reject(error401)) // original api call
+        fetchMock.mock(SETTINGS.session_url, {
+          has_token: false
+        })
+
+        await assert.isRejected(authFunc("/url"))
+
+        assert.ok(fetchMock.called)
+        assert.ok(fetchStub.calledOnce)
+        assert.ok(fetchStub.calledWith("/url"))
+        assert.equal(window.location.pathname, "/auth_required/")
+      })
+
+      it("renews and redirect to /auth_required/ if renew fails", async () => {
+        fetchStub.returns(Promise.reject(error401)) // original api call
+        fetchMock.mock(SETTINGS.session_url, 401)
+
+        await assert.isRejected(authFunc("/url"))
+
+        assert.ok(fetchMock.called)
+        assert.ok(fetchStub.calledOnce)
+        assert.ok(fetchStub.calledWith("/url"))
+        assert.equal(window.location.pathname, "/auth_required/")
+      })
     })
-  }
-
-  it("renews and retries if the request failed", async () => {
-    fetchStub.onFirstCall().returns(Promise.reject(error401)) // original api call
-    fetchStub.onSecondCall().returns(Promise.resolve()) // original api call again
-    fetchMock.mock(SETTINGS.session_url, {
-      has_token: true
-    })
-
-    await assert.isFulfilled(auth.fetchWithAuthFailure("/url"))
-
-    assert.ok(fetchMock.called)
-    assert.ok(fetchStub.calledTwice)
-    assert.ok(fetchStub.firstCall.calledWith("/url"))
-    assert.ok(fetchStub.secondCall.calledWith("/url"))
-    assert.equal(window.location.pathname, "/") // no redirect happened
-  })
-
-  it("redirects and rejects if no token", async () => {
-    fetchStub.onFirstCall().returns(Promise.reject(error401)) // original api call
-    fetchMock.mock(SETTINGS.session_url, {
-      has_token: false
-    })
-
-    await assert.isRejected(auth.fetchWithAuthFailure("/url"))
-
-    assert.ok(fetchMock.called)
-    assert.ok(fetchStub.calledOnce)
-    assert.ok(fetchStub.calledWith("/url"))
-    assert.equal(window.location.pathname, "/auth_required/")
-  })
-
-  it("renews and redirect to /auth_required/ if renew fails", async () => {
-    fetchStub.returns(Promise.reject(error401)) // original api call
-    fetchMock.mock(SETTINGS.session_url, 401)
-
-    await assert.isRejected(auth.fetchWithAuthFailure("/url"))
-
-    assert.ok(fetchMock.called)
-    assert.ok(fetchStub.calledOnce)
-    assert.ok(fetchStub.calledWith("/url"))
-    assert.equal(window.location.pathname, "/auth_required/")
   })
 })

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -1,6 +1,12 @@
 // @flow
 import * as api from "../lib/api"
-import { GET, POST, PATCH, INITIAL_STATE } from "redux-hammock/constants"
+import {
+  GET,
+  POST,
+  PATCH,
+  DELETE,
+  INITIAL_STATE
+} from "redux-hammock/constants"
 
 import { SET_POST_DATA } from "../actions/post"
 
@@ -28,16 +34,18 @@ const mergeMultiplePosts = (
 
 export const postsEndpoint = {
   name:     "posts",
-  verbs:    [GET, POST, PATCH],
+  verbs:    [GET, POST, PATCH, DELETE],
   getFunc:  (id: string) => api.getPost(id),
   postFunc: (name: string, payload: CreatePostPayload) =>
     api.createPost(name, payload),
-  patchFunc:           (id: string, post: Post) => api.editPost(id, post),
-  postSuccessHandler:  mergePostData,
-  initialState:        { ...INITIAL_STATE, data: new Map() },
-  getSuccessHandler:   mergePostData,
-  patchSuccessHandler: mergePostData,
-  extraActions:        {
+  patchFunc:            (id: string, post: Post) => api.editPost(id, post),
+  deleteFunc:           (id: string) => api.deletePost(id),
+  postSuccessHandler:   mergePostData,
+  initialState:         { ...INITIAL_STATE, data: new Map() },
+  getSuccessHandler:    mergePostData,
+  patchSuccessHandler:  mergePostData,
+  deleteSuccessHandler: (_: any, data: Map<string, Post>) => data,
+  extraActions:         {
     [SET_POST_DATA]: (state, action) => {
       const update =
         action.payload instanceof Array


### PR DESCRIPTION
#### What are the relevant tickets?

closes #234 

#### What's this PR do?

This adds UI so that a user can delete their own posts.

#### How should this be manually tested?

If you look at the detail view for one of your own posts you should see a little 'delete' button.

- clicking this button should open a confirmation dialog
- canceling the dialog, hitting 'escape', or clicking outside should close it
- confirming the dialog should redirect you to the channel page.

If you delete your post it's, like, _really_ deleted (forever...) so don't delete a post that is special, I guess?