### PR TITLE
add post sorting UI

### DIFF
--- a/static/js/components/Card.js
+++ b/static/js/components/Card.js
@@ -5,7 +5,7 @@ import React from "react"
 type CardProps = {
   children: any,
   className?: string,
-  title?: string
+  title?: any
 }
 
 const Card = ({ children, className, title }: CardProps) =>

--- a/static/js/components/PostSortPicker.js
+++ b/static/js/components/PostSortPicker.js
@@ -1,0 +1,23 @@
+// @flow
+import React from "react"
+
+import { VALID_SORT_LABELS } from "../lib/sorting"
+
+type PostSortProps = {
+  updateSortParam: (t: string) => void,
+  value: string
+}
+
+const PostSortPicker = ({ updateSortParam, value }: PostSortProps) =>
+  <div className="sorter">
+    <div className="sort-label">Sort:</div>
+    <select onChange={updateSortParam} value={value}>
+      {VALID_SORT_LABELS.map(([type, label]) =>
+        <option label={label} value={type} key={type}>
+          {label}
+        </option>
+      )}
+    </select>
+  </div>
+
+export default PostSortPicker

--- a/static/js/components/PostSortPicker_test.js
+++ b/static/js/components/PostSortPicker_test.js
@@ -1,0 +1,38 @@
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+import R from "ramda"
+import sinon from "sinon"
+
+import PostSortPicker from "./PostSortPicker"
+
+import { VALID_SORT_LABELS } from "../lib/sorting"
+
+describe("PostSortPicker", () => {
+  const renderPicker = (props = {}) => shallow(<PostSortPicker {...props} />)
+
+  it("should have all the options we expect", () => {
+    const wrapper = renderPicker()
+    R.zip(
+      [...wrapper.find("option")],
+      VALID_SORT_LABELS
+    ).forEach(([optionWrapper, [postSortType, postSortLabel]]) => {
+      const props = optionWrapper.props
+      assert.equal(props.label, postSortLabel)
+      assert.equal(props.value, postSortType)
+      assert.equal(props.children, postSortLabel)
+      assert.equal(optionWrapper.key, postSortType)
+    })
+  })
+
+  it("should do what we want with the props we pass in", () => {
+    const updateSortStub = sinon.stub()
+    const wrapper = renderPicker({
+      updateSortParam: updateSortStub,
+      value:           "a great value"
+    })
+    assert.equal(wrapper.find("select").props().value, "a great value")
+    wrapper.find("select").props().onChange()
+    assert(updateSortStub.called)
+  })
+})

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -13,6 +13,7 @@ import PostListNavigation from "../components/PostListNavigation"
 import ChannelBreadcrumbs from "../components/ChannelBreadcrumbs"
 import withNavAndChannelSidebars from "../hoc/withNavAndChannelSidebars"
 import NotFound from "../components/404"
+import PostSortPicker from "../components/PostSortPicker"
 
 import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
@@ -27,6 +28,7 @@ import { getSubscribedChannels } from "../lib/redux_selectors"
 import { formatTitle } from "../lib/title"
 import { clearChannelError } from "../actions/channel"
 import { evictPostsForChannel } from "../actions/posts_for_channel"
+import { updateSortParam, POSTS_SORT_HOT } from "../lib/sorting"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -118,7 +120,8 @@ class ChannelPage extends React.Component<*, void> {
       pagination,
       channelName,
       isModerator,
-      notFound
+      notFound,
+      location: { search }
     } = this.props
 
     if (notFound) {
@@ -132,7 +135,19 @@ class ChannelPage extends React.Component<*, void> {
         <div>
           <DocumentTitle title={formatTitle(channel.title)} />
           <ChannelBreadcrumbs channel={channel} />
-          <Card title={channel.title}>
+          <Card
+            title={
+              <div className="post-list-title">
+                <div>
+                  {channel.title}
+                </div>
+                <PostSortPicker
+                  updateSortParam={updateSortParam(this.props)}
+                  value={qs.parse(search).sort || POSTS_SORT_HOT}
+                />
+              </div>
+            }
+          >
             <PostList
               channel={channel}
               posts={posts}

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -8,6 +8,7 @@ import PostList from "../components/PostList"
 import SubscriptionsList from "../components/SubscriptionsList"
 import CompactPostDisplay from "../components/CompactPostDisplay"
 import NotFound from "../components/404"
+import ChannelPage from "./ChannelPage"
 
 import {
   makeChannel,
@@ -22,6 +23,7 @@ import { EVICT_POSTS_FOR_CHANNEL } from "../actions/posts_for_channel"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { channelURL } from "../lib/url"
 import { formatTitle } from "../lib/title"
+import { VALID_POST_SORT_TYPES } from "../lib/sorting"
 
 describe("ChannelPage", () => {
   let helper,
@@ -100,6 +102,34 @@ describe("ChannelPage", () => {
     sinon.assert.calledWith(helper.editPostStub, postList[0].id, {
       stickied: !post.stickied
     })
+  })
+
+  it("should switch the sorting method when an option is selected", async () => {
+    const [wrapper] = await renderPage(currentChannel)
+
+    for (const sortType of VALID_POST_SORT_TYPES) {
+      await listenForActions(
+        [
+          EVICT_POSTS_FOR_CHANNEL,
+          actions.channels.get.requestType,
+          actions.channels.get.successType,
+          actions.postsForChannel.get.requestType,
+          actions.postsForChannel.get.successType,
+          actions.channelModerators.get.requestType,
+          actions.channelModerators.get.successType,
+          SET_POST_DATA
+        ],
+        () => {
+          const select = wrapper.find(".post-list-title").find("select")
+          select.simulate("change", { target: { value: sortType } })
+        }
+      )
+
+      assert.equal(
+        wrapper.find(ChannelPage).props().location.search,
+        `?sort=${sortType}`
+      )
+    }
   })
 
   it("should fetch postsForChannel, set post data, and render", async () => {

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -6,10 +6,10 @@ import qs from "query-string"
 
 import PostList from "../components/PostList"
 import Card from "../components/Card"
-
 import withLoading from "../components/Loading"
 import withNavSidebar from "../hoc/withNavSidebar"
 import PostListNavigation from "../components/PostListNavigation"
+import PostSortPicker from "../components/PostSortPicker"
 
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
@@ -18,6 +18,7 @@ import { getPostIds } from "../lib/posts"
 import { FRONTPAGE_URL } from "../lib/url"
 import { toggleUpvote } from "../util/api_actions"
 import { getSubscribedChannels } from "../lib/redux_selectors"
+import { updateSortParam, POSTS_SORT_HOT } from "../lib/sorting"
 
 import type { Dispatch } from "redux"
 import type { Location } from "react-router"
@@ -57,11 +58,21 @@ class HomePage extends React.Component<*, void> {
   }
 
   render() {
-    const { posts, pagination, dispatch } = this.props
+    const { posts, pagination, dispatch, location: { search } } = this.props
     const dispatchableToggleUpvote = toggleUpvote(dispatch)
 
     return (
-      <Card title="Home">
+      <Card
+        title={
+          <div className="post-list-title">
+            <div>Home</div>
+            <PostSortPicker
+              updateSortParam={updateSortParam(this.props)}
+              value={qs.parse(search).sort || POSTS_SORT_HOT}
+            />
+          </div>
+        }
+      >
         <PostList
           posts={posts}
           toggleUpvote={dispatchableToggleUpvote}

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 
 import PostList from "../components/PostList"
 import SubscriptionsList from "../components/SubscriptionsList"
+import HomePage from "./HomePage"
 
 import { makeChannelList } from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
@@ -10,9 +11,10 @@ import { actions } from "../actions"
 import { SET_CHANNEL_DATA } from "../actions/channel"
 import { SET_POST_DATA } from "../actions/post"
 import IntegrationTestHelper from "../util/integration_test_helper"
+import { VALID_POST_SORT_TYPES } from "../lib/sorting"
 
 describe("HomePage", () => {
-  let helper, renderComponent, postList, channels
+  let helper, renderComponent, postList, channels, listenForActions
 
   beforeEach(() => {
     channels = makeChannelList()
@@ -21,6 +23,7 @@ describe("HomePage", () => {
     helper.getFrontpageStub.returns(Promise.resolve({ posts: postList }))
     helper.getChannelsStub.returns(Promise.resolve(channels))
     renderComponent = helper.renderComponent.bind(helper)
+    listenForActions = helper.listenForActions.bind(helper)
   })
 
   afterEach(() => {
@@ -47,5 +50,28 @@ describe("HomePage", () => {
     wrapper.find(SubscriptionsList).forEach(component => {
       assert.deepEqual(component.props().subscribedChannels, channels)
     })
+  })
+
+  it("should switch the sorting method when an option is selected", async () => {
+    const [wrapper] = await renderPage()
+
+    for (const sortType of VALID_POST_SORT_TYPES) {
+      await listenForActions(
+        [
+          actions.frontpage.get.requestType,
+          actions.frontpage.get.successType,
+          SET_POST_DATA
+        ],
+        () => {
+          const select = wrapper.find(".post-list-title").find("select")
+          select.simulate("change", { target: { value: sortType } })
+        }
+      )
+
+      assert.equal(
+        wrapper.find(HomePage).props().location.search,
+        `?sort=${sortType}`
+      )
+    }
   })
 })

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -8,7 +8,7 @@ import { PATCH, POST, DELETE } from "redux-hammock/constants"
 
 import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./auth"
 import { toQueryString } from "../lib/url"
-import { getPaginationParams } from "../lib/posts"
+import { getPaginationSortParams } from "../lib/posts"
 
 import type {
   Channel,
@@ -22,15 +22,15 @@ import type {
   GenericReport
 } from "../flow/discussionTypes"
 
-const getPaginationQS = R.compose(
+const getPaginationSortQS = R.compose(
   toQueryString,
   R.reject(R.isNil),
-  getPaginationParams
+  getPaginationSortParams
 )
 
 export function getFrontpage(params: PostListPaginationParams): Promise<Post> {
   return fetchJSONWithAuthFailure(
-    `/api/v0/frontpage/${getPaginationQS(params)}`
+    `/api/v0/frontpage/${getPaginationSortQS(params)}`
   )
 }
 
@@ -77,7 +77,7 @@ export function getPostsForChannel(
   params: PostListPaginationParams
 ): Promise<Array<Post>> {
   return fetchJSONWithAuthFailure(
-    `/api/v0/channels/${channelName}/posts/${getPaginationQS(params)}`
+    `/api/v0/channels/${channelName}/posts/${getPaginationSortQS(params)}`
   )
 }
 

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -31,7 +31,12 @@ export const mapPostListResponse = (
 
 export const getPostIds = R.propOr([], "postIds")
 
-export const getPaginationParams = R.pickAll(["count", "after", "before"])
+export const getPaginationSortParams = R.pickAll([
+  "count",
+  "after",
+  "before",
+  "sort"
+])
 
 export const formatPostTitle = (post: Post) =>
   post.text

--- a/static/js/lib/sorting.js
+++ b/static/js/lib/sorting.js
@@ -1,0 +1,33 @@
+// @flow
+import R from "ramda"
+import qs from "query-string"
+
+export const POSTS_SORT_HOT = "hot"
+export const POSTS_SORT_TOP = "top"
+export const POSTS_SORT_NEW = "new"
+
+export const VALID_POST_SORT_TYPES = [
+  POSTS_SORT_HOT,
+  POSTS_SORT_TOP,
+  POSTS_SORT_NEW
+]
+
+export const VALID_SORT_LABELS = [
+  [POSTS_SORT_HOT, "active"],
+  [POSTS_SORT_TOP, "top"],
+  [POSTS_SORT_NEW, "new"]
+]
+
+export const updateSortParam = R.curry((props, e) => {
+  const { history, location: { pathname, search } } = props
+  const { target: { value } } = e
+
+  e.preventDefault()
+
+  if (R.contains(value, VALID_POST_SORT_TYPES)) {
+    history.push({
+      pathname: pathname,
+      search:   qs.stringify(Object.assign({}, qs.parse(search), { sort: value }))
+    })
+  }
+})

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -1,3 +1,28 @@
+.post-list-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .sorter {
+    display: flex;
+    align-items: center;
+
+    .sort-label {
+      color: $font-grey;
+      margin-right: 5px;
+      font-size: 16px;
+    }
+
+    select {
+      width: 90px;
+      height: 30px;
+      padding: 0 0;
+      text-align: center;
+      text-align-last: center;
+    }
+  }
+}
+
 .post-list {
   .empty-list-msg {
     height: 200px;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #228 

#### What's this PR do?

This adds a UI for sorting posts for both the frontpage and the channel page. There will be a little drop-down in the upper-right corner which will let you choose from 'hot', 'top', and 'new'. Selecting from these will probably only change the output for you if you have a lot of posts and users, with some posts commented and upvoted a lot and others not.

#### How should this be manually tested?

Make sure that you can pick the sorting method. It should add a `sort` url query param when you pick it (it defaults to 'hot'). If you have pagination params in the url the `sort` param should be cleanly added to the existing params. This should all work on the frontpage and any channel page.

If the post listing isn't changing when you pick the different sorting methods it is probably enough to just confirm that the param gets sent to the backend in the post list request.