### PR TITLE
upgrade node version

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,9 +1,9 @@
-FROM node:6.2
+FROM node:9.3
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 RUN apt-get update && apt-get install libelf1
 
-RUN adduser --disabled-password --gecos "" mitodl
+RUN mkdir /src/
 
 COPY package.json /src/
 
@@ -11,8 +11,4 @@ COPY scripts /src/scripts
 
 RUN node /src/scripts/install_yarn.js
 
-RUN mkdir -p /home/mitodl/.cache/yarn
-
-RUN chown mitodl:mitodl /home/mitodl/.cache/yarn
-
-USER mitodl
+USER node

--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "webpack-hot-middleware": "^2.18.2"
   },
   "engines": {
-    "node": "6.2.0",
-    "yarn": "0.27.0"
+    "node": "9.3.0",
+    "yarn": "1.3.2"
   },
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -58,6 +58,8 @@ describe("CommentForms", () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     post = makePost()
+    helper.getPostStub.returns(Promise.resolve(post))
+    helper.store.dispatch(actions.posts.get(post.id))
     comment = makeComment(post)
     postKeys = {
       post_id: post.id,

--- a/static/js/components/SpinnerButton_test.js
+++ b/static/js/components/SpinnerButton_test.js
@@ -17,32 +17,39 @@ describe("SpinnerButton", () => {
   })
 
   for (const promiseState of ["not_clicked", "rejected", "resolved"]) {
-    it(`passes through all props when promise state is ${promiseState}`, async () => {
-      const promise =
-        promiseState === "rejected" ? Promise.reject() : Promise.resolve()
-      const onClickPromise = () => promise
-      const props = {
-        "data-x":       "y",
-        onClickPromise: onClickPromise,
-        className:      "class1 class2"
-      }
-      const wrapper = shallow(
-        <SpinnerButton {...props}>childText</SpinnerButton>
-      )
-      const button = wrapper.find("button")
-      const buttonProps = button.props()
-
-      if (promiseState !== "not_clicked") {
-        buttonProps.onClick()
-      }
-
-      for (const key of Object.keys(props)) {
-        if (key !== "onClickPromise") {
-          assert.deepEqual(buttonProps[key].trim(), props[key])
+    it(`passes through all props when promise state is ${promiseState}`, () => {
+      return new Promise((resolve, reject) => {
+        const onClickPromise = () =>
+          promiseState === "rejected" ? reject() : resolve()
+        const props = {
+          "data-x":       "y",
+          onClickPromise: onClickPromise,
+          className:      "class1 class2"
         }
-      }
-      assert.equal(button.children().text(), "childText")
-      assert.isFalse(buttonProps.disabled)
+        const wrapper = shallow(
+          <SpinnerButton {...props}>childText</SpinnerButton>
+        )
+        const button = wrapper.find("button")
+        const buttonProps = button.props()
+
+        if (promiseState !== "not_clicked") {
+          buttonProps.onClick()
+        }
+
+        for (const key of Object.keys(props)) {
+          if (key !== "onClickPromise") {
+            assert.deepEqual(buttonProps[key].trim(), props[key])
+          }
+        }
+        assert.equal(button.children().text(), "childText")
+        assert.isFalse(buttonProps.disabled)
+
+        if (promiseState === "not_clicked") {
+          resolve()
+        }
+      }).catch(err => {
+        assert.isNotOk(err)
+      })
     })
   }
 

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -2,6 +2,7 @@
 /* global SETTINGS */
 import { assert } from "chai"
 import sinon from "sinon"
+import R from "ramda"
 
 import PostList from "../components/PostList"
 import SubscriptionsList from "../components/SubscriptionsList"
@@ -74,6 +75,16 @@ describe("ChannelPage", () => {
       Promise.resolve(makeModerators(SETTINGS.username))
     )
     const post = makePost()
+    helper.editPostStub.returns(
+      Promise.resolve(
+        R.evolve(
+          {
+            stickied: R.not
+          },
+          post
+        )
+      )
+    )
     postList[0] = post
     const [wrapper] = await renderPage(currentChannel)
     wrapper

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -6,7 +6,7 @@ import { Dialog } from "@mitodl/mdl-react-components"
 
 import CommentTree from "../components/CommentTree"
 
-import { makePost } from "../factories/posts"
+import { makePost, makeChannelPostList } from "../factories/posts"
 import {
   makeComment,
   makeCommentsResponse,
@@ -48,6 +48,11 @@ describe("PostPage", function() {
     helper.getChannelsStub.returns(Promise.resolve([]))
     helper.getCommentsStub.returns(Promise.resolve(commentsResponse))
     helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
+    helper.getPostsForChannelStub.returns(
+      Promise.resolve({
+        posts: makeChannelPostList()
+      })
+    )
     helper.deletePostStub.returns(Promise.resolve())
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)

--- a/static/js/containers/admin/EditChannelPage_test.js
+++ b/static/js/containers/admin/EditChannelPage_test.js
@@ -24,6 +24,12 @@ describe("EditChannelPage", () => {
         posts:      []
       })
     )
+    helper.getFrontpageStub.returns(
+      Promise.resolve({
+        pagination: {},
+        posts:      []
+      })
+    )
     helper.updateChannelStub.returns(Promise.resolve(channel))
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
@@ -90,8 +96,6 @@ describe("EditChannelPage", () => {
   })
 
   it("cancel and navigate to previous page", async () => {
-    helper.getFrontpageStub.returns(Promise.resolve([]))
-
     const [wrapper] = await renderPage()
 
     wrapper.find(".cancel").simulate("click")

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -13,6 +13,8 @@ const _createSettings = () => ({
 
 global.SETTINGS = _createSettings()
 
+window.scrollTo = () => "scroll!"
+
 // polyfill for Object.entries
 import entries from "object.entries"
 if (!Object.entries) {

--- a/travis/Dockerfile-travis-watch
+++ b/travis/Dockerfile-travis-watch
@@ -1,21 +1,15 @@
-FROM mitodl/open_discussions_watch_travis
+FROM mitodl/open_discussions_watch_travis_next
 
 WORKDIR /src
 
-COPY package.json /src
-
-COPY yarn.lock /src
-
-ADD ./webpack_if_prod.sh /src
-
-USER mitodl
-
-RUN yarn install --frozen-lockfile
-
-COPY . /src
+COPY package.json yarn.lock webpack_if_prod.sh /src/
 
 USER root
 
-RUN chown -R mitodl:mitodl /src
+COPY . /src
 
-USER mitodl
+RUN chown -R node:node /src
+
+USER node
+
+RUN yarn install --frozen-lockfile --ignore-engines

--- a/travis/Dockerfile-travis-watch-build
+++ b/travis/Dockerfile-travis-watch-build
@@ -1,4 +1,4 @@
-FROM node:6.2
+FROM node:9.3
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # this dockerfile builds the hub image for the watch container
@@ -8,23 +8,20 @@ LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 RUN apt-get update && apt-get install libelf1
 
-RUN mkdir /src
+RUN mkdir /src/
 
-WORKDIR /src
+COPY package.json /src/
 
-RUN adduser --disabled-password --gecos "" mitodl
+COPY yarn.lock /src/
 
-COPY package.json yarn.lock ./webpack_if_prod.sh /src/
 COPY scripts /src/scripts
 
 RUN node /src/scripts/install_yarn.js
 
-RUN chown -R mitodl:mitodl /src
-
-USER mitodl
+USER node
 
 # this is just to get a warm cache, we delete node_modules afterwards to
 # avoid issues with native extensions (mainly node-sass)
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --ignore-engines
 
 RUN rm -rf node_modules

--- a/travis/update-docker-hub.sh
+++ b/travis/update-docker-hub.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 docker build -t mitodl/open_discussions_web_travis_next -f Dockerfile .
-docker build -t mitodl/open_discussions_watch_travis -f travis/Dockerfile-travis-watch-build .
+docker build -t mitodl/open_discussions_watch_travis_next -f travis/Dockerfile-travis-watch-build .
 
 docker push mitodl/open_discussions_web_travis_next
-docker push mitodl/open_discussions_watch_travis
+docker push mitodl/open_discussions_watch_travis_next

--- a/webpack_dev_server.sh
+++ b/webpack_dev_server.sh
@@ -17,7 +17,7 @@ if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
   echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
 else
   if [[ "$1" == "--install" ]] ; then
-    yarn install --frozen-lockfile && echo "Finished yarn install"
+    yarn install --frozen-lockfile --ignore-engines && echo "Finished yarn install"
   fi
   # Start the webpack dev server on the appropriate host and port
   node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #321 

#### What's this PR do?

This upgrades our node.js version to 9.3 everywhere, and also does a healthy bump to our yarn version.

It seems that in the time since we last upgraded node it started throwing warnings for unhandled promise rejections, so I went through the tests to fix all of the examples that I could find (mostly things related to our API stub functions). Most of the code changes (other than just changing node.js version numbers) have to do with that.

I also refactored some of the node.js Dockerfiles to be more inline with how we have them in MM now.

#### How should this be manually tested?

Everything should work normally. You should be able to check out this branch, build the docker container, and run things in development mode. The tests should pass on travis, and the build should work alright on the CI.