### PR TITLE
Added handling for praw errors in email notifications

### DIFF
--- a/notifications/notifiers/comments.py
+++ b/notifications/notifiers/comments.py
@@ -9,6 +9,7 @@ from channels.serializers import (
 )
 from notifications.models import CommentEvent
 from notifications.notifiers.email import EmailNotifier
+from notifications.utils import praw_error_to_cancelled
 from open_discussions import features
 
 
@@ -35,6 +36,7 @@ class CommentNotifier(EmailNotifier):
             super().can_notify(last_notification)
         )
 
+    @praw_error_to_cancelled()
     def _get_notification_data(
             self, current_notification, last_notification
     ):  # pylint: disable=unused-argument

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -3,6 +3,12 @@ from contextlib import contextmanager
 import logging
 
 from django.db import transaction
+from praw.exceptions import APIException, PRAWException
+from prawcore.exceptions import (
+    Forbidden,
+    NotFound,
+    Redirect,
+)
 
 from notifications.notifiers.exceptions import CancelNotificationError
 from notifications.models import EmailNotification
@@ -46,3 +52,21 @@ def mark_as_sent_or_canceled(notification):
             log.exception("EmailNotification rolled back to pending: %s", notification.id)
             notification.state = EmailNotification.STATE_PENDING
             notification.save()
+
+
+@contextmanager
+def praw_error_to_cancelled():
+    """Raises CancelNotificationErrors from certain praw errors, otherwise raises the original error"""
+    try:
+        yield
+    except (Forbidden, NotFound, Redirect) as exc:
+        raise CancelNotificationError() from exc
+    except APIException as exc:
+        if exc.error_type in ('SUBREDDIT_NOTALLOWED', 'SUBREDDIT_NOEXIST', 'DELETED_COMMENT'):
+            raise CancelNotificationError() from exc
+        raise
+    except PRAWException as exc:
+        # special case if the user isn't a contributor on channel we call comment.parent()
+        if exc.args[0].startswith("No 'Comment' data returned for thing"):
+            raise CancelNotificationError() from exc
+        raise

--- a/notifications/utils_test.py
+++ b/notifications/utils_test.py
@@ -1,5 +1,13 @@
 """Utils tests"""
+from unittest.mock import MagicMock
+
 import pytest
+from praw.exceptions import APIException, PRAWException
+from prawcore.exceptions import (
+    Forbidden,
+    NotFound,
+    Redirect,
+)
 
 from notifications import utils
 from notifications.notifiers.exceptions import CancelNotificationError
@@ -56,3 +64,29 @@ def test_mark_as_sent_or_canceled_misc_error():
     notification.refresh_from_db()
     assert notification.state == EmailNotification.STATE_PENDING
     assert notification.sent_at is None
+
+
+@pytest.mark.parametrize('error,expected_cls', [
+    (PRAWException("No 'Comment' data returned for thing t1_u5"), CancelNotificationError),
+    (PRAWException("NOT TRANSLATED"), PRAWException),
+    (APIException("FAKE_ERROR_TYPE", '', ''), APIException),
+    (Exception("NOT TRANSLATED"), Exception),
+] + [
+    (APIException(error_type, '', ''), CancelNotificationError)
+    for error_type
+    in ('SUBREDDIT_NOTALLOWED', 'SUBREDDIT_NOEXIST', 'DELETED_COMMENT')
+] + [
+    (error_cls(MagicMock(
+        # because of side-affecting constructors
+        headers={
+            'location': 'http://exmaple.com/',
+        },
+    )), CancelNotificationError)
+    for error_cls in
+    (Forbidden, NotFound, Redirect)
+])
+def test_praw_error_to_cancelled(error, expected_cls):
+    """Test that each of the errors is correctly translated to CancelNotificationError or reraised"""
+    with pytest.raises(expected_cls):
+        with utils.praw_error_to_cancelled():
+            raise error


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #639 

#### What's this PR do?
This PR adds a decorator/contextmanager that is used to translate praw errors to notification cancellation errors instead. These errors can happen when the user no longer has permissions to certain objects in Reddit, so sending a notification for them isn't useful.

Most of the translation logic was inspired by `channels.utils.translate_praw_exceptions()`, so this covers a bit more than just the error reported by Sentry so we don't have to revisit this for edge cases we've already hit in other areas.

Only added this to comment notifications because we haven't seen it for the frontpage yet and that situation would be more complicated anyway.

#### How should this be manually tested?
- Stop your celery worker: `docker-compose stop celery`
- Ensure your notification settings for comments are set to "immediate"
- Subscribe to a post (or create a new one) in a private channel
- Comment on the post
- Remove your user from the channel the post is in via the shell: `channels.api.Api.remove_contributor('USERNAME')`
- Start the celery worker: `docker-compose start celery`
- After about a minute it should try to send the email and it should cancel the notification instead of raising an error. You can verify this with:
```python
from discussions.models import EmailNotification
assert EmailNotification.objects.order_by('id').last().state == EmailNotification.STATE_CANCELED
```

#### What GIF best describes this PR or how it makes you feel?

This came up when I searched giphy for "cancel" so why not?

![Cancel](https://media.giphy.com/media/Xbpf4eEW7yNBC/giphy.gif)