### PR TITLE
add comment permalink

### DIFF
--- a/cassettes/channels.views.comments_test.test_get_comment.json
+++ b/cassettes/channels.views.comments_test.test_get_comment.json
@@ -1,0 +1,869 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-17T16:54:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C42GPZ8J1YPMNEAAVQ1X83CT"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NtfNtnBNMw3JMwlNrDT2jywKdw8w9nRKrczL9ylX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZluRubGjin+7slhni7mRhleIZEZSV6O5UEGLmC9KSklmUmp8ZnpoAMhnCUagGXa9fEuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:54:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=xRh9vtJETooUdzoXX4; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 17-Jan-2020 16:54:57 GMT",
+            "loidcreated=2018-01-17T16%3A54%3A57.506Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 17-Jan-2020 16:54:57 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C42GPZ8J1YPMNEAAVQ1X83CT"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C42GQ2J40SZ565ZCVNXFS17J"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0ttCNrywrMzTOzSor8TNL8tCt8vCLMnYNNyg0MUlW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblu/r5F3oa5IWEGDu6OBY7p+UWm/rmVwYF+qaD9KSklmUmp8ZnpoAMhnCUagFvdp71uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C42GQ2J40SZ565ZCVNXFS17J"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Aliquid+fuga+consectetur+illum+nam+voluptatibus+nobis+atque+deserunt.+Temporibus+deleniti+eaque+atque+quis+suscipit+sit+praesentium+dolores.+Animi+eum+ipsum+eveniet+qui+aliquam+quam.+Modi+saepe+perspiciatis+id.%0ANemo+exercitationem+molestiae+unde+corrupti+at+repudiandae+harum.+Cumque+libero+incidunt+dicta+odio.+Voluptatem+asperiores+distinctio+aliquid.+Temporibus+quo+laboriosam+placeat+quam.&link_type=any&name=1516208101_placeat&public_description=Eius+fugiat+molestiae+delectus+ducimus+aut.+Eius+quo+laboriosam+atque+sit.&title=Ab+corporis+unde+laudantium+magni.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 138-_yvv13mjvtN6bH-zHNZ3EW0q44c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "625"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "299"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C42GPZ8J1YPMNEAAVQ1X83CT&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 138-_yvv13mjvtN6bH-zHNZ3EW0q44c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516208101_placeat/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "296"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516208101_placeat/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516208101_placeat"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "77"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "296"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1516208101_placeat&text=Dolorum+veritatis+aliquid+accusantium+voluptatum.+Id+dignissimos+facilis+ut+repellat+placeat.&title=Minus+id+fuga+dignissimos+nisi+tenetur."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "221"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1516208101_placeat/comments/b/minus_id_fuga_dignissimos_nisi_tenetur/\", \"id\": \"b\", \"name\": \"t3_b\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "164"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "296"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/b/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516208101_placeat\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EDolorum veritatis aliquid accusantium voluptatum. Id dignissimos facilis ut repellat placeat.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Dolorum veritatis aliquid accusantium voluptatum. Id dignissimos facilis ut repellat placeat.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"b\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C42GPZ8J1YPMNEAAVQ1X83CT\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516208101_placeat\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_6\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516208101_placeat/comments/b/minus_id_fuga_dignissimos_nisi_tenetur/\", \"locked\": false, \"name\": \"t3_b\", \"created\": 1516208104.0, \"url\": \"http://reddit.local/r/1516208101_placeat/comments/b/minus_id_fuga_dignissimos_nisi_tenetur/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Minus id fuga dignissimos nisi tenetur.\", \"created_utc\": 1516208104.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1770"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "296"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=vIiaWLVnDa1T6uRex4lRrDha8Hp1BPt%2FVyIUk9eUjRAUiMfz8vDWGyXTmuF%2BVxIYsJ94m3%2BKuMbkCzw252LMFE8fyinvvI1f"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/b/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Id+rem+cupiditate+officia+explicabo+perspiciatis.+Consectetur+earum+voluptatibus+deserunt+tempora.&thing_id=t3_b"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "131"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_6\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_b\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"1m\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C42GPZ8J1YPMNEAAVQ1X83CT\", \"parent_id\": \"t3_b\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Id rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EId rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516208101_placeat\", \"score_hidden\": false, \"name\": \"t1_1m\", \"created\": 1516208107.0, \"author_flair_text\": null, \"created_utc\": 1516208107.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "997"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:07 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "293"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_1m&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_6\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_b\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"1m\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C42GPZ8J1YPMNEAAVQ1X83CT\", \"parent_id\": \"t3_b\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Id rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EId rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516208101_placeat\", \"score_hidden\": false, \"name\": \"t1_1m\", \"created\": 1516208107.0, \"author_flair_text\": null, \"created_utc\": 1516208107.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1042"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "290"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=lgxLBwYGSiIPaHiFU7w5NYk8m%2BwwmReh0%2F5jvpfkgbep79w8uGlv5laGKJoBtE%2Bg3WoczHRd5aY%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_1m&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T16:55:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 137-k8Ef5Tn4Uay3OYrWGP3IBeynoLw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=xRh9vtJETooUdzoXX4; loidcreated=2018-01-17T16%3A54%3A57.506Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.9.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/b/_/1m?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1516208101_placeat\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EDolorum veritatis aliquid accusantium voluptatum. Id dignissimos facilis ut repellat placeat.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Dolorum veritatis aliquid accusantium voluptatum. Id dignissimos facilis ut repellat placeat.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"b\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01C42GPZ8J1YPMNEAAVQ1X83CT\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1516208101_placeat\", \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_6\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1516208101_placeat/comments/b/minus_id_fuga_dignissimos_nisi_tenetur/\", \"locked\": false, \"name\": \"t3_b\", \"created\": 1516208104.0, \"url\": \"http://reddit.local/r/1516208101_placeat/comments/b/minus_id_fuga_dignissimos_nisi_tenetur/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Minus id fuga dignissimos nisi tenetur.\", \"created_utc\": 1516208104.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_6\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_b\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"1m\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01C42GPZ8J1YPMNEAAVQ1X83CT\", \"parent_id\": \"t3_b\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Id rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EId rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1516208101_placeat\", \"score_hidden\": false, \"name\": \"t1_1m\", \"created\": 1516208107.0, \"author_flair_text\": null, \"created_utc\": 1516208107.0, \"ups\": 1, \"mod_reports\": [], \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2719"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 16:55:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "290"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=X%2BYIn8UIREYheeGK6P7c8wyqn1TYQvK5e%2FTEa972XZUVeM1xFU1PXe2ONH0T7DGnOcr94Wm04XmEjzoWqIm23zhCl91zt6cO"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/b/_/1m?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.comments_test.test_get_comment_404.json
+++ b/cassettes/channels.views.comments_test.test_get_comment_404.json
@@ -1,0 +1,507 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-01-17T17:15:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C42HW5KGRH6MNNCETW11SX55"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdUNCA4uLAkzygsPcqvKKs+rrDQxiUz2CPfKSPZU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5OhqYFAbpppaFZls65TulZHlWprpkFhq7FaWD9KSklmUmp8ZnpoAMhnCUagHFDziTuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 17-Jan-2020 17:15:16 GMT",
+            "loidcreated=2018-01-17T17%3A15%3A16.418Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 17-Jan-2020 17:15:16 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C42HW5KGRH6MNNCETW11SX55"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T17:15:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; loidcreated=2018-01-17T17%3A15%3A16.418Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01C42HW8XPB2PK6HECN5D96TF2"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdMNLU8y9yrx80oLNfKriEoPLsuqSrNMywtxNwxU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZGASnmWcGe0UYeycbBOeVOGWWefkkW3gmmbiC9KSklmUmp8ZnpoAMhnCUagGGk00UuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01C42HW8XPB2PK6HECN5D96TF2"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T17:15:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Error+necessitatibus+cumque+sunt+omnis+pariatur+est.+Voluptatem+quibusdam+placeat+labore+officiis+laboriosam+ullam.+Ipsum+in+quasi+accusantium+aliquid+animi+alias.%0AError+reprehenderit+similique+tempora+quisquam+ipsa+repellat+vel+facere.+Deleniti+accusamus+aliquid+sint+ullam.+Reiciendis+impedit+eius+facilis+quos+ipsa.+Mollitia+ratione+ipsum+nulla.&link_type=any&name=1516209320_porro&public_description=Eius+quas+ad+atque.+Perferendis+asperiores+odio+aliquid+corporis.&title=Quisquam+cupiditate+pariatur+est+eligendi+harum.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 146-Uwb7JtNJfU2NxZgSvjzf9fnTG1Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "583"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; loidcreated=2018-01-17T17%3A15%3A16.418Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.10.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "280"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T17:15:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01C42HW5KGRH6MNNCETW11SX55&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 146-Uwb7JtNJfU2NxZgSvjzf9fnTG1Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; loidcreated=2018-01-17T17%3A15%3A16.418Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.10.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1516209320_porro/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "277"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1516209320_porro/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T17:15:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1516209320_porro"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 145-PSSqtV2nWRFzjwnyy44YcHWJhcI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; loidcreated=2018-01-17T17%3A15%3A16.418Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.10.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "277"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-01-17T17:15:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 145-PSSqtV2nWRFzjwnyy44YcHWJhcI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=sMQJhCK3oFVVTSOydk; loidcreated=2018-01-17T17%3A15%3A16.418Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.10.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_23432&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "93"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 17 Jan 2018 17:15:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "277"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2B3L0NVhaW4pWexJQLIMdneVyWB32IzN%2FIjYGdEHWxD6o4nxL45PtalUIonW5IK1h6BBk4mHhtGU%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_23432&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/views/comments_test.py
+++ b/channels/views/comments_test.py
@@ -327,6 +327,47 @@ def test_list_deleted_comments(client, logged_in_profile):
     ]
 
 
