### PR TITLE
fix how we calculate loaded and notFound for the post page

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -428,15 +428,7 @@ class PostPage extends React.Component<*, void> {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const {
-    posts,
-    channels,
-    comments,
-    forms,
-    channelModerators,
-    subscribedChannels,
-    ui
-  } = state
+  const { posts, channels, comments, forms, channelModerators, ui } = state
   const postID = getPostID(ownProps)
   const channelName = getChannelName(ownProps)
   const commentID = getCommentID(ownProps)
@@ -445,9 +437,11 @@ const mapStateToProps = (state, ownProps) => {
   const commentsTree = comments.data.get(postID)
   const moderators = channelModerators.data.get(channelName)
 
-  const loaded = posts.loaded && subscribedChannels.loaded && comments.loaded
+  const notFound = any404Error([posts, comments])
 
-  const notFound = loaded && any404Error([posts, comments])
+  const loaded = notFound
+    ? true
+    : R.none(R.isNil, [post, channel, commentsTree])
 
   return {
     ...postModerationSelector(state, ownProps),


### PR DESCRIPTION
#### What are the relevant tickets?

closes #514

#### What's this PR do?

this fixes a bug that I introduced, where making a comment would cause the whole post page to be taken over by a spinner. Uh instead, we shouldn't do that.

#### How should this be manually tested?

confirm that, on master, if you make a comment you see that the whole post page becomes a spinner. then, checkout this branch and confirm that it no longer does that!

also confirm that the 404 page behavior for the post page (for both a post 404 and a comment permalink 404) works as it should.