### PR TITLE
Added API for listing reported content (#398)

### DIFF
--- a/cassettes/channels.views.reports_test.test_list_reports.json
+++ b/cassettes/channels.views.reports_test.test_list_reports.json
@@ -1,0 +1,1326 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-11T15:46:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYCYG7N4GTJ7PSNXF639Y5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwMdP1Tks0cw71zzQ2iPd1zncOdimtcDXPrUw30fVU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZZBkGZvhUVDmlpltYOIfm5vmlGxa4JSaGRJaD9KSklmUmp8ZnpoAMhnCUagEAxbwmuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:46:18 GMT",
+            "loidcreated=2018-01-11T15%3A46%3A18.311Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:46:18 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYCYG7N4GTJ7PSNXF639Y5"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Vero+culpa+maiores+magnam+libero.+Pariatur+tempora+nostrum+ducimus+aut+veritatis+distinctio+ab.+Tempore+esse+atque+nam+at+sed.+Maiores+dolor+aspernatur+minima.%0ALaborum+sapiente+modi+voluptas+saepe+nesciunt+aut.+Aspernatur+saepe+nesciunt+recusandae+alias.+Consequuntur+aut+quis+quis+quae+quia+ratione.&link_type=any&name=1515685578_fugit&public_description=Consectetur+vitae+facilis+asperiores+hic+sit.+Vel+minus+perspiciatis+maiores+officia+cupiditate.&title=Id+sed+voluptatem+vero+incidunt.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "550"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "222"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYD4WWEX8AJS8STZ3N4SW5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJI0gMW4Ojk4ERRcmrY8sYICrw0pGv9dKpPjPbnn3jcRSoEx3HYNPMkuINskDfGeRXyqR3Fw5XkvwbWMRSq3R9OQdUDA9RrBcO2FmFE6s5/P7dSDH5EgENB3jeoWtPIJ4TqLt/+3l91kxamgj7KVg7rkyRCmcY/Iw9o7FYxaAdeVH14C+XwBShbgMLgAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:25 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYD4WWEX8AJS8STZ3N4SW5"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C3JYD4WWEX8AJS8STZ3N4SW5&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1515685578_fugit/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:25 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "215"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515685578_fugit/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1515685578_fugit"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:25 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "215"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1515685578_fugit&text=Sit+ipsa+soluta+atque+ipsam.+Natus+nam+rerum+nam.+Omnis+odio+delectus+fugit+ipsam+similique.&title=Eos+inventore+accusantium+hic."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "209"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"id\": \"hr\", \"name\": \"t3_hr\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "156"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:25 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "215"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/hr/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1515685578_fugit\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESit ipsa soluta atque ipsam. Natus nam rerum nam. Omnis odio delectus fugit ipsam similique.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Sit ipsa soluta atque ipsam. Natus nam rerum nam. Omnis odio delectus fugit ipsam similique.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"hr\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C3JYD4WWEX8AJS8STZ3N4SW5\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1515685578_fugit\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_bo\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"locked\": false, \"name\": \"t3_hr\", \"created\": 1515685585.0, \"url\": \"http://reddit.local/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Eos inventore accusantium hic.\", \"created_utc\": 1515685585.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1738"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:25 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "215"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=oztfs0Mp7nhFQClnnRzbJsAMlfl0aue%2FhTtzcYRoACeMXP%2FA94bwPcefwlyOlVrf9LjXo5mkV1bBXo5l40fWVlL3OoCh4ycp"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/hr/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Consequatur+possimus+dolorem+quos+porro.+Quisquam+facilis+dolorum+rerum+natus+culpa+inventore.&thing_id=t3_hr"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "128"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_bo\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_hr\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"4e\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C3JYD4WWEX8AJS8STZ3N4SW5\", \"parent_id\": \"t3_hr\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Consequatur possimus dolorem quos porro. Quisquam facilis dolorum rerum natus culpa inventore.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EConsequatur possimus dolorem quos porro. Quisquam facilis dolorum rerum natus culpa inventore.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1515685578_fugit\", \"score_hidden\": false, \"name\": \"t1_4e\", \"created\": 1515685588.0, \"author_flair_text\": null, \"created_utc\": 1515685588.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "990"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:28 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "212"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_4e&reason=spam"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "34"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/report/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/report/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_hr&reason=bad"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 847-rjS2_ygvaIxYWCbexl662cUtMsk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/report/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/report/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_4e&reason=spam"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "34"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/report/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/report/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_hr&reason=junk"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "34"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/report/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/report/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515685578_fugit/about/moderators/?user=01C3JYCYG7N4GTJ7PSNXF639Y5&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1515685578.0, \"mod_permissions\": [\"all\"], \"name\": \"01C3JYCYG7N4GTJ7PSNXF639Y5\", \"id\": \"t2_ni\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=1ZqqbSHM840iePAYa9xWtbGKeZ7ufPwtav6yBRN15iWcPOYDMwAzGmPbu1luC8NXFTk8UUm36FSulrtKdi97GGGTJlJClrYn"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515685578_fugit/about/moderators/?user=01C3JYCYG7N4GTJ7PSNXF639Y5&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515685578_fugit/about/reports/?limit=100&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"link_url\": \"http://reddit.local/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"subreddit_id\": \"t5_bo\", \"link_title\": \"Eos inventore accusantium hic.\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_hr\", \"link_author\": \"01C3JYD4WWEX8AJS8STZ3N4SW5\", \"likes\": null, \"replies\": \"\", \"user_reports\": [[\"spam\", 1]], \"saved\": false, \"id\": \"4e\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"01C3JYD4WWEX8AJS8STZ3N4SW5\", \"parent_id\": \"t3_hr\", \"score\": 1, \"approved_by\": null, \"over_18\": false, \"controversiality\": 0, \"body\": \"Consequatur possimus dolorem quos porro. Quisquam facilis dolorum rerum natus culpa inventore.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EConsequatur possimus dolorem quos porro. Quisquam facilis dolorum rerum natus culpa inventore.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1515685578_fugit\", \"score_hidden\": false, \"name\": \"t1_4e\", \"created\": 1515685588.0, \"author_flair_text\": null, \"quarantine\": false, \"created_utc\": 1515685588.0, \"ups\": 1, \"mod_reports\": [[\"spam\", \"01C3JYCYG7N4GTJ7PSNXF639Y5\"]], \"num_reports\": 2, \"distinguished\": null}}, {\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"domain\": \"self.1515685578_fugit\", \"subreddit\": \"1515685578_fugit\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESit ipsa soluta atque ipsam. Natus nam rerum nam. Omnis odio delectus fugit ipsam similique.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Sit ipsa soluta atque ipsam. Natus nam rerum nam. Omnis odio delectus fugit ipsam similique.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [[\"bad\", 1]], \"secure_media\": null, \"saved\": false, \"id\": \"hr\", \"media_embed\": {}, \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"01C3JYD4WWEX8AJS8STZ3N4SW5\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_bo\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"locked\": false, \"name\": \"t3_hr\", \"created\": 1515685585.0, \"url\": \"http://reddit.local/r/1515685578_fugit/comments/hr/eos_inventore_accusantium_hic/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Eos inventore accusantium hic.\", \"created_utc\": 1515685585.0, \"link_flair_text\": null, \"ups\": 1, \"mod_reports\": [[\"junk\", \"01C3JYCYG7N4GTJ7PSNXF639Y5\"]], \"visited\": false, \"num_reports\": 2, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "3040"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:32 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "209"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=N0ArpR%2BuiWTqN5UC7mOHXggfNSYedomdes40Ew9U6CDrT9gsl1xAEcNQ7dL5WfVzGiJZA4s%2BcDHvXwnkEcRFU0qIh2SkUt%2FP"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515685578_fugit/about/reports/?limit=100&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:46:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 846-Kfa6CUOi30_MCoCSDuxE7myg4-I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=OJ51IT6YJtGTU0pgqE; loidcreated=2018-01-11T15%3A46%3A18.311Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515685578_fugit/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"bo\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1515685578_fugit\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EVero culpa maiores magnam libero. Pariatur tempora nostrum ducimus aut veritatis distinctio ab. Tempore esse atque nam at sed. Maiores dolor aspernatur minima.\\nLaborum sapiente modi voluptas saepe nesciunt aut. Aspernatur saepe nesciunt recusandae alias. Consequuntur aut quis quis quae quia ratione.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Id sed voluptatem vero incidunt.\", \"collapse_deleted_comments\": false, \"public_description\": \"Consectetur vitae facilis asperiores hic sit. Vel minus perspiciatis maiores officia cupiditate.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EConsectetur vitae facilis asperiores hic sit. Vel minus perspiciatis maiores officia cupiditate.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Vero culpa maiores magnam libero. Pariatur tempora nostrum ducimus aut veritatis distinctio ab. Tempore esse atque nam at sed. Maiores dolor aspernatur minima.\\nLaborum sapiente modi voluptas saepe nesciunt aut. Aspernatur saepe nesciunt recusandae alias. Consequuntur aut quis quis quae quia ratione.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 3, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_bo\", \"created\": 1515685578.0, \"url\": \"/r/1515685578_fugit/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1515685578.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2141"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:46:32 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "208"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=GE7wODD9zMYVE34D%2F%2BygyafaQlIS%2BJ320dbiK7RphbSIw%2F31q%2FGUgpDuHIzVsK0JYlsgKmNdGDdpqln9XR%2BI5c5Yx9pCS4lH"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515685578_fugit/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.reports_test.test_list_reports_empty.json
+++ b/cassettes/channels.views.reports_test.test_list_reports_empty.json
@@ -1,0 +1,344 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-11T15:54:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVE0BPG7N1MKBT6PE8ZAP"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwsdANzrGs9AmoqCyNSHH3d89NTqtMLy+zTHPyLwxV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5lgUmh3u4hSUFBpd5ZFc55ZfnF1UlZ2Qkp3mC9KSklmUmp8ZnpoAMhnCUagEAO1N9uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=dks0qTQ4yohiVvtqU2; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:54:13 GMT",
+            "loidcreated=2018-01-11T15%3A54%3A12.937Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:54:13 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVE0BPG7N1MKBT6PE8ZAP"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Quis+cupiditate+dolorum+neque.+Blanditiis+quas+pariatur+eligendi+cumque+blanditiis+nemo+facilis.+Illo+ratione+labore+similique+quaerat.%0ADolores+nihil+nesciunt+ipsam+architecto+minima.+Illo+quod+qui+non+dignissimos.+Repellendus+velit+officiis+deserunt+cum+eos+perspiciatis.&link_type=any&name=1515686053_cupiditate&public_description=Porro+error+nisi+fuga+incidunt+incidunt+sed.+Quas+aliquam+perferendis+quibusdam+omnis.&title=Dolore+porro+perferendis+excepturi+nisi.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 848-Sl9yLPxyuXdGOGmcfygwv9fBOqU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "525"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=dks0qTQ4yohiVvtqU2; loidcreated=2018-01-11T15%3A54%3A12.937Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "347"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 848-Sl9yLPxyuXdGOGmcfygwv9fBOqU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=dks0qTQ4yohiVvtqU2; loidcreated=2018-01-11T15%3A54%3A12.937Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515686053_cupiditate/about/moderators/?user=01C3JYVE0BPG7N1MKBT6PE8ZAP&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1515686053.0, \"mod_permissions\": [\"all\"], \"name\": \"01C3JYVE0BPG7N1MKBT6PE8ZAP\", \"id\": \"t2_nk\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "344"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=9KguhF57Ch0DU6fKuhq2s2PLnOhPp3LIfrfubhmQV2zs0oBjfzRpVlSjrenQC8zdv5xx5G0kfp8c9bW24mLnOMFGtiEcJs94"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515686053_cupiditate/about/moderators/?user=01C3JYVE0BPG7N1MKBT6PE8ZAP&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 848-Sl9yLPxyuXdGOGmcfygwv9fBOqU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=dks0qTQ4yohiVvtqU2; loidcreated=2018-01-11T15%3A54%3A12.937Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515686053_cupiditate/about/reports/?limit=100&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "93"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "344"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=dqQCEwr1DUBF6ISpKgzyKLW6Hbm1GFNbwRaqK9LUzSO7foMwRfcqtISYKmV3hnLt3YbT5O87JmoDpilzj87qqjVzHQzg6hQ%2FuZg5pJn6EaES1G%2BOp%2BBM%2Bw%3D%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1515686053_cupiditate/about/reports/?limit=100&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.reports_test.test_patch_channel_noauth.json
+++ b/cassettes/channels.views.reports_test.test_patch_channel_noauth.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-11T15:59:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JZ4JVZMT2P12536C6J8S3C"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwNdQtq/BMDE7NyvauiAhO93bySjb2ytXNS3Fy9C1W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLalpySWe7oZGFaaGToHVIUaphi7Fjhb6paEF5eD9KSklmUmp8ZnpoAMhnCUagGsdZmzuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:59:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=cdzaqleJGipwdGydhW; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:59:13 GMT",
+            "loidcreated=2018-01-11T15%3A59%3A12.847Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:59:13 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JZ4JVZMT2P12536C6J8S3C"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:59:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Maxime+eius+nisi+earum+nam+sapiente+ex.+Ipsum+veniam+architecto+sed+pariatur.+Eos+illo+est+laudantium+vero+quia+aspernatur+labore.+Repellat+facere+nihil+laborum+iste.%0ANihil+consequuntur+optio+corrupti+aperiam+fugit.+Ratione+veniam+at+perferendis+doloremque+odit+dolorum+voluptates.+Est+minima+architecto+quia+eligendi+unde+labore+neque.+Cupiditate+nobis+tempora+sit+ea+sed+quae+blanditiis.+Saepe+et+dignissimos+excepturi+minima+debitis+itaque+nulla.&link_type=any&name=1515686353_ad&public_description=Vel+a+voluptatum+optio.+Minima+quasi+rem+totam+repudiandae+fugit+ipsa+maiores.&title=Non+tempore+quisquam+nam+magnam.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 851-vxIaSejkKxXSgKBJc3Jm-ndBAMs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "678"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=cdzaqleJGipwdGydhW; loidcreated=2018-01-11T15%3A59%3A12.847Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:59:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "47"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.reports_test.test_patch_channel_nonstaff.json
+++ b/cassettes/channels.views.reports_test.test_patch_channel_nonstaff.json
@@ -1,0 +1,311 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-11T15:54:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVMF9E3NA1AG5PD2QGQJ5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwsdQtT/LWdQ8oD/ZLDs02NnEOiHCtrMpJ9Hfzj8pX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVJCeVhpv7R2YYGSabR1ZmZLmnWfibBpR4u0eC9KSklmUmp8ZnpoAMhnCUagHrJ/iHuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=nvpDPCNIH7BAmDs8OV; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:54:19 GMT",
+            "loidcreated=2018-01-11T15%3A54%3A19.553Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 11-Jan-2020 15:54:19 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVMF9E3NA1AG5PD2QGQJ5"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nvpDPCNIH7BAmDs8OV; loidcreated=2018-01-11T15%3A54%3A19.553Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVQRFD7XNYF4PK9WXRG6E"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwNdANynFzcTULSPIvT/YI8q3yjMzQrSp2jfeMSvdV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFFHt5lDsHG/uZZpa6WBplpQZZuKd5JFaWuUeC9KSklmUmp8ZnpoAMhnCUagHU5KqjuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C3JYVQRFD7XNYF4PK9WXRG6E"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Reprehenderit+rerum+perspiciatis+illum+in+blanditiis+adipisci.+Voluptates+nam+quidem+quae.+Voluptas+cupiditate+tempore+in+nihil.+Tempore+qui+non+eum+distinctio+itaque+quas+explicabo.%0AAsperiores+veritatis+quam+ut+dolores+eligendi+perspiciatis.+Reiciendis+aspernatur+deleniti+exercitationem+beatae.+Doloribus+quis+asperiores+ipsum.%0ACorporis+quasi+eum+itaque+nam+similique.+Officia+molestias+quibusdam+molestiae+deserunt.+Recusandae+praesentium+vitae+iure.&link_type=any&name=1515686063_numquam&public_description=Atque+aliquam+eum+laboriosam.+Dolor+sequi+quae+ad+atque+dignissimos+harum.&title=Repellat+accusantium+nisi+esse+consequatur.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 850-RlFDE6PbOwcHRMzIYh-zsE_IZgM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "696"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nvpDPCNIH7BAmDs8OV; loidcreated=2018-01-11T15%3A54%3A19.553Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "337"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-11T15:54:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 849-wbK-GPwSNcUk34CPXEyzlaOFOZo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nvpDPCNIH7BAmDs8OV; loidcreated=2018-01-11T15%3A54%3A19.553Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.8.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1515686063_numquam/about/moderators/?user=01C3JYVMF9E3NA1AG5PD2QGQJ5&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 11 Jan 2018 15:54:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=evIINjFd%2BT8zX4NMLzu2URXiAljnVPpYUD%2BdFtRIcyEs9sNH1CiRuyiZARQ6zNJkJcBY5bzaM6ESDWenEnJzC53hdNa2QPQI"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/r/1515686063_numquam/about/moderators/?user=01C3JYVMF9E3NA1AG5PD2QGQJ5&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/api.py
+++ b/channels/api.py
@@ -851,3 +851,15 @@ class Api:
             reason(str): the reason why the comment is being reported
         """
         self.get_comment(comment_id).report(reason)
+
+    def list_reports(self, channel_name):
+        """
+        Lists reported content in a channel
+
+        Args:
+            channel_name(str): the channel name identifier
+
+        Returns:
+            praw.models.listing.generator.ListingGenerator: a generator representing the reports in the channel
+        """
+        return self.get_channel(channel_name).mod.reports()

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -613,3 +613,11 @@ def test_report_post(mock_client):
     client.report_post('id', 'reason')
     mock_client.submission.assert_called_once_with(id='id')
     mock_client.submission.return_value.report.assert_called_once_with('reason')
+
+
+def test_list_reports(mock_client):
+    """Test list_reports"""
+    client = api.Api(UserFactory.create())
+    assert client.list_reports('channel') == mock_client.subreddit.return_value.mod.reports.return_value
+    mock_client.subreddit.assert_called_once_with('channel')
+    mock_client.subreddit.return_value.mod.reports.assert_called_once_with()

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -567,3 +567,35 @@ class ReportSerializer(serializers.Serializer):
             api.report_comment(comment_id, reason)
             result['comment_id'] = comment_id
         return result
+
+
+class ReportedContentSerializer(serializers.Serializer):
+    """
+    Serializer for reported content
+    """
+    comment = serializers.SerializerMethodField()
+    post = serializers.SerializerMethodField()
+    reasons = serializers.SerializerMethodField()
+
+    def get_comment(self, instance):
+        """Returns the comment if this report was for one"""
+        if isinstance(instance, Comment):
+            return CommentSerializer(instance, context=self.context).data
+
+        return None
+
+    def get_post(self, instance):
+        """Returns the post if this report was for one"""
+        if isinstance(instance, Submission):
+            return PostSerializer(instance, context=self.context).data
+
+        return None
+
+    def get_reasons(self, instance):
+        """
+        Returns the reasons that have been reported so far
+
+        Returns:
+            list of str: list of reasons a post/comment has been reported for
+        """
+        return sorted(list(set([report[0] for report in instance.user_reports + instance.mod_reports])))

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -17,6 +17,7 @@ from channels.serializers import (
     ModeratorSerializer,
     PostSerializer,
     ReportSerializer,
+    ReportedContentSerializer,
     SubscriberSerializer,
 )
 from open_discussions.factories import UserFactory
@@ -388,3 +389,11 @@ def test_report_post_create():
             "view": Mock()
         }).create(payload) == payload
         api.return_value.report_post.assert_called_once_with('abc', 'reason')
+
+
+def test_reported_comment():
+    """Serialize of a reported content object"""
+    reported_content = Mock()
+    reported_content.user_reports = [['spam', 1]]
+    reported_content.mod_reports = [['spam', 'jane'], ['junk', 'jow']]
+    assert ReportedContentSerializer().get_reasons(reported_content) == sorted(['spam', 'junk'])

--- a/channels/urls.py
+++ b/channels/urls.py
@@ -54,6 +54,11 @@ urlpatterns = [
         name='subscriber-detail',
     ),
     url(
+        r'^api/v0/channels/(?P<channel_name>[A-Za-z0-9_]+)/reports/$',
+        reports.ChannelReportListView.as_view(),
+        name='channel-reports',
+    ),
+    url(
         r'api/v0/posts/(?P<post_id>[A-Za-z0-9_]+)/$',
         posts.PostDetailView.as_view(),
         name='post-detail',

--- a/channels/views/reports_test.py
+++ b/channels/views/reports_test.py
@@ -3,6 +3,8 @@ import pytest
 from django.core.urlresolvers import reverse
 from rest_framework import status
 
+from channels.api import Api
+
 pytestmark = [
     pytest.mark.django_db,
     pytest.mark.usefixtures("use_betamax", "praw_settings"),
@@ -38,3 +40,87 @@ def test_report_comment(client, private_channel_and_contributor, reddit_factorie
     resp = client.post(url, data=payload)
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == payload
+
+
+def test_list_reports(staff_client, private_channel_and_contributor, reddit_factories, staff_api):
+    """List reported content"""
+    channel, user = private_channel_and_contributor
+    post = reddit_factories.text_post('post', user, channel=channel)
+    comment = reddit_factories.comment("comment", user, post_id=post.id)
+    # report both with a regular user
+    api = Api(user)
+    api.report_comment(comment.id, "spam")
+    api.report_post(post.id, "bad")
+    # report both with a moderator user
+    staff_api.report_comment(comment.id, "spam")
+    staff_api.report_post(post.id, "junk")
+    url = reverse('channel-reports', kwargs={'channel_name': channel.name})
+    resp = staff_client.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == [{
+        "post": None,
+        "comment": {
+            'author_id': user.username,
+            'created': comment.created,
+            'id': comment.id,
+            'parent_id': None,
+            'post_id': post.id,
+            'score': 1,
+            'text': comment.text,
+            'upvoted': False,
+            'downvoted': False,
+            "removed": False,
+            'profile_image': user.profile.image_small,
+            'author_name': user.profile.name,
+            'edited': False,
+            'comment_type': 'comment',
+        },
+        "reasons": ["spam"],
+    }, {
+        "post": {
+            "url": None,
+            "text": post.text,
+            "title": post.title,
+            "upvoted": False,
+            'removed': False,
+            "score": 1,
+            "author_id": user.username,
+            "id": post.id,
+            "created": post.created,
+            "num_comments": 1,
+            "channel_name": channel.name,
+            "channel_title": channel.title,
+            'author_name': user.profile.name,
+            'profile_image': user.profile.image_small,
+            'edited': False,
+            "stickied": False,
+        },
+        "comment": None,
+        "reasons": ["bad", "junk"],
+    }]
+
+
+def test_list_reports_empty(staff_client, private_channel):
+    """List reported content when there is none"""
+    url = reverse('channel-reports', kwargs={'channel_name': private_channel.name})
+    resp = staff_client.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == []
+
+
+def test_patch_channel_nonstaff(client, jwt_header, private_channel):
+    """
+    Fail to list a channels reported content if nonstaff user
+    """
+    url = reverse('channel-reports', kwargs={'channel_name': private_channel.name})
+    resp = client.get(url, **jwt_header)
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_patch_channel_noauth(client, private_channel):
+    """
+    Fail to list a channels reported content if no auth
+    """
+    url = reverse('channel-reports', kwargs={'channel_name': private_channel.name})
+    resp = client.get(url)
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED

--- a/conftest.py
+++ b/conftest.py
@@ -65,3 +65,10 @@ def client():
     Similar to the builtin client but this provides the DRF client instead of the Django test client.
     """
     return APIClient()
+
+
+@pytest.fixture
+def staff_client(client, staff_user):
+    """Version of the client that is authenticated with the staff_user"""
+    client.force_login(staff_user)
+    return client

--- a/factory_data/channels.views.reports_test.test_list_reports.json
+++ b/factory_data/channels.views.reports_test.test_list_reports.json
@@ -1,0 +1,35 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Vero culpa maiores magnam libero. Pariatur tempora nostrum ducimus aut veritatis distinctio ab. Tempore esse atque nam at sed. Maiores dolor aspernatur minima.\nLaborum sapiente modi voluptas saepe nesciunt aut. Aspernatur saepe nesciunt recusandae alias. Consequuntur aut quis quis quae quia ratione.",
+      "name": "1515685578_fugit",
+      "public_description": "Consectetur vitae facilis asperiores hic sit. Vel minus perspiciatis maiores officia cupiditate.",
+      "title": "Id sed voluptatem vero incidunt."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "4e",
+      "post_id": "hr",
+      "text": "Consequatur possimus dolorem quos porro. Quisquam facilis dolorum rerum natus culpa inventore."
+    }
+  },
+  "posts": {
+    "post": {
+      "id": "hr",
+      "text": "Sit ipsa soluta atque ipsam. Natus nam rerum nam. Omnis odio delectus fugit ipsam similique.",
+      "title": "Eos inventore accusantium hic."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C3JYD4WWEX8AJS8STZ3N4SW5"
+    },
+    "staff_user": {
+      "username": "01C3JYCYG7N4GTJ7PSNXF639Y5"
+    }
+  }
+}

