### PR TITLE
fix settings page

### DIFF
--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -7,7 +7,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeChannelList } from "../factories/channels"
 import { actions } from "../actions"
 import { SETTINGS_URL } from "../lib/url"
-import { makeNotificationSetting } from "../factories/settings"
+import { makeFrontpageSetting } from "../factories/settings"
 
 describe("App", () => {
   let helper, renderComponent, channels
@@ -48,7 +48,7 @@ describe("App", () => {
 
   it("doesnt redirect if you have no session url but are on the settings page", async () => {
     delete SETTINGS.authenticated_site.session_url
-    helper.getSettingsStub.returns(Promise.resolve([makeNotificationSetting()]))
+    helper.getSettingsStub.returns(Promise.resolve([makeFrontpageSetting()]))
     await renderComponent(SETTINGS_URL, [
       actions.settings.get.requestType,
       actions.settings.get.successType

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react"
+import R from "ramda"
 import { connect } from "react-redux"
 import DocumentTitle from "react-document-title"
 import { Radio } from "@mitodl/mdl-react-components"
@@ -11,12 +12,19 @@ import { formatTitle } from "../lib/title"
 import { actions } from "../actions"
 import {
   FRONTPAGE_FREQUENCY_CHOICES,
-  FREQUENCY_DAILY
+  FREQUENCY_DAILY,
+  FRONTPAGE_NOTIFICATION
 } from "../reducers/settings"
 import { setSnackbarMessage } from "../actions/ui"
 
 export const SETTINGS_FORM_KEY = "SETTINGS_FORM_KEY"
+
 const FREQUENCY_INPUT_NAME = "trigger_frequency"
+
+const getFrontpageFrequency = R.compose(
+  R.prop("trigger_frequency"),
+  R.find(R.propEq("notification_type", FRONTPAGE_NOTIFICATION))
+)
 
 class SettingsPage extends React.Component<*, *> {
   componentWillMount() {
@@ -26,13 +34,13 @@ class SettingsPage extends React.Component<*, *> {
   loadData = async () => {
     const { dispatch, token } = this.props
 
-    const [{ trigger_frequency }] = await dispatch(actions.settings.get(token))
+    const settings = await dispatch(actions.settings.get(token))
 
     dispatch(
       actions.forms.formBeginEdit({
         formKey: SETTINGS_FORM_KEY,
         value:   {
-          [FREQUENCY_INPUT_NAME]: trigger_frequency
+          [FREQUENCY_INPUT_NAME]: getFrontpageFrequency(settings)
         }
       })
     )

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -1,0 +1,47 @@
+import { assert } from "chai"
+import { Radio } from "@mitodl/mdl-react-components"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { FORM_BEGIN_EDIT } from "../actions/forms"
+import { makeFrontpageSetting, makeCommentSetting } from "../factories/settings"
+
+describe("SettingsPage", () => {
+  let helper, renderComponent
+
+  const renderPage = () =>
+    renderComponent("/settings/", [
+      actions.settings.get.requestType,
+      actions.settings.get.successType,
+      FORM_BEGIN_EDIT
+    ])
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    renderComponent = helper.renderComponent.bind(helper)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should work ok when the frontpage setting comes back first", async () => {
+    const settings = [makeFrontpageSetting(), makeCommentSetting()]
+    helper.getSettingsStub.returns(Promise.resolve(settings))
+    const [wrapper] = await renderPage()
+    assert.equal(
+      wrapper.find(Radio).props().value,
+      settings[0].trigger_frequency
+    )
+  })
+
+  it("should work ok if the frontpage setting doesnt come back first", async () => {
+    const settings = [makeCommentSetting(), makeFrontpageSetting()]
+    helper.getSettingsStub.returns(Promise.resolve(settings))
+    const [wrapper] = await renderPage()
+    assert.equal(
+      wrapper.find(Radio).props().value,
+      settings[1].trigger_frequency
+    )
+  })
+})

--- a/static/js/factories/settings.js
+++ b/static/js/factories/settings.js
@@ -3,13 +3,19 @@ import R from "ramda"
 
 import {
   FRONTPAGE_NOTIFICATION,
+  COMMENT_NOTIFICATION,
   FRONTPAGE_FREQUENCY_CHOICES
 } from "../reducers/settings"
 import { draw } from "./util"
 
 import type { NotificationSetting } from "../flow/settingsTypes"
 
-export const makeNotificationSetting = (): NotificationSetting => ({
+export const makeFrontpageSetting = (): NotificationSetting => ({
   notification_type: FRONTPAGE_NOTIFICATION,
+  trigger_frequency: draw(R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES))
+})
+
+export const makeCommentSetting = (): NotificationSetting => ({
+  notification_type: COMMENT_NOTIFICATION,
   trigger_frequency: draw(R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES))
 })

--- a/static/js/factories/settings_test.js
+++ b/static/js/factories/settings_test.js
@@ -4,14 +4,24 @@ import R from "ramda"
 
 import {
   FRONTPAGE_NOTIFICATION,
+  COMMENT_NOTIFICATION,
   FRONTPAGE_FREQUENCY_CHOICES
 } from "../reducers/settings"
-import { makeNotificationSetting } from "./settings"
+import { makeFrontpageSetting, makeCommentSetting } from "./settings"
 
 describe("settings factory", () => {
-  it("should make a setting object", () => {
-    const setting = makeNotificationSetting()
+  it("should make a frontpage setting object", () => {
+    const setting = makeFrontpageSetting()
     assert.equal(setting.notification_type, FRONTPAGE_NOTIFICATION)
+    assert.include(
+      R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES),
+      setting.trigger_frequency
+    )
+  })
+
+  it("should make a comment setting object", () => {
+    const setting = makeCommentSetting()
+    assert.equal(setting.notification_type, COMMENT_NOTIFICATION)
     assert.include(
       R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES),
       setting.trigger_frequency

--- a/static/js/reducers/settings.js
+++ b/static/js/reducers/settings.js
@@ -10,6 +10,7 @@ export const FREQUENCY_WEEKLY = "weekly"
 export const FREQUENCY_NEVER = "never"
 
 export const FRONTPAGE_NOTIFICATION = "frontpage"
+export const COMMENT_NOTIFICATION = "comments"
 
 export const FRONTPAGE_FREQUENCY_CHOICES = [
   { value: FREQUENCY_NEVER, label: "Never" },


### PR DESCRIPTION
#### What are the relevant tickets?

closes #552 

#### What's this PR do?

The UI before assumed that the list of `NotificationSettings` objects would only include the frontpage one, and didn't account for there being others (uh, oops). So, now it does.

I also added a regression test, which really probably should have been there in the first place. Ah well, c'est la vie.

#### How should this be manually tested?

Make sure your user has a `comments` and `frontpage` notification setting object created, and go to `/settings/`. The Radio menu for the frontpage setting should reflect the DB value, and you should be able to save it and have the UI change (when you refresh the page I mean).