### PR TITLE
add profile picture and name of user to UI

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -6,12 +6,16 @@ from datetime import timedelta
 
 import jwt
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import render
 from rest_framework_jwt.settings import api_settings
 
 from open_discussions.templatetags.render_bundle import public_path
 from sites.models import AuthenticatedSite
+
+
+User = get_user_model()
 
 
 def index(request, **kwargs):  # pylint: disable=unused-argument
@@ -41,11 +45,21 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
     if site is None:
         raise ImproperlyConfigured("Unable to find site for site key: '{}'".format(site_key))
 
+    user_full_name = None
+    profile_image_small = None
+
+    if username is not None:
+        user = User.objects.get(username=username)
+        user_full_name = user.profile.name
+        profile_image_small = user.profile.image_small
+
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "public_path": public_path(request),
         "max_comment_depth": settings.OPEN_DISCUSSIONS_MAX_COMMENT_DEPTH,
         "username": username,
+        "user_full_name": user_full_name,
+        "profile_image_small": profile_image_small,
         "authenticated_site": {
             "title": site.title,
             "base_url": site.base_url,

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -28,6 +28,8 @@ def test_webpack_url(settings, staff_client, mocker, authenticated_site):
         'public_path': '/static/bundles/',
         'max_comment_depth': 6,
         'username': None,
+        'profile_image_small': None,
+        'user_full_name': None,
         'authenticated_site': {
             'title': authenticated_site.title,
             'login_url': authenticated_site.login_url,

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -3,6 +3,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
+import UserInfo from "./UserInfo"
 
 import { newPostURL, getChannelNameFromPathname } from "../lib/url"
 
@@ -20,6 +21,7 @@ const Navigation = (props: NavigationProps) => {
 
   return (
     <div className="navigation">
+      <UserInfo />
       <Link
         className="mdc-button mdc-button--raised blue-button"
         to={newPostURL(channelName)}

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom"
 
 import Navigation from "./Navigation"
 import SubscriptionsList from "./SubscriptionsList"
+import UserInfo from "./UserInfo"
 
 import { newPostURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
@@ -44,6 +45,11 @@ describe("Navigation", () => {
         wrapper.find(SubscriptionsList).props().subscribedChannels,
         channels
       )
+    })
+
+    it("should show UserInfo", () => {
+      const wrapper = renderComponent()
+      assert.ok(wrapper.find(UserInfo).exists())
     })
 
     it("should pass the current channel down to the SubscriptionsList", () => {

--- a/static/js/components/UserInfo.js
+++ b/static/js/components/UserInfo.js
@@ -1,0 +1,15 @@
+/* global SETTINGS:false */
+// @flow
+import React from "react"
+
+const UserInfo = () =>
+  SETTINGS.user_full_name && SETTINGS.profile_image_small
+    ? <div className="user-info">
+      <img className="profile-image" src={SETTINGS.profile_image_small} />
+      <span>
+        {SETTINGS.user_full_name}{" "}
+      </span>
+    </div>
+    : null
+
+export default UserInfo

--- a/static/js/components/UserInfo_test.js
+++ b/static/js/components/UserInfo_test.js
@@ -1,0 +1,37 @@
+/* global SETTINGS:false */
+// @flow
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import UserInfo from "./UserInfo"
+
+describe("UserInfo", () => {
+  const renderUserInfo = () => shallow(<UserInfo />)
+
+  it("should show nothing if relevant info is null", () => {
+    [
+      [null, "http://example.com/profile_image"],
+      ["Full Name", null],
+      [null, null]
+    ].forEach(([name, imgUrl]) => {
+      SETTINGS.user_full_name = name
+      SETTINGS.profile_image_small = imgUrl
+
+      const wrapper = renderUserInfo()
+      assert.isNull(wrapper.type())
+    })
+  })
+
+  it("should include the name and image, otherwise", () => {
+    SETTINGS.user_full_name = "Full Name"
+    SETTINGS.profile_image_small = "http://example.com/profile_image"
+    const wrapper = renderUserInfo()
+    assert.equal(wrapper.find("span").text().trim(), "Full Name")
+    const img = wrapper.find("img")
+    assert.deepEqual(img.props(), {
+      className: "profile-image",
+      src:       "http://example.com/profile_image"
+    })
+  })
+})

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -9,6 +9,8 @@ declare var SETTINGS: {
     [key: string]: boolean,
   },
   username: string,
+  user_full_name: ?string,
+  profile_image_small: ?string,
   authenticated_site: {
     title: string,
     login_url: string,

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -6,6 +6,7 @@ $font-black: rgba(0,0,0,.87);
 $font-grey: #888;
 $font-darkgrey: #666;
 $border-grey: #d3d3d3;
+$border-grey-alt: #cecece;
 $card-background: #fff;
 $card-shadow: #cccaca;
 $app-background: #f1f1f1;
@@ -16,3 +17,4 @@ $validation-text: #f07183;
 $bg-grey: #dad9d9;
 $footer-link-color: #4e8398;
 $report-count-red: #e21d13;
+$navigation-text: rgba(0,0,0,.77)

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -31,6 +31,7 @@
 @import "reports";
 @import "sort-picker";
 @import "settings";
+@import "user-info";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -62,14 +62,14 @@
   width: 100%;
   padding: 16px 0 18px 0;
   box-sizing: border-box;
-  border: 1px solid #cecece;
+  border: 1px solid $border-grey-alt;
   border-width: 1px 0;
 
   .channelname {
     margin: 0 0 0 0;
 
     a {
-      color: rgba(0,0,0,.77);
+      color: $navigation-text;
       display: block;
       font-size: 15px;
       padding: 11px 20px 11px 34px;

--- a/static/scss/user-info.scss
+++ b/static/scss/user-info.scss
@@ -1,0 +1,11 @@
+.user-info {
+  display: flex;
+  align-items: center;
+  margin: 0 0 15px 53px;
+  width: 100%;
+  color: $navigation-text;
+
+  img {
+    margin-right: 15px;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #230 

#### What's this PR do?

This adds the users profile image and full name to the OD UI. We show it in the upper corner, and in the top of the nav thingy on mobile.

#### How should this be manually tested?

If you go to open-discussions you should see something like this:

![marxy](https://user-images.githubusercontent.com/6207644/37225302-2e854fe6-23a4-11e8-9d0c-f460e70ed7d5.png)

If your user lacks either a name or a profile image it should not show anything.