--- a/factory_data/channels.views.reports_test.test_list_reports_empty.json
+++ b/factory_data/channels.views.reports_test.test_list_reports_empty.json
@@ -1,0 +1,16 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Quis cupiditate dolorum neque. Blanditiis quas pariatur eligendi cumque blanditiis nemo facilis. Illo ratione labore similique quaerat.\nDolores nihil nesciunt ipsam architecto minima. Illo quod qui non dignissimos. Repellendus velit officiis deserunt cum eos perspiciatis.",
+      "name": "1515686053_cupiditate",
+      "public_description": "Porro error nisi fuga incidunt incidunt sed. Quas aliquam perferendis quibusdam omnis.",
+      "title": "Dolore porro perferendis excepturi nisi."
+    }
+  },
+  "users": {
+    "staff_user": {
+      "username": "01C3JYVE0BPG7N1MKBT6PE8ZAP"
+    }
+  }
+}

--- a/factory_data/channels.views.reports_test.test_patch_channel_noauth.json
+++ b/factory_data/channels.views.reports_test.test_patch_channel_noauth.json
@@ -1,0 +1,16 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Maxime eius nisi earum nam sapiente ex. Ipsum veniam architecto sed pariatur. Eos illo est laudantium vero quia aspernatur labore. Repellat facere nihil laborum iste.\nNihil consequuntur optio corrupti aperiam fugit. Ratione veniam at perferendis doloremque odit dolorum voluptates. Est minima architecto quia eligendi unde labore neque. Cupiditate nobis tempora sit ea sed quae blanditiis. Saepe et dignissimos excepturi minima debitis itaque nulla.",
+      "name": "1515686353_ad",
+      "public_description": "Vel a voluptatum optio. Minima quasi rem totam repudiandae fugit ipsa maiores.",
+      "title": "Non tempore quisquam nam magnam."
+    }
+  },
+  "users": {
+    "staff_user": {
+      "username": "01C3JZ4JVZMT2P12536C6J8S3C"
+    }
+  }
+}

