### PR TITLE
Fixed loading spinner on channel page

### DIFF
--- a/static/js/actions/posts_for_channel.js
+++ b/static/js/actions/posts_for_channel.js
@@ -1,0 +1,5 @@
+// @flow
+import { createAction } from "redux-actions"
+
+export const EVICT_POSTS_FOR_CHANNEL = "EVICT_POSTS_FOR_CHANNEL"
+export const evictPostsForChannel = createAction(EVICT_POSTS_FOR_CHANNEL)

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -17,6 +17,7 @@ import { makeChannelPostList, makePost } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
 import { SET_CHANNEL_DATA, CLEAR_CHANNEL_ERROR } from "../actions/channel"
+import { EVICT_POSTS_FOR_CHANNEL } from "../actions/posts_for_channel"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { channelURL } from "../lib/url"
 import { formatTitle } from "../lib/title"
@@ -131,7 +132,8 @@ describe("ChannelPage", () => {
         actions.postsForChannel.get.requestType,
         actions.postsForChannel.get.successType,
         actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType
+        actions.channelModerators.get.successType,
+        EVICT_POSTS_FOR_CHANNEL
       ],
       () => {
         helper.browserHistory.push(channelURL(otherChannel.name))

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -176,44 +176,6 @@ describe("reducers", () => {
     })
   })
 
-  describe("postsForChannel reducer", () => {
-    beforeEach(() => {
-      dispatchThen = store.createDispatchThen(state => state.postsForChannel)
-      helper.getPostsForChannelStub.returns(
-        Promise.resolve({ posts: makeChannelPostList() })
-      )
-    })
-
-    it("should have some initial state", () => {
-      assert.deepEqual(store.getState().postsForChannel, {
-        ...INITIAL_STATE,
-        data: new Map()
-      })
-    })
-
-    it("should let you get the posts for a channel", async () => {
-      const { requestType, successType } = actions.postsForChannel.get
-      const { data } = await dispatchThen(
-        actions.postsForChannel.get("channel"),
-        [requestType, successType]
-      )
-      const channel = data.get("channel").postIds
-      assert.isArray(channel)
-      assert.lengthOf(channel, 20)
-    })
-
-    it("should support multiple channels", async () => {
-      await Promise.all([
-        store.dispatch(actions.postsForChannel.get("first")),
-        store.dispatch(actions.postsForChannel.get("second"))
-      ])
-      const { postsForChannel: { data } } = store.getState()
-      assert.isArray(data.get("first").postIds)
-      assert.isArray(data.get("second").postIds)
-      assert.equal(data.size, 2)
-    })
-  })
-
   describe("frontpage reducer", () => {
     beforeEach(() => {
       dispatchThen = store.createDispatchThen(state => state.frontpage)

--- a/static/js/reducers/posts_for_channel.js
+++ b/static/js/reducers/posts_for_channel.js
@@ -3,6 +3,7 @@ import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
 import * as api from "../lib/api"
 import { mapPostListResponse } from "../lib/posts"
+import { EVICT_POSTS_FOR_CHANNEL } from "../actions/posts_for_channel"
 
 import type {
   PostListResponse,
@@ -31,5 +32,16 @@ export const postsForChannelEndpoint = {
     const update = new Map(data)
     update.set(channelName, mapPostListResponse(response))
     return update
+  },
+  extraActions: {
+    [EVICT_POSTS_FOR_CHANNEL]: (state, action: Action<string, *>) => {
+      const update = new Map(state.data)
+      const channelName = action.payload
+      update.delete(channelName)
+      return {
+        ...state,
+        data: update
+      }
+    }
   }
 }

--- a/static/js/reducers/posts_for_channel_test.js
+++ b/static/js/reducers/posts_for_channel_test.js
@@ -1,0 +1,67 @@
+// @flow
+import { assert } from "chai"
+import { INITIAL_STATE } from "redux-hammock/constants"
+
+import { actions } from "../actions"
+import { evictPostsForChannel } from "../actions/posts_for_channel"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+import { makeChannelPostList } from "../factories/posts"
+
+describe("postsForChannel reducer", () => {
+  let helper, store, dispatchThen
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    store = helper.store
+    dispatchThen = store.createDispatchThen(state => state.postsForChannel)
+    helper.getPostsForChannelStub.returns(
+      Promise.resolve({ posts: makeChannelPostList() })
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should have some initial state", () => {
+    assert.deepEqual(store.getState().postsForChannel, {
+      ...INITIAL_STATE,
+      data: new Map()
+    })
+  })
+
+  it("should let you get the posts for a channel", async () => {
+    const { requestType, successType } = actions.postsForChannel.get
+    const { data } = await dispatchThen(
+      actions.postsForChannel.get("channel"),
+      [requestType, successType]
+    )
+    const channel = data.get("channel").postIds
+    assert.isArray(channel)
+    assert.lengthOf(channel, 20)
+  })
+
+  it("should support multiple channels", async () => {
+    await Promise.all([
+      store.dispatch(actions.postsForChannel.get("first")),
+      store.dispatch(actions.postsForChannel.get("second"))
+    ])
+    const { postsForChannel: { data } } = store.getState()
+    assert.isArray(data.get("first").postIds)
+    assert.isArray(data.get("second").postIds)
+    assert.equal(data.size, 2)
+  })
+
+  it("should clear data for a single channel", async () => {
+    await Promise.all([
+      store.dispatch(actions.postsForChannel.get("first")),
+      store.dispatch(actions.postsForChannel.get("second"))
+    ])
+    await store.dispatch(evictPostsForChannel("second"))
+    const { postsForChannel: { data } } = store.getState()
+    assert.equal(data.size, 1)
+    assert.isArray(data.get("first").postIds)
+    assert.isUndefined(data.get("second"))
+  })
+})


### PR DESCRIPTION
Fixes #403 

#### What's this PR do?
Evicts channel post data when navigating away from the channel listing page.

#### How should this be manually tested?
Navigate back and forth between a channel page, homepage, post page, and other channel pages. You should always see a spinner when going to the channel page.
