### PR TITLE
Fix button styles on frontpage digest

### DIFF
--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -176,6 +176,16 @@ a {
   border-width: 3px;
   color: #348eda;
   padding: 2px 20px;
+  text-decoration: none;
+  border: solid #348eda;
+  line-height: 2;
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 5px;
+  text-transform: capitalize;
+  margin: 15px 0 15px;
 }
 
 /* -------------------------------------

--- a/mail/templates/frontpage/body.html
+++ b/mail/templates/frontpage/body.html
@@ -48,7 +48,7 @@ div.read-more {
 	<tbody>
     {% for post in posts %}
     <tr>
-      <td width="72" style="width: 72px"><img src="{{ post.profile_image }}" class="user-photo" /></td>
+      <td width="72" style="width: 72px"><img src="{{ post.profile_image }}" class="user-photo" width="72" height="72"/></td>
       <td><div>
     		<h3 class="post-title">
           <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">{{ post.title }}</a>
@@ -61,6 +61,6 @@ div.read-more {
 	</tbody>
 </table>
 <div class="read-more">
-  <a href="{{ base_url }}" class="btn-primary ghost-button">Read More</a>
+  <a href="{{ base_url }}" class="ghost-button">Read More</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes wonkiness in outlook rendering of the frontpage email.

#### How should this be manually tested?
Send an email and make sure it looks ok in outlook webmail.

What it was looking like before:

Button background was wrong:
![2018-04-11-145938_1920x1080_scrot](https://user-images.githubusercontent.com/28598/38640114-54c6ff9e-3da1-11e8-958e-bd7c8eeead2d.png)

Default profile image sizing was off:
![2018-04-11-152718_1920x1080_scrot](https://user-images.githubusercontent.com/28598/38640124-5d4f71c8-3da1-11e8-904a-24d60d645562.png)
