### PR TITLE
add email settings page

### DIFF
--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     url(r'^manage/', index),
     url(r'^create_post/', index),
     url(r'^moderation/', index),
+    url(r'^settings/', index),
 ]
 
 if settings.DEBUG:

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -13,6 +13,7 @@ import AdminPage from "./admin/AdminPage"
 import AuthRequiredPage from "./AuthRequiredPage"
 import CreatePostPage from "./CreatePostPage"
 import ChannelModerationPage from "./ChannelModerationPage"
+import SettingsPage from "./SettingsPage"
 import Toolbar from "../components/Toolbar"
 import Snackbar from "../components/material/Snackbar"
 import Drawer from "../containers/Drawer"
@@ -21,7 +22,7 @@ import Footer from "../components/Footer"
 import { actions } from "../actions"
 import { setShowDrawer } from "../actions/ui"
 import { setChannelData } from "../actions/channel"
-import { AUTH_REQUIRED_URL } from "../lib/url"
+import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -45,7 +46,8 @@ class App extends React.Component<*, void> {
     const { location: { pathname } } = this.props
     if (
       pathname === AUTH_REQUIRED_URL ||
-      !SETTINGS.authenticated_site.session_url
+      !SETTINGS.authenticated_site.session_url ||
+      pathname.startsWith(SETTINGS_URL)
     ) {
       // either user is at auth required page
       // or they will be soon redirected there due to missing session_url
@@ -67,7 +69,8 @@ class App extends React.Component<*, void> {
 
     if (
       !SETTINGS.authenticated_site.session_url &&
-      pathname !== AUTH_REQUIRED_URL
+      pathname !== AUTH_REQUIRED_URL &&
+      !pathname.startsWith(SETTINGS_URL)
     ) {
       // user does not have the jwt cookie, they must go through login workflow first
       return <Redirect to={AUTH_REQUIRED_URL} />
@@ -112,6 +115,11 @@ class App extends React.Component<*, void> {
           <Route
             path={`${match.url}content_policy/`}
             component={ContentPolicyPage}
+          />
+          <Route
+            exact
+            path={`${match.url}settings/:token?`}
+            component={SettingsPage}
           />
         </div>
         <Footer />

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,10 +1,13 @@
 // @flow
+/* global SETTINGS: false */
 import sinon from "sinon"
 import { assert } from "chai"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeChannelList } from "../factories/channels"
 import { actions } from "../actions"
+import { SETTINGS_URL } from "../lib/url"
+import { makeNotificationSetting } from "../factories/settings"
 
 describe("App", () => {
   let helper, renderComponent, channels
@@ -35,5 +38,21 @@ describe("App", () => {
         actions.subscribedChannels.get.successType
       ])
     )
+  })
+
+  it("redirects if you have no session url", async () => {
+    delete SETTINGS.authenticated_site.session_url
+    await renderComponent("/channel/foobaz", [])
+    assert.equal(document.title, "Login Required | MIT Open Discussions")
+  })
+
+  it("doesnt redirect if you have no session url but are on the settings page", async () => {
+    delete SETTINGS.authenticated_site.session_url
+    helper.getSettingsStub.returns(Promise.resolve([makeNotificationSetting()]))
+    await renderComponent(SETTINGS_URL, [
+      actions.settings.get.requestType,
+      actions.settings.get.successType
+    ])
+    assert.notEqual(document.title, "Login Required | MIT Open Discussions")
   })
 })

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -1,0 +1,109 @@
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
+import { Radio } from "@mitodl/mdl-react-components"
+import { FETCH_PROCESSING } from "redux-hammock/constants"
+
+import Card from "../components/Card"
+
+import { formatTitle } from "../lib/title"
+import { actions } from "../actions"
+import {
+  FRONTPAGE_FREQUENCY_CHOICES,
+  FREQUENCY_DAILY
+} from "../reducers/settings"
+import { setSnackbarMessage } from "../actions/ui"
+
+export const SETTINGS_FORM_KEY = "SETTINGS_FORM_KEY"
+const FREQUENCY_INPUT_NAME = "trigger_frequency"
+
+class SettingsPage extends React.Component<*, *> {
+  componentWillMount() {
+    this.loadData()
+  }
+
+  loadData = async () => {
+    const { dispatch, token } = this.props
+
+    const [{ trigger_frequency }] = await dispatch(actions.settings.get(token))
+
+    dispatch(
+      actions.forms.formBeginEdit({
+        formKey: SETTINGS_FORM_KEY,
+        value:   {
+          [FREQUENCY_INPUT_NAME]: trigger_frequency
+        }
+      })
+    )
+  }
+
+  onSubmit = async (e: Object) => {
+    const { dispatch, form, token } = this.props
+
+    e.preventDefault()
+
+    await dispatch(actions.settings.patch(form.value, token))
+    dispatch(
+      setSnackbarMessage({
+        message: "Notification Settings Saved"
+      })
+    )
+  }
+
+  onChange = (e: Object) => {
+    const { dispatch } = this.props
+    dispatch(
+      actions.forms.formUpdate({
+        formKey: SETTINGS_FORM_KEY,
+        value:   {
+          [e.target.name]: e.target.value
+        }
+      })
+    )
+  }
+
+  render() {
+    const { form, saving } = this.props
+
+    return form
+      ? <div className="content">
+        <DocumentTitle title={formatTitle("Settings")} />
+        <div className="main-content settings-page">
+          <div className="breadcrumbs">Email Settings</div>
+          <form onSubmit={this.onSubmit} className="form">
+            <Card>
+              <label htmlFor="frequency" className="label">
+                  How often do you want to receive discussion digest emails?
+              </label>
+              <Radio
+                className="settings-radio"
+                name={FREQUENCY_INPUT_NAME}
+                value={form.value[FREQUENCY_INPUT_NAME] || FREQUENCY_DAILY}
+                onChange={this.onChange}
+                options={FRONTPAGE_FREQUENCY_CHOICES}
+              />
+            </Card>
+            <button
+              type="submit"
+              disabled={saving}
+              className={`blue-button ${saving ? "disabled" : ""}`}
+            >
+                Save
+            </button>
+          </form>
+        </div>
+      </div>
+      : null
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  settings: state.settings.data,
+  token:    ownProps.match.params.token || "",
+  form:     state.forms[SETTINGS_FORM_KEY],
+  saving:
+    state.settings.processing && state.settings.patchStatus === FETCH_PROCESSING
+})
+
+export default connect(mapStateToProps)(SettingsPage)

--- a/static/js/factories/settings.js
+++ b/static/js/factories/settings.js
@@ -1,0 +1,15 @@
+// @flow
+import R from "ramda"
+
+import {
+  FRONTPAGE_NOTIFICATION,
+  FRONTPAGE_FREQUENCY_CHOICES
+} from "../reducers/settings"
+import { draw } from "./util"
+
+import type { NotificationSetting } from "../flow/settingsTypes"
+
+export const makeNotificationSetting = (): NotificationSetting => ({
+  notification_type: FRONTPAGE_NOTIFICATION,
+  trigger_frequency: draw(R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES))
+})

--- a/static/js/factories/settings_test.js
+++ b/static/js/factories/settings_test.js
@@ -1,0 +1,20 @@
+// @flow
+import { assert } from "chai"
+import R from "ramda"
+
+import {
+  FRONTPAGE_NOTIFICATION,
+  FRONTPAGE_FREQUENCY_CHOICES
+} from "../reducers/settings"
+import { makeNotificationSetting } from "./settings"
+
+describe("settings factory", () => {
+  it("should make a setting object", () => {
+    const setting = makeNotificationSetting()
+    assert.equal(setting.notification_type, FRONTPAGE_NOTIFICATION)
+    assert.include(
+      R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES),
+      setting.trigger_frequency
+    )
+  })
+})

--- a/static/js/factories/util.js
+++ b/static/js/factories/util.js
@@ -6,7 +6,9 @@ export const arrayN = (min: number, max: number) =>
   R.range(0, casual.integer(min, max))
 
 export const randomSelection = (n: number, xs: Array<any>) =>
-  R.times(() => xs[casual.integer(0, xs.length - 1)], n)
+  R.times(() => draw(xs), n)
+
+export const draw = (xs: Array<any>) => xs[casual.integer(0, xs.length - 1)]
 
 export function* incrementer(): Generator<number, *, *> {
   let int = 1

--- a/static/js/flow/settingsTypes.js
+++ b/static/js/flow/settingsTypes.js
@@ -1,0 +1,6 @@
+// @flow
+
+export type NotificationSetting = {
+  notification_type: string,
+  trigger_frequency: string,
+}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -6,7 +6,11 @@ import "isomorphic-fetch"
 import qs from "query-string"
 import { PATCH, POST, DELETE } from "redux-hammock/constants"
 
-import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./auth"
+import {
+  fetchJSONWithAuthFailure,
+  fetchWithAuthFailure,
+  fetchJSONWithToken
+} from "./auth"
 import { toQueryString } from "../lib/url"
 import { getPaginationSortParams } from "../lib/posts"
 
@@ -22,6 +26,7 @@ import type {
   GenericReport,
   ReportRecord
 } from "../flow/discussionTypes"
+import type { NotificationSetting } from "../flow/settingsTypes"
 
 const paramsToQueryString = paramSelector =>
   R.compose(toQueryString, R.reject(R.isNil), paramSelector)
@@ -200,3 +205,22 @@ export function reportContent(payload: GenericReport): Promise<GenericReport> {
 
 export const getReports = (channelName: string): Promise<Array<ReportRecord>> =>
   fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/reports/`)
+
+export const getSettings = (token: ?string = undefined) =>
+  token
+    ? fetchJSONWithToken("/api/v0/notification_settings/", token)
+    : fetchJSONWithAuthFailure("/api/v0/notification_settings/")
+
+export const patchFrontpageSetting = (
+  setting: NotificationSetting,
+  token: ?string = undefined
+) =>
+  token
+    ? fetchJSONWithToken("/api/v0/notification_settings/frontpage/", token, {
+      method: PATCH,
+      body:   JSON.stringify(setting)
+    })
+    : fetchJSONWithAuthFailure("/api/v0/notification_settings/frontpage/", {
+      method: PATCH,
+      body:   JSON.stringify(setting)
+    })

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -57,3 +57,25 @@ export const fetchJSONWithAuthFailure = withAuthFailure((...args) =>
 export const fetchWithAuthFailure = withAuthFailure((...args) =>
   fetchWithCSRF(...args)
 )
+
+export const fetchJSONWithToken = async (
+  url: string,
+  token: string,
+  body: ?Object = {}
+) => {
+  try {
+    return await fetchJSONWithCSRF(url, {
+      headers: {
+        Authorization:  `Token ${token}`,
+        "content-type": "application/json"
+      },
+      ...body
+    })
+  } catch (fetchError) {
+    if (fetchError.errorStatusCode !== 401) {
+      // not an authentication failure, rethrow
+      throw fetchError
+    }
+    return redirectAndReject("invalid token")
+  }
+}

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -9,6 +9,7 @@ import { postUpvotesEndpoint } from "../reducers/post_upvotes"
 import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
 import { postRemovedEndpoint } from "../reducers/post_removed"
 import { reportsEndpoint } from "../reducers/reports"
+import { settingsEndpoint } from "../reducers/settings"
 
 export const endpoints = [
   postsEndpoint,
@@ -21,5 +22,6 @@ export const endpoints = [
   moreCommentsEndpoint,
   postUpvotesEndpoint,
   postRemovedEndpoint,
-  reportsEndpoint
+  reportsEndpoint,
+  settingsEndpoint
 ]

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -33,6 +33,7 @@ export const getChannelNameFromPathname = R.compose(
 export const FRONTPAGE_URL = "/"
 export const AUTH_REQUIRED_URL = "/auth_required/"
 export const CONTENT_POLICY_URL = "/content_policy/"
+export const SETTINGS_URL = "/settings/"
 
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`

--- a/static/js/reducers/settings.js
+++ b/static/js/reducers/settings.js
@@ -1,0 +1,26 @@
+// @flow
+import * as api from "../lib/api"
+import { GET, PATCH } from "redux-hammock/constants"
+
+import type { NotificationSetting } from "../flow/settingsTypes"
+
+export const FREQUENCY_IMMEDIATE = "immediate"
+export const FREQUENCY_DAILY = "daily"
+export const FREQUENCY_WEEKLY = "weekly"
+export const FREQUENCY_NEVER = "never"
+
+export const FRONTPAGE_NOTIFICATION = "frontpage"
+
+export const FRONTPAGE_FREQUENCY_CHOICES = [
+  { value: FREQUENCY_NEVER, label: "Never" },
+  { value: FREQUENCY_DAILY, label: "Daily" },
+  { value: FREQUENCY_WEEKLY, label: "Weekly" }
+]
+
+export const settingsEndpoint = {
+  name:      "settings",
+  verbs:     [GET, PATCH],
+  getFunc:   (token: ?string) => api.getSettings(token),
+  patchFunc: (object: NotificationSetting, token: ?string) =>
+    api.patchFrontpageSetting(object, token)
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -30,6 +30,7 @@
 @import "footer";
 @import "reports";
 @import "sort-picker";
+@import "settings";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/settings.scss
+++ b/static/scss/settings.scss
@@ -1,0 +1,16 @@
+.settings-page {
+  button {
+    margin-left: 15px;
+  }
+
+  .settings-radio {
+    & > div {
+      display: flex;
+      align-items: center;
+
+      label {
+        margin: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #451 

#### What's this PR do?

This adds a notifications page at `/settings` where the user can adjust their notification preferences.

If the user is logged in, it works as any other page in the app. However, it also supports authenticating to the API with a stateless token, which we can use to authenticate only with the notification settings API.

Basically, if the user visits `/settings/${TOKEN]/` the application will include the `TOKEN` value in the headers for the HTTP requests it issues, so that the user can fetch their current notification preference values and also issue a `PATCH` request. If the `TOKEN` supplied is not a valid token (i.e. if we get a 401 back) it will redirect the user to the 'sign in' page.

#### How should this be manually tested?

First you'll need to create a `NotificationSettings` for yourself for the `frontpage` notification type. There are instructions for doing that on Nathan's PR, here: https://github.com/mitodl/open-discussions/pull/497

Normal auth:

- go to `/settings` and confirm you see the current value of the frontpage notification setting selected in the Radio
- confirm you can use the form to change the value

Token auth:

- follow the instructions here to generate a token for yourself: https://github.com/mitodl/open-discussions/pull/506
- in an incognito window (or a different browser where you are not signed in) go to `/settings/${token}/`, where `${token}` is the base64 encoded token you just generated
- you should not see any errors when fetching the current value for the notification setting or editing and saving it.
- if you do the same with a nonsense token (like `asdfasdf`) you should be redirected to `/auth_required/` after the first request.

I think that's it...