### PR TITLE
fix post page 403

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -172,22 +172,22 @@ class PostPage extends React.Component<*, void> {
         dispatch(actions.posts.get(postID)),
         dispatch(actions.comments.get(postID, commentID, qs.parse(search)))
       ])
+
+      if (!channel) {
+        dispatch(actions.channels.get(channelName))
+      }
+
+      if (!moderators) {
+        const { response } = await dispatch(
+          actions.channelModerators.get(channelName)
+        )
+        moderators = response
+      }
+
+      if (isModerator(moderators, SETTINGS.username)) {
+        await dispatch(actions.reports.get(channelName))
+      }
     } catch (_) {} // eslint-disable-line no-empty
-
-    if (!channel) {
-      dispatch(actions.channels.get(channelName))
-    }
-
-    if (!moderators) {
-      const { response } = await dispatch(
-        actions.channelModerators.get(channelName)
-      )
-      moderators = response
-    }
-
-    if (isModerator(moderators, SETTINGS.username)) {
-      await dispatch(actions.reports.get(channelName))
-    }
   }
 
   upvote = async (comment: CommentInTree) => {
@@ -387,6 +387,10 @@ class PostPage extends React.Component<*, void> {
       location: { search }
     } = this.props
 
+    if (notFound) {
+      return <NotFound />
+    }
+
     if (!channel) {
       return null
     }
@@ -395,9 +399,8 @@ class PostPage extends React.Component<*, void> {
     const showPermalinkUI = R.not(R.isNil(commentID))
     const postReport = postReports.get(postID)
 
-    return notFound
-      ? <NotFound />
-      : <div>
+    return (
+      <div>
         <ChannelBreadcrumbs channel={channel} />
         <DocumentTitle title={formatTitle(post.title)} />
         <Dialog
@@ -407,7 +410,7 @@ class PostPage extends React.Component<*, void> {
           title="Delete Comment"
           submitText="Yes, Delete"
         >
-            Are you sure you want to delete this comment?
+          Are you sure you want to delete this comment?
         </Dialog>
         <Dialog
           open={postDeleteDialogVisible}
@@ -416,7 +419,7 @@ class PostPage extends React.Component<*, void> {
           title="Delete Post"
           submitText="Yes, Delete"
         >
-            Are you sure you want to delete this post?
+          Are you sure you want to delete this post?
         </Dialog>
         <Dialog
           open={postReportDialogVisible}
@@ -486,7 +489,7 @@ class PostPage extends React.Component<*, void> {
           ? <Card className="comment-detail-card">
             <div>You are viewing a single comment's thread.</div>
             <Link to={postDetailURL(channel.name, post.id)}>
-                  View the rest of the comments
+                View the rest of the comments
             </Link>
           </Card>
           : <div className="count-and-sort">
@@ -515,6 +518,7 @@ class PostPage extends React.Component<*, void> {
           commentReports={commentReports}
         />
       </div>
+    )
   }
 }
 

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -540,10 +540,6 @@ describe("PostPage", function() {
         actions.comments.get.successType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         SET_CHANNEL_DATA
       ]
     )
@@ -562,10 +558,6 @@ describe("PostPage", function() {
         actions.comments.get.failureType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         SET_CHANNEL_DATA
       ]
     )
@@ -583,10 +575,6 @@ describe("PostPage", function() {
         actions.comments.get.successType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         SET_CHANNEL_DATA
       ]
     )


### PR DESCRIPTION
#### What are the relevant tickets?

closes #393 

#### What's this PR do?

This PR does 2 things:

- fixes the issue in #393, which is that, on the Post page, we were still issuing the request to get moderators for the channel even if the post and channel came back with 404 or 403 errors.
- I also noticed that if you visited a post on a channel which does not exist the 404 page was not rendering (because we checked first if the `channel` was nil), so I changed it so that we would render the 404 component in such a case.

#### How should this be manually tested?

- visit a post, that exists, which your user does not have permission to view. If you look in the network tab you should not issue a request to the moderators backend.
- visit a nonsense url (like `/channel/asdfasdfasdf/1020`) and make sure you get a 404 page. Maybe confirm that, on the current `master`, visiting the same URL just shows a blank page.