### PR TITLE
Updated post/comment APIs to enable ignoring future reports

### DIFF
--- a/cassettes/channels.views.comments_test.test_update_comment_ignore_reports.json
+++ b/cassettes/channels.views.comments_test.test_update_comment_ignore_reports.json
@@ -1,0 +1,1053 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-16T19:36:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C407JY9W953SEX5YGNCT2HB0"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwN9J1yi82Mk2JMsn1CglONTU2LXbKyUzyTI+KNw5V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaF+/iGeHt6+wWHBkeVZ4TpWniUJkYk+weHBPmC9KSklmUmp8ZnpoAMhnCUagH9kRDQuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:36:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:36:59 GMT",
+            "loidcreated=2018-01-16T19%3A36%3A59.413Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:36:59 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C407JY9W953SEX5YGNCT2HB0"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:36:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Distinctio+voluptatibus+laudantium+accusantium+quod.+Esse+ipsa+est+facilis.+Velit+alias+dolores+delectus+praesentium+rerum.+Deleniti+consectetur+ut+ullam+earum+nemo.+Ex+vel+fugit+provident+consequatur+iusto+pariatur+corrupti.%0AHarum+vel+nemo+provident+ullam+vero+saepe+quidem.+Accusantium+accusamus+aliquid+ab+eius+aspernatur.+Sunt+eos+ea+ut+praesentium+amet+neque+nulla.&link_type=any&name=1516131419_dicta&public_description=Facilis+accusamus+nemo+maiores.+Explicabo+vel+atque+hic+commodi.&title=Officia+id+deleniti+temporibus+magni.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "593"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:36:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "181"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C407K4P5YC8WB7H8C3PF37NB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwN9b1NIoydHQ3NDZ29kt1L00MLYkstQjzCnfS9bBQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFBgcZ6WZUZKaHZvibxAfFp0eWeRo75fgb+6aD9KSklmUmp8ZnpoAMhnCUagE3Ih15uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C407K4P5YC8WB7H8C3PF37NB"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C407K4P5YC8WB7H8C3PF37NB&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516131419_dicta/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "174"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516131419_dicta/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516131419_dicta"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 873-I2Z1AG133CNeGuaUtYu8VJWB-H8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "174"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1516131419_dicta&text=Deleniti+fugit+et+hic+quae+a+dolore+exercitationem.+Magnam+reprehenderit+esse+voluptates+numquam.&title=Alias+ullam+quidem+incidunt+culpa+quas."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 873-I2Z1AG133CNeGuaUtYu8VJWB-H8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "223"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1516131419_dicta/comments/il/alias_ullam_quidem_incidunt_culpa_quas/\", \"id\": \"il\", \"name\": \"t3_il\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "165"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "174"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 873-I2Z1AG133CNeGuaUtYu8VJWB-H8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/il/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516131419_dicta\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EDeleniti fugit et hic quae a dolore exercitationem. Magnam reprehenderit esse voluptates numquam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Deleniti fugit et hic quae a dolore exercitationem. Magnam reprehenderit esse voluptates numquam.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"il\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C407K4P5YC8WB7H8C3PF37NB\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516131419_dicta\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516131419_dicta/comments/il/alias_ullam_quidem_incidunt_culpa_quas/\", \"locked\": false, \"name\": \"t3_il\", \"created\": 1516131426.0, \"url\": \"http://reddit.local/r/1516131419_dicta/comments/il/alias_ullam_quidem_incidunt_culpa_quas/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Alias ullam quidem incidunt culpa quas.\", \"created_utc\": 1516131426.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1775"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "174"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=kLDL3NhB46OdPLMboT2ec94P7A0UZ5%2F5dZHXzhLClLkEtkdCtkLHI4e%2Bu4tQxr%2FT3l2tYuYtUq%2FjLbnnSPgxQzZt7kwtU8bE"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/il/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Repellat+ullam+placeat+a+eaque+ut.+Perspiciatis+harum+fuga+quae+dolores+itaque+voluptas.&thing_id=t3_il"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 873-I2Z1AG133CNeGuaUtYu8VJWB-H8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "122"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_c2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_il\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"4j\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C407K4P5YC8WB7H8C3PF37NB\", \"parent_id\": \"t3_il\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Repellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ERepellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516131419_dicta\", \"score_hidden\": false, \"name\": \"t1_4j\", \"created\": 1516131429.0, \"author_flair_text\": null, \"created_utc\": 1516131429.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "978"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:09 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "171"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_4j"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "168"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/approve/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_4j"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/ignore_reports/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "168"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/ignore_reports/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_4j&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_c2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_il\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"4j\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"01C407K4P5YC8WB7H8C3PF37NB\", \"parent_id\": \"t3_il\", \"score\": 1, \"approved_by\": \"01C407JY9W953SEX5YGNCT2HB0\", \"controversiality\": 0, \"body\": \"Repellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ERepellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516131419_dicta\", \"score_hidden\": false, \"name\": \"t1_4j\", \"created\": 1516131429.0, \"author_flair_text\": null, \"created_utc\": 1516131429.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": 0, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1042"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "168"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=iZbqYN6GgvxsKA%2BNNxPHSd4uwY%2B7bBCR49bBibtpmESORLk2uK97I6NJNzaf3aicDvyTu0rbdS0%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_4j&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 872-Bos25dZ4mJTSe535sBlibIgZ_3U"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=gFpCTmfiKB5d7prX4T; loidcreated=2018-01-16T19%3A36%3A59.413Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_4j&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_c2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_il\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"4j\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"01C407K4P5YC8WB7H8C3PF37NB\", \"parent_id\": \"t3_il\", \"score\": 1, \"approved_by\": \"01C407JY9W953SEX5YGNCT2HB0\", \"controversiality\": 0, \"body\": \"Repellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ERepellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516131419_dicta\", \"score_hidden\": false, \"name\": \"t1_4j\", \"created\": 1516131429.0, \"author_flair_text\": null, \"created_utc\": 1516131429.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": 0, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1042"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:12 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "168"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=rc2yFp2kN1nPlN2bGNKhuR5ZnTIaEoYLyFPrX6wVzAVr1nmOTNMm0vfinv3555g9Jwfe14PaFeQ%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_4j&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.comments_test.test_update_comment_ignore_reports_forbidden.json
+++ b/cassettes/channels.views.comments_test.test_update_comment_ignore_reports_forbidden.json
@@ -1,0 +1,783 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-16T19:46:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C4084ARWE84XE9X4TH4P3VFM"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwN9M1zPQwN08xjfIzCCx3Mrfw8/D2d3KuSvFJSs5W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLalVxoVRoUHFFpEppsmhvj6lvm4GpcWFReZWTiC9KSklmUmp8ZnpoAMhnCUagHh3re1uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:46:29 GMT",
+            "loidcreated=2018-01-16T19%3A46%3A29.255Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:46:29 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C4084ARWE84XE9X4TH4P3VFM"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Tempore+et+sed+perspiciatis.+Velit+assumenda+cum+vel+fuga+corrupti.+Veniam+animi+vel+est+earum+totam.%0ARepellat+sunt+blanditiis+animi+corrupti+expedita.+Distinctio+velit+molestiae+distinctio+consequuntur+in+alias+commodi+rerum.+Sequi+dolorum+eos+ab+perferendis.+Totam+ut+eos+incidunt+occaecati+repudiandae+perferendis.+Molestias+quia+illum+ut+ducimus.&link_type=any&name=1516131989_repellendu&public_description=Harum+officiis+repellat+magnam+expedita.+Corrupti+voluptas+saepe+sequi+quam+modi.&title=Eius+possimus+repellat+quaerat+a+quis+esse.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 876-1iH77d5ZN0QwB78NHKOBCzdLbck"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "601"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "211"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C4084H50X9QBWTN64S0J12X0"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwN9cNzghx80kJSnNO9Xf0ck5xijLKyvZKqsiu8A5U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLallXul+yQmB+lm+YdlhGdYZBXlujnlp6WZh5WD9KSklmUmp8ZnpoAMhnCUagFtD5iZuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C4084H50X9QBWTN64S0J12X0"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C4084H50X9QBWTN64S0J12X0&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 876-1iH77d5ZN0QwB78NHKOBCzdLbck"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516131989_repellendu/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "204"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516131989_repellendu/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516131989_repellendu"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 877-ShTFLdRfCeOAJCdBZ2jkJbxkxKQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "80"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "204"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1516131989_repellendu&text=Assumenda+quasi+ipsum+repellendus+quidem+occaecati+officiis.+A+excepturi+magnam+quos.&title=Aperiam+ut+dicta+iusto+amet."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 877-ShTFLdRfCeOAJCdBZ2jkJbxkxKQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "205"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1516131989_repellendu/comments/in/aperiam_ut_dicta_iusto_amet/\", \"id\": \"in\", \"name\": \"t3_in\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "159"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "204"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 877-ShTFLdRfCeOAJCdBZ2jkJbxkxKQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/in/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516131989_repellendu\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EAssumenda quasi ipsum repellendus quidem occaecati officiis. A excepturi magnam quos.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Assumenda quasi ipsum repellendus quidem occaecati officiis. A excepturi magnam quos.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"in\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C4084H50X9QBWTN64S0J12X0\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516131989_repellendu\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c4\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516131989_repellendu/comments/in/aperiam_ut_dicta_iusto_amet/\", \"locked\": false, \"name\": \"t3_in\", \"created\": 1516131996.0, \"url\": \"http://reddit.local/r/1516131989_repellendu/comments/in/aperiam_ut_dicta_iusto_amet/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Aperiam ut dicta iusto amet.\", \"created_utc\": 1516131996.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1738"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "204"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=o2ugCXqHUJfO1XC%2BjJh%2BlvgOD7ZgxlQbiD3MyY7RlS%2BQyo0nAeGF2ZUOrcRObN1bed7KZTshYyXmeag7F6Uq1BUwI0bSWXHd"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/in/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Laborum+nobis+itaque+tenetur.+Molestiae+vitae+sit+porro+rerum+dolores+corporis+quis.&thing_id=t3_in"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 877-ShTFLdRfCeOAJCdBZ2jkJbxkxKQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_c4\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_in\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"4k\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C4084H50X9QBWTN64S0J12X0\", \"parent_id\": \"t3_in\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Laborum nobis itaque tenetur. Molestiae vitae sit porro rerum dolores corporis quis.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ELaborum nobis itaque tenetur. Molestiae vitae sit porro rerum dolores corporis quis.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516131989_repellendu\", \"score_hidden\": false, \"name\": \"t1_4k\", \"created\": 1516131999.0, \"author_flair_text\": null, \"created_utc\": 1516131999.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "975"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "201"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_4k"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 877-ShTFLdRfCeOAJCdBZ2jkJbxkxKQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=u9TiKFAXAPRqPB9eyj; loidcreated=2018-01-16T19%3A46%3A29.255Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "198"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/api/approve/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.posts_test.test_update_post_ignore_reports.json
+++ b/cassettes/channels.views.posts_test.test_update_post_ignore_reports.json
@@ -1,0 +1,1050 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-16T19:37:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C407KN9DD61656RYH8040BXF"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBiEX4V0NJI0EW1108HBaOLQOLA00P5AIQi0pdQY310qk+N9ue/ujTIhwBhuuwae6BAhSpJ4W7YJuafu5obap9STfTtiFk+STWgdIfC90mC4CsJmh/HMfj63rx7CSA6ZBh26RnQLWoWkoZjF6v/tLI9NfaIXMjpp4VpYYKV75BMeTHAkOCWAKxmGl4A+X72yuBy4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=atQKuqZo2srX1M2VBN; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:37:23 GMT",
+            "loidcreated=2018-01-16T19%3A37%3A22.962Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:37:23 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C407KN9DD61656RYH8040BXF"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Porro+dicta+cum+laudantium+minima+qui+necessitatibus+ipsum.+Doloremque+laborum+sed+qui+quasi+ut+accusamus+voluptate.+Quaerat+dolorem+perferendis+ut+deleniti+ullam+ab+rerum+deserunt.+Excepturi+quibusdam+reiciendis+eos+voluptas+aut+exercitationem.+Est+perspiciatis+ducimus+excepturi+maxime+id+saepe+aliquam.%0ARatione+iusto+aliquam+nisi.+Facilis+deleniti+delectus+ea+eius+minima+molestias.+Ipsa+mollitia+voluptas+aspernatur+reprehenderit.&link_type=any&name=1516131443_laudantium&public_description=Quia+quo+dicta+qui+culpa.+Optio+ex+eos+corrupti+mollitia+dolor+laboriosam.+Facere+illum+eos+unde.&title=Nesciunt+vero+dignissimos+eum.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "688"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "157"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C407KVRKK48XX8ZKVFN0QNTK"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwN9V19QgprXAsKLU0TvWMrzDLdYo0KU4JCHYuNfBV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYlhYeFFZgFm5qERZRnenqbpRWbFAcHGrp6BRuA9KSklmUmp8ZnpoAMhnCUagEDUJzCuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C407KVRKK48XX8ZKVFN0QNTK"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C407KVRKK48XX8ZKVFN0QNTK&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516131443_laudantium/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "151"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516131443_laudantium/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516131443_laudantium"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 875-EHTuxApu93eI_x6mBY4sdPSCu0M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "80"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "150"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1516131443_laudantium&text=Facilis+excepturi+debitis+ea+velit+corrupti.+Voluptatem+doloribus+possimus+error+saepe.&title=Magnam+architecto+esse+dicta."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 875-EHTuxApu93eI_x6mBY4sdPSCu0M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "208"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"id\": \"im\", \"name\": \"t3_im\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "160"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "150"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 875-EHTuxApu93eI_x6mBY4sdPSCu0M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516131443_laudantium\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFacilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Facilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"im\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C407KVRKK48XX8ZKVFN0QNTK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516131443_laudantium\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c3\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"locked\": false, \"name\": \"t3_im\", \"created\": 1516131450.0, \"url\": \"http://reddit.local/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Magnam architecto esse dicta.\", \"created_utc\": 1516131450.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1745"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "150"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=nlAV80LDTqdPq0QIPMQSFpQ851t8j%2BoR1zH7l2OHkE3UV7Gz8OYN%2FFFACGvWfoA8nvH4Eqj1hiKnJbCMU5tEKC2rPQxTeM7N"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_im"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "147"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/approve/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_im"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/ignore_reports/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "147"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/ignore_reports/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516131443_laudantium\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFacilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Facilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"im\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C407KVRKK48XX8ZKVFN0QNTK\", \"media\": null, \"score\": 1, \"approved_by\": \"01C407KN9DD61656RYH8040BXF\", \"over_18\": false, \"domain\": \"self.1516131443_laudantium\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c3\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"locked\": false, \"name\": \"t3_im\", \"created\": 1516131450.0, \"url\": \"http://reddit.local/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Magnam architecto esse dicta.\", \"created_utc\": 1516131450.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1764"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "147"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=Mve3mabcY7EwsCkbyRd7mMA1z6FjI%2B%2BrkdDlXGWNODVGdySV1DPUFjYJtjfbTm3%2FredvPl4e1HqGI2gYATF5oBq5Ch1PXVGE"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516131443_laudantium\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFacilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Facilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"im\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01C407KVRKK48XX8ZKVFN0QNTK\", \"media\": null, \"score\": 1, \"approved_by\": \"01C407KN9DD61656RYH8040BXF\", \"over_18\": false, \"domain\": \"self.1516131443_laudantium\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c3\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"locked\": false, \"name\": \"t3_im\", \"created\": 1516131450.0, \"url\": \"http://reddit.local/r/1516131443_laudantium/comments/im/magnam_architecto_esse_dicta/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Magnam architecto esse dicta.\", \"created_utc\": 1516131450.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1764"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "147"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=UJCeEAO4uj1Ezko6mrWd3yEVCgPnjpArUj3AQl7t6r70JmutJ1Vm2Dt84f3XlzWjOL%2B%2Fy06hgPstaEHPsTjrGzpEzICWWeco"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/im/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:37:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 874-5gm47PZvMvqjxZ8x79mu0T-wdTw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=atQKuqZo2srX1M2VBN; loidcreated=2018-01-16T19%3A37%3A22.962Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1516131443_laudantium/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"c3\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1516131443_laudantium\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPorro dicta cum laudantium minima qui necessitatibus ipsum. Doloremque laborum sed qui quasi ut accusamus voluptate. Quaerat dolorem perferendis ut deleniti ullam ab rerum deserunt. Excepturi quibusdam reiciendis eos voluptas aut exercitationem. Est perspiciatis ducimus excepturi maxime id saepe aliquam.\\nRatione iusto aliquam nisi. Facilis deleniti delectus ea eius minima molestias. Ipsa mollitia voluptas aspernatur reprehenderit.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Nesciunt vero dignissimos eum.\", \"collapse_deleted_comments\": false, \"public_description\": \"Quia quo dicta qui culpa. Optio ex eos corrupti mollitia dolor laboriosam. Facere illum eos unde.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EQuia quo dicta qui culpa. Optio ex eos corrupti mollitia dolor laboriosam. Facere illum eos unde.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Porro dicta cum laudantium minima qui necessitatibus ipsum. Doloremque laborum sed qui quasi ut accusamus voluptate. Quaerat dolorem perferendis ut deleniti ullam ab rerum deserunt. Excepturi quibusdam reiciendis eos voluptas aut exercitationem. Est perspiciatis ducimus excepturi maxime id saepe aliquam.\\nRatione iusto aliquam nisi. Facilis deleniti delectus ea eius minima molestias. Ipsa mollitia voluptas aspernatur reprehenderit.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 2, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_c3\", \"created\": 1516131443.0, \"url\": \"/r/1516131443_laudantium/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1516131443.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2419"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:37:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "147"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=KNmezCn%2BLUnS7hviR4J8dApvnAeVU9rX40l33z5P3iCyWLVFZBlsY1taXToeAjyBJ4iucd42FGKNO7jDEp9MrVXmI5SYDzLK"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516131443_laudantium/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.posts_test.test_update_post_ignore_reports_forbidden.json
+++ b/cassettes/channels.views.posts_test.test_update_post_ignore_reports_forbidden.json
@@ -1,0 +1,691 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-16T19:46:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C40851JP3DHQSV4J0CWKX5HH"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULIwt9DNszBwrUxKNLJ0DQzPtgiuMioIdPdJKnAzDo9U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVZhc5FuemGhUmm+eHJTpZeGQFFxfkZfnne3uC9KSklmUmp8ZnpoAMhnCUagFJZ4gEuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:52 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=wfihhug9I6HyaC0QeE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:46:52 GMT",
+            "loidcreated=2018-01-16T19%3A46%3A52.604Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 16-Jan-2020 19:46:52 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C40851JP3DHQSV4J0CWKX5HH"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Molestias+sapiente+minus+dicta+id+repellendus+repudiandae+dolorem.+Non+amet+enim+debitis+id.+Voluptatem+sapiente+at+neque+amet.+Rem+reiciendis+rerum+facilis+quia+cumque+veritatis+reprehenderit.%0AVoluptas+possimus+accusamus+culpa+dolorem+blanditiis+porro.+Architecto+dolorem+expedita+tempore+consequuntur+recusandae+dignissimos.+Fugiat+unde+dignissimos+ipsa+dolor.&link_type=any&name=1516132012_similique&public_description=Adipisci+est+aliquid+pariatur+praesentium+repellat.+Sapiente+quia+delectus+optio+dolores.&title=Nam+atque+et+excepturi+consequuntur+commodi.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 878-n80Eyba29EQWk8Sz2pQGLbpF3WY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "621"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "188"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C40857Y2QKZBV6F6G43Z2JZB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNyw7CIBREf6VhaTQh1ge4NW3aZeOrO1LhEomtEMAGa/x3i125nJM5M2/UcA7OMa/v8EC7BJEtXSx5ZsqyleFZVWro1mdZO5OvhmNO0DxBEIyy4JiKQrrBeGQ/n/mXgThyhcaCjV3H9YRmMVmQo3j7fzt0LQ3yxHyWYkoELqDueXEBttfREdArDkyJODwF9PkCkNfhrrgAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C40857Y2QKZBV6F6G43Z2JZB"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C40857Y2QKZBV6F6G43Z2JZB&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 878-n80Eyba29EQWk8Sz2pQGLbpF3WY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516132012_similique/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "181"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516132012_similique/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516132012_similique"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 879-2cEpIIlfxuQQizm5VfXspF4zTF8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "181"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1516132012_similique&text=Nemo+magnam+enim+saepe+fugit+beatae+nisi.+Iure+eligendi+odit+eveniet+cum+fugiat+ea.&title=Neque+nihil+odit+provident+omnis."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 879-2cEpIIlfxuQQizm5VfXspF4zTF8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1516132012_similique/comments/io/neque_nihil_odit_provident_omnis/\", \"id\": \"io\", \"name\": \"t3_io\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "163"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "181"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:46:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 879-2cEpIIlfxuQQizm5VfXspF4zTF8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/io/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516132012_similique\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENemo magnam enim saepe fugit beatae nisi. Iure eligendi odit eveniet cum fugiat ea.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Nemo magnam enim saepe fugit beatae nisi. Iure eligendi odit eveniet cum fugiat ea.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"io\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C40857Y2QKZBV6F6G43Z2JZB\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516132012_similique\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_c5\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516132012_similique/comments/io/neque_nihil_odit_provident_omnis/\", \"locked\": false, \"name\": \"t3_io\", \"created\": 1516132019.0, \"url\": \"http://reddit.local/r/1516132012_similique/comments/io/neque_nihil_odit_provident_omnis/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Neque nihil odit provident omnis.\", \"created_utc\": 1516132019.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1745"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:46:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "181"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=BVevZxogazMpikJBWnMOKiLFBZ%2B8%2F5q6RsPeUiTfvKUy68Lp8IiqcWErkPMurK38PApkwEmBKkCmeL7OxoStavv%2BZXkinyhH"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/io/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-16T19:47:02",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_io"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 879-2cEpIIlfxuQQizm5VfXspF4zTF8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "22"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=wfihhug9I6HyaC0QeE; loidcreated=2018-01-16T19%3A46%3A52.604Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Forbidden\", \"error\": 403}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Jan 2018 19:47:02 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "178"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 403,
+          "message": "Forbidden"
+        },
+        "url": "https://reddit.local/api/approve/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/api.py
+++ b/channels/api.py
@@ -897,3 +897,21 @@ class Api:
             praw.models.listing.generator.ListingGenerator: a generator representing the reports in the channel
         """
         return self.get_channel(channel_name).mod.reports()
+
+    def ignore_comment_reports(self, comment_id):
+        """
+        Ignore further reports on this comment
+
+        Args:
+            comment_id(str): the id of the comment to report
+        """
+        self.get_comment(comment_id).mod.ignore_reports()
+
+    def ignore_post_reports(self, post_id):
+        """
+        Ignore further reports on this post
+
+        Args:
+            post_id(str): the id of the post to report
+        """
+        self.get_post(post_id).mod.ignore_reports()

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -662,3 +662,19 @@ def test_list_reports(mock_client):
     assert client.list_reports('channel') == mock_client.subreddit.return_value.mod.reports.return_value
     mock_client.subreddit.assert_called_once_with('channel')
     mock_client.subreddit.return_value.mod.reports.assert_called_once_with()
+
+
+def test_ignore_comment_resports(mock_client):
+    """Test ignore_comment_reports"""
+    client = api.Api(UserFactory.create())
+    client.ignore_comment_reports('id')
+    mock_client.comment.assert_called_once_with('id')
+    mock_client.comment.return_value.mod.ignore_reports.assert_called_once_with()
+
+
+def test_ignore_post_resports(mock_client):
+    """Test ignore_post_reports"""
+    client = api.Api(UserFactory.create())
+    client.ignore_post_reports('id')
+    mock_client.submission.assert_called_once_with(id='id')
+    mock_client.submission.return_value.mod.ignore_reports.assert_called_once_with()

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -123,6 +123,7 @@ class PostSerializer(serializers.Serializer):
     title = serializers.CharField()
     upvoted = WriteableSerializerMethodField()
     removed = WriteableSerializerMethodField()
+    ignore_reports = serializers.BooleanField(required=False, write_only=True)
     stickied = serializers.BooleanField(required=False)
     score = serializers.IntegerField(source='ups', read_only=True)
     author_id = serializers.CharField(read_only=True, source='author')
@@ -267,6 +268,12 @@ class PostSerializer(serializers.Serializer):
             elif removed is False:
                 api.approve_post(post_id)
 
+        if "ignore_reports" in validated_data:
+            ignore_reports = validated_data["ignore_reports"]
+            if ignore_reports is True:
+                api.approve_post(post_id)
+                api.ignore_post_reports(post_id)
+
         if "text" in validated_data:
             instance = api.update_post(post_id=post_id, text=validated_data['text'])
 
@@ -289,6 +296,7 @@ class CommentSerializer(serializers.Serializer):
     score = serializers.IntegerField(read_only=True)
     upvoted = WriteableSerializerMethodField()
     removed = WriteableSerializerMethodField()
+    ignore_reports = serializers.BooleanField(required=False, write_only=True)
     downvoted = WriteableSerializerMethodField()
     created = serializers.SerializerMethodField()
     profile_image = serializers.SerializerMethodField()
@@ -431,6 +439,12 @@ class CommentSerializer(serializers.Serializer):
                 api.remove_comment(comment_id=instance.id)
             else:
                 api.approve_comment(comment_id=instance.id)
+
+        if "ignore_reports" in validated_data:
+            ignore_reports = validated_data["ignore_reports"]
+            if ignore_reports is True:
+                api.approve_comment(comment_id=instance.id)
+                api.ignore_comment_reports(instance.id)
 
         _apply_vote(instance, validated_data, True)
 

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -633,6 +633,45 @@ def test_update_post_clear_removed(client, staff_user, staff_api, private_channe
     }
 
 
+def test_update_post_ignore_reports(client, staff_user, staff_api, private_channel_and_contributor, reddit_factories):
+    """Test updating a post to ignore reports"""
+    channel, user = private_channel_and_contributor
+    post = reddit_factories.text_post('just a post', user, channel=channel)
+    url = reverse('post-detail', kwargs={'post_id': post.id})
+    client.force_login(staff_user)
+    resp = client.patch(url, format='json', data={"ignore_reports": True})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == {
+        'url': None,
+        'text': post.text,
+        'title': post.title,
+        'upvoted': False,
+        'score': 1,
+        'removed': False,
+        'author_id': user.username,
+        'id': post.id,
+        'created': post.created,
+        'num_comments': 0,
+        'channel_name': channel.name,
+        'channel_title': channel.title,
+        "profile_image": user.profile.image_small,
+        "author_name": user.profile.name,
+        'edited': False,
+        "stickied": False,
+        'num_reports': 0,
+    }
+
+
+def test_update_post_ignore_reports_forbidden(client, private_channel_and_contributor, reddit_factories):
+    """Test updating a post to ignore reports with a nonstaff user"""
+    channel, user = private_channel_and_contributor
+    post = reddit_factories.text_post('just a post', user, channel=channel)
+    url = reverse('post-detail', kwargs={'post_id': post.id})
+    client.force_login(user)
+    resp = client.patch(url, format='json', data={"ignore_reports": True})
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
 def test_update_post_removed_forbidden(client, private_channel_and_contributor, reddit_factories):
     """Test updating a post to remove with a nonstaff user"""
     channel, user = private_channel_and_contributor

--- a/factory_data/channels.views.comments_test.test_update_comment_ignore_reports.json
+++ b/factory_data/channels.views.comments_test.test_update_comment_ignore_reports.json
@@ -1,0 +1,35 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Distinctio voluptatibus laudantium accusantium quod. Esse ipsa est facilis. Velit alias dolores delectus praesentium rerum. Deleniti consectetur ut ullam earum nemo. Ex vel fugit provident consequatur iusto pariatur corrupti.\nHarum vel nemo provident ullam vero saepe quidem. Accusantium accusamus aliquid ab eius aspernatur. Sunt eos ea ut praesentium amet neque nulla.",
+      "name": "1516131419_dicta",
+      "public_description": "Facilis accusamus nemo maiores. Explicabo vel atque hic commodi.",
+      "title": "Officia id deleniti temporibus magni."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "4j",
+      "post_id": "il",
+      "text": "Repellat ullam placeat a eaque ut. Perspiciatis harum fuga quae dolores itaque voluptas."
+    }
+  },
+  "posts": {
+    "post": {
+      "id": "il",
+      "text": "Deleniti fugit et hic quae a dolore exercitationem. Magnam reprehenderit esse voluptates numquam.",
+      "title": "Alias ullam quidem incidunt culpa quas."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C407K4P5YC8WB7H8C3PF37NB"
+    },
+    "staff_user": {
+      "username": "01C407JY9W953SEX5YGNCT2HB0"
+    }
+  }
+}

--- a/factory_data/channels.views.comments_test.test_update_comment_ignore_reports_forbidden.json
+++ b/factory_data/channels.views.comments_test.test_update_comment_ignore_reports_forbidden.json
@@ -1,0 +1,35 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Tempore et sed perspiciatis. Velit assumenda cum vel fuga corrupti. Veniam animi vel est earum totam.\nRepellat sunt blanditiis animi corrupti expedita. Distinctio velit molestiae distinctio consequuntur in alias commodi rerum. Sequi dolorum eos ab perferendis. Totam ut eos incidunt occaecati repudiandae perferendis. Molestias quia illum ut ducimus.",
+      "name": "1516131989_repellendu",
+      "public_description": "Harum officiis repellat magnam expedita. Corrupti voluptas saepe sequi quam modi.",
+      "title": "Eius possimus repellat quaerat a quis esse."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "4k",
+      "post_id": "in",
+      "text": "Laborum nobis itaque tenetur. Molestiae vitae sit porro rerum dolores corporis quis."
+    }
+  },
+  "posts": {
+    "post": {
+      "id": "in",
+      "text": "Assumenda quasi ipsum repellendus quidem occaecati officiis. A excepturi magnam quos.",
+      "title": "Aperiam ut dicta iusto amet."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C4084H50X9QBWTN64S0J12X0"
+    },
+    "staff_user": {
+      "username": "01C4084ARWE84XE9X4TH4P3VFM"
+    }
+  }
+}

--- a/factory_data/channels.views.posts_test.test_update_post_ignore_reports.json
+++ b/factory_data/channels.views.posts_test.test_update_post_ignore_reports.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Porro dicta cum laudantium minima qui necessitatibus ipsum. Doloremque laborum sed qui quasi ut accusamus voluptate. Quaerat dolorem perferendis ut deleniti ullam ab rerum deserunt. Excepturi quibusdam reiciendis eos voluptas aut exercitationem. Est perspiciatis ducimus excepturi maxime id saepe aliquam.\nRatione iusto aliquam nisi. Facilis deleniti delectus ea eius minima molestias. Ipsa mollitia voluptas aspernatur reprehenderit.",
+      "name": "1516131443_laudantium",
+      "public_description": "Quia quo dicta qui culpa. Optio ex eos corrupti mollitia dolor laboriosam. Facere illum eos unde.",
+      "title": "Nesciunt vero dignissimos eum."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "im",
+      "text": "Facilis excepturi debitis ea velit corrupti. Voluptatem doloribus possimus error saepe.",
+      "title": "Magnam architecto esse dicta."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C407KVRKK48XX8ZKVFN0QNTK"
+    },
+    "staff_user": {
+      "username": "01C407KN9DD61656RYH8040BXF"
+    }
+  }
+}

--- a/factory_data/channels.views.posts_test.test_update_post_ignore_reports_forbidden.json
+++ b/factory_data/channels.views.posts_test.test_update_post_ignore_reports_forbidden.json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Molestias sapiente minus dicta id repellendus repudiandae dolorem. Non amet enim debitis id. Voluptatem sapiente at neque amet. Rem reiciendis rerum facilis quia cumque veritatis reprehenderit.\nVoluptas possimus accusamus culpa dolorem blanditiis porro. Architecto dolorem expedita tempore consequuntur recusandae dignissimos. Fugiat unde dignissimos ipsa dolor.",
+      "name": "1516132012_similique",
+      "public_description": "Adipisci est aliquid pariatur praesentium repellat. Sapiente quia delectus optio dolores.",
+      "title": "Nam atque et excepturi consequuntur commodi."
+    }
+  },
+  "posts": {
+    "just a post": {
+      "id": "io",
+      "text": "Nemo magnam enim saepe fugit beatae nisi. Iure eligendi odit eveniet cum fugiat ea.",
+      "title": "Neque nihil odit provident omnis."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C40857Y2QKZBV6F6G43Z2JZB"
+    },
+    "staff_user": {
+      "username": "01C40851JP3DHQSV4J0CWKX5HH"
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #427 

#### What's this PR do?
Adds functionality to comment/post APIs to ignore future reports on the items

#### How should this be manually tested?
- Report a comment and a post
- Verify the reports show up on `/api/v0/channels/:channel_name/reports/`
- Go to `/api/v0/posts/:post_id` and `/api/v0/comments/:comment_id` and patch with `{"ignore_reports": true}`
- Verify the reports no longer show up on `/api/v0/channels/:channel_name/reports/`
- Report the comment and post again under a **different user**
- Verify the reports still don't show up on `/api/v0/channels/:channel_name/reports/`