### PR TITLE
Upgrade celery

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ beautifulsoup4==4.6.0
 betamax
 betamax_serializers
 boto==2.39.0
-celery==4.0.2
+celery==4.1.0
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ betamax-serializers==0.2.0
 betamax==0.8.0
 billiard==3.5.0.2         # via celery
 boto==2.39.0
-celery==4.0.2
+celery==4.1.0
 certifi==2017.4.17        # via requests
 chardet==3.0.4            # via requests
 contextlib2==0.5.5        # via raven


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #641 

#### What's this PR do?
Upgrades celery. In 4.1 there is automatic exponential backoff for tasks

#### How should this be manually tested?
Nothing should break
