### PR TITLE
Upgrade Django to 1.11, other upgrades

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 """Configuration for pytest fixtures"""
 # pylint: disable=unused-argument, redefined-outer-name
+import warnings
+
 import factory
 import pytest
 from rest_framework.test import APIClient
@@ -9,6 +11,34 @@ from open_discussions.factories import UserFactory
 from sites.factories import AuthenticatedSiteFactory
 
 pytestmark = pytest.mark.usefixtures('authenticated_site')
+
+
+@pytest.fixture(autouse=True)
+def warnings_as_errors():
+    """
+    Convert warnings to errors. This should only affect unit tests, letting pylint and other plugins
+    raise DeprecationWarnings without erroring.
+    """
+    try:
+        warnings.resetwarnings()
+        warnings.simplefilter('error')
+        # For celery
+        warnings.simplefilter('ignore', category=ImportWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message="'async' and 'await' will become reserved keywords in Python 3.7",
+            category=DeprecationWarning,
+        )
+        # Ignore deprecation warnings in third party libraries
+        warnings.filterwarnings(
+            "ignore",
+            module=".*(api_jwt|api_jws|rest_framework_jwt|betamax).*",
+            category=DeprecationWarning,
+        )
+
+        yield
+    finally:
+        warnings.resetwarnings()
 
 
 @pytest.fixture(scope="function")

--- a/open_discussions/templatetags/render_bundle.py
+++ b/open_discussions/templatetags/render_bundle.py
@@ -3,8 +3,8 @@
 from django import template
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.safestring import mark_safe
 
-from webpack_loader.templatetags.webpack_loader import render_as_tags
 from webpack_loader.utils import get_loader
 
 from open_discussions.utils import webpack_dev_server_url
@@ -31,6 +31,15 @@ def public_path(request):
 def _get_bundle(request, bundle_name):
     """
     Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
+
+    Args:
+        request (django.http.request.HttpRequest): A request
+        bundle_name (str): The name of the webpack bundle
+
+    Returns:
+        iterable of dict:
+            The chunks of the bundle. Usually there's only one but I suppose you could have
+            CSS and JS chunks for one bundle for example
     """
     if not settings.DISABLE_WEBPACK_LOADER_STATS:
         for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
@@ -46,9 +55,46 @@ def _get_bundle(request, bundle_name):
 def render_bundle(context, bundle_name):
     """
     Render the script tags for a Webpack bundle
+
+    We use this instead of webpack_loader.templatetags.webpack_loader.render_bundle because we want to substitute
+    a dynamic URL for webpack dev environments. Maybe in the future we should refactor to use publicPath
+    instead for this.
+
+    Args:
+        context (dict): The context for rendering the template (includes request)
+        bundle_name (str): The name of the bundle to render
+
+    Returns:
+        django.utils.safestring.SafeText: The tags for JS and CSS
     """
     try:
-        return render_as_tags(_get_bundle(context['request'], bundle_name), '')
+        bundle = _get_bundle(context['request'], bundle_name)
+        return _render_tags(bundle)
     except OSError:
         # webpack-stats.json doesn't exist
-        return ''
+        return mark_safe('')
+
+
+def _render_tags(bundle):
+    """
+    Outputs tags for template rendering.
+    Adapted from webpack_loader.utils.get_as_tags and webpack_loader.templatetags.webpack_loader.
+
+    Args:
+        bundle (iterable of dict): The information about a webpack bundle
+
+    Returns:
+        django.utils.safestring.SafeText: HTML for rendering bundles
+    """
+
+    tags = []
+    for chunk in bundle:
+        if chunk['name'].endswith(('.js', '.js.gz')):
+            tags.append((
+                '<script type="text/javascript" src="{}" ></script>'
+            ).format(chunk['url']))
+        elif chunk['name'].endswith(('.css', '.css.gz')):
+            tags.append((
+                '<link type="text/css" href="{}" rel="stylesheet" />'
+            ).format(chunk['url']))
+    return mark_safe('\n'.join(tags))

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -22,7 +22,7 @@ from open_discussions.views import index
 
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^status/', include('server_status.urls')),
     url(r'', include('channels.urls')),
     url(r'', include('profiles.urls')),

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,3 @@ norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.e
 pep8ignore =
    */migrations/* ALL
 pep8maxlinelength = 119
-filterwarnings =
-    error
-    ignore::DeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango20Warning
-    ignore::PendingDeprecationWarning
-    ignore::ImportWarning
-    ignore:Failed to load HostKeys

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 django-cors-headers==2.1.0
-Django==1.10.5
+Django==1.11.10
 PyYAML==3.11
 betamax
 betamax_serializers
@@ -8,10 +8,10 @@ celery==4.0.2
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
-django-server-status==0.3.2
-django-webpack-loader==0.4.1
+django-server-status==0.5.0
+django-webpack-loader==0.5.0
 django-anymail[mailgun]
-djangorestframework==3.5.2
+djangorestframework==3.7.7
 djangorestframework-jwt==1.11.0
 factory_boy
 faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,11 @@ dj-static==0.0.6
 django-anymail[mailgun]==1.2
 django-cors-headers==2.1.0
 django-redis==4.7.0
-django-server-status==0.3.2
-django-webpack-loader==0.4.1
-django==1.10.5
+django-server-status==0.5.0
+django-webpack-loader==0.5.0
+django==1.11.10
 djangorestframework-jwt==1.11.0
-djangorestframework==3.5.2
+djangorestframework==3.7.7
 elasticsearch==5.4.0      # via django-server-status
 factory-boy==2.8.1
 faker==0.7.17
@@ -44,7 +44,7 @@ ptyprocess==0.5.1         # via pexpect
 pygments==2.2.0           # via ipython
 pyjwt==1.5.2              # via djangorestframework-jwt
 python-dateutil==2.6.0    # via faker
-pytz==2017.2              # via celery
+pytz==2017.2              # via celery, django
 pyyaml==3.11
 raven==6.1.0
 redis==2.10.5


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
 - Upgrade Django to 1.11
 - Change pytest filtering to be more specific with deprecation warnings
 - Update django-webpack-loader and related templatetags
 - Update Django REST framework and django-server-status

#### How should this be manually tested?
Nothing should break
