### PR TITLE
add comment / post settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "redux-hammock": "^0.2.3",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
+    "rmwc": "^1.5.1",
     "sanctuary": "^0.13.2",
     "sass-lint": "^1.10.2",
     "sass-loader": "^6.0.6",

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -52,6 +52,8 @@ if [[ $(
     cat "$TMP_FILE" |
     grep -v 'ignored, nothing could be mapped' |
     grep -v "This browser doesn't support the \`onScroll\` event" |
+    grep -v "Accessing PropTypes" |
+    grep -v "Accessing createClass" |
     wc -l |
     awk '{print $1}'
     ) -ne 0 ]]  # is file empty?

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -7,7 +7,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeChannelList } from "../factories/channels"
 import { actions } from "../actions"
 import { SETTINGS_URL } from "../lib/url"
-import { makeFrontpageSetting } from "../factories/settings"
+import { makeFrontpageSetting, makeCommentSetting } from "../factories/settings"
 
 describe("App", () => {
   let helper, renderComponent, channels
@@ -48,7 +48,9 @@ describe("App", () => {
 
   it("doesnt redirect if you have no session url but are on the settings page", async () => {
     delete SETTINGS.authenticated_site.session_url
-    helper.getSettingsStub.returns(Promise.resolve([makeFrontpageSetting()]))
+    helper.getSettingsStub.returns(
+      Promise.resolve([makeFrontpageSetting(), makeCommentSetting()])
+    )
     await renderComponent(SETTINGS_URL, [
       actions.settings.get.requestType,
       actions.settings.get.successType

--- a/static/js/containers/SettingsPage_test.js
+++ b/static/js/containers/SettingsPage_test.js
@@ -1,10 +1,12 @@
 import { assert } from "chai"
 import { Radio } from "@mitodl/mdl-react-components"
+import Checkbox from "rmwc/Checkbox"
 
 import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { FORM_BEGIN_EDIT } from "../actions/forms"
 import { makeFrontpageSetting, makeCommentSetting } from "../factories/settings"
+import { FREQUENCY_IMMEDIATE } from "../reducers/settings"
 
 describe("SettingsPage", () => {
   let helper, renderComponent
@@ -33,6 +35,10 @@ describe("SettingsPage", () => {
       wrapper.find(Radio).props().value,
       settings[0].trigger_frequency
     )
+    assert.equal(
+      wrapper.find(Checkbox).props().checked,
+      settings[1].trigger_frequency === FREQUENCY_IMMEDIATE
+    )
   })
 
   it("should work ok if the frontpage setting doesnt come back first", async () => {
@@ -42,6 +48,10 @@ describe("SettingsPage", () => {
     assert.equal(
       wrapper.find(Radio).props().value,
       settings[1].trigger_frequency
+    )
+    assert.equal(
+      wrapper.find(Checkbox).props().checked,
+      settings[0].trigger_frequency === FREQUENCY_IMMEDIATE
     )
   })
 })

--- a/static/js/factories/settings.js
+++ b/static/js/factories/settings.js
@@ -4,7 +4,9 @@ import R from "ramda"
 import {
   FRONTPAGE_NOTIFICATION,
   COMMENT_NOTIFICATION,
-  FRONTPAGE_FREQUENCY_CHOICES
+  FRONTPAGE_FREQUENCY_CHOICES,
+  FREQUENCY_NEVER,
+  FREQUENCY_IMMEDIATE
 } from "../reducers/settings"
 import { draw } from "./util"
 
@@ -17,5 +19,5 @@ export const makeFrontpageSetting = (): NotificationSetting => ({
 
 export const makeCommentSetting = (): NotificationSetting => ({
   notification_type: COMMENT_NOTIFICATION,
-  trigger_frequency: draw(R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES))
+  trigger_frequency: draw([FREQUENCY_IMMEDIATE, FREQUENCY_NEVER])
 })

--- a/static/js/factories/settings_test.js
+++ b/static/js/factories/settings_test.js
@@ -5,7 +5,9 @@ import R from "ramda"
 import {
   FRONTPAGE_NOTIFICATION,
   COMMENT_NOTIFICATION,
-  FRONTPAGE_FREQUENCY_CHOICES
+  FRONTPAGE_FREQUENCY_CHOICES,
+  FREQUENCY_IMMEDIATE,
+  FREQUENCY_NEVER
 } from "../reducers/settings"
 import { makeFrontpageSetting, makeCommentSetting } from "./settings"
 
@@ -23,7 +25,7 @@ describe("settings factory", () => {
     const setting = makeCommentSetting()
     assert.equal(setting.notification_type, COMMENT_NOTIFICATION)
     assert.include(
-      R.pluck("value", FRONTPAGE_FREQUENCY_CHOICES),
+      [FREQUENCY_IMMEDIATE, FREQUENCY_NEVER],
       setting.trigger_frequency
     )
   })

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -224,3 +224,17 @@ export const patchFrontpageSetting = (
       method: PATCH,
       body:   JSON.stringify(setting)
     })
+
+export const patchCommentSetting = (
+  setting: NotificationSetting,
+  token: ?string = undefined
+) =>
+  token
+    ? fetchJSONWithToken("/api/v0/notification_settings/comments/", token, {
+      method: PATCH,
+      body:   JSON.stringify(setting)
+    })
+    : fetchJSONWithAuthFailure("/api/v0/notification_settings/comments/", {
+      method: PATCH,
+      body:   JSON.stringify(setting)
+    })

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -27,7 +27,8 @@ import {
   reportContent,
   getReports,
   getSettings,
-  patchFrontpageSetting
+  patchFrontpageSetting,
+  patchCommentSetting
 } from "./api"
 import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
@@ -491,6 +492,37 @@ describe("api", function() {
         assert.ok(
           fetchAuthFailureStub.calledWith(
             "/api/v0/notification_settings/frontpage/",
+            {
+              method: PATCH,
+              body:   JSON.stringify(setting)
+            }
+          )
+        )
+      })
+    })
+
+    describe("patchCommentSetting", () => {
+      it("should call fetchJSONWithToken when passed a token", async () => {
+        await patchCommentSetting(setting, "great token")
+        assert.isNotOk(fetchAuthFailureStub.called)
+        assert.ok(
+          fetchTokenStub.calledWith(
+            "/api/v0/notification_settings/comments/",
+            "great token",
+            {
+              method: PATCH,
+              body:   JSON.stringify(setting)
+            }
+          )
+        )
+      })
+
+      it("calls fetchJSONWithAuthFailure when not passed a token", async () => {
+        await patchCommentSetting(setting)
+        assert.isNotOk(fetchTokenStub.called)
+        assert.ok(
+          fetchAuthFailureStub.calledWith(
+            "/api/v0/notification_settings/comments/",
             {
               method: PATCH,
               body:   JSON.stringify(setting)

--- a/static/js/reducers/settings.js
+++ b/static/js/reducers/settings.js
@@ -2,8 +2,6 @@
 import * as api from "../lib/api"
 import { GET, PATCH } from "redux-hammock/constants"
 
-import type { NotificationSetting } from "../flow/settingsTypes"
-
 export const FREQUENCY_IMMEDIATE = "immediate"
 export const FREQUENCY_DAILY = "daily"
 export const FREQUENCY_WEEKLY = "weekly"
@@ -22,6 +20,20 @@ export const settingsEndpoint = {
   name:      "settings",
   verbs:     [GET, PATCH],
   getFunc:   (token: ?string) => api.getSettings(token),
-  patchFunc: (object: NotificationSetting, token: ?string) =>
-    api.patchFrontpageSetting(object, token)
+  patchFunc: async (object: Object, token: ?string) => {
+    await api.patchFrontpageSetting(
+      {
+        notification_type: FRONTPAGE_NOTIFICATION,
+        trigger_frequency: object[FRONTPAGE_NOTIFICATION]
+      },
+      token
+    )
+    await api.patchCommentSetting(
+      {
+        notification_type: COMMENT_NOTIFICATION,
+        trigger_frequency: object[COMMENT_NOTIFICATION]
+      },
+      token
+    )
+  }
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -5,6 +5,7 @@
 @import "node_modules/@material/snackbar/dist/mdc.snackbar";
 @import "node_modules/@material/dialog/dist/mdc.dialog";
 @import "node_modules/@material/radio/dist/mdc.radio";
+@import "node_modules/@material/checkbox/dist/mdc.checkbox";
 @import "node_modules/spinkit/scss/spinners/7-three-bounce";
 @import "node_modules/spinkit/scss/spinners/10-fading-circle";
 @import "breakpoints";

--- a/static/scss/settings.scss
+++ b/static/scss/settings.scss
@@ -13,4 +13,13 @@
       }
     }
   }
+
+  .mdc-form-field {
+    display: flex;
+    align-items: center;
+
+    label {
+      margin: 0;
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.3.1.tgz#229de6927d0590d6d6b20157d778d264ef02229a"
 
+"@material/animation@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.34.0.tgz#a99cc9dabf7d0179b4da9a0aaa1575c4d1513823"
+
+"@material/auto-init@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-0.34.0.tgz#a97d8b00f91832984583c10fb508983fb2f3ed47"
+
 "@material/base@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.2.3.tgz#c4eb26b6d6e5840c254ad487588dc4f69b971f3e"
@@ -22,6 +30,10 @@
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.29.0.tgz#5fac94c45907e38c969130e959722288d4ce06b2"
 
+"@material/base@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.34.0.tgz#73f915227f9f0548e24587f502d74c351250224a"
+
 "@material/button@^0.3.11":
   version "0.3.11"
   resolved "https://registry.yarnpkg.com/@material/button/-/button-0.3.11.tgz#17ab4cd5d55389e3da3496b1c1626dce4f6a7839"
@@ -30,6 +42,45 @@
     "@material/ripple" "^0.8.2"
     "@material/theme" "^0.1.7"
     "@material/typography" "^0.3.0"
+
+"@material/button@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-0.34.1.tgz#683fa3ace6a46cb0212c874a500ae9a6315ef9a8"
+  dependencies:
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/card@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/card/-/card-0.34.1.tgz#5f74e0fb19816f8cd338bfda8b06655c82259113"
+  dependencies:
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
+"@material/checkbox@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-0.34.1.tgz#bacc7f4cd65cf625cf382ad5f45776ffad3aec6f"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/selection-control" "^0.34.1"
+    "@material/theme" "^0.34.0"
+
+"@material/chips@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-0.34.1.tgz#af5c00c41d7dab3c9ed8068f8affc59fa07f06ed"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/checkbox" "^0.34.1"
+    "@material/ripple" "^0.34.1"
 
 "@material/dialog@^0.27.0":
   version "0.27.0"
@@ -43,6 +94,30 @@
     "@material/theme" "^0.27.0"
     "@material/typography" "^0.1.1"
     focus-trap "^2.3.0"
+
+"@material/dialog@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-0.34.1.tgz#690a98f0fcf298af9183d3e349f6f68e06647350"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.1.1"
+    focus-trap "^2.3.0"
+
+"@material/drawer@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-0.34.0.tgz#b462099898d934cb252b4eb31d29c1635f1e2271"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
 
 "@material/drawer@^0.5.4":
   version "0.5.4"
@@ -68,6 +143,85 @@
     "@material/animation" "^0.25.0"
     "@material/theme" "^0.4.0"
 
+"@material/elevation@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.34.0.tgz#8e1e3c9141daab5dcfb444571102df7625293a21"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/theme" "^0.4.0"
+
+"@material/fab@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-0.34.1.tgz#912ef4e0ad1c2977ccdf6f81b590bc9e18705f48"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/theme" "^0.34.0"
+
+"@material/floating-label@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-0.34.0.tgz#9755a18c26df0f29463df5406037e5218973b7e6"
+  dependencies:
+    "@material/base" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
+"@material/form-field@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-0.34.1.tgz#b85b2a58d0e9b771bffe3893e35730f2c54d9b36"
+  dependencies:
+    "@material/base" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/selection-control" "^0.34.1"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/grid-list@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/grid-list/-/grid-list-0.34.0.tgz#677faee1edf58f352a6f6191515655019463de54"
+  dependencies:
+    "@material/base" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/icon-toggle@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/icon-toggle/-/icon-toggle-0.34.1.tgz#62f297c263308609e9368d5015983ed1cd851e3d"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/theme" "^0.34.0"
+
+"@material/image-list@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-0.34.0.tgz#81b3c5167ede262dce5c98309e09f677a4eb578f"
+  dependencies:
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/layout-grid@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-0.34.0.tgz#f730bdd962401b691ab7538e7d2b4d91764f4052"
+
+"@material/line-ripple@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-0.34.0.tgz#6b5048d6573e908a98c9ca69f54e3bdc750a7d0f"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
+"@material/linear-progress@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-0.34.0.tgz#1f3e06cb8185831a8b5259f025309c963a8fedb5"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
 "@material/list@^0.2.14":
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/@material/list/-/list-0.2.14.tgz#8388a07b042281ff425f7977942bb5326e762711"
@@ -76,6 +230,25 @@
     "@material/rtl" "^0.1.7"
     "@material/theme" "^0.1.7"
     "@material/typography" "^0.3.0"
+
+"@material/list@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/list/-/list-0.34.1.tgz#0c900c69e777a837b7e9d9737345f0bf90aef46a"
+  dependencies:
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/menu@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-0.34.0.tgz#65b531c8e2a6dab1cfefebdb609a1a15cdeef799"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
 
 "@material/menu@^0.4.3":
   version "0.4.3"
@@ -87,6 +260,14 @@
     "@material/theme" "^0.1.7"
     "@material/typography" "^0.3.0"
 
+"@material/notched-outline@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-0.34.0.tgz#62eee7328764f0b4a8802c009d59b6b48876c18a"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
 "@material/radio@^0.30.0":
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/@material/radio/-/radio-0.30.0.tgz#3bb84ba7016738a5d0d567c70514deb887ece5c2"
@@ -96,6 +277,16 @@
     "@material/ripple" "^0.30.0"
     "@material/selection-control" "^0.30.0"
     "@material/theme" "^0.30.0"
+
+"@material/radio@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-0.34.1.tgz#595a2ea6b340db766c89a4d5672071ddb2860262"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/selection-control" "^0.34.1"
+    "@material/theme" "^0.34.0"
 
 "@material/ripple@^0.27.0":
   version "0.27.0"
@@ -111,6 +302,13 @@
     "@material/base" "^0.29.0"
     "@material/theme" "^0.30.0"
 
+"@material/ripple@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.34.1.tgz#805dc02922ba345304845297c85bf7570434a32c"
+  dependencies:
+    "@material/base" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
 "@material/ripple@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.8.2.tgz#f1844079701121b3905fa4c47c83035dc10ed60a"
@@ -122,11 +320,41 @@
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.8.tgz#2462db15e2d4e041666485559c028382872b01fb"
 
+"@material/rtl@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.34.0.tgz#6116d9c99f0c0ff40a8ae97ea5bc1a5fd29bcff5"
+
+"@material/select@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/select/-/select-0.34.1.tgz#e081355d5bf3d91bc5e1e5b41afd9a6d17fb1a5d"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
 "@material/selection-control@^0.30.0":
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/@material/selection-control/-/selection-control-0.30.0.tgz#80f2230ce9a8ea8cd9a7f1a853e8179ca0a72de1"
   dependencies:
     "@material/ripple" "^0.30.0"
+
+"@material/selection-control@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/selection-control/-/selection-control-0.34.1.tgz#78ca5c0cc557d4f5c7dc1219c995de1d082a3940"
+  dependencies:
+    "@material/ripple" "^0.34.1"
+
+"@material/slider@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-0.34.0.tgz#851d4613c946942b31cffdc9783fe47fa1ea8739"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
 
 "@material/snackbar@^0.25.0":
   version "0.25.0"
@@ -137,6 +365,49 @@
     "@material/rtl" "^0.1.8"
     "@material/theme" "^0.25.0"
     "@material/typography" "^0.3.0"
+
+"@material/snackbar@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-0.34.0.tgz#cb47b46533eff56239ac0d8a1d7e60ea85bfb3e8"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/switch@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-0.34.0.tgz#56ebe51f9f0e06069992e5f835730d84295650d0"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/theme" "^0.34.0"
+
+"@material/tabs@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/tabs/-/tabs-0.34.1.tgz#1fd435992fd5ba6da4cccbbfdc0c893a3bc89db0"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
+"@material/textfield@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-0.34.1.tgz#1683d3c6b4ee28c8d52316e7149674b4526dfdd1"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/floating-label" "^0.34.0"
+    "@material/line-ripple" "^0.34.0"
+    "@material/notched-outline" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
 
 "@material/theme@^0.1.7":
   version "0.1.7"
@@ -154,9 +425,24 @@
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.30.0.tgz#503d7fd5ac88ff70763bb277236ee7188982e5d2"
 
+"@material/theme@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.34.0.tgz#0118b935c2ecbcf3b4a1c84cd949e6344fa8bcb5"
+
 "@material/theme@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.4.0.tgz#0aef1a0279b65c15990584fb8b8eca095c734641"
+
+"@material/toolbar@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/toolbar/-/toolbar-0.34.1.tgz#b10999bf810111c477926ddd10557d0de5c61df8"
+  dependencies:
+    "@material/base" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
 
 "@material/toolbar@^0.4.4":
   version "0.4.4"
@@ -168,6 +454,18 @@
     "@material/theme" "^0.1.7"
     "@material/typography" "^0.3.0"
 
+"@material/top-app-bar@^0.34.1":
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-0.34.1.tgz#1b1d5f7682318703208e0a541fa1bee6980f6c67"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/theme" "^0.34.0"
+    "@material/typography" "^0.34.0"
+
 "@material/typography@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.1.1.tgz#fb2e3437bd3284d39e9fb91485767ade6b2bd0c1"
@@ -175,6 +473,10 @@
 "@material/typography@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.3.0.tgz#f828c2d3215bfd66c58072709b4260c64125390a"
+
+"@material/typography@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.34.0.tgz#cb365ecd2eb0d785410c743ec3426a107a687e3d"
 
 "@mitodl/mdl-react-components@^0.0.3":
   version "0.0.3"
@@ -1566,6 +1868,10 @@ clap@^1.0.9:
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
   dependencies:
     chalk "^1.1.3"
+
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -4204,6 +4510,47 @@ markdown-escapes@^1.0.0:
     buffers "~0.1.1"
     readable-stream "~1.0.0"
 
+material-components-web@0.34.1:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-0.34.1.tgz#e43fdfee4da622df47bbfb624d8f3f80a997b709"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/auto-init" "^0.34.0"
+    "@material/base" "^0.34.0"
+    "@material/button" "^0.34.1"
+    "@material/card" "^0.34.1"
+    "@material/checkbox" "^0.34.1"
+    "@material/chips" "^0.34.1"
+    "@material/dialog" "^0.34.1"
+    "@material/drawer" "^0.34.0"
+    "@material/elevation" "^0.34.0"
+    "@material/fab" "^0.34.1"
+    "@material/floating-label" "^0.34.0"
+    "@material/form-field" "^0.34.1"
+    "@material/grid-list" "^0.34.0"
+    "@material/icon-toggle" "^0.34.1"
+    "@material/image-list" "^0.34.0"
+    "@material/layout-grid" "^0.34.0"
+    "@material/line-ripple" "^0.34.0"
+    "@material/linear-progress" "^0.34.0"
+    "@material/list" "^0.34.1"
+    "@material/menu" "^0.34.0"
+    "@material/notched-outline" "^0.34.0"
+    "@material/radio" "^0.34.1"
+    "@material/ripple" "^0.34.1"
+    "@material/rtl" "^0.34.0"
+    "@material/select" "^0.34.1"
+    "@material/selection-control" "^0.34.1"
+    "@material/slider" "^0.34.0"
+    "@material/snackbar" "^0.34.0"
+    "@material/switch" "^0.34.0"
+    "@material/tabs" "^0.34.1"
+    "@material/textfield" "^0.34.1"
+    "@material/theme" "^0.34.0"
+    "@material/toolbar" "^0.34.1"
+    "@material/top-app-bar" "^0.34.1"
+    "@material/typography" "^0.34.0"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -6009,6 +6356,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+rmwc@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/rmwc/-/rmwc-1.5.1.tgz#8f6430db2cc7f0288dea820b0b31a4736e58f2cd"
+  dependencies:
+    classnames "^2.2.5"
+    material-components-web "0.34.1"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #474 

#### What's this PR do?

This adds a setting to the settings page (`/settings`) for managing post / comment replies (basically, it's a checkbox which toggles the value of the comments notification setting between 'never' and 'immediate').

#### How should this be manually tested?

First you'll need to make sure you have a `NotificationSetting` with type `comment` created for your user. Then if you go to the settings page you should see  a checkbox. Checking or unchecking the checkbox should save the value between page loads, and a checked checkbox should correlated with the frequency setting for the `NotificationSetting` being 'immediate' and an unchecked box with 'never'.