### PR TITLE
 Added post/comment reporting UI

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -31,6 +31,7 @@ import type { CommentVoteFunc } from "./CommentVoteForm"
 
 type LoadMoreCommentsFunc = (comment: MoreCommentsInTree) => Promise<*>
 type BeginEditingFunc = (fk: string, iv: Object, e: ?Object) => void
+type ReportCommentFunc = (comment: CommentInTree) => void
 
 type CommentTreeProps = {
   comments: Array<GenericComment>,
@@ -43,7 +44,8 @@ type CommentTreeProps = {
   beginEditing: BeginEditingFunc,
   isModerator: boolean,
   processing: boolean,
-  deleteComment: CommentRemoveFunc
+  deleteComment: CommentRemoveFunc,
+  reportComment: ReportCommentFunc
 }
 
 export default class CommentTree extends React.Component<*, *> {
@@ -59,7 +61,8 @@ export default class CommentTree extends React.Component<*, *> {
       deleteComment,
       beginEditing,
       processing,
-      isModerator
+      isModerator,
+      reportComment
     } = this.props
     const formKey = replyToCommentKey(comment)
     const editFormKey = editCommentKey(comment)
@@ -146,6 +149,12 @@ export default class CommentTree extends React.Component<*, *> {
               approve={approve}
               isModerator={isModerator}
             />
+            <div
+              className="comment-action-button report-button"
+              onClick={preventDefaultAndInvoke(() => reportComment(comment))}
+            >
+              <a href="#">report</a>
+            </div>
           </div>
           {atMaxDepth
             ? null

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -29,7 +29,8 @@ describe("CommentTree", () => {
     approveStub,
     beginEditingStub,
     loadMoreCommentsStub,
-    deleteCommentStub
+    deleteCommentStub,
+    reportCommentStub
 
   beforeEach(() => {
     post = makePost()
@@ -42,6 +43,7 @@ describe("CommentTree", () => {
     beginEditingStub = sandbox.stub()
     loadMoreCommentsStub = sandbox.stub()
     deleteCommentStub = sandbox.stub()
+    reportCommentStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -61,6 +63,7 @@ describe("CommentTree", () => {
         processing={false}
         loadMoreComments={loadMoreCommentsStub}
         deleteComment={deleteCommentStub}
+        reportComment={reportCommentStub}
         {...props}
       />
     )
@@ -111,6 +114,16 @@ describe("CommentTree", () => {
     wrapper.find(".comment-action-button").at(0).simulate("click")
     assert.ok(beginEditingStub.called)
     assert.ok(beginEditingStub.calledWith(replyToCommentKey(comments[0])))
+  })
+
+  it('should include a "report" button', () => {
+    const wrapper = renderCommentTree()
+    wrapper
+      .find(".comment-action-button.report-button")
+      .at(0)
+      .simulate("click", null)
+    assert.ok(reportCommentStub.called)
+    assert.ok(reportCommentStub.calledWith(comments[0]))
   })
 
   it('should include an "Edit" button, if the user wrote the comment', () => {
@@ -171,9 +184,9 @@ describe("CommentTree", () => {
         .find(".comment-actions")
         .at(0)
         .find(".comment-action-button"),
-      1
+      2
     )
-    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 0)
+    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 1)
 
     assert.lengthOf(topCommentWrapper.find(ReplyToCommentForm), 1)
     assert.lengthOf(nextCommentWrapper.find(ReplyToCommentForm), 0)

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -31,7 +31,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     forms: FormsState,
     isModerator: boolean,
     beginEditing: (key: string, initialValue: Object, e: ?Event) => void,
-    showPostDeleteDialog: () => void
+    showPostDeleteDialog: () => void,
+    showPostReportDialog: () => void
   }
 
   renderTextContent = () => {
@@ -64,7 +65,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
       post,
       beginEditing,
       isModerator,
-      showPostDeleteDialog
+      showPostDeleteDialog,
+      showPostReportDialog
     } = this.props
 
     return (
@@ -106,6 +108,12 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             <a href="#">approve</a>
           </div>
           : null}
+        <div
+          className="comment-action-button report-post"
+          onClick={showPostReportDialog}
+        >
+          <a href="#">report</a>
+        </div>
       </div>
     )
   }

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -23,7 +23,8 @@ describe("ExpandedPostDisplay", () => {
     beginEditingStub,
     approvePostStub,
     removePostStub,
-    showPostDeleteDialogStub
+    showPostDeleteDialogStub,
+    showPostReportDialogStub
 
   const renderPostDisplay = props => {
     props = {
@@ -34,6 +35,7 @@ describe("ExpandedPostDisplay", () => {
       approvePost:          approvePostStub,
       removePost:           removePostStub,
       showPostDeleteDialog: showPostDeleteDialogStub,
+      showPostReportDialog: showPostReportDialogStub,
       forms:                {},
       ...props
     }
@@ -51,6 +53,7 @@ describe("ExpandedPostDisplay", () => {
     approvePostStub = helper.sandbox.stub()
     removePostStub = helper.sandbox.stub()
     showPostDeleteDialogStub = helper.sandbox.stub()
+    showPostReportDialogStub = helper.sandbox.stub()
   })
 
   afterEach(() => {
@@ -145,6 +148,13 @@ describe("ExpandedPostDisplay", () => {
     const wrapper = renderPostDisplay({ post })
     wrapper.find(".delete-post").simulate("click")
     assert.ok(showPostDeleteDialogStub.called)
+  })
+
+  it("should call showPostReportDialog when user clicks 'report'", () => {
+    const post = makePost()
+    const wrapper = renderPostDisplay({ post })
+    wrapper.find(".report-post").simulate("click")
+    assert.ok(showPostReportDialogStub.called)
   })
 
   it('should call beginEditing when user clicks "edit"', () => {

--- a/static/js/components/ReportForm.js
+++ b/static/js/components/ReportForm.js
@@ -1,0 +1,46 @@
+// @flow
+import React from "react"
+
+import { validationMessage } from "../lib/validation"
+
+import type { GenericReport, ReportValidation } from "../flow/discussionTypes"
+
+type ReportFormProps = {
+  onUpdate: Function,
+  reportForm: GenericReport,
+  validation: ReportValidation,
+  description: string,
+  label: string
+}
+
+const ReportForm = ({
+  reportForm,
+  validation,
+  onUpdate,
+  description,
+  label
+  }: ReportFormProps) => {
+  const { reason } = reportForm
+  return (
+    <div className="form">
+      <p>
+        {description}
+      </p>
+      <div className="reason row">
+        <label>
+          {label}
+        </label>
+        <input
+          type="text"
+          placeholder="e.g. this is spam, abusive, etc"
+          name="reason"
+          value={reason}
+          onChange={onUpdate}
+        />
+        {validationMessage(validation.reason)}
+      </div>
+    </div>
+  )
+}
+
+export default ReportForm

--- a/static/js/components/ReportForm_test.js
+++ b/static/js/components/ReportForm_test.js
@@ -1,0 +1,56 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { mount } from "enzyme"
+import { assert } from "chai"
+
+import ReportForm from "./ReportForm"
+
+describe("ReportForm", () => {
+  let sandbox, onUpdateStub
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    onUpdateStub = sandbox.stub()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const renderForm = (
+    reportForm = {
+      reason:     "reason",
+      reportType: "comment",
+      commentId:  "1"
+    },
+    validation = { reason: "" }
+  ) =>
+    mount(
+      <ReportForm
+        reportForm={reportForm}
+        validation={validation}
+        onUpdate={onUpdateStub}
+        description="description"
+        label="label"
+      />
+    )
+
+  it("displays the description and label", () => {
+    const wrapper = renderForm()
+    assert.equal(wrapper.find("p").text(), "description")
+    assert.equal(wrapper.find("label").text(), "label")
+  })
+
+  it("calls onUpdate", () => {
+    const wrapper = renderForm()
+    const event = {
+      target: {
+        name:  "reason",
+        value: "abc"
+      }
+    }
+    wrapper.find("input").simulate("change", event)
+    assert.ok(onUpdateStub.called)
+  })
+})

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -136,3 +136,23 @@ export type Moderator = {
 }
 
 export type ChannelModerators = Array<Moderator>
+
+export type Report = {
+  reason: string,
+}
+
+export type CommentReport = Report & {
+  reportType:  "comment",
+  commentId:    string,
+}
+
+export type PostReport = Report & {
+  reportType:  "post",
+  postId:       string,
+}
+
+export type GenericReport = PostReport | CommentReport
+
+export type ReportValidation = {
+  reason: string
+}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -18,7 +18,8 @@ import type {
   PostListPaginationParams,
   Post,
   CommentFromAPI,
-  MoreCommentsFromAPI
+  MoreCommentsFromAPI,
+  GenericReport
 } from "../flow/discussionTypes"
 
 const getPaginationQS = R.compose(
@@ -178,4 +179,11 @@ export function getMoreComments(
   return fetchJSONWithAuthFailure(
     `/api/v0/morecomments/?${qs.stringify(payload)}`
   )
+}
+
+export function reportContent(payload: GenericReport): Promise<GenericReport> {
+  return fetchJSONWithAuthFailure(`/api/v0/reports/`, {
+    method: POST,
+    body:   JSON.stringify(payload)
+  })
 }

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -22,7 +22,8 @@ import {
   updateChannel,
   updateRemoved,
   deletePost,
-  deleteComment
+  deleteComment,
+  reportContent
 } from "./api"
 import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
@@ -358,6 +359,38 @@ describe("api", function() {
         )
         assert.deepEqual(response, moreComments)
       })
+    })
+
+    it("reports a comment", async () => {
+      const payload = {
+        comment_id: 1,
+        reason:     "spam"
+      }
+      fetchJSONStub.returns(Promise.resolve())
+
+      await reportContent(payload)
+      assert.ok(
+        fetchJSONStub.calledWith(`/api/v0/reports/`, {
+          method: POST,
+          body:   JSON.stringify(payload)
+        })
+      )
+    })
+
+    it("reports a post", async () => {
+      const payload = {
+        post_id: 1,
+        reason:  "spam"
+      }
+      fetchJSONStub.returns(Promise.resolve())
+
+      await reportContent(payload)
+      assert.ok(
+        fetchJSONStub.calledWith(`/api/v0/reports/`, {
+          method: POST,
+          body:   JSON.stringify(payload)
+        })
+      )
     })
   })
 })

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -7,7 +7,8 @@ import { frontPageEndpoint } from "../reducers/frontpage"
 import { commentsEndpoint, moreCommentsEndpoint } from "../reducers/comments"
 import { postUpvotesEndpoint } from "../reducers/post_upvotes"
 import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
-import { postRemoved } from "../reducers/post_removed"
+import { postRemovedEndpoint } from "../reducers/post_removed"
+import { reportsEndpoint } from "../reducers/reports"
 
 export const endpoints = [
   postsEndpoint,
@@ -19,5 +20,6 @@ export const endpoints = [
   commentsEndpoint,
   moreCommentsEndpoint,
   postUpvotesEndpoint,
-  postRemoved
+  postRemovedEndpoint,
+  reportsEndpoint
 ]

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -37,7 +37,9 @@ export const goBackAndHandleEvent = R.curry((history, e) => {
 
 export const preventDefaultAndInvoke = R.curry(
   (invokee: Function, e: Event) => {
-    e.preventDefault()
+    if (e) {
+      e.preventDefault()
+    }
     invokee()
   }
 )

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -75,6 +75,19 @@ export const validateChannelEditForm = validate([
   )
 ])
 
+export const validateContentReportForm = validate([
+  validation(
+    R.compose(R.lt(100), R.length),
+    R.lensPath(["value", "reason"]),
+    "Reason length is limited to 100 characters"
+  ),
+  validation(
+    R.compose(R.gt(3), R.length),
+    R.lensPath(["value", "reason"]),
+    "Reason must be at least 3 characters"
+  )
+])
+
 export const validationMessage = (message: string) =>
   R.isEmpty(message) || R.isNil(message)
     ? null

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -7,7 +7,8 @@ import {
   validation,
   validate,
   validatePostCreateForm,
-  validateChannelEditForm
+  validateChannelEditForm,
+  validateContentReportForm
 } from "./validation"
 
 describe("validation library", () => {
@@ -154,6 +155,31 @@ describe("validation library", () => {
       })
       channel.value.description = "a".repeat(5120)
       assert.deepEqual(validateChannelEditForm(channel), {})
+    })
+  })
+
+  describe("validateContentReportForm", () => {
+    it("should complain about too long of a description", () => {
+      const report = {
+        value: {
+          reason: "a".repeat(101)
+        }
+      }
+      assert.deepEqual(validateContentReportForm(report), {
+        value: {
+          reason: "Reason length is limited to 100 characters"
+        }
+      })
+      report.value.reason = "a".repeat(2)
+      assert.deepEqual(validateContentReportForm(report), {
+        value: {
+          reason: "Reason must be at least 3 characters"
+        }
+      })
+      report.value.reason = "a".repeat(100)
+      assert.deepEqual(validateContentReportForm(report), {})
+      report.value.reason = "a".repeat(3)
+      assert.deepEqual(validateContentReportForm(report), {})
     })
   })
 })

--- a/static/js/reducers/focus_test.js
+++ b/static/js/reducers/focus_test.js
@@ -13,10 +13,11 @@ import { makeComment } from "../factories/comments"
 import { makePost } from "../factories/posts"
 
 describe("focus reducer", () => {
-  let helper, store, dispatchThen, comment
+  let helper, store, dispatchThen, comment, post
 
   beforeEach(() => {
-    comment = makeComment(makePost())
+    post = makePost()
+    comment = makeComment(post)
     helper = new IntegrationTestHelper()
     store = helper.store
     dispatchThen = store.createDispatchThen(state => state.focus)
@@ -30,7 +31,7 @@ describe("focus reducer", () => {
     assert.deepEqual(store.getState().focus, INITIAL_FOCUS_STATE)
   })
 
-  it("should let you set and clear the moderation comment", async () => {
+  it("should let you set and clear the focused comment", async () => {
     let state = await dispatchThen(setFocusedComment(comment), [
       SET_FOCUSED_COMMENT
     ])

--- a/static/js/reducers/post_removed.js
+++ b/static/js/reducers/post_removed.js
@@ -2,7 +2,7 @@
 import * as api from "../lib/api"
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
-export const postRemoved = {
+export const postRemovedEndpoint = {
   name:         "postRemoved",
   verbs:        [PATCH],
   patchFunc:    (id: string, removed: boolean) => api.updateRemoved(id, removed),

--- a/static/js/reducers/reports.js
+++ b/static/js/reducers/reports.js
@@ -1,0 +1,12 @@
+// @flow
+import * as api from "../lib/api"
+import { POST, INITIAL_STATE } from "redux-hammock/constants"
+
+import type { GenericReport } from "../flow/discussionTypes"
+
+export const reportsEndpoint = {
+  name:         "reports",
+  verbs:        [POST],
+  postFunc:     (report: GenericReport) => api.reportContent(report),
+  initialState: { ...INITIAL_STATE }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #235 

#### What's this PR do?
Adds link and confirmation dialog to report posts and comments

#### How should this be manually tested?
Go to a post, verify that you can report both posts and comments and that the validation on the input displays and doesn't let you submit until you've fixed it.
  