### PR TITLE
add remove post link to channel view

### DIFF
--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -12,7 +12,8 @@ type PostListProps = {
   toggleUpvote: Post => void,
   togglePinPost?: Post => Promise<*>,
   isModerator?: boolean,
-  reportPost: (p: Post) => void
+  reportPost: (p: Post) => void,
+  removePost?: (p: Post) => void
 }
 
 const PostList = (props: PostListProps) => {
@@ -23,7 +24,8 @@ const PostList = (props: PostListProps) => {
     isModerator,
     toggleUpvote,
     togglePinPost,
-    reportPost
+    reportPost,
+    removePost
   } = props
 
   return (
@@ -39,6 +41,7 @@ const PostList = (props: PostListProps) => {
             isModerator={isModerator}
             togglePinPost={togglePinPost}
             reportPost={reportPost}
+            removePost={removePost}
           />
         )
         : <div className="empty-list-msg">There are no posts to display.</div>}

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -78,4 +78,14 @@ describe("PostList", () => {
     wrapper.find(CompactPostDisplay).first().props().reportPost()
     assert.ok(reportStub.called)
   })
+
+  it("should pass the removePost prop to CompactPostDisplay", () => {
+    const removeStub = sinon.stub()
+    const wrapper = renderPostList({
+      posts:      makeChannelPostList(),
+      removePost: removeStub
+    })
+    wrapper.find(CompactPostDisplay).first().props().removePost()
+    assert.ok(removeStub.called)
+  })
 })

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -51,7 +51,8 @@ type ChannelPageProps = {
   errored: boolean,
   isModerator: boolean,
   notFound: boolean,
-  reportPost: (p: Post) => void
+  reportPost: (p: Post) => void,
+  removePost: (p: Post) => void
 }
 
 const shouldLoadData = R.complement(
@@ -128,7 +129,8 @@ class ChannelPage extends React.Component<*, void> {
       isModerator,
       notFound,
       location: { search },
-      reportPost
+      reportPost,
+      removePost
     } = this.props
 
     if (notFound) {
@@ -162,6 +164,7 @@ class ChannelPage extends React.Component<*, void> {
               isModerator={isModerator}
               togglePinPost={this.togglePinPost}
               reportPost={reportPost}
+              removePost={removePost}
               showPinUI
             />
             {pagination


### PR DESCRIPTION
#### What are the relevant tickets?

closes #567 

#### What's this PR do?

this adds the remove post button to the channel view.

#### How should this be manually tested?

Go to the channel page as a moderator, make sure the button shows up! It should do what you expect. The button shouldn't show up if you're not a moderator (that logic is in the `CompactPostDisplay` and not in this PR though).