### PR TITLE
Have update-docker-hub update local dockerfiles

### DIFF
--- a/travis/update-docker-hub.sh
+++ b/travis/update-docker-hub.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -eo pipefail
 
-docker build -t mitodl/open_discussions_web_travis_next -f Dockerfile .
-docker build -t mitodl/open_discussions_watch_travis_next -f travis/Dockerfile-travis-watch-build .
+export NEXT=$(date | md5sum | cut -c -6)
+export PROJECT_NAME="open_discussions"
+echo "Next hash is $NEXT"
 
-docker push mitodl/open_discussions_web_travis_next
-docker push mitodl/open_discussions_watch_travis_next
+export WEB_IMAGE=mitodl/${PROJECT_NAME}_web_travis_${NEXT}
+export WATCH_IMAGE=mitodl/${PROJECT_NAME}_watch_travis_${NEXT}
+
+docker build -t $WEB_IMAGE -f Dockerfile .
+docker build -t $WATCH_IMAGE -f travis/Dockerfile-travis-watch-build .
+
+docker push $WEB_IMAGE
+docker push $WATCH_IMAGE
+
+sed -r -i "s|^FROM mitodl.+$|FROM $WEB_IMAGE|" travis/Dockerfile-travis-web
+sed -r -i "s|^FROM mitodl.+$|FROM $WATCH_IMAGE|" travis/Dockerfile-travis-watch


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Make `update-docker-hub.sh` provide hash values for the new docker images, and update the references in our dockerfiles

#### How should this be manually tested?
Update the docker images
