### PR TITLE
Added report counts to post/comment serializers (#432)

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -134,6 +134,7 @@ class PostSerializer(serializers.Serializer):
     profile_image = serializers.SerializerMethodField()
     author_name = serializers.SerializerMethodField()
     edited = serializers.SerializerMethodField()
+    num_reports = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -187,6 +188,11 @@ class PostSerializer(serializers.Serializer):
     def get_channel_title(self, instance):
         """The title of the channel"""
         return instance.subreddit.title
+
+    def get_num_reports(self, instance):
+        """The number of reports for this post"""
+        # user_reports is a list of (str, int), so we want to sum the counts
+        return len(instance.mod_reports) + sum(report[1] for report in instance.user_reports)
 
     def get_edited(self, instance):
         """Return a Boolean signifying if the post has been edited or not"""
@@ -289,6 +295,7 @@ class CommentSerializer(serializers.Serializer):
     author_name = serializers.SerializerMethodField()
     edited = serializers.SerializerMethodField()
     comment_type = serializers.SerializerMethodField()
+    num_reports = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
         """
@@ -358,6 +365,11 @@ class CommentSerializer(serializers.Serializer):
     def get_edited(self, instance):
         """Return a Boolean signifying if the comment has been edited or not"""
         return instance.edited if instance.edited is False else True
+
+    def get_num_reports(self, instance):
+        """The number of reports for this comment"""
+        # user_reports is a list of (str, int), so we want to sum the counts
+        return len(instance.mod_reports) + sum(report[1] for report in instance.user_reports)
 
     def get_comment_type(self, instance):  # pylint: disable=unused-argument
         """Let the frontend know which type this is"""

--- a/channels/test_constants.py
+++ b/channels/test_constants.py
@@ -15,7 +15,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '2',
@@ -31,7 +32,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '3',
@@ -47,7 +49,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '4',
@@ -63,7 +66,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '5',
@@ -79,7 +83,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'l',
@@ -95,7 +100,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'p',
@@ -111,7 +117,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8x',
@@ -127,7 +134,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8y',
@@ -143,7 +151,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8z',
@@ -159,7 +168,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e90',
@@ -175,7 +185,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e91',
@@ -191,7 +202,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e92',
@@ -207,7 +219,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e93',
@@ -223,7 +236,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e94',
@@ -239,7 +253,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e95',
@@ -255,7 +270,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e96',
@@ -271,7 +287,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e97',
@@ -287,7 +304,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e99',
@@ -303,7 +321,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9b',
@@ -319,7 +338,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9c',
@@ -335,7 +355,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9d',
@@ -351,7 +372,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9f',
@@ -367,7 +389,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9g',
@@ -383,7 +406,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9h',
@@ -399,7 +423,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9i',
@@ -415,7 +440,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9j',
@@ -431,7 +457,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e9k',
@@ -447,7 +474,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'parent_id': None,
@@ -473,6 +501,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'author_name': '[deleted]',
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '6',
@@ -488,7 +517,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '7',
@@ -504,7 +534,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '8',
@@ -520,7 +551,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'edited': False,
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'n',
@@ -536,7 +568,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': '9',
@@ -552,7 +585,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'c',
@@ -568,7 +602,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'o',
@@ -584,7 +619,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'a',
@@ -600,7 +636,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'b',
@@ -616,7 +653,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'f',
@@ -632,7 +670,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'g',
@@ -648,7 +687,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'h',
@@ -664,7 +704,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'i',
@@ -680,7 +721,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'd',
@@ -696,7 +738,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e',
@@ -712,7 +755,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'j',
@@ -728,7 +772,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'k',
@@ -744,7 +789,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8s',
@@ -760,7 +806,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': True,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8t',
@@ -776,7 +823,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': True,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8u',
@@ -792,7 +840,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': True,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'id': 'e8v',
@@ -808,7 +857,8 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': True,
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
-        'comment_type': 'comment'
+        'comment_type': 'comment',
+        'num_reports': 0,
     },
     {
         'parent_id': 'e8v',

--- a/channels/views/comments_test.py
+++ b/channels/views/comments_test.py
@@ -49,6 +49,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
             'author_name': name,
             'edited': False,
             'comment_type': 'comment',
+            'num_reports': 0,
         },
         {
             "id": "2",
@@ -65,6 +66,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
             'author_name': name,
             'edited': True,
             'comment_type': 'comment',
+            'num_reports': 0,
         },
         {
             "id": "3",
@@ -81,6 +83,7 @@ def test_list_comments(client, logged_in_profile, missing_user):
             'author_name': name,
             'edited': False,
             'comment_type': 'comment',
+            'num_reports': 0,
         },
     ]
 
@@ -139,7 +142,8 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "profile_image": image_url,
             "author_name": name,
             "edited": False,
-            "comment_type": "comment"
+            "comment_type": "comment",
+            'num_reports': 0,
         },
         {
             "id": "n",
@@ -155,7 +159,8 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "profile_image": image_url,
             "author_name": name,
             "edited": False,
-            "comment_type": "comment"
+            "comment_type": "comment",
+            'num_reports': 0,
         },
         {
             "id": "o",
@@ -171,7 +176,8 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "profile_image": image_url,
             "author_name": name,
             "edited": False,
-            "comment_type": "comment"
+            "comment_type": "comment",
+            'num_reports': 0,
         }
     ]
 
@@ -220,7 +226,8 @@ def test_more_comments_children(client, logged_in_profile):
             "profile_image": image_url,
             "author_name": name,
             "edited": False,
-            "comment_type": "comment"
+            "comment_type": "comment",
+            'num_reports': 0,
         },
         {
             "id": "e9m",
@@ -236,7 +243,8 @@ def test_more_comments_children(client, logged_in_profile):
             "profile_image": image_url,
             "author_name": name,
             "edited": False,
-            "comment_type": "comment"
+            "comment_type": "comment",
+            'num_reports': 0,
         }
     ]
 
@@ -297,6 +305,7 @@ def test_list_deleted_comments(client, logged_in_profile):
             'id': '1s',
             'edited': False,
             "author_name": "[deleted]",
+            'num_reports': 0,
         },
         {
             'author_id': user.username,
@@ -313,6 +322,7 @@ def test_list_deleted_comments(client, logged_in_profile):
             "removed": False,
             'edited': False,
             "author_name": user.profile.name,
+            'num_reports': 0,
         }
     ]
 
@@ -340,6 +350,7 @@ def test_create_comment(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -387,6 +398,7 @@ def test_create_comment_no_upvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -414,6 +426,7 @@ def test_create_comment_downvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -442,6 +455,7 @@ def test_create_comment_reply_to_comment(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -467,6 +481,7 @@ def test_update_comment_text(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': True,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -504,6 +519,7 @@ def test_update_comment_upvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -530,6 +546,7 @@ def test_update_comment_downvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -555,6 +572,7 @@ def test_update_comment_clear_upvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -581,6 +599,7 @@ def test_update_comment_clear_downvote(client, logged_in_profile):
         'author_name': logged_in_profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -612,6 +631,7 @@ def test_update_comment_remove(
         'author_name': user.profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 
@@ -644,6 +664,7 @@ def test_update_comment_approve(
         'author_name': user.profile.name,
         'edited': False,
         'comment_type': 'comment',
+        'num_reports': 0,
     }
 
 

--- a/channels/views/frontpage_test.py
+++ b/channels/views/frontpage_test.py
@@ -58,6 +58,7 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
+            'num_reports': 0,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': POSTS_SORT_HOT,
@@ -99,6 +100,7 @@ def test_frontpage_sorted(client, private_channel_and_contributor, reddit_factor
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
+            'num_reports': 0,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': sort,

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -45,6 +45,7 @@ def test_create_url_post(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -77,6 +78,7 @@ def test_create_text_post(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -159,6 +161,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         "profile_image": profile_image,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -204,6 +207,7 @@ def test_get_post_stickied(client, private_channel_and_contributor, reddit_facto
         "profile_image": user.profile.image_small,
         "edited": False,
         "stickied": True,
+        'num_reports': 0,
     }
 
 
@@ -254,6 +258,7 @@ def test_list_posts(client, missing_user, private_channel_and_contributor, reddi
                     "profile_image": user.profile.image_small,
                     "edited": False,
                     "stickied": False,
+                    'num_reports': 0,
                 } for post in posts
             ],
             'pagination': {
@@ -296,6 +301,7 @@ def test_list_posts_sorted(client, private_channel_and_contributor, reddit_facto
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
+            'num_reports': 0,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': sort,
@@ -331,7 +337,8 @@ def test_list_posts_stickied(client, private_channel_and_contributor, reddit_fac
         'author_name': user.profile.name,
         "profile_image": user.profile.image_small,
         "edited": False,
-        "stickied": True
+        "stickied": True,
+        'num_reports': 0,
     }
 
 
@@ -454,6 +461,7 @@ def test_update_post_text(client, private_channel_and_contributor, reddit_factor
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -482,6 +490,7 @@ def test_update_post_stickied(client, private_channel_and_contributor, reddit_fa
         "author_name": user.profile.name,
         'edited': False,
         "stickied": True,
+        'num_reports': 0,
     }
 
 
@@ -532,6 +541,7 @@ def test_update_post_clear_vote(client, private_channel_and_contributor, reddit_
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -560,6 +570,7 @@ def test_update_post_upvote(client, private_channel_and_contributor, reddit_fact
         "author_name": user.profile.name,
         "edited": False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -588,6 +599,7 @@ def test_update_post_removed(client, staff_user, private_channel_and_contributor
         "author_name": user.profile.name,
         "edited": False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -617,6 +629,7 @@ def test_update_post_clear_removed(client, staff_user, staff_api, private_channe
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 
@@ -675,6 +688,7 @@ def test_create_post_without_upvote(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
+        'num_reports': 0,
     }
 
 

--- a/channels/views/reports_test.py
+++ b/channels/views/reports_test.py
@@ -74,6 +74,7 @@ def test_list_reports(staff_client, private_channel_and_contributor, reddit_fact
             'author_name': user.profile.name,
             'edited': False,
             'comment_type': 'comment',
+            'num_reports': 2,
         },
         "reasons": ["spam"],
     }, {
@@ -94,6 +95,7 @@ def test_list_reports(staff_client, private_channel_and_contributor, reddit_fact
             'profile_image': user.profile.image_small,
             'edited': False,
             "stickied": False,
+            'num_reports': 2,
         },
         "comment": None,
         "reasons": ["bad", "junk"],


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #432 

#### What's this PR do?
Adds the report count to the post and comment serializers

#### How should this be manually tested?

- Report a comment and a post and verify you now the see appropriate count on the results returned from the post and comment APIs

#### What GIF best describes this PR or how it makes you feel?
![counts](https://media.giphy.com/media/SUFuaOfn7qXaE/giphy.gif)