--- a/factory_data/channels.views.reports_test.test_patch_channel_nonstaff.json
+++ b/factory_data/channels.views.reports_test.test_patch_channel_nonstaff.json
@@ -1,0 +1,19 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Reprehenderit rerum perspiciatis illum in blanditiis adipisci. Voluptates nam quidem quae. Voluptas cupiditate tempore in nihil. Tempore qui non eum distinctio itaque quas explicabo.\nAsperiores veritatis quam ut dolores eligendi perspiciatis. Reiciendis aspernatur deleniti exercitationem beatae. Doloribus quis asperiores ipsum.\nCorporis quasi eum itaque nam similique. Officia molestias quibusdam molestiae deserunt. Recusandae praesentium vitae iure.",
+      "name": "1515686063_numquam",
+      "public_description": "Atque aliquam eum laboriosam. Dolor sequi quae ad atque dignissimos harum.",
+      "title": "Repellat accusantium nisi esse consequatur."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C3JYVMF9E3NA1AG5PD2QGQJ5"
+    },
+    "staff_user": {
+      "username": "01C3JYVQRFD7XNYF4PK9WXRG6E"
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #398 

#### What's this PR do?
- Adds the API to list reported posts/comments
- Refactored some of our permissions to reduce duplicity and add a new `StaffOrModeratorPermission` and made sure our moderator logic is tested

#### How should this be manually tested?
- Report some posts and comments under different users
- Login as a moderator and go to `/api/v0/channels/:channel_name/reports/` and verify you see the data.
- Try for a different channel that has no reports and verify you see an empty list
- Try as a nonmoderator user and verify you get a 403