### PR TITLE
add profile images to CompactPostDisplay

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -55,6 +55,7 @@ class CompactPostDisplay extends React.Component<*, void> {
         className={`post-summary ${post.stickied && showPinUI ? "sticky" : ""}`}
       >
         <PostVotingButtons post={post} toggleUpvote={toggleUpvote} />
+        <img className="profile-image" src={post.profile_image} />
         <div className="summary">
           <div className="post-title">
             {formatPostTitle(post)}

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -50,6 +50,10 @@ describe("CompactPostDisplay", () => {
     const authoredBy = wrapper.find(".authored-by").text()
     assert(authoredBy.startsWith(`by ${post.author_name}`))
     assert.isNotEmpty(authoredBy.substring(post.author_name.length))
+    const img = wrapper.find(".profile-image")
+    assert.ok(img.exists())
+    const { src } = img.props()
+    assert.equal(src, post.profile_image)
   })
 
   it("should link to the subreddit, if told to", () => {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -64,12 +64,15 @@
     }
   }
 
+  .profile-image {
+    margin-right: 15px;
+  }
+
   .summary {
     overflow: hidden;
 
     img {
       float: left;
-      margin-right: 15px;
       position: relative;
       top: 6px;
     }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #458 

#### What's this PR do?

this just adds an `<img>` tag to the compact post display which displays the profile image associated with the post (the profile image of the author).

#### How should this be manually tested?

Make sure that it puts the image on the post list on the channel page and the homepage.