### PR TITLE
add a 404 message to the channel page

### DIFF
--- a/cassettes/channels.views.channels_test.test_get_short_channel.json
+++ b/cassettes/channels.views.channels_test.test_get_short_channel.json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-09T14:38:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3DNR1Z20EVR3AWNKMCY3N25"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NtItTAmNcPYyLwzwyzfz9UjJMQvOy4zKcUkPNQhV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVuyS56Hr5uvqFFxZmpESlpeUYeDglhZsbJHmC9KSklmUmp8ZnpoAMhnCUagFXKKq/uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 09 Jan 2018 14:38:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=BUbhaH3k6spzXrTpli; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jan-2020 14:38:53 GMT",
+            "loidcreated=2018-01-09T14%3A38%3A52.932Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jan-2020 14:38:53 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3DNR1Z20EVR3AWNKMCY3N25"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/views/channels.py
+++ b/channels/views/channels.py
@@ -5,6 +5,8 @@ from rest_framework.generics import (
     RetrieveUpdateAPIView,
 )
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
 
 from channels.api import Api
 from channels.serializers import ChannelSerializer
@@ -45,6 +47,10 @@ class ChannelDetailView(RetrieveUpdateAPIView):
         return api.get_channel(self.kwargs['channel_name'])
 
     def get(self, request, *args, **kwargs):
+        # we don't want to let this through to Reddit, because it blows up :/
+        if len(kwargs['channel_name']) == 1:
+            return Response({}, status=status.HTTP_404_NOT_FOUND)
+
         with translate_praw_exceptions():
             return super().get(request, *args, **kwargs)
 

--- a/channels/views/channels_test.py
+++ b/channels/views/channels_test.py
@@ -133,6 +133,15 @@ def test_get_channel(client, jwt_header, private_channel_and_contributor):
     }
 
 
+def test_get_short_channel(client, jwt_header):
+    """
+    test getting a one-character channel name
+    """
+    url = reverse('channel-detail', kwargs={'channel_name': 'a'})
+    resp = client.get(url, **jwt_header)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_get_channel_forbidden(client):
     """
     If PRAW returns a 403 error we should also return a 403 error

--- a/factory_data/channels.views.channels_test.test_get_short_channel.json
+++ b/factory_data/channels.views.channels_test.test_get_short_channel.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "contributor": {
+      "username": "01C3DNR1Z20EVR3AWNKMCY3N25"
+    }
+  }
+}

--- a/static/js/actions/post.js
+++ b/static/js/actions/post.js
@@ -3,3 +3,6 @@ import { createAction } from "redux-actions"
 
 export const SET_POST_DATA = "SET_POST_DATA"
 export const setPostData = createAction(SET_POST_DATA)
+
+export const CLEAR_POST_ERROR = "CLEAR_POST_ERROR"
+export const clearPostError = createAction(CLEAR_POST_ERROR)

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -37,6 +37,8 @@ import { getSubscribedChannels } from "../lib/redux_selectors"
 import { beginEditing } from "../components/CommentForms"
 import { formatTitle } from "../lib/title"
 import { channelURL } from "../lib/url"
+import { clearPostError } from "../actions/post"
+
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
 import type { FormsState } from "../flow/formTypes"
@@ -69,7 +71,8 @@ type PostPageProps = {
   commentDeleteDialogVisible: boolean,
   postReportDialogVisible: boolean,
   commentReportDialogVisible: boolean,
-  notFound: boolean
+  notFound: boolean,
+  errored: boolean
 }
 
 const DIALOG_REMOVE_COMMENT = "DIALOG_REMOVE_COMMENT"
@@ -103,6 +106,14 @@ class PostPage extends React.Component<*, void> {
 
   componentWillMount() {
     this.loadData()
+  }
+
+  componentWillUnmount() {
+    const { dispatch, errored, notFound } = this.props
+
+    if (errored || notFound) {
+      dispatch(clearPostError())
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -211,6 +211,7 @@ describe("PostPage", function() {
         actions.channels.get.successType,
         actions.postsForChannel.get.requestType,
         actions.channelModerators.get.requestType,
+        actions.channelModerators.get.successType,
         SET_SNACKBAR_MESSAGE
       ],
       () => {

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -7,8 +7,9 @@ import {
   DELETE,
   INITIAL_STATE
 } from "redux-hammock/constants"
+import R from "ramda"
 
-import { SET_POST_DATA } from "../actions/post"
+import { SET_POST_DATA, CLEAR_POST_ERROR } from "../actions/post"
 
 import type { CreatePostPayload, Post } from "../flow/discussionTypes"
 
@@ -52,6 +53,7 @@ export const postsEndpoint = {
           ? mergeMultiplePosts(action.payload, state.data)
           : mergePostData(action.payload, state.data)
       return Object.assign({}, state, { data: update, loaded: true })
-    }
+    },
+    [CLEAR_POST_ERROR]: R.dissoc("error")
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #408 
closes #393 

#### What's this PR do?

This adds a 404 page to the channel, which you should see if you try to visit a channel that doesn't exist. I also moved stuff around so we no longer raise an unhandled exception when the request comes back with a 404.

Additional, there was previously an issue where if you visited a post that doesn't exist and then tried to navigate to a channel, the 404 error from the post would prevent the channel data from showing itself. To fix this I just added an action to the post reducer to clear out the error state, which we can call on the channel page if we need to.

#### How should this be manually tested?

Go to something like `/channel/flflasdfajsdf` (well unless you have a channel called that :P). You should see a 404 message, like what we have now on the post page. Then if you visit another channel all should be well. Additionally, the error situation I described above (visiting a 'not found' post and then going to a channel page) should no longer raise any errors.
  