### PR TITLE
add follow button to posts and comments

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -47,7 +47,8 @@ type CommentTreeProps = {
   reportComment: ReportCommentFunc,
   commentPermalink: (commentID: string) => string,
   moderationUI: boolean,
-  ignoreCommentReports: (c: CommentInTree) => void
+  ignoreCommentReports: (c: CommentInTree) => void,
+  toggleFollowComment: Function
 }
 
 export default class CommentTree extends React.Component<*, *> {
@@ -67,7 +68,8 @@ export default class CommentTree extends React.Component<*, *> {
       reportComment,
       commentPermalink,
       moderationUI,
-      ignoreCommentReports
+      ignoreCommentReports,
+      toggleFollowComment
     } = this.props
     const formKey = replyToCommentKey(comment)
     const editFormKey = editCommentKey(comment)
@@ -124,6 +126,23 @@ export default class CommentTree extends React.Component<*, *> {
                 }}
               >
                 <a href="#">reply</a>
+              </div>}
+            {comment.subscribed
+              ? <div
+                className="comment-action-button subscribe-comment subscribed"
+                onClick={preventDefaultAndInvoke(() => {
+                  toggleFollowComment(comment)
+                })}
+              >
+                <a href="#">unfollow</a>
+              </div>
+              : <div
+                className="comment-action-button subscribe-comment unsubscribed"
+                onClick={preventDefaultAndInvoke(() => {
+                  toggleFollowComment(comment)
+                })}
+              >
+                <a href="#">follow</a>
               </div>}
             {comment.num_reports
               ? <div className="comment-action-button report-count">

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -34,6 +34,7 @@ describe("CommentTree", () => {
     loadMoreCommentsStub,
     deleteCommentStub,
     reportCommentStub,
+    toggleFollowCommentStub,
     permalinkFunc,
     helper
 
@@ -49,6 +50,7 @@ describe("CommentTree", () => {
     loadMoreCommentsStub = helper.sandbox.stub()
     deleteCommentStub = helper.sandbox.stub()
     reportCommentStub = helper.sandbox.stub()
+    toggleFollowCommentStub = helper.sandbox.stub()
     permalinkFunc = commentPermalink("channel", post.id)
   })
 
@@ -72,6 +74,7 @@ describe("CommentTree", () => {
           deleteComment={deleteCommentStub}
           reportComment={reportCommentStub}
           commentPermalink={permalinkFunc}
+          toggleFollowComment={toggleFollowCommentStub}
           {...props}
         />
       </Router>
@@ -154,10 +157,25 @@ describe("CommentTree", () => {
   it('should include an "Edit" button, if the user wrote the comment', () => {
     SETTINGS.username = comments[0].author_id
     const wrapper = renderCommentTree()
-    wrapper.find(".comment-action-button").at(1).simulate("click")
+    wrapper.find(".comment-action-button").at(2).simulate("click")
     assert.ok(beginEditingStub.called)
     assert.ok(beginEditingStub.calledWith(editCommentKey(comments[0])))
     assert.deepEqual(beginEditingStub.args[0][1], comments[0])
+  })
+
+  //
+  ;[
+    [true, "unfollow"],
+    [false, "follow"]
+  ].forEach(([subscribed, buttonText]) => {
+    it(`should include a ${buttonText} button when subscribed === ${subscribed}`, () => {
+      comments[0].subscribed = subscribed
+      const wrapper = renderCommentTree()
+      const button = wrapper.find(".subscribe-comment").at(0)
+      assert.equal(button.text(), buttonText)
+      button.simulate("click")
+      assert.ok(toggleFollowCommentStub.called)
+    })
   })
 
   it("should include a 'delete' button, if the user wrote the comment", () => {
@@ -218,9 +236,9 @@ describe("CommentTree", () => {
         .find(".comment-actions")
         .at(0)
         .find(".comment-action-button"),
-      3
+      4
     )
-    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 2)
+    assert.lengthOf(nextCommentWrapper.find(".comment-action-button"), 3)
 
     assert.lengthOf(topCommentWrapper.find(ReplyToCommentForm), 1)
     assert.lengthOf(nextCommentWrapper.find(ReplyToCommentForm), 0)

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -8,6 +8,7 @@ import { EditPostForm } from "../components/CommentForms"
 import { renderTextContent } from "./Markdown"
 
 import { formatPostTitle, PostVotingButtons } from "../lib/posts"
+import { preventDefaultAndInvoke } from "../lib/util"
 import { editPostKey } from "../components/CommentForms"
 
 import type { Post } from "../flow/discussionTypes"
@@ -24,7 +25,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     beginEditing: (key: string, initialValue: Object, e: ?Event) => void,
     showPostDeleteDialog: () => void,
     showPostReportDialog: () => void,
-    showPermalinkUI: boolean
+    showPermalinkUI: boolean,
+    toggleFollowPost: Post => void
   }
 
   renderTextContent = () => {
@@ -54,6 +56,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
   postActionButtons = () => {
     const {
       toggleUpvote,
+      toggleFollowPost,
       post,
       beginEditing,
       isModerator,
@@ -89,6 +92,23 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             <a href="#">delete</a>
           </div>
           : null}
+        {post.subscribed
+          ? <div
+            className="comment-action-button subscribe-post subscribed"
+            onClick={preventDefaultAndInvoke(() => {
+              toggleFollowPost(post)
+            })}
+          >
+            <a href="#">unfollow</a>
+          </div>
+          : <div
+            className="comment-action-button subscribe-post unsubscribed"
+            onClick={preventDefaultAndInvoke(() => {
+              toggleFollowPost(post)
+            })}
+          >
+            <a href="#">follow</a>
+          </div>}
         {isModerator && !post.removed
           ? <div
             className="comment-action-button remove-post"

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -1,4 +1,3 @@
-// @flow
 /* global SETTINGS: false */
 import React from "react"
 import { assert } from "chai"
@@ -24,7 +23,8 @@ describe("ExpandedPostDisplay", () => {
     approvePostStub,
     removePostStub,
     showPostDeleteDialogStub,
-    showPostReportDialogStub
+    showPostReportDialogStub,
+    toggleFollowPostStub
 
   const renderPostDisplay = props => {
     props = {
@@ -36,6 +36,7 @@ describe("ExpandedPostDisplay", () => {
       removePost:           removePostStub,
       showPostDeleteDialog: showPostDeleteDialogStub,
       showPostReportDialog: showPostReportDialogStub,
+      toggleFollowPost:     toggleFollowPostStub,
       forms:                {},
       ...props
     }
@@ -54,6 +55,7 @@ describe("ExpandedPostDisplay", () => {
     removePostStub = helper.sandbox.stub()
     showPostDeleteDialogStub = helper.sandbox.stub()
     showPostReportDialogStub = helper.sandbox.stub()
+    toggleFollowPostStub = helper.sandbox.stub()
   })
 
   afterEach(() => {
@@ -133,6 +135,22 @@ describe("ExpandedPostDisplay", () => {
       }
       const wrapper = renderPostDisplay({ post })
       assert.equal(wrapper.find(".edit-post").exists(), shouldShowLink)
+    })
+  })
+
+  //
+  ;[
+    [true, "unfollow"],
+    [false, "follow"]
+  ].forEach(([subscribed, buttonText]) => {
+    it(`should include a ${buttonText} button when subscribed === ${subscribed}`, () => {
+      const post = makePost()
+      post.subscribed = subscribed
+      const wrapper = renderPostDisplay({ post })
+      const button = wrapper.find(".subscribe-post")
+      assert.equal(button.text(), buttonText)
+      button.simulate("click")
+      assert.ok(toggleFollowPostStub.called)
     })
   })
 

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -34,7 +34,11 @@ import { replaceMoreComments } from "../actions/comment"
 import { setFocusedComment, clearFocusedComment } from "../actions/focus"
 import { formBeginEdit, formEndEdit } from "../actions/forms"
 import { setSnackbarMessage, showDialog, hideDialog } from "../actions/ui"
-import { toggleUpvote } from "../util/api_actions"
+import {
+  toggleUpvote,
+  toggleFollowPost,
+  toggleFollowComment
+} from "../util/api_actions"
 import { getChannelName, getPostID, getCommentID } from "../lib/util"
 import { isModerator } from "../lib/channels"
 import {
@@ -376,6 +380,7 @@ class PostPage extends React.Component<*, void> {
                 reportPost(post)
               )}
               showPermalinkUI={showPermalinkUI}
+              toggleFollowPost={toggleFollowPost(dispatch)}
             />
             {showPermalinkUI
               ? null
@@ -416,6 +421,7 @@ class PostPage extends React.Component<*, void> {
           beginEditing={beginEditing(dispatch)}
           processing={commentInFlight}
           commentPermalink={commentPermalink(channel.name, post.id)}
+          toggleFollowComment={toggleFollowComment(dispatch)}
         />
       </div>
     )

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -35,7 +35,8 @@ export const makeComment = (
     author_name:   casual.name,
     edited:        casual.boolean,
     comment_type:  "comment",
-    num_reports:   0
+    num_reports:   0,
+    subscribed:    casual.boolean
   }
 
   if (comment.upvoted && comment.downvoted) {

--- a/static/js/factories/comments_test.js
+++ b/static/js/factories/comments_test.js
@@ -21,6 +21,7 @@ describe("comment factories", () => {
       assert.isString(comment.profile_image)
       assert.isString(comment.author_name)
       assert.isBoolean(comment.edited)
+      assert.isBoolean(comment.subscribed)
     })
   })
 

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -28,7 +28,8 @@ export const makePost = (
   edited:        casual.boolean,
   stickied:      casual.boolean,
   removed:       casual.boolean,
-  num_reports:   null
+  num_reports:   null,
+  subscribed:    casual.boolean
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/posts_test.js
+++ b/static/js/factories/posts_test.js
@@ -21,6 +21,7 @@ describe("posts factories", () => {
       assert.isBoolean(post.edited)
       assert.isBoolean(post.stickied)
       assert.isBoolean(post.removed)
+      assert.isBoolean(post.subscribed)
     })
 
     it("should make a URL post", () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -36,6 +36,7 @@ export type AuthoredContent = {
   edited:          boolean,
   num_reports:     ?number,
   ignore_reports?: boolean,
+  subscribed:      boolean,
 }
 
 export type Post = AuthoredContent & {

--- a/static/js/util/api_actions.js
+++ b/static/js/util/api_actions.js
@@ -41,3 +41,14 @@ export const removeComment = R.curry(
       })
     )
 )
+
+export const toggleFollowPost = R.curry((dispatch: Dispatch, post: Post) =>
+  dispatch(actions.posts.patch(post.id, { subscribed: !post.subscribed }))
+)
+
+export const toggleFollowComment = R.curry(
+  (dispatch: Dispatch, comment: CommentInTree) =>
+    dispatch(
+      actions.comments.patch(comment.id, { subscribed: !comment.subscribed })
+    )
+)

--- a/static/js/util/api_actions_test.js
+++ b/static/js/util/api_actions_test.js
@@ -1,4 +1,3 @@
-// @flow
 import R from "ramda"
 import { assert } from "chai"
 
@@ -9,12 +8,14 @@ import {
   approvePost,
   removePost,
   approveComment,
-  removeComment
+  removeComment,
+  toggleFollowComment,
+  toggleFollowPost
 } from "../util/api_actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 import { makePost } from "../factories/posts"
-import { makeCommentsResponse } from "../factories/comments"
+import { makeCommentsResponse, makeComment } from "../factories/comments"
 import { findComment } from "../lib/comments"
 
 describe("api_actions util", () => {
@@ -45,6 +46,42 @@ describe("api_actions util", () => {
         assert.isOk(helper.updateUpvoteStub.calledWith(post.id, !value))
       })
     }
+  })
+
+  describe("toggleFollowPost", () => {
+    beforeEach(() => {
+      helper.editPostStub.returns(Promise.resolve(makePost))
+    })
+    ;[true, false].forEach(subscribed => {
+      it(`should let you toggle subscribed from ${subscribed} to ${!subscribed}`, async () => {
+        const post = makePost()
+        post.subscribed = subscribed
+
+        const { requestType, successType } = actions.posts.patch
+
+        await helper.listenForActions([requestType, successType], () => {
+          toggleFollowPost(helper.store.dispatch, post)
+        })
+      })
+    })
+  })
+
+  describe("toggleFollowComment", () => {
+    beforeEach(() => {
+      helper.updateCommentStub.returns(Promise.resolve(makePost))
+    })
+    ;[true, false].forEach(subscribed => {
+      it(`should let you toggle subscribed from ${subscribed} to ${!subscribed}`, async () => {
+        const comment = makeComment(makePost())
+        comment.subscribed = subscribed
+
+        const { requestType, successType } = actions.comments.patch
+
+        await helper.listenForActions([requestType, successType], () => {
+          toggleFollowComment(helper.store.dispatch, comment)
+        })
+      })
+    })
   })
 
   describe("approvePost", () => {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -17,4 +17,5 @@ $validation-text: #f07183;
 $bg-grey: #dad9d9;
 $footer-link-color: #4e8398;
 $report-count-red: #e21d13;
-$navigation-text: rgba(0,0,0,.77)
+$navigation-text: rgba(0,0,0,.77);
+$subscribed-yellow: #fcffb0;

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -82,8 +82,12 @@ $replyPaddingLeft: 8px;
         margin: 4px 0 5px;
         display: inline-block;
 
-        > div {
-          margin-right: 10px;
+        .votes-form {
+          margin-right: 5px;
+        }
+
+        a {
+          margin: 0 5px;
         }
       }
 
@@ -193,6 +197,12 @@ $replyPaddingLeft: 8px;
     font-size: .9em;
     font-weight: 400;
     display: inline-block;
+  }
+}
+
+.comment-action-button {
+  &.subscribed {
+    background-color: $subscribed-yellow;
   }
 }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -96,7 +96,7 @@
     margin-top: 10px;
 
     a {
-      margin-left: 10px;
+      margin: 0 5px;
     }
 
     .report-count {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #469 

#### What's this PR do?

This adds follow / unfollow buttons to both posts and comments. Following should create a subscription object, and unfollowing should destroy it. Having a subscription doesn't yet do anything.

#### How should this be manually tested?

Go to one of your posts, you should be able to follow and unfollow it. Same with comments. The UI should change to say 'unfollow' if you are already following (in line with the design).

I wrote this code a few weeks ago and uhh forgot to open a PR >_<