### PR TITLE
fix missing profile picture in email

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for channel REST APIs
 """
+from urllib.parse import urljoin
 from datetime import (
     datetime,
     timezone,
@@ -18,6 +19,7 @@ from channels.api import (
 )
 from channels.constants import VALID_CHANNEL_TYPES
 from channels.models import Subscription
+from open_discussions import settings
 
 default_profile_image = "/static/images/avatar_default.png"
 
@@ -171,11 +173,11 @@ class PostSerializer(serializers.Serializer):
         return "[deleted]"
 
     def get_profile_image(self, instance):
-        """Find the Profile for the comment author"""
+        """Find the profile image for the post author"""
         user = self._get_user(instance)
         if user and user.profile.image_small:
             return user.profile.image_small
-        return default_profile_image
+        return urljoin(settings.SITE_BASE_URL, default_profile_image)
 
     def get_text(self, instance):
         """Returns text or null depending on if it's a self post"""

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -1,5 +1,6 @@
 """Tests for views for REST APIs for posts"""
 # pylint: disable=unused-argument
+from urllib.parse import urljoin
 import pytest
 from django.core.urlresolvers import reverse
 from rest_framework import status
@@ -11,6 +12,7 @@ from channels.constants import (
     POSTS_SORT_HOT,
 )
 from channels.models import Subscription
+from open_discussions.settings import SITE_BASE_URL
 
 pytestmark = [
     pytest.mark.django_db,
@@ -140,7 +142,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         user.profile.image_small = '/just/a/great/image.png.jpg.gif'
     user.profile.save()
 
-    profile_image = default_profile_image if missing_image else user.profile.image_small
+    profile_image = urljoin(SITE_BASE_URL, default_profile_image) if missing_image else user.profile.image_small
 
     post = reddit_factories.text_post('my geat post', user, channel=channel)
     url = reverse('post-detail', kwargs={'post_id': post.id})


### PR DESCRIPTION
#### What are the relevant tickets?

closes #576 

#### What's this PR do?

This just does a little bit of work to make the default profile picture URL included in the email into an absolute URL, so that it will actually work when the html is rendered in an email client. Previously we were just shipping a relative URL, which obviously didn't work.

#### How should this be manually tested?

OK! So the following code will render the frontpage email template with your user's current frontpage:

```py
from mail.api import render_email_templates
from channels.utils import ListingParams, get_pagination_and_posts
from channels.api import Api
from channels.serializers import PostSerializer
from profiles.models import Profile

p = Profile.objects.get(name='asdf Pote')

user = p.user

api = Api(user)

lp = ListingParams(None, None, 0, 'hot')

pagination, posts = get_pagination_and_posts(api.front_page(lp), lp)

serialized_posts = PostSerializer(posts,context={'current_user':user}, many=True).data

subject, fallback, html = render_email_templates('frontpage', user, context={'posts': serialized_posts})

print(html)
```

you can either paste that into a django shell or you can save it to a file and use the `%run filename.py` magic in iPython, to print out the rendered HTML. Assuming that works ok, test two things:

1. if your user has no `profile.image_small` you should see a full, absolute URL in the HTML which points to something like `http://localhost:8063/static/images/avatar_default.png`.

2. If your user does have a `profile.image_small`, that URL should be included without being messed with in any way.

I think that's it...
