### PR TITLE
fix non moderator post edit issue

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -25,7 +25,7 @@ type CommentFormProps = {
   formDataLens: (s: string) => Object,
   processing: boolean,
   patchComment: (c: Object) => void,
-  patchPost: (p: Post) => void,
+  patchPost: (p: Object) => void,
   comment: CommentInTree
 }
 
@@ -311,10 +311,10 @@ export const EditPostForm = connect(mapStateToProps, mapDispatchToProps)(
 
       e.preventDefault()
 
-      const updatedPost = { ...post, text: text }
+      const { id } = post
       this.setState({ patching: true })
       try {
-        await patchPost(updatedPost)
+        await patchPost({ id, text })
       } catch (_) {
         this.setState({ patching: false })
       }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #482 

#### What's this PR do?

Similar to the comment editing issue. We were posting the whole `Post` object, but for non-moderator users there are a few read-only fields on the object. So, when they tried to edit a post, they would get a 403 error. Unlike the comment issue, the edit wouldn't even go through (the comment edit would go through but then show an error page).

Anyway, this applies the same fix I did for the comment issue.

#### How should this be manually tested?

You should be able to edit posts successfully, without any network or UI errors, as both a moderator and non-moderator user.