### PR TITLE
Some small font, margin, and profile image size tweaks

### DIFF
--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -1,4 +1,4 @@
-$profileImageWidth: 30px;
+$profileImageWidth: 45px;
 $profileImageHeight: $profileImageWidth;
 $commentTopMargin: 19px;
 $commentPaddingLeftDesktop: 12px;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -75,6 +75,7 @@ body {
 
     .main-content {
       margin-top: 20px;
+      margin-bottom: 50px;
 
       @include breakpoint(desktop) {
         margin-left: auto;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -14,6 +14,8 @@
 .post-summary {
   display: flex;
   flex-direction: column;
+  font-size: 15px;
+  line-height: 1.3;
 
   &:not(:last-child):not(.expanded):not(.sticky) {
     border-bottom: 1px solid $border-grey;
@@ -91,6 +93,7 @@
 
   .post-actions {
     display: flex;
+    margin-top: 10px;
 
     a {
       margin-left: 10px;


### PR DESCRIPTION
## What's this PR do?
This makes the font sizes and profile images sizes consistent between posts and comments (on the post page) and adds some margin at the bottom of the main-content div.

#### How should this be manually tested?
Just a quick check that it looks ok.
