### PR TITLE
Fixed query error on populate command

### DIFF
--- a/notifications/management/commands/populate_notification_settings.py
+++ b/notifications/management/commands/populate_notification_settings.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
         if not options['inactive']:
             # unless the --inactive flag is specified, default to the safer subset of active users
-            users = users.filter(profile__last_active_on=True)
+            users = users.filter(profile__last_active_on__isnull=False)
 
         if options['username']:
             users = users.filter(username__in=options['username'])


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #539 

#### What's this PR do?
Fixes an obvious error in the query filter

#### How should this be manually tested?
Run `./manage.py populate_notification_settings` in master, it should error. Run it in this branch and it should not error.
