### PR TITLE
Css tweaks to community guidelines page

### DIFF
--- a/static/scss/content-policy.scss
+++ b/static/scss/content-policy.scss
@@ -1,5 +1,16 @@
 .content-policy {
-  padding: 0 25px;
-  display: flex;
-  flex-direction: column;
+  padding: 30px 25px;
+  max-width: 1100px;
+  width: 80%;
+  margin: 0 auto;
+
+  h1 {
+  	font-size: 25px;
+    font-weight: 400;
+    margin: 0 0 25px;
+  }
+
+  li {
+  	margin: 0 0 10px;
+  }
 }

--- a/static/scss/content-policy.scss
+++ b/static/scss/content-policy.scss
@@ -5,12 +5,12 @@
   margin: 0 auto;
 
   h1 {
-  	font-size: 25px;
+    font-size: 25px;
     font-weight: 400;
     margin: 0 0 25px;
   }
 
   li {
-  	margin: 0 0 10px;
+    margin: 0 0 10px;
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Fixes the styling for the Community Guidelines page. There were no left-right margins, and the header font was too big.

#### How should this be manually tested?
See that it looks ok.

Before: 
![image](https://user-images.githubusercontent.com/20047260/34223561-c745fb40-e58d-11e7-8e49-9b3cfd74bdca.png)

After:
![image](https://user-images.githubusercontent.com/20047260/34223584-e19a93ac-e58d-11e7-9b4e-aeb3c8b2a778.png)
