### PR TITLE
Fixed issue with request KeyError on email send

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -139,6 +139,11 @@ class PostSerializer(serializers.Serializer):
     num_reports = serializers.IntegerField(read_only=True)
     subscribed = WriteableSerializerMethodField()
 
+    @property
+    def _current_user(self):
+        """Get the current user"""
+        return self.context['current_user']
+
     def _get_user(self, instance):
         """
         Look up user in the context from the post author
@@ -229,7 +234,7 @@ class PostSerializer(serializers.Serializer):
         if 'post_subscriptions' not in self.context:
             # this code is run if a post was just created
             return Subscription.objects.filter(
-                user=self.context['request'].user,
+                user=self._current_user,
                 post_id=instance.id,
                 comment_id__isnull=True,
             ).exists()
@@ -252,7 +257,7 @@ class PostSerializer(serializers.Serializer):
         else:
             kwargs['url'] = url
 
-        api = Api(user=self.context['request'].user)
+        api = Api(user=self._current_user)
         channel_name = self.context['view'].kwargs['channel_name']
         post = api.create_post(
             channel_name,
@@ -274,7 +279,7 @@ class PostSerializer(serializers.Serializer):
         if "url" in validated_data:
             raise ValidationError("Cannot edit url for a post")
 
-        api = Api(user=self.context['request'].user)
+        api = Api(user=self._current_user)
 
         if "removed" in validated_data:
             removed = validated_data["removed"]

--- a/channels/views/frontpage.py
+++ b/channels/views/frontpage.py
@@ -20,6 +20,7 @@ class FrontPageView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'current_user': self.request.user,
             'request': self.request,
             'view': self,
         }

--- a/channels/views/posts.py
+++ b/channels/views/posts.py
@@ -24,6 +24,7 @@ class PostListView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'current_user': self.request.user,
             'request': self.request,
             'view': self,
         }
@@ -68,6 +69,7 @@ class PostDetailView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'current_user': self.request.user,
             'request': self.request,
             'view': self,
         }

--- a/channels/views/reports.py
+++ b/channels/views/reports.py
@@ -20,6 +20,7 @@ class ReportContentView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'current_user': self.request.user,
             'request': self.request,
         }
 
@@ -48,6 +49,7 @@ class ChannelReportListView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'current_user': self.request.user,
             'request': self.request,
         }
 

--- a/notifications/notifiers/frontpage.py
+++ b/notifications/notifiers/frontpage.py
@@ -138,7 +138,12 @@ class FrontpageDigestNotifier(EmailNotifier):
 
         return {
             'posts': [
-                serializers.PostSerializer(post).data
+                serializers.PostSerializer(
+                    post,
+                    context={
+                        'current_user': notification_settings.user,
+                    },
+                ).data
                 for post in posts
             ],
         }

--- a/notifications/notifiers/frontpage_test.py
+++ b/notifications/notifiers/frontpage_test.py
@@ -122,7 +122,9 @@ def test_send_notification(mocker):
 
     notifier.send_notification(note)
 
-    serializer_mock.assert_called_once_with(post)
+    serializer_mock.assert_called_once_with(post, context={
+        'current_user': note.user,
+    })
 
     send_messages_mock.assert_called_once_with([any_instance_of(EmailMessage)])
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #544 

#### What's this PR do?
Updates `PostSerializer` to take an explicit current user on the context instead of looking it up on the request, which we don't have in certain contexts like email sending.

#### How should this be manually tested?
See instructions in #504 