### PR TITLE
fix report dialog preventDefault issue

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -44,6 +44,7 @@ import { beginEditing } from "../components/CommentForms"
 import { formatTitle } from "../lib/title"
 import { channelURL, postDetailURL, commentPermalink } from "../lib/url"
 import { clearPostError } from "../actions/post"
+import { preventDefaultAndInvoke } from "../lib/util"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -419,7 +420,7 @@ class PostPage extends React.Component<*, void> {
         </Dialog>
         <Dialog
           open={postReportDialogVisible}
-          hideDialog={this.hideReportPostDialog}
+          hideDialog={preventDefaultAndInvoke(this.hideReportPostDialog)}
           onCancel={this.hideReportPostDialog}
           onAccept={this.reportPost}
           validateOnClick={true}
@@ -466,7 +467,9 @@ class PostPage extends React.Component<*, void> {
               forms={forms}
               beginEditing={beginEditing(dispatch)}
               showPostDeleteDialog={this.showPostDialog(DELETE_POST_DIALOG)}
-              showPostReportDialog={this.showReportPostDialog}
+              showPostReportDialog={preventDefaultAndInvoke(
+                this.showReportPostDialog
+              )}
               showPermalinkUI={showPermalinkUI}
               report={postReport}
             />

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -448,11 +448,13 @@ describe("PostPage", function() {
 
     helper.reportContentStub.returns(Promise.resolve())
 
+    const preventDefaultStub = helper.sandbox.stub()
     await listenForActions([SHOW_DIALOG, FORM_BEGIN_EDIT], () => {
       const reportPostFunc = wrapper.find("ExpandedPostDisplay").props()
         .showPostReportDialog
-      reportPostFunc()
+      reportPostFunc({ preventDefault: preventDefaultStub })
     })
+    assert.ok(preventDefaultStub.called)
 
     const dialog = wrapper.find("Dialog").at(4)
     dialog.find("input").simulate("change", {
@@ -493,6 +495,8 @@ describe("PostPage", function() {
         expectedActions.push(SET_FOCUSED_COMMENT)
       }
 
+      const preventDefaultStub = helper.sandbox.stub()
+
       await listenForActions(expectedActions, () => {
         if (isComment) {
           const comment = comments[0].replies[2]
@@ -502,7 +506,8 @@ describe("PostPage", function() {
         } else {
           const reportPostFunc = wrapper.find("ExpandedPostDisplay").props()
             .showPostReportDialog
-          reportPostFunc()
+          reportPostFunc({ preventDefault: preventDefaultStub })
+          assert.ok(preventDefaultStub.called)
         }
       })
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #442 

#### What's this PR do?

this just adds the preventDefaultAndInvoke wrapper to two callbacks for the report post dialog. this should mean that it no longer puts a little '#' at the end of the URL.

#### How should this be manually tested?

Fiddle around with the report post dialog (on the post page), and just make sure you never see a '#'! Functionality should all be normal.