### PR TITLE
Added report counts to frontpage

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -135,7 +135,7 @@ class PostSerializer(serializers.Serializer):
     profile_image = serializers.SerializerMethodField()
     author_name = serializers.SerializerMethodField()
     edited = serializers.SerializerMethodField()
-    num_reports = serializers.SerializerMethodField()
+    num_reports = serializers.IntegerField(read_only=True)
 
     def _get_user(self, instance):
         """
@@ -189,11 +189,6 @@ class PostSerializer(serializers.Serializer):
     def get_channel_title(self, instance):
         """The title of the channel"""
         return instance.subreddit.title
-
-    def get_num_reports(self, instance):
-        """The number of reports for this post"""
-        # user_reports is a list of (str, int), so we want to sum the counts
-        return len(instance.mod_reports) + sum(report[1] for report in instance.user_reports)
 
     def get_edited(self, instance):
         """Return a Boolean signifying if the post has been edited or not"""
@@ -303,7 +298,7 @@ class CommentSerializer(serializers.Serializer):
     author_name = serializers.SerializerMethodField()
     edited = serializers.SerializerMethodField()
     comment_type = serializers.SerializerMethodField()
-    num_reports = serializers.SerializerMethodField()
+    num_reports = serializers.IntegerField(read_only=True)
     deleted = serializers.SerializerMethodField()
 
     def _get_user(self, instance):
@@ -374,11 +369,6 @@ class CommentSerializer(serializers.Serializer):
     def get_edited(self, instance):
         """Return a Boolean signifying if the comment has been edited or not"""
         return instance.edited if instance.edited is False else True
-
-    def get_num_reports(self, instance):
-        """The number of reports for this comment"""
-        # user_reports is a list of (str, int), so we want to sum the counts
-        return len(instance.mod_reports) + sum(report[1] for report in instance.user_reports)
 
     def get_comment_type(self, instance):  # pylint: disable=unused-argument
         """Let the frontend know which type this is"""

--- a/channels/test_constants.py
+++ b/channels/test_constants.py
@@ -17,7 +17,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '2',
@@ -35,7 +35,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '3',
@@ -53,7 +53,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '4',
@@ -71,7 +71,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '5',
@@ -89,7 +89,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'l',
@@ -107,7 +107,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'p',
@@ -125,7 +125,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8x',
@@ -143,7 +143,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8y',
@@ -161,7 +161,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8z',
@@ -179,7 +179,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e90',
@@ -197,7 +197,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e91',
@@ -215,7 +215,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e92',
@@ -233,7 +233,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e93',
@@ -251,7 +251,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e94',
@@ -269,7 +269,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e95',
@@ -287,7 +287,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e96',
@@ -305,7 +305,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e97',
@@ -323,7 +323,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e99',
@@ -341,7 +341,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9b',
@@ -359,7 +359,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9c',
@@ -377,7 +377,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9d',
@@ -395,7 +395,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9f',
@@ -413,7 +413,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9g',
@@ -431,7 +431,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9h',
@@ -449,7 +449,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9i',
@@ -467,7 +467,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9j',
@@ -485,7 +485,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e9k',
@@ -503,7 +503,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'parent_id': None,
@@ -530,7 +530,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'author_name': '[deleted]',
         'edited': False,
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '6',
@@ -548,7 +548,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '7',
@@ -566,7 +566,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '8',
@@ -584,7 +584,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'edited': False,
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'n',
@@ -602,7 +602,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': '9',
@@ -620,7 +620,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'c',
@@ -638,7 +638,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'o',
@@ -656,7 +656,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'a',
@@ -674,7 +674,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'b',
@@ -692,7 +692,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'f',
@@ -710,7 +710,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'g',
@@ -728,7 +728,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'h',
@@ -746,7 +746,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'i',
@@ -764,7 +764,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'd',
@@ -782,7 +782,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e',
@@ -800,7 +800,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'j',
@@ -818,7 +818,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'k',
@@ -836,7 +836,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/static/images/avatar_default.png',
         'author_name': '[deleted]',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8s',
@@ -854,7 +854,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8t',
@@ -872,7 +872,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8u',
@@ -890,7 +890,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'id': 'e8v',
@@ -908,7 +908,7 @@ LIST_MORE_COMMENTS_RESPONSE = [
         'profile_image': '/deserunt/consequatur.jpg',
         'author_name': 'Brooke Robles',
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     },
     {
         'parent_id': 'e8v',

--- a/channels/views/comments_test.py
+++ b/channels/views/comments_test.py
@@ -147,7 +147,7 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "author_name": name,
             "edited": False,
             "comment_type": "comment",
-            'num_reports': 0,
+            'num_reports': None,
         },
         {
             "id": "n",
@@ -165,7 +165,7 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "author_name": name,
             "edited": False,
             "comment_type": "comment",
-            'num_reports': 0,
+            'num_reports': None,
         },
         {
             "id": "o",
@@ -183,7 +183,7 @@ def test_more_comments(client, logged_in_profile, is_root_comment):
             "author_name": name,
             "edited": False,
             "comment_type": "comment",
-            'num_reports': 0,
+            'num_reports': None,
         }
     ]
 
@@ -234,7 +234,7 @@ def test_more_comments_children(client, logged_in_profile):
             "author_name": name,
             "edited": False,
             "comment_type": "comment",
-            'num_reports': 0,
+            'num_reports': None,
         },
         {
             "id": "e9m",
@@ -252,7 +252,7 @@ def test_more_comments_children(client, logged_in_profile):
             "author_name": name,
             "edited": False,
             "comment_type": "comment",
-            'num_reports': 0,
+            'num_reports': None,
         }
     ]
 
@@ -314,7 +314,7 @@ def test_list_deleted_comments(client, logged_in_profile):
             'id': '1s',
             'edited': False,
             "author_name": "[deleted]",
-            'num_reports': 0,
+            'num_reports': None,
         },
         {
             'author_id': user.username,
@@ -332,7 +332,7 @@ def test_list_deleted_comments(client, logged_in_profile):
             'edited': False,
             "deleted": False,
             "author_name": user.profile.name,
-            'num_reports': 0,
+            'num_reports': None,
         }
     ]
 
@@ -364,7 +364,7 @@ def test_get_comment(client, jwt_header, private_channel_and_contributor, reddit
         'author_name': user.profile.name,
         'edited': False,
         'comment_type': 'comment',
-        'num_reports': 0,
+        'num_reports': None,
     }]
 
 

--- a/channels/views/frontpage_test.py
+++ b/channels/views/frontpage_test.py
@@ -58,7 +58,7 @@ def test_frontpage(client, private_channel_and_contributor, reddit_factories, mi
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
-            'num_reports': 0,
+            "num_reports": None,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': POSTS_SORT_HOT,
@@ -100,7 +100,7 @@ def test_frontpage_sorted(client, private_channel_and_contributor, reddit_factor
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
-            'num_reports': 0,
+            'num_reports': None,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': sort,

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -45,7 +45,7 @@ def test_create_url_post(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -78,7 +78,7 @@ def test_create_text_post(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -161,7 +161,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         "profile_image": profile_image,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -207,7 +207,7 @@ def test_get_post_stickied(client, private_channel_and_contributor, reddit_facto
         "profile_image": user.profile.image_small,
         "edited": False,
         "stickied": True,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -258,7 +258,7 @@ def test_list_posts(client, missing_user, private_channel_and_contributor, reddi
                     "profile_image": user.profile.image_small,
                     "edited": False,
                     "stickied": False,
-                    'num_reports': 0,
+                    'num_reports': None,
                 } for post in posts
             ],
             'pagination': {
@@ -301,7 +301,7 @@ def test_list_posts_sorted(client, private_channel_and_contributor, reddit_facto
             "profile_image": user.profile.image_small,
             "edited": False,
             "stickied": False,
-            'num_reports': 0,
+            'num_reports': None,
         } for post in [fourth_post, third_post, second_post, first_post]],
         'pagination': {
             'sort': sort,
@@ -338,7 +338,7 @@ def test_list_posts_stickied(client, private_channel_and_contributor, reddit_fac
         "profile_image": user.profile.image_small,
         "edited": False,
         "stickied": True,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -461,7 +461,7 @@ def test_update_post_text(client, private_channel_and_contributor, reddit_factor
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -541,7 +541,7 @@ def test_update_post_clear_vote(client, private_channel_and_contributor, reddit_
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -570,7 +570,7 @@ def test_update_post_upvote(client, private_channel_and_contributor, reddit_fact
         "author_name": user.profile.name,
         "edited": False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 
@@ -727,7 +727,7 @@ def test_create_post_without_upvote(client, private_channel_and_contributor):
         "author_name": user.profile.name,
         'edited': False,
         "stickied": False,
-        'num_reports': 0,
+        'num_reports': None,
     }
 
 

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -22,8 +22,7 @@ import {
 import type {
   GenericComment,
   CommentInTree,
-  MoreCommentsInTree,
-  CommentReportRecord
+  MoreCommentsInTree
 } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
 import type { CommentRemoveFunc } from "./CommentRemovalForm"
@@ -47,7 +46,6 @@ type CommentTreeProps = {
   deleteComment: CommentRemoveFunc,
   reportComment: ReportCommentFunc,
   commentPermalink: (commentID: string) => string,
-  commentReports: Map<string, CommentReportRecord>,
   moderationUI: boolean,
   ignoreCommentReports: (c: CommentInTree) => void
 }
@@ -68,7 +66,6 @@ export default class CommentTree extends React.Component<*, *> {
       isModerator,
       reportComment,
       commentPermalink,
-      commentReports,
       moderationUI,
       ignoreCommentReports
     } = this.props
@@ -81,8 +78,6 @@ export default class CommentTree extends React.Component<*, *> {
     )
 
     const atMaxDepth = depth + 1 >= SETTINGS.max_comment_depth
-
-    const report = commentReports.get(comment.id)
 
     return (
       <div
@@ -130,9 +125,9 @@ export default class CommentTree extends React.Component<*, *> {
               >
                 <a href="#">reply</a>
               </div>}
-            {isModerator && report !== undefined
+            {comment.num_reports
               ? <div className="comment-action-button report-count">
-                  Reports: {report.comment.num_reports}
+                  Reports: {comment.num_reports}
               </div>
               : null}
             {SETTINGS.username === comment.author_id && !moderationUI
@@ -155,7 +150,7 @@ export default class CommentTree extends React.Component<*, *> {
                 <a href="#">delete</a>
               </div>
               : null}
-            {isModerator && report && ignoreCommentReports
+            {comment.num_reports && ignoreCommentReports
               ? <div
                 className="comment-action-button ignore-button"
                 onClick={preventDefaultAndInvoke(() =>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -72,7 +72,6 @@ describe("CommentTree", () => {
           deleteComment={deleteCommentStub}
           reportComment={reportCommentStub}
           commentPermalink={permalinkFunc}
-          commentReports={new Map()}
           {...props}
         />
       </Router>
@@ -233,11 +232,9 @@ describe("CommentTree", () => {
   describe("moderation UI", () => {
     const moderationUI = true
     const isModerator = true
-    let report, commentReports
+    let report
     beforeEach(() => {
       report = makeCommentReport(makePost())
-      commentReports = new Map()
-      commentReports.set(report.comment.id, report)
     })
 
     it("should hide the reply button", () => {
@@ -258,17 +255,21 @@ describe("CommentTree", () => {
     it("should include the report count if the user is a moderator", () => {
       const wrapper = renderCommentTree({
         isModerator,
-        commentReports,
         comments: [report.comment]
       })
       assert.ok(wrapper.find(".report-count").exists())
       assert.equal(wrapper.find(".report-count").text(), "Reports: 2")
     })
 
+    it("should not render a report count, if comment has no report data", () => {
+      const wrapper = renderCommentTree({ moderationUI })
+      const count = wrapper.find(".report-count")
+      assert.isNotOk(count.exists())
+    })
+
     it("should include an ignoreCommentReports button if report and moderator", () => {
       const ignoreCommentReportsStub = helper.sandbox.stub()
       const wrapper = renderCommentTree({
-        commentReports,
         isModerator,
         ignoreCommentReports: ignoreCommentReportsStub,
         comments:             [report.comment]

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -11,7 +11,7 @@ import {
   PostVotingButtons
 } from "../lib/posts"
 
-import type { Post, PostReportRecord } from "../flow/discussionTypes"
+import type { Post } from "../flow/discussionTypes"
 
 class CompactPostDisplay extends React.Component<*, void> {
   props: {
@@ -21,7 +21,6 @@ class CompactPostDisplay extends React.Component<*, void> {
     togglePinPost: Post => void,
     showPinUI: boolean,
     isModerator: boolean,
-    report?: PostReportRecord,
     removePost?: (p: Post) => void,
     ignorePostReports?: (p: Post) => void
   }
@@ -44,7 +43,6 @@ class CompactPostDisplay extends React.Component<*, void> {
       showPinUI,
       togglePinPost,
       isModerator,
-      report,
       removePost,
       ignorePostReports
     } = this.props
@@ -68,9 +66,9 @@ class CompactPostDisplay extends React.Component<*, void> {
             <Link to={postDetailURL(post.channel_name, post.id)}>
               {formatCommentsCount(post)}
             </Link>
-            {isModerator && report
+            {post.num_reports
               ? <div className="report-count">
-                  Reports: {report.post.num_reports}
+                  Reports: {post.num_reports}
               </div>
               : null}
             {showPinUI && post.text && isModerator

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -12,7 +12,6 @@ import { urlHostname } from "../lib/url"
 import { formatCommentsCount } from "../lib/posts"
 import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { makePostReport } from "../factories/reports"
 
 describe("CompactPostDisplay", () => {
   let helper, post
@@ -153,7 +152,7 @@ describe("CompactPostDisplay", () => {
     }
   }
   ;[true, false].forEach(prevUpvote => {
-    it(`should show the correct UI when the upvote 
+    it(`should show the correct UI when the upvote
     button is clicked when prev state was ${String(prevUpvote)}`, async () => {
       post.upvoted = prevUpvote
       // setting to a function so Flow doesn't complain
@@ -181,12 +180,19 @@ describe("CompactPostDisplay", () => {
     })
   })
 
-  it("should render a report count, if passed a report and moderator", () => {
-    const report = makePostReport(post)
-    const wrapper = renderPostDisplay({ post, report, isModerator: true })
+  it("should render a report count, if post is reported", () => {
+    post.num_reports = 2
+    const wrapper = renderPostDisplay({ post })
     const count = wrapper.find(".report-count")
     assert.ok(count.exists())
-    assert.equal(count.text(), `Reports: ${report.post.num_reports}`)
+    // $FlowFixMe: thinks this doesn't exist
+    assert.equal(count.text(), `Reports: ${post.num_reports}`)
+  })
+
+  it("should not render a report count, if post has no report data", () => {
+    const wrapper = renderPostDisplay({ post })
+    const count = wrapper.find(".report-count")
+    assert.isNotOk(count.exists())
   })
 
   it("should put a remove button, if it gets the right props", () => {

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -10,7 +10,7 @@ import { renderTextContent } from "./Markdown"
 import { formatPostTitle, PostVotingButtons } from "../lib/posts"
 import { editPostKey } from "../components/CommentForms"
 
-import type { Post, PostReportRecord } from "../flow/discussionTypes"
+import type { Post } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
 
 export default class ExpandedPostDisplay extends React.Component<*, void> {
@@ -24,8 +24,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     beginEditing: (key: string, initialValue: Object, e: ?Event) => void,
     showPostDeleteDialog: () => void,
     showPostReportDialog: () => void,
-    showPermalinkUI: boolean,
-    report?: PostReportRecord
+    showPermalinkUI: boolean
   }
 
   renderTextContent = () => {
@@ -59,8 +58,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
       beginEditing,
       isModerator,
       showPostDeleteDialog,
-      showPostReportDialog,
-      report
+      showPostReportDialog
     } = this.props
 
     return (
@@ -78,9 +76,9 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             <a href="#">edit</a>
           </div>
           : null}
-        {isModerator && report
+        {post.num_reports
           ? <div className="report-count">
-              Reports: {report.post.num_reports}
+              Reports: {post.num_reports}
           </div>
           : null}
         {SETTINGS.username === post.author_id

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -16,7 +16,6 @@ import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
 import { editPostKey } from "../components/CommentForms"
-import { makePostReport } from "../factories/reports"
 
 describe("ExpandedPostDisplay", () => {
   let helper,
@@ -265,11 +264,18 @@ describe("ExpandedPostDisplay", () => {
     assert.ok(removePostStub.called)
   })
 
-  it("should display a report count, if passed a report and isModerator", () => {
-    const report = makePostReport(post)
-    const wrapper = renderPostDisplay({ post, report, isModerator: true })
+  it("should display a report count, if num_reports has a value", () => {
+    post.num_reports = 2
+    const wrapper = renderPostDisplay({ post })
     const count = wrapper.find(".report-count")
     assert.ok(count.exists())
-    assert.equal(count.text(), `Reports: ${report.post.num_reports}`)
+    // $FlowFixMe: thinks this doesn't exist
+    assert.equal(count.text(), `Reports: ${post.num_reports}`)
+  })
+
+  it("should not render a report count, if post has no report data", () => {
+    const wrapper = renderPostDisplay({ post })
+    const count = wrapper.find(".report-count")
+    assert.isNotOk(count.exists())
   })
 })

--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -3,7 +3,7 @@ import React from "react"
 
 import CompactPostDisplay from "./CompactPostDisplay"
 
-import type { Post, PostReportRecord } from "../flow/discussionTypes"
+import type { Post } from "../flow/discussionTypes"
 
 type PostListProps = {
   posts: Array<Post>,
@@ -11,8 +11,7 @@ type PostListProps = {
   showPinUI?: boolean,
   toggleUpvote: Post => void,
   togglePinPost?: Post => Promise<*>,
-  isModerator?: boolean,
-  postReports?: Map<string, PostReportRecord>
+  isModerator?: boolean
 }
 
 const PostList = (props: PostListProps) => {
@@ -22,8 +21,7 @@ const PostList = (props: PostListProps) => {
     showPinUI,
     isModerator,
     toggleUpvote,
-    togglePinPost,
-    postReports
+    togglePinPost
   } = props
 
   return (
@@ -38,7 +36,6 @@ const PostList = (props: PostListProps) => {
             showPinUI={showPinUI}
             isModerator={isModerator}
             togglePinPost={togglePinPost}
-            report={postReports ? postReports.get(post.id) : undefined}
           />
         )
         : <div className="empty-list-msg">There are no posts to display.</div>}

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -7,8 +7,7 @@ import sinon from "sinon"
 import PostList from "./PostList"
 import CompactPostDisplay from "./CompactPostDisplay"
 
-import { makeChannelPostList, makePost } from "../factories/posts"
-import { makePostReport } from "../factories/reports"
+import { makeChannelPostList } from "../factories/posts"
 
 describe("PostList", () => {
   const renderPostList = (props = { posts: makeChannelPostList() }) =>
@@ -68,16 +67,5 @@ describe("PostList", () => {
     wrapper.find(CompactPostDisplay).forEach(postSummary => {
       assert.equal(postSummary.props().togglePinPost, pinStub)
     })
-  })
-
-  it("should pass a report down to CompactPostDisplay", () => {
-    const post = makePost()
-    const report = makePostReport(post)
-    const postReports = new Map([[post.id, report]])
-    const wrapper = renderPostList({
-      posts: [post],
-      postReports
-    })
-    assert.deepEqual(wrapper.find(CompactPostDisplay).props().report, report)
   })
 })

--- a/static/js/containers/ChannelModerationPage.js
+++ b/static/js/containers/ChannelModerationPage.js
@@ -110,7 +110,8 @@ class ChannelModerationPage extends React.Component<*, *> {
 const mapStateToProps = (state, ownProps) => {
   return {
     ...postModerationSelector(state, ownProps),
-    ...commentModerationSelector(state, ownProps)
+    ...commentModerationSelector(state, ownProps),
+    shouldGetReports: true
   }
 }
 

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -32,12 +32,7 @@ import { updatePostSortParam, POSTS_SORT_HOT } from "../lib/sorting"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
-import type {
-  Channel,
-  Post,
-  PostListPagination,
-  PostReportRecord
-} from "../flow/discussionTypes"
+import type { Channel, Post, PostListPagination } from "../flow/discussionTypes"
 
 type ChannelPageProps = {
   match: Match,
@@ -51,8 +46,7 @@ type ChannelPageProps = {
   pagination: PostListPagination,
   errored: boolean,
   isModerator: boolean,
-  notFound: boolean,
-  postReports: Map<string, PostReportRecord>
+  notFound: boolean
 }
 
 const shouldLoadData = R.complement(
@@ -103,13 +97,7 @@ class ChannelPage extends React.Component<*, void> {
 
     try {
       await dispatch(actions.channels.get(channelName))
-      const { response } = await dispatch(
-        actions.channelModerators.get(channelName)
-      )
-
-      if (isModerator(response, SETTINGS.username)) {
-        await dispatch(actions.reports.get(channelName))
-      }
+      await dispatch(actions.channelModerators.get(channelName))
 
       this.fetchPostsForChannel()
     } catch (_) {} // eslint-disable-line no-empty
@@ -134,8 +122,7 @@ class ChannelPage extends React.Component<*, void> {
       channelName,
       isModerator,
       notFound,
-      location: { search },
-      postReports
+      location: { search }
     } = this.props
 
     if (notFound) {
@@ -168,7 +155,6 @@ class ChannelPage extends React.Component<*, void> {
               toggleUpvote={toggleUpvote(dispatch)}
               isModerator={isModerator}
               togglePinPost={this.togglePinPost}
-              postReports={postReports}
               showPinUI
             />
             {pagination
@@ -213,7 +199,6 @@ const mapStateToProps = (state, ownProps) => {
     pagination:         postsForChannel.pagination,
     posts:              safeBulkGet(postIds, state.posts.data),
     subscribedChannels: getSubscribedChannels(state),
-    postReports:        state.reports.data.posts,
     errored:            anyErrorExcept404([
       channels,
       state.posts,

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -102,8 +102,6 @@ describe("ChannelPage", () => {
       actions.subscribedChannels.get.successType,
       actions.channelModerators.get.requestType,
       actions.channelModerators.get.successType,
-      actions.reports.get.requestType,
-      actions.reports.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA
     ])

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -55,9 +55,7 @@ import type {
   CommentInTree,
   GenericComment,
   MoreCommentsInTree,
-  Post,
-  CommentReportRecord,
-  PostReportRecord
+  Post
 } from "../flow/discussionTypes"
 
 type PostPageProps = {
@@ -83,12 +81,10 @@ type PostPageProps = {
   commentReportDialogVisible: boolean,
   notFound: boolean,
   errored: boolean,
-  commentReports: Map<string, CommentReportRecord>,
   approvePost: (p: Post) => void,
   removePost: (p: Post) => void,
   approveComment: (c: Comment) => void,
   removeComment: (c: Comment) => void,
-  postReports: Map<string, PostReportRecord>,
   location: Location
 }
 
@@ -160,7 +156,7 @@ class PostPage extends React.Component<*, void> {
       channel,
       location: { search }
     } = this.props
-    let { moderators } = this.props
+    const { moderators } = this.props
 
     if (!postID || !channelName) {
       // should not happen, this should be guaranteed by react-router
@@ -178,14 +174,7 @@ class PostPage extends React.Component<*, void> {
       }
 
       if (!moderators) {
-        const { response } = await dispatch(
-          actions.channelModerators.get(channelName)
-        )
-        moderators = response
-      }
-
-      if (isModerator(moderators, SETTINGS.username)) {
-        await dispatch(actions.reports.get(channelName))
+        await dispatch(actions.channelModerators.get(channelName))
       }
     } catch (_) {} // eslint-disable-line no-empty
   }
@@ -317,7 +306,7 @@ class PostPage extends React.Component<*, void> {
   }
 
   reportPost = async () => {
-    const { dispatch, post, forms, isModerator, channelName } = this.props
+    const { dispatch, post, forms } = this.props
     const form = getReportForm(forms)
     const { reason } = form.value
     const validation = validateContentReportForm(form)
@@ -336,10 +325,6 @@ class PostPage extends React.Component<*, void> {
           reason:  reason
         })
       )
-
-      if (isModerator) {
-        await dispatch(actions.reports.get(channelName))
-      }
 
       this.hideReportPostDialog()
       dispatch(
@@ -377,13 +362,10 @@ class PostPage extends React.Component<*, void> {
       commentReportDialogVisible,
       notFound,
       commentID,
-      commentReports,
-      postReports,
       removePost,
       approvePost,
       removeComment,
       approveComment,
-      postID,
       location: { search }
     } = this.props
 
@@ -397,7 +379,6 @@ class PostPage extends React.Component<*, void> {
 
     const reportForm = getReportForm(forms)
     const showPermalinkUI = R.not(R.isNil(commentID))
-    const postReport = postReports.get(postID)
 
     return (
       <div>
@@ -474,7 +455,6 @@ class PostPage extends React.Component<*, void> {
                 this.showReportPostDialog
               )}
               showPermalinkUI={showPermalinkUI}
-              report={postReport}
             />
             {showPermalinkUI
               ? null
@@ -515,7 +495,6 @@ class PostPage extends React.Component<*, void> {
           beginEditing={beginEditing(dispatch)}
           processing={commentInFlight}
           commentPermalink={commentPermalink(channel.name, post.id)}
-          commentReports={commentReports}
         />
       </div>
     )

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -291,8 +291,6 @@ describe("PostPage", function() {
           SET_FOCUSED_POST,
           actions.postRemoved.patch.requestType,
           actions.postRemoved.patch.successType,
-          actions.reports.get.requestType,
-          actions.reports.get.successType,
           SET_POST_DATA,
           SET_SNACKBAR_MESSAGE
         ],

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -28,7 +28,7 @@ export const makePost = (
   edited:        casual.boolean,
   stickied:      casual.boolean,
   removed:       casual.boolean,
-  num_reports:   0
+  num_reports:   null
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -34,7 +34,7 @@ export type AuthoredContent = {
   profile_image:   string,
   author_name:     string,
   edited:          boolean,
-  num_reports:     number,
+  num_reports:     ?number,
   ignore_reports?: boolean,
 }
 

--- a/static/js/hoc/withCommentModeration.js
+++ b/static/js/hoc/withCommentModeration.js
@@ -34,10 +34,12 @@ export const withCommentModeration = (
     }
 
     approveComment = async (comment: CommentInTree) => {
-      const { dispatch, channelName } = this.props
+      const { dispatch, channelName, shouldGetReports } = this.props
 
       await approveComment(dispatch, comment)
-      await dispatch(actions.reports.get(channelName))
+      if (shouldGetReports) {
+        await dispatch(actions.reports.get(channelName))
+      }
       dispatch(
         setSnackbarMessage({
           message: "Comment has been approved"
@@ -46,7 +48,12 @@ export const withCommentModeration = (
     }
 
     removeComment = async () => {
-      const { dispatch, focusedComment, channelName } = this.props
+      const {
+        dispatch,
+        focusedComment,
+        channelName,
+        shouldGetReports
+      } = this.props
 
       if (!focusedComment) {
         // we are getting double events for this, so this is a hack to avoid dispatching
@@ -55,7 +62,9 @@ export const withCommentModeration = (
       }
 
       await removeComment(dispatch, focusedComment)
-      await dispatch(actions.reports.get(channelName))
+      if (shouldGetReports) {
+        await dispatch(actions.reports.get(channelName))
+      }
 
       dispatch(
         setSnackbarMessage({
@@ -65,12 +74,14 @@ export const withCommentModeration = (
     }
 
     ignoreReports = async (comment: CommentInTree) => {
-      const { dispatch, channelName } = this.props
+      const { dispatch, channelName, shouldGetReports } = this.props
 
       await dispatch(
         actions.comments.patch(comment.id, { ignore_reports: true })
       )
-      await dispatch(actions.reports.get(channelName))
+      if (shouldGetReports) {
+        await dispatch(actions.reports.get(channelName))
+      }
     }
 
     render() {
@@ -105,12 +116,11 @@ export const withCommentModeration = (
 }
 
 export const commentModerationSelector = (state: Object, ownProps: Object) => {
-  const { ui, focus, reports } = state
+  const { ui, focus } = state
 
   return {
     showRemoveCommentDialog: ui.dialogs.has(DIALOG_REMOVE_COMMENT),
     focusedComment:          focus.comment,
-    channelName:             getChannelName(ownProps),
-    commentReports:          reports.data.comments
+    channelName:             getChannelName(ownProps)
   }
 }

--- a/static/js/hoc/withPostModeration.js
+++ b/static/js/hoc/withPostModeration.js
@@ -38,9 +38,16 @@ export const withPostModeration = (
     }
 
     removePost = async () => {
-      const { dispatch, focusedPost, channelName } = this.props
+      const {
+        dispatch,
+        focusedPost,
+        channelName,
+        shouldGetReports
+      } = this.props
       await removePost(dispatch, focusedPost)
-      await dispatch(actions.reports.get(channelName))
+      if (shouldGetReports) {
+        await dispatch(actions.reports.get(channelName))
+      }
       dispatch(
         setSnackbarMessage({
           message: "Post has been removed"
@@ -59,10 +66,12 @@ export const withPostModeration = (
     }
 
     ignoreReports = async (post: Post) => {
-      const { dispatch, channelName } = this.props
+      const { dispatch, channelName, shouldGetReports } = this.props
 
       await dispatch(actions.posts.patch(post.id, { ignore_reports: true }))
-      await dispatch(actions.reports.get(channelName))
+      if (shouldGetReports) {
+        await dispatch(actions.reports.get(channelName))
+      }
     }
 
     render() {
@@ -116,10 +125,10 @@ export const postModerationSelector = (state: Object, ownProps: Object) => {
     channel,
     loaded,
     notFound,
+    shouldGetReports:     false, // by default, we won't fetch these
     isModerator:          userIsModerator,
     subscribedChannels:   getSubscribedChannels(state),
     reports:              reports.data.reports,
-    postReports:          state.reports.data.posts,
     showRemovePostDialog: ui.dialogs.has(DIALOG_REMOVE_POST),
     focusedPost:          focus.post,
     errored:              anyErrorExcept404([


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #495 

#### What's this PR do?
Adds the report counts to the frontpage and removes no longer needed calls to fetch the reports.

#### How should this be manually tested?
Verify that the counts still show up and you don't see report counts for channels you're not a moderator of.