+def test_get_comment(client, jwt_header, private_channel_and_contributor, reddit_factories):
+    """
+    should be able to GET a comment
+    """
+    channel, user = private_channel_and_contributor
+    post = reddit_factories.text_post('my geat post', user, channel=channel)
+    comment = reddit_factories.comment("comment", user, post_id=post.id)
+    client.force_login(user)
+    url = reverse('comment-detail', kwargs={'comment_id': comment.id})
+    resp = client.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == [{
+        'author_id': user.username,
+        'created': comment.created,
+        'id': comment.id,
+        'parent_id': None,
+        'post_id': post.id,
+        'score': 1,
+        'text': comment.text,
+        'upvoted': True,
+        'downvoted': False,
+        "removed": False,
+        'profile_image': user.profile.image_small,
+        'author_name': user.profile.name,
+        'edited': False,
+        'comment_type': 'comment',
+        'num_reports': 0,
+    }]
+
+
+def test_get_comment_404(client, jwt_header, private_channel_and_contributor, reddit_factories):
+    """
+    test that we get a 404 for a missing comment
+    """
+    _, user = private_channel_and_contributor
+    client.force_login(user)
+    url = reverse('comment-detail', kwargs={'comment_id': '23432'})
+    resp = client.get(url)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_create_comment(client, logged_in_profile):
     """Create a comment"""
     post_id = '2'

--- a/factory_data/channels.views.comments_test.test_get_comment.json
+++ b/factory_data/channels.views.comments_test.test_get_comment.json
@@ -1,0 +1,35 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Aliquid fuga consectetur illum nam voluptatibus nobis atque deserunt. Temporibus deleniti eaque atque quis suscipit sit praesentium dolores. Animi eum ipsum eveniet qui aliquam quam. Modi saepe perspiciatis id.\nNemo exercitationem molestiae unde corrupti at repudiandae harum. Cumque libero incidunt dicta odio. Voluptatem asperiores distinctio aliquid. Temporibus quo laboriosam placeat quam.",
+      "name": "1516208101_placeat",
+      "public_description": "Eius fugiat molestiae delectus ducimus aut. Eius quo laboriosam atque sit.",
+      "title": "Ab corporis unde laudantium magni."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "1m",
+      "post_id": "b",
+      "text": "Id rem cupiditate officia explicabo perspiciatis. Consectetur earum voluptatibus deserunt tempora."
+    }
+  },
+  "posts": {
+    "my geat post": {
+      "id": "b",
+      "text": "Dolorum veritatis aliquid accusantium voluptatum. Id dignissimos facilis ut repellat placeat.",
+      "title": "Minus id fuga dignissimos nisi tenetur."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C42GPZ8J1YPMNEAAVQ1X83CT"
+    },
+    "staff_user": {
+      "username": "01C42GQ2J40SZ565ZCVNXFS17J"
+    }
+  }
+}

--- a/factory_data/channels.views.comments_test.test_get_comment_404.json
+++ b/factory_data/channels.views.comments_test.test_get_comment_404.json
@@ -1,0 +1,19 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Error necessitatibus cumque sunt omnis pariatur est. Voluptatem quibusdam placeat labore officiis laboriosam ullam. Ipsum in quasi accusantium aliquid animi alias.\nError reprehenderit similique tempora quisquam ipsa repellat vel facere. Deleniti accusamus aliquid sint ullam. Reiciendis impedit eius facilis quos ipsa. Mollitia ratione ipsum nulla.",
+      "name": "1516209320_porro",
+      "public_description": "Eius quas ad atque. Perferendis asperiores odio aliquid corporis.",
+      "title": "Quisquam cupiditate pariatur est eligendi harum."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01C42HW5KGRH6MNNCETW11SX55"
+    },
+    "staff_user": {
+      "username": "01C42HW8XPB2PK6HECN5D96TF2"
+    }
+  }
+}

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -3,6 +3,7 @@
 import React from "react"
 import R from "ramda"
 import moment from "moment"
+import { Link } from "react-router-dom"
 
 import ReactMarkdown from "react-markdown"
 
@@ -45,7 +46,8 @@ type CommentTreeProps = {
   isModerator: boolean,
   processing: boolean,
   deleteComment: CommentRemoveFunc,
-  reportComment: ReportCommentFunc
+  reportComment: ReportCommentFunc,
+  commentPermalink: (commentID: string) => string
 }
 
 export default class CommentTree extends React.Component<*, *> {
@@ -62,7 +64,8 @@ export default class CommentTree extends React.Component<*, *> {
       beginEditing,
       processing,
       isModerator,
-      reportComment
+      reportComment,
+      commentPermalink
     } = this.props
     const formKey = replyToCommentKey(comment)
     const editFormKey = editCommentKey(comment)
@@ -143,6 +146,9 @@ export default class CommentTree extends React.Component<*, *> {
                 <a href="#">delete</a>
               </div>
               : null}
+            <div className="comment-action-button permalink-button">
+              <Link to={commentPermalink(comment.id)}>permalink</Link>
+            </div>
             <CommentRemovalForm
               comment={comment}
               remove={remove}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -4,6 +4,7 @@ import sinon from "sinon"
 import R from "ramda"
 import { assert } from "chai"
 import { shallow } from "enzyme"
+import { Link } from "react-router-dom"
 
 import ReactMarkdown from "react-markdown"
 
@@ -14,6 +15,7 @@ import {
   replyToCommentKey,
   editCommentKey
 } from "./CommentForms"
+import { commentPermalink } from "../lib/url"
 
 import { makeCommentsResponse, makeMoreComments } from "../factories/comments"
 import { makePost } from "../factories/posts"
@@ -30,7 +32,8 @@ describe("CommentTree", () => {
     beginEditingStub,
     loadMoreCommentsStub,
     deleteCommentStub,
-    reportCommentStub
+    reportCommentStub,
+    permalinkFunc
 
   beforeEach(() => {
     post = makePost()
@@ -44,6 +47,7 @@ describe("CommentTree", () => {
     loadMoreCommentsStub = sandbox.stub()
     deleteCommentStub = sandbox.stub()
     reportCommentStub = sandbox.stub()
+    permalinkFunc = commentPermalink("channel", post.id)
   })
 
   afterEach(() => {
@@ -64,6 +68,7 @@ describe("CommentTree", () => {
         loadMoreComments={loadMoreCommentsStub}
         deleteComment={deleteCommentStub}
         reportComment={reportCommentStub}
+        commentPermalink={permalinkFunc}
         {...props}
       />
     )
@@ -154,6 +159,15 @@ describe("CommentTree", () => {
     assert.isNotOk(renderCommentTree().find(".delete-button").exists())
   })
 
+  it("should include a permalink", () => {
+    const button = renderCommentTree().find(".permalink-button")
+    assert(button.exists())
+    assert.equal(
+      button.find(Link).at(0).props().to,
+      permalinkFunc(comments[0].id)
+    )
+  })
+
   it("should show the author name", () => {
     const wrapper = renderCommentTree()
     const authorName = wrapper
@@ -184,9 +198,9 @@ describe("CommentTree", () => {
         .find(".comment-actions")
         .at(0)
         .find(".comment-action-button"),
-      2
+      3
     )
-    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 1)
+    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 2)
 
     assert.lengthOf(topCommentWrapper.find(ReplyToCommentForm), 1)
     assert.lengthOf(nextCommentWrapper.find(ReplyToCommentForm), 0)

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -32,7 +32,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     isModerator: boolean,
     beginEditing: (key: string, initialValue: Object, e: ?Event) => void,
     showPostDeleteDialog: () => void,
-    showPostReportDialog: () => void
+    showPostReportDialog: () => void,
+    showPermalinkUI: boolean
   }
 
   renderTextContent = () => {
@@ -119,7 +120,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
   }
 
   render() {
-    const { post, forms } = this.props
+    const { post, forms, showPermalinkUI } = this.props
     const formattedDate = moment(post.created).fromNow()
 
     return (
@@ -134,7 +135,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             {formattedDate}
           </div>
         </div>
-        {post.text ? this.renderTextContent() : null}
+        {!showPermalinkUI && post.text ? this.renderTextContent() : null}
         {R.has(editPostKey(post), forms) ? null : this.postActionButtons()}
       </div>
     )

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -71,6 +71,11 @@ describe("ExpandedPostDisplay", () => {
     assert.isNotEmpty(authoredBy.substring(post.author_name.length))
   })
 
+  it("should hide text content if passed showPermalinkUI", () => {
+    const wrapper = renderPostDisplay({ post, showPermalinkUI: true })
+    assert.isFalse(wrapper.find(ReactMarkdown).exists())
+  })
+
   it("should display post text", () => {
     const string = "JUST SOME GREAT TEXT!"
     post.text = string

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -80,7 +80,13 @@ class App extends React.Component<*, void> {
             component={ChannelPage}
           />
           <Route
+            exact
             path={`${match.url}channel/:channelName/:postID`}
+            component={PostPage}
+          />
+          <Route
+            exact
+            path={`${match.url}channel/:channelName/:postID/comment/:commentID`}
             component={PostPage}
           />
           <Route path={`${match.url}manage/`} component={AdminPage} />

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -106,6 +106,11 @@ export function getComments(
   return fetchJSONWithAuthFailure(`/api/v0/posts/${postID}/comments/`)
 }
 
+export const getComment = (
+  commentID: string
+): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> =>
+  fetchJSONWithAuthFailure(`/api/v0/comments/${commentID}`)
+
 export const createComment = (
   postId: string,
   text: string,

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -14,6 +14,7 @@ import {
   getPost,
   getPostsForChannel,
   getComments,
+  getComment,
   createComment,
   createPost,
   updateComment,
@@ -219,6 +220,15 @@ describe("api", function() {
       fetchJSONStub.returns(Promise.resolve(response))
 
       const resp = await getComments(post.id)
+      assert.deepEqual(resp, response)
+    })
+
+    it("gets a single comment", async () => {
+      const post = makePost()
+      const response = R.slice(0, 1, makeCommentsResponse(post))
+      fetchJSONStub.returns(response)
+
+      const resp = await getComment(post.id)
       assert.deepEqual(resp, response)
     })
 

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -13,6 +13,11 @@ export const postDetailURL = (channelName: string, postID: string) =>
 export const newPostURL = (channelName: ?string) =>
   channelName ? `/create_post/${channelName}` : "/create_post/"
 
+export const commentPermalink = R.curry(
+  (channelName: string, postID: string, commentID: string) =>
+    `${postDetailURL(channelName, postID)}/comment/${commentID}/`
+)
+
 // pull the channel name out of location.pathname
 // see here for why this hackish approach was necessary:
 // https://github.com/mitodl/open-discussions/pull/118#discussion_r135284591

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -8,6 +8,7 @@ import {
   newPostURL,
   postDetailURL,
   getChannelNameFromPathname,
+  commentPermalink,
   toQueryString,
   urlHostname
 } from "./url"
@@ -55,6 +56,15 @@ describe("url helper functions", () => {
 
     it("should return null otherwise", () => {
       assert.equal(null, getChannelNameFromPathname(""))
+    })
+  })
+
+  describe("commentPermalink", () => {
+    it("should return a comment permalink", () => {
+      assert.equal(
+        "/channel/channel_name/post_id/comment/comment_id/",
+        commentPermalink("channel_name", "post_id", "comment_id")
+      )
     })
   })
 

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -9,6 +9,9 @@ export const getChannelName = (props: { match: Match }): string =>
 export const getPostID = (props: { match: Match }): string =>
   props.match.params.postID || ""
 
+export const getCommentID = (props: { match: Match }): string | void =>
+  props.match.params.commentID || undefined
+
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
  */

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -181,16 +181,11 @@ export const createCommentTree = (
     }
 
     const parentId = commentResponse.parent_id
-    if (!parentId) {
-      tree.push(copy)
-    } else {
-      const parent = lookup[parentId]
-      if (parent === undefined) {
-        // I don't think this will happen, I think PRAW returns the comments in order of traversal
-        throw new Error("Unable to find parent for comment")
-      }
 
-      parent.replies.push(copy)
+    if (parentId && lookup[parentId]) {
+      lookup[parentId].replies.push(copy)
+    } else {
+      tree.push(copy)
     }
   }
 
@@ -218,8 +213,14 @@ type CommentData = Map<string, Array<GenericComment>>
 export const commentsEndpoint = {
   name:    "comments",
   verbs:   [GET, PATCH, POST, DELETE],
-  getFunc: async (postId: string): Promise<GetCommentsPayload> => {
-    const comments = await api.getComments(postId)
+  getFunc: async (
+    postId: string,
+    commentId?: string
+  ): Promise<GetCommentsPayload> => {
+    const comments = commentId
+      ? await api.getComment(commentId)
+      : await api.getComments(postId)
+
     return {
       postId:   postId,
       comments: comments

--- a/static/js/reducers/comments_test.js
+++ b/static/js/reducers/comments_test.js
@@ -70,6 +70,20 @@ describe("comments reducers", () => {
     assert.isNotEmpty(comments[0].replies)
   })
 
+  it("should handle a comment whose parent we don't have", async () => {
+    // this can happen when we're looking at a permalink for a nested comment
+    const first = makeComment(post)
+    const response = [makeComment(post, first.id), makeComment(post, first.id)]
+    helper.getCommentStub.returns(Promise.resolve(response))
+    const { requestType, successType } = actions.comments.get
+    const { data } = await dispatchThen(
+      actions.comments.get(post.id, response[0].id),
+      [requestType, successType]
+    )
+    const comments = data.get(post.id)
+    assert.deepEqual(comments, response)
+  })
+
   it("should handle an empty response ok", () => {
     const { requestType, successType } = actions.comments.get
     helper.getCommentsStub.returns([])

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -8,12 +8,12 @@
 @import "node_modules/spinkit/scss/spinners/10-fading-circle";
 @import "breakpoints";
 @import "variables";
+@import "card";
 @import "basic";
 @import "breadcrumbs";
 @import "form";
 @import "post";
 @import "post-list";
-@import "card";
 @import "createPost";
 @import "sidebar";
 @import "channel";

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -6,6 +6,11 @@
   }
 }
 
+.comment-detail-card {
+  background-color: $bg-blue;
+  font-size: 15px;
+}
+
 .post-summary {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #272 

#### What's this PR do?

This adds a 'permalink' to each comment. Basically, we have to do the following:

- add a new API endpoint for GET-ing a single comment and it's children
- modify the `PostPage` to look for a comment parameter in the URL and, when present, show some different UI and fetch just that comment instead of all comments
- make a slight change to the comments reducer to support handling a top-level comment whose parent we do not have (which we need if the comment we're 'focused' on is a nested comment, since it's parents will not be returned from the API).

I think those are the major changes.

#### How should this be manually tested?

Every comment should have a little 'permalink' button. If you click on it you should see a special UI, basically a little 'hey you're looking at one comment' thingy and the post display should collapse a little bit. You should be able to click back to all the comments. Looking at all the comments for a post should work as normal.

Here's what it looks like:

![beepboop](https://user-images.githubusercontent.com/6207644/35059553-8a315b8e-fb89-11e7-945e-0ddc764855f3.png)
