### PR TITLE
fix comment permalink 404

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -38,7 +38,11 @@ import { setSnackbarMessage, showDialog, hideDialog } from "../actions/ui"
 import { toggleUpvote } from "../util/api_actions"
 import { getChannelName, getPostID, getCommentID } from "../lib/util"
 import { isModerator } from "../lib/channels"
-import { anyErrorExcept404, anyErrorExcept404or410 } from "../util/rest"
+import {
+  anyErrorExcept404,
+  anyErrorExcept404or410,
+  any404Error
+} from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { beginEditing } from "../components/CommentForms"
 import { formatTitle } from "../lib/title"
@@ -502,7 +506,15 @@ class PostPage extends React.Component<*, void> {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { posts, channels, comments, forms, channelModerators, ui } = state
+  const {
+    posts,
+    channels,
+    comments,
+    forms,
+    channelModerators,
+    subscribedChannels,
+    ui
+  } = state
   const postID = getPostID(ownProps)
   const channelName = getChannelName(ownProps)
   const commentID = getCommentID(ownProps)
@@ -510,12 +522,10 @@ const mapStateToProps = (state, ownProps) => {
   const channel = channels.data.get(channelName)
   const commentsTree = comments.data.get(postID)
   const moderators = channelModerators.data.get(channelName)
-  const loaded = posts.error
-    ? true
-    : R.none(R.isNil, [post, channel, commentsTree])
-  const notFound = loaded
-    ? posts.error && posts.error.errorStatusCode === 404
-    : false
+
+  const loaded = posts.loaded && subscribedChannels.loaded && comments.loaded
+
+  const notFound = loaded && any404Error([posts, comments])
 
   return {
     ...postModerationSelector(state, ownProps),

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -544,6 +544,23 @@ describe("PostPage", function() {
     assert(wrapper.find(NotFound).exists())
   })
 
+  it("should show a 404 page for a comment 404", async () => {
+    helper.getCommentsStub.returns(Promise.reject({ errorStatusCode: 404 }))
+    const [wrapper] = await renderComponent(
+      postDetailURL(channel.name, post.id),
+      [
+        actions.posts.get.requestType,
+        actions.posts.get.successType,
+        actions.comments.get.requestType,
+        actions.comments.get.failureType,
+        actions.subscribedChannels.get.requestType,
+        actions.subscribedChannels.get.successType,
+        SET_CHANNEL_DATA
+      ]
+    )
+    assert(wrapper.find(NotFound).exists())
+  })
+
   it("should show the PostPage if a 410 happens on comments", async () => {
     // really this only happens on comments.post, but we don't have per-verb status codes so this is close enough
     helper.getCommentsStub.returns(Promise.reject({ errorStatusCode: 410 }))

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -27,5 +27,11 @@ export const anyErrorExcept = (codes: Array<number>) =>
     R.filter(hasError)
   )
 
+export const any404Error = R.compose(
+  R.any(R.propSatisfies(R.equals(404), "errorStatusCode")),
+  R.map(R.prop("error")),
+  R.filter(hasError)
+)
+
 export const anyErrorExcept404 = anyErrorExcept([404])
 export const anyErrorExcept404or410 = anyErrorExcept([404, 410])

--- a/static/js/util/rest_test.js
+++ b/static/js/util/rest_test.js
@@ -1,7 +1,15 @@
 // @flow
 import { assert } from "chai"
 
-import { anyProcessing, allLoaded, anyError, anyErrorExcept404 } from "./rest"
+import {
+  anyProcessing,
+  allLoaded,
+  anyError,
+  anyErrorExcept404,
+  any404Error
+} from "./rest"
+
+const makeError = n => ({ error: { errorStatusCode: n } })
 
 describe("rest utils", () => {
   describe("anyProcessing", () => {
@@ -77,26 +85,38 @@ describe("rest utils", () => {
     })
 
     it("should return true if some or all codes are not 404", () => {
-      assert.isTrue(
-        anyErrorExcept404([
-          { error: { errorStatusCode: 401 } },
-          { error: { errorStatusCode: 404 } }
-        ])
-      )
-      assert.isTrue(
-        anyErrorExcept404([
-          { error: { errorStatusCode: 401 } },
-          { error: { errorStatusCode: 500 } }
+      assert.isTrue(anyErrorExcept404([makeError(401), makeError(404)]))
+      assert.isTrue(anyErrorExcept404([makeError(401), makeError(500)]))
+    })
+
+    it("should return false if all codes are 404", () => {
+      assert.isFalse(anyErrorExcept404([makeError(404), makeError(404)]))
+    })
+  })
+
+  describe("any404Error", () => {
+    it("should return false for empty array", () => {
+      assert.isFalse(any404Error([]))
+    })
+
+    it("should return false if all codes are not 404", () => {
+      assert.isFalse(
+        any404Error([
+          makeError(303),
+          makeError(400),
+          makeError(500),
+          { error: {} }
         ])
       )
     })
 
-    it("should return false if all codes are 404", () => {
-      assert.isFalse(
-        anyErrorExcept404([
-          { error: { errorStatusCode: 404 } },
-          { error: { errorStatusCode: 404 } }
-        ])
+    it("should return true if some or all codes are 404", () => {
+      assert.isTrue(
+        any404Error([makeError(404), makeError(500), makeError(4932)])
+      )
+
+      assert.isTrue(
+        any404Error([makeError(404), makeError(404), makeError(404)])
       )
     })
   })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #499 

#### What's this PR do?

This fixes the logic for when we show the 404 component on the post page, so that the case when we visit a comment permalink for a non-existent comment is taken into account.

#### How should this be manually tested?

Confirm that viewing the post page and viewing an individual comment works as it should. Then confirm that going to a nonexistent post works as it should, and also that going to a comment permalink for a non-existent comment shows a 404 page.