### PR TITLE
This fixes an issue where images where being squeezed on the channel page

### DIFF
--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -38,6 +38,7 @@ $replyPaddingLeft: 8px;
     img.profile-image {
       width: $profileImageWidth;
       height: $profileImageHeight;
+      flex-shrink: 0;
 
       @include breakpoint(phone) {
         display: none;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -66,6 +66,7 @@
 
   .profile-image {
     margin-right: 15px;
+    flex-shrink: 0;
   }
 
   .summary {


### PR DESCRIPTION
#### What are the relevant tickets?
closes #565

#### What's this PR do?
This fixes an issue where images where being squeezed on the channel page. I added flex-shrink: 0; to the images on the channel page and also in comments.

#### How should this be manually tested?
This bug is a bit hard to reproduce. I could not reproduce it on local. Looking on production, I see it occasionally.

