### PR TITLE
fix edit comment 403 error

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -23,7 +23,7 @@ type CommentFormProps = {
   cancelReply: () => void,
   formDataLens: (s: string) => Object,
   processing: boolean,
-  patchComment: (c: CommentInTree) => void,
+  patchComment: (c: Object) => void,
   patchPost: (p: Post) => void,
   comment: CommentInTree
 }
@@ -247,7 +247,8 @@ export const EditCommentForm = connect(mapStateToProps, mapDispatchToProps)(
 
       e.preventDefault()
 
-      const updatedComment: CommentInTree = { ...comment, text: text }
+      const { id } = comment
+      const updatedComment = { text, id }
       this.setState({ patching: true })
       await patchComment(updatedComment)
       this.setState({ patching: false })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #476

#### What's this PR do?

This PR fixes an error that was occurring for non-moderator users when editing comments. Basically, we were patching the whole comment object, which includes fields which are read-only for non-moderators. So when the backend tried to save the object, the user would get a 403 because they do not have the ability to modify e.g. the 'removed' field.

This changes the comment editing so that we only post the things we need to.

#### How should this be manually tested?

As a moderator you should be able to create and edit comments as usual. As a non-moderator you should also be able to edit comments, but with the added bonus of not seeing an error page!