### PR TITLE
add a 404 page to the post

### DIFF
--- a/static/js/components/404.js
+++ b/static/js/components/404.js
@@ -1,0 +1,18 @@
+// @flow
+import React from "react"
+
+import Card from "../components/Card"
+
+const NotFound = () =>
+  <div>
+    <Card>
+      <div className="not-found">
+        <div className="header">Page not found.</div>
+        <div className="detail">
+          This is a 404 error. This is not the page you were looking for.
+        </div>
+      </div>
+    </Card>
+  </div>
+
+export default NotFound

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -3,6 +3,22 @@ import R from "ramda"
 
 export const anyProcessing = R.any(R.propEq("processing", true))
 
-export const allLoaded = R.all(R.propEq("loaded", true))
+export const allLoaded = R.both(
+  R.complement(R.isEmpty),
+  R.all(R.propEq("loaded", true))
+)
 
-export const anyError = R.any(R.propSatisfies(R.complement(R.isNil), "error"))
+const hasError = R.propSatisfies(R.complement(R.isNil), "error")
+
+export const anyError = R.any(hasError)
+
+export const anyErrorExcept404 = R.compose(
+  R.any(
+    R.either(
+      R.propSatisfies(R.isNil, "errorStatusCode"),
+      R.propSatisfies(R.complement(R.equals(404)), "errorStatusCode")
+    )
+  ),
+  R.map(R.prop("error")),
+  R.filter(hasError)
+)

--- a/static/js/util/rest_test.js
+++ b/static/js/util/rest_test.js
@@ -1,0 +1,103 @@
+// @flow
+import { assert } from "chai"
+
+import { anyProcessing, allLoaded, anyError, anyErrorExcept404 } from "./rest"
+
+describe("rest utils", () => {
+  describe("anyProcessing", () => {
+    it("should return false if nothing has processing true", () => {
+      assert.isFalse(anyProcessing([{}, { bip: "bop" }, { processing: false }]))
+    })
+
+    it("should return false for an empty array", () => {
+      assert.isFalse(anyProcessing([]))
+    })
+
+    it("should return true if one object has processing true", () => {
+      assert.isTrue(
+        anyProcessing([
+          {},
+          { bip: "bop" },
+          { processing: false },
+          { processing: true }
+        ])
+      )
+    })
+
+    it("should return true if all objects have processing true", () => {
+      assert.isTrue(
+        anyProcessing([
+          { bip: "bop", processing: true },
+          { processing: true },
+          { processing: true }
+        ])
+      )
+    })
+  })
+
+  describe("allLoaded", () => {
+    it("should return false if one does not have loaded true", () => {
+      assert.isFalse(
+        allLoaded([{}, { bip: "bop" }, { loaded: true }, { loaded: false }])
+      )
+    })
+
+    it("should return false for empty array", () => {
+      assert.isFalse(allLoaded([]))
+    })
+
+    it("should return true if all have loaded true", () => {
+      assert.isTrue(
+        allLoaded([{ loaded: true }, { loaded: true, other: "prop" }])
+      )
+    })
+  })
+
+  describe("anyError", () => {
+    it("should return false for empty array", () => {
+      assert.isFalse(anyError([]))
+    })
+
+    it("should return false if none have an error prop", () => {
+      assert.isFalse(anyError([{}, { bip: "bop" }, { loaded: true }]))
+    })
+
+    it("should return true if any have an error prop", () => {
+      assert.isTrue(anyError([{}, { bip: "bop" }, { error: ":(" }]))
+    })
+  })
+
+  describe("anyErrorExcept404", () => {
+    it("should return false for an empty array", () => {
+      assert.isFalse(anyErrorExcept404([]))
+    })
+
+    it("should return true if errors lack codes", () => {
+      assert.isTrue(anyErrorExcept404([{}, { bip: "bop" }, { error: {} }]))
+    })
+
+    it("should return true if some or all codes are not 404", () => {
+      assert.isTrue(
+        anyErrorExcept404([
+          { error: { errorStatusCode: 401 } },
+          { error: { errorStatusCode: 404 } }
+        ])
+      )
+      assert.isTrue(
+        anyErrorExcept404([
+          { error: { errorStatusCode: 401 } },
+          { error: { errorStatusCode: 500 } }
+        ])
+      )
+    })
+
+    it("should return false if all codes are 404", () => {
+      assert.isFalse(
+        anyErrorExcept404([
+          { error: { errorStatusCode: 404 } },
+          { error: { errorStatusCode: 404 } }
+        ])
+      )
+    })
+  })
+})

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -25,6 +25,7 @@
 @import "auth-required";
 @import "content-policy";
 @import "admin";
+@import "not-found";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/not-found.scss
+++ b/static/scss/not-found.scss
@@ -1,0 +1,15 @@
+.not-found {
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .header {
+    font-size: 20px;
+    margin-top: 50px;
+  }
+
+  .detail {
+    margin-top: 25px;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

#215 

#### What's this PR do?

This implements a 'not found' component and makes some changes so we can show it on the post page, when we get a 404 back from Reddit.

#### How should this be manually tested?

Go to a post that doesn't exist, and you should see a nice 404 page instead of just a generic error.

You should be able to do anything else you would normally be able to do with a post