### PR TITLE
Fixed race condition with NotificationSettings trigger_frequency

### DIFF
--- a/notifications/notifiers/email.py
+++ b/notifications/notifiers/email.py
@@ -64,8 +64,13 @@ class EmailNotifier(BaseNotifier):
         user = email_notification.user
 
         with utils.mark_as_sent_or_canceled(email_notification) as will_send:
+            # check against programmer error
             if user != self.user:
                 raise Exception("Notification user doesn't match settings user")
+
+            # if we're trying to send an email, but the preference is never, we should just cancel it
+            if self.notification_settings.is_triggered_never:
+                raise CancelNotificationError()
 
             if not will_send:
                 return


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #609 

#### What's this PR do?
Fixes a race condition where we queue an email to be sent but the user changes their settings prior to the actual send

#### How should this be manually tested?
This is a bit tricky to test, but the fix here is very simple so I think passing tests and code review should be sufficient.