### PR TITLE
Fixed safe_format_recipients to quote display name

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -21,6 +21,7 @@ try:
 except SendEmailsException as exc:
     pass  # handle failed emails
 """
+from email.utils import formataddr
 import re
 
 from anymail.message import AnymailMessage
@@ -52,11 +53,10 @@ def safe_format_recipients(recipients):
     if settings.MAILGUN_RECIPIENT_OVERRIDE is not None:
         return [(settings.MAILGUN_RECIPIENT_OVERRIDE, recipients[0])]
 
-    return [
-        (_format_recipient(user.email, name=user.profile.name), user)
-        for user in recipients
-        if can_email_user(user)
-    ]
+    return [(
+        formataddr((user.profile.name, user.email)),
+        user,
+    ) for user in recipients if can_email_user(user)]
 
 
 def can_email_user(user):
@@ -70,26 +70,6 @@ def can_email_user(user):
         bool: True if we can email this user
     """
     return bool(user.email)
-
-
-def _format_recipient(email, *, name=None):
-    """
-    Formats a recipient's email address using an optional name
-
-    Args:
-        email (str): email address of the recipients
-        name (str): name of the recipient
-
-    Returns:
-        str: formatted email address
-    """
-    if name:
-        return "{name} <{email}>".format(
-            name=name,
-            email=email,
-        )
-    else:
-        return email
 
 
 def render_email_templates(template_name, user, context=None):

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -1,4 +1,5 @@
 """API tests"""
+from email.utils import formataddr
 import pytest
 
 from mail.api import (
@@ -29,8 +30,8 @@ def test_safe_format_recipients():
     assert safe_format_recipients([
         user, user_no_email, user_no_name
     ]) == [
-        ("{} <{}>".format(user.profile.name, user.email), user),
-        (user_no_name.email, user_no_name),
+        (formataddr((user.profile.name, user.email)), user),
+        (formataddr((None, user_no_name.email)), user_no_name),
     ]
 
 
@@ -71,7 +72,7 @@ def test_messages_for_recipients():
     assert len(messages) == len(users)
 
     for user, msg in zip(users, messages):
-        assert user.email in msg.to[0]
+        assert user.email in str(msg.to[0])
         assert msg.subject == "Welcome {}".format(user.profile.name)
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #588

#### What's this PR do?
Switches to use `email.utils.formataddr` so we safely escape email address display names.

#### How should this be manually tested?
Put a `"` or `\` character in your user's name, follow the test instructions detailed in the earlier PR: https://github.com/mitodl/open-discussions/pull/527

and verify the email still sends OK