### PR TITLE
Remove email_optin logic (#631)

### DIFF
--- a/notifications/api.py
+++ b/notifications/api.py
@@ -13,7 +13,6 @@ from notifications.models import (
     FREQUENCY_IMMEDIATE,
     FREQUENCY_DAILY,
     FREQUENCY_WEEKLY,
-    FREQUENCY_NEVER,
 )
 from notifications.notifiers import comments, frontpage
 from notifications import tasks
@@ -38,7 +37,7 @@ def ensure_notification_settings(user):
             user=user,
             notification_type=NOTIFICATION_TYPE_FRONTPAGE,
             defaults={
-                'trigger_frequency': FREQUENCY_DAILY if user.profile.email_optin else FREQUENCY_NEVER,
+                'trigger_frequency': FREQUENCY_DAILY,
             }
         )
 
@@ -47,7 +46,7 @@ def ensure_notification_settings(user):
             user=user,
             notification_type=NOTIFICATION_TYPE_COMMENTS,
             defaults={
-                'trigger_frequency': FREQUENCY_IMMEDIATE if user.profile.email_optin else FREQUENCY_NEVER,
+                'trigger_frequency': FREQUENCY_IMMEDIATE,
             }
         )
 

--- a/notifications/api_test.py
+++ b/notifications/api_test.py
@@ -23,24 +23,20 @@ from open_discussions.factories import UserFactory
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize('email_optin', [None, True, False])
-def test_ensure_notification_settings(user, email_optin):
+def test_ensure_notification_settings(user):
     """Assert that notification settings are created"""
-    profile = user.profile
-    profile.email_optin = email_optin
-    profile.save()
     assert NotificationSettings.objects.filter(user=user).count() == 0
     api.ensure_notification_settings(user)
     assert NotificationSettings.objects.filter(user=user).count() == 2
     ns = NotificationSettings.objects.get(user=user, notification_type=NOTIFICATION_TYPE_FRONTPAGE)
     assert ns.via_app is False
     assert ns.via_email is True
-    assert ns.trigger_frequency == FREQUENCY_DAILY if email_optin else FREQUENCY_NEVER
+    assert ns.trigger_frequency == FREQUENCY_DAILY
 
     ns = NotificationSettings.objects.get(user=user, notification_type=NOTIFICATION_TYPE_COMMENTS)
     assert ns.via_app is False
     assert ns.via_email is True
-    assert ns.trigger_frequency == FREQUENCY_IMMEDIATE if email_optin else FREQUENCY_NEVER
+    assert ns.trigger_frequency == FREQUENCY_IMMEDIATE
 
 
 def test_ensure_notification_settings_existing(user):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #631 

#### What's this PR do?
Removes logic checking `email_optin` to disable default notifications

#### How should this be manually tested?
- Remove all your notification settings, set `email_optin` to `False`
- Run `./manage.py population_notification_settings --username USERNAME` and verify you get the right defaults and not 'never' anymore
