### PR TITLE
Fix travis errors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program uwsgi uwsgi.ini
-worker: celery -A open_discussions worker -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker: celery -A open_discussions worker -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: celery -A open_discussions.celery:app worker -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker: celery -A open_discussions.celery:app worker -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -18,3 +18,7 @@ services:
       # for celery, to avoid ImproperlyConfigured
       MAILGUN_URL: 'http://fake.example.com'
       MAILGUN_KEY: 'fake'
+      MAILGUN_SENDER_DOMAIN: 'fake.example.com'
+      OPEN_DISCUSSIONS_COOKIE_NAME: 'fake'
+      OPEN_DISCUSSIONS_BASE_URL: 'http://localhost'
+      OPEN_DISCUSSIONS_DEFAULT_SITE_KEY: 'fake'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions worker -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app worker -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #335 

#### What's this PR do?
Fixes error output in travis for when celery starts up

#### How should this be manually tested?
Verify no error output in celery process on travis python job and that you can start celery locally. See this run on master that has stracktraces in it: https://travis-ci.org/mitodl/open-discussions/jobs/350342875