### PR TITLE
add report post links to the frontpage and channel page

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -22,7 +22,8 @@ class CompactPostDisplay extends React.Component<*, void> {
     showPinUI: boolean,
     isModerator: boolean,
     removePost?: (p: Post) => void,
-    ignorePostReports?: (p: Post) => void
+    ignorePostReports?: (p: Post) => void,
+    reportPost: (p: Post) => void
   }
 
   showChannelLink = () => {
@@ -44,7 +45,8 @@ class CompactPostDisplay extends React.Component<*, void> {
       togglePinPost,
       isModerator,
       removePost,
-      ignorePostReports
+      ignorePostReports,
+      reportPost
     } = this.props
     const formattedDate = moment(post.created).fromNow()
 
@@ -84,6 +86,7 @@ class CompactPostDisplay extends React.Component<*, void> {
                   ignore all reports
               </a>
               : null}
+            <a onClick={() => reportPost(post)}>report</a>
           </div>
         </div>
       </div>

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -88,8 +88,16 @@ describe("CompactPostDisplay", () => {
   it("should not show a pin link otherwise", () => {
     [true, false].forEach(showPinUI => {
       const wrapper = renderPostDisplay({ post, showPinUI })
-      assert.lengthOf(wrapper.find(".post-links").find("a"), 1)
+      assert.lengthOf(wrapper.find(".post-links").find("a"), 2)
     })
+  })
+
+  it("should show a report link", () => {
+    const reportPost = helper.sandbox.stub()
+    const wrapper = renderPostDisplay({ post, reportPost })
+    const link = wrapper.find({ children: "report" })
+    link.props().onClick()
+    assert.ok(reportPost.called)
   })
 
   it("should set a class if stickied and showing pin ui", () => {

--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -11,7 +11,8 @@ type PostListProps = {
   showPinUI?: boolean,
   toggleUpvote: Post => void,
   togglePinPost?: Post => Promise<*>,
-  isModerator?: boolean
+  isModerator?: boolean,
+  reportPost: (p: Post) => void
 }
 
 const PostList = (props: PostListProps) => {
@@ -21,7 +22,8 @@ const PostList = (props: PostListProps) => {
     showPinUI,
     isModerator,
     toggleUpvote,
-    togglePinPost
+    togglePinPost,
+    reportPost
   } = props
 
   return (
@@ -36,6 +38,7 @@ const PostList = (props: PostListProps) => {
             showPinUI={showPinUI}
             isModerator={isModerator}
             togglePinPost={togglePinPost}
+            reportPost={reportPost}
           />
         )
         : <div className="empty-list-msg">There are no posts to display.</div>}

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -58,7 +58,7 @@ describe("PostList", () => {
     })
   })
 
-  it("should pass thesinon.stub() showChannelLinks prop to CompactPostDisplay", () => {
+  it("should pass the togglePinPost prop to CompactPostDisplay", () => {
     const pinStub = sinon.stub()
     const wrapper = renderPostList({
       posts:         makeChannelPostList(),
@@ -67,5 +67,15 @@ describe("PostList", () => {
     wrapper.find(CompactPostDisplay).forEach(postSummary => {
       assert.equal(postSummary.props().togglePinPost, pinStub)
     })
+  })
+
+  it("should pass the reportPost prop to CompactPostDisplay", () => {
+    const reportStub = sinon.stub()
+    const wrapper = renderPostList({
+      posts:      makeChannelPostList(),
+      reportPost: reportStub
+    })
+    wrapper.find(CompactPostDisplay).first().props().reportPost()
+    assert.ok(reportStub.called)
   })
 })

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -14,6 +14,10 @@ import withNavAndChannelSidebars from "../hoc/withNavAndChannelSidebars"
 import NotFound from "../components/404"
 import { PostSortPicker } from "../components/SortPicker"
 import { ChannelBreadcrumbs } from "../components/ChannelBreadcrumbs"
+import {
+  withPostModeration,
+  postModerationSelector
+} from "../hoc/withPostModeration"
 
 import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
@@ -46,7 +50,8 @@ type ChannelPageProps = {
   pagination: PostListPagination,
   errored: boolean,
   isModerator: boolean,
-  notFound: boolean
+  notFound: boolean,
+  reportPost: (p: Post) => void
 }
 
 const shouldLoadData = R.complement(
@@ -122,7 +127,8 @@ class ChannelPage extends React.Component<*, void> {
       channelName,
       isModerator,
       notFound,
-      location: { search }
+      location: { search },
+      reportPost
     } = this.props
 
     if (notFound) {
@@ -155,6 +161,7 @@ class ChannelPage extends React.Component<*, void> {
               toggleUpvote={toggleUpvote(dispatch)}
               isModerator={isModerator}
               togglePinPost={this.togglePinPost}
+              reportPost={reportPost}
               showPinUI
             />
             {pagination
@@ -191,6 +198,7 @@ const mapStateToProps = (state, ownProps) => {
   const userIsModerator = isModerator(channelModerators, SETTINGS.username)
 
   return {
+    ...postModerationSelector(state, ownProps),
     channelName,
     channel,
     loaded,
@@ -209,6 +217,7 @@ const mapStateToProps = (state, ownProps) => {
 
 export default R.compose(
   connect(mapStateToProps),
+  withPostModeration,
   withNavAndChannelSidebars,
   withLoading
 )(ChannelPage)

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -262,7 +262,7 @@ describe("PostPage", function() {
         SET_SNACKBAR_MESSAGE
       ],
       () => {
-        wrapper.find(Dialog).at(3).props().onAccept()
+        wrapper.find(Dialog).at(4).props().onAccept()
       }
     )
     const { location: { pathname } } = helper.browserHistory
@@ -297,7 +297,7 @@ describe("PostPage", function() {
         () => {
           const props = wrapper.find("ExpandedPostDisplay").props()
           props.removePost(post)
-          wrapper.find("Dialog").at(0).props().onAccept()
+          wrapper.find("Dialog").at(1).props().onAccept()
         }
       )
 
@@ -381,7 +381,7 @@ describe("PostPage", function() {
         if (!isRemoved) {
           // if we are removing the comment, handle the confirmation dialog
           newState = await listenForActions(patchActions, () => {
-            wrapper.find("Dialog").at(1).props().onAccept()
+            wrapper.find("Dialog").at(2).props().onAccept()
           })
         }
 
@@ -447,14 +447,17 @@ describe("PostPage", function() {
     helper.reportContentStub.returns(Promise.resolve())
 
     const preventDefaultStub = helper.sandbox.stub()
-    await listenForActions([SHOW_DIALOG, FORM_BEGIN_EDIT], () => {
-      const reportPostFunc = wrapper.find("ExpandedPostDisplay").props()
-        .showPostReportDialog
-      reportPostFunc({ preventDefault: preventDefaultStub })
-    })
+    await listenForActions(
+      [SHOW_DIALOG, FORM_BEGIN_EDIT, SET_FOCUSED_POST],
+      () => {
+        const reportPostFunc = wrapper.find("ExpandedPostDisplay").props()
+          .showPostReportDialog
+        reportPostFunc({ preventDefault: preventDefaultStub })
+      }
+    )
     assert.ok(preventDefaultStub.called)
 
-    const dialog = wrapper.find("Dialog").at(4)
+    const dialog = wrapper.find("Dialog").at(0)
     dialog.find("input").simulate("change", {
       target: {
         name:  "reason",
@@ -491,6 +494,8 @@ describe("PostPage", function() {
 
       if (isComment) {
         expectedActions.push(SET_FOCUSED_COMMENT)
+      } else {
+        expectedActions.push(SET_FOCUSED_POST)
       }
 
       const preventDefaultStub = helper.sandbox.stub()
@@ -509,7 +514,8 @@ describe("PostPage", function() {
         }
       })
 
-      const dialog = wrapper.find("Dialog").at(4)
+      const dialog = wrapper.find(Dialog).at(isComment ? 5 : 0)
+
       dialog.find("input").simulate("change", {
         target: {
           name:  "reason",

--- a/static/js/lib/reports.js
+++ b/static/js/lib/reports.js
@@ -1,0 +1,30 @@
+// @flow
+import R from "ramda"
+
+import { actions } from "../actions"
+
+export const REPORT_FORM_KEY = "report:content"
+
+export const getReportForm = R.prop(REPORT_FORM_KEY)
+
+export const REPORT_CONTENT_PAYLOAD = {
+  formKey: REPORT_FORM_KEY
+}
+
+export const REPORT_CONTENT_NEW_FORM = {
+  ...REPORT_CONTENT_PAYLOAD,
+  value: {
+    reason: ""
+  }
+}
+
+export const onReportUpdate = R.curry((dispatch: Function, e: Object) => {
+  dispatch(
+    actions.forms.formUpdate({
+      ...REPORT_CONTENT_PAYLOAD,
+      value: {
+        [e.target.name]: e.target.value
+      }
+    })
+  )
+})


### PR DESCRIPTION
#### What are the relevant tickets?

closes #486 

#### What's this PR do?

what it says on the tin. I refactored the `withPostModeration` HOC to include the reporting functionality (and the relevant `Dialog` and so on) in there. Then it was pretty easy to just add the functionality to the channel page and the frontpage.

#### How should this be manually tested?

Moderation on the post page (for both comments and the post) should work totally as before. There should now be a 'report' link on the frontpage and on the channel page for each post - clicking this should bring up the same dialog as on the post page. There should be no issues with reporting a post from the channel page.