### PR TITLE
Add check_pip.sh

### DIFF
--- a/scripts/test/check_pip.sh
+++ b/scripts/test/check_pip.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+PIP_OLD=$(mktemp)
+PIP_NEW=$(mktemp)
+VENV=$(mktemp -d)
+
+
+pip freeze > $PIP_NEW
+/usr/local/bin/pip freeze > $PIP_OLD
+if ! cmp -s $PIP_OLD $PIP_NEW
+then
+  echo "requirements files differ from docker image pip environment. Running diff image-pip tox-pip:"
+  diff $PIP_OLD $PIP_NEW
+  exit 1
+fi
+
+rm $PIP_OLD
+rm $PIP_NEW
+rm -r $VENV

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands =
+    {toxinidir}/scripts/test/check_pip.sh
     py.test {posargs}
     {toxinidir}/travis/codecov_python.sh
     {toxinidir}/scripts/test/detect_missing_migrations.sh


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Add script to check whether the python docker image is up to date, and have it run with tox

#### How should this be manually tested?
 - Add a package to `requirements.txt`, for example `tornado`
 - `rm -rf .tox`, then run `docker-compose run web tox`
 - You should see a diff listing the new `tornado` package as a missing requirement
