### PR TITLE
Omit status check for code coverage to prevent blocking of deploys

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: no
+    patch:
+      default:
+        enabled: no
+    changes:
+      default:
+        enabled: no


### PR DESCRIPTION
#### What are the relevant tickets?
See https://github.com/mitodl/micromasters/pull/3811

#### What's this PR do?
Turns off status checks for code coverage so that it doesn't block releases

#### How should this be manually tested?
The checks should not be present in this PR
