### PR TITLE
add embedly frontend

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -1,0 +1,55 @@
+// @flow
+import React from "react"
+
+export default class Embedly extends React.Component<*> {
+  renderEmbed() {
+    const { embedly } = this.props
+
+    // the response includes HTML which can be used to load a rich embed
+    // (either a video or the 'rich' type)
+    if (embedly.html) {
+      return (
+        <div
+          className="embed-container"
+          dangerouslySetInnerHTML={{ __html: embedly.html }}
+        />
+      )
+    }
+
+    if (embedly.type === "photo") {
+      return (
+        <div className="photo">
+          <img src={embedly.url} />
+        </div>
+      )
+    }
+
+    return (
+      <a href={embedly.url} target="_blank" className="link">
+        {embedly.thumbnail_url
+          ? <div className="thumbnail">
+            <img src={embedly.thumbnail_url} />
+          </div>
+          : null}
+        <div className="link-summary">
+          <h2>
+            {embedly.title}
+          </h2>
+          <div className="description">
+            {embedly.description}
+          </div>
+        </div>
+      </a>
+    )
+  }
+
+  render() {
+    const { embedly } = this.props
+
+    return (
+      <div className="embedly">
+        {embedly && embedly.type !== "error" ? this.renderEmbed() : null}
+      </div>
+    )
+  }
+}

--- a/static/js/components/Embedly_test.js
+++ b/static/js/components/Embedly_test.js
@@ -1,0 +1,47 @@
+import React from "react"
+import { mount } from "enzyme"
+import { assert } from "chai"
+
+import Embedly from "./Embedly"
+
+import { makeArticle, makeYoutubeVideo, makeImage } from "../factories/embedly"
+
+const renderEmbedly = embedlyResponse =>
+  mount(<Embedly embedly={embedlyResponse} />)
+
+describe("Embedly", () => {
+  it("should render the returned HTML for a video", () => {
+    const wrapper = renderEmbedly(makeYoutubeVideo())
+    assert.equal(wrapper.text(), "dummy html")
+  })
+
+  it("should render an image sensibly", () => {
+    const image = makeImage()
+    const wrapper = renderEmbedly(image)
+    assert.ok(wrapper.find(".photo"))
+    const img = wrapper.find("img")
+    assert.equal(img.props().src, image.url)
+  })
+
+  it("should render generic article-type content sensibly", () => {
+    const article = makeArticle()
+    const wrapper = renderEmbedly(article)
+    assert.equal(wrapper.find("a").props().href, article.url)
+    assert.equal(
+      wrapper.find(".thumbnail img").props().src,
+      article.thumbnail_url
+    )
+    assert.equal(wrapper.find(".link-summary h2").text(), article.title)
+    assert.equal(
+      wrapper.find(".link-summary .description").text(),
+      article.description
+    )
+  })
+
+  it("shouldnt render anything if embedly had some kind of error", () => {
+    const article = makeArticle()
+    article.type = "error"
+    const wrapper = renderEmbedly(article)
+    assert.lengthOf(wrapper.children(), 0)
+  })
+})

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -4,8 +4,9 @@ import React from "react"
 import moment from "moment"
 import R from "ramda"
 
-import { EditPostForm } from "../components/CommentForms"
+import { EditPostForm } from "./CommentForms"
 import { renderTextContent } from "./Markdown"
+import Embedly from "./Embedly"
 
 import { formatPostTitle, PostVotingButtons } from "../lib/posts"
 import { preventDefaultAndInvoke } from "../lib/util"
@@ -26,7 +27,8 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     showPostDeleteDialog: () => void,
     showPostReportDialog: () => void,
     showPermalinkUI: boolean,
-    toggleFollowPost: Post => void
+    toggleFollowPost: Post => void,
+    embedly: Object
   }
 
   renderTextContent = () => {
@@ -136,7 +138,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
   }
 
   render() {
-    const { post, forms, showPermalinkUI } = this.props
+    const { post, forms, showPermalinkUI, embedly } = this.props
     const formattedDate = moment(post.created).fromNow()
 
     return (
@@ -150,6 +152,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             by <span className="author-name">{post.author_name}</span>,{" "}
             {formattedDate}
           </div>
+          <Embedly embedly={embedly} />
         </div>
         {!showPermalinkUI && post.text ? this.renderTextContent() : null}
         {R.has(editPostKey(post), forms) ? null : this.postActionButtons()}

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -35,6 +35,7 @@ import { formatTitle } from "../lib/title"
 import { createCommentTree } from "../reducers/comments"
 import { makeReportRecord } from "../factories/reports"
 import { VALID_COMMENT_SORT_TYPES } from "../lib/sorting"
+import { makeArticle } from "../factories/embedly"
 
 describe("PostPage", function() {
   let helper,
@@ -55,6 +56,7 @@ describe("PostPage", function() {
 
     helper = new IntegrationTestHelper()
     helper.getPostStub.returns(Promise.resolve(post))
+    helper.getEmbedlyStub.returns(Promise.resolve(makeArticle()))
     helper.getChannelStub.returns(Promise.resolve(channel))
     helper.getChannelsStub.returns(Promise.resolve([]))
     helper.getCommentsStub.returns(Promise.resolve(commentsResponse))

--- a/static/js/factories/embedly.js
+++ b/static/js/factories/embedly.js
@@ -1,0 +1,48 @@
+// @flow
+
+export const makeArticle = () => ({
+  provider_url: "https://www.nytimes.com",
+  description:
+    'The German government said in a statement that Ms. Merkel, President Emmanuel Macron of France and Prime Minister Theresa May of Britain agreed after speaking on the phone that if the tariffs go into force, "The European Union should be ready to decisively defend its interests within the framework of multilateral trade rules."',
+  title:       "U.S. Allies Brace for Trade War as Tariff Negotiations Stall",
+  author_name: "Jack Ewing and Ana Swanson",
+  url:
+    "https://www.nytimes.com/2018/04/29/us/politics/us-allies-trade-war-tariff-negotiations.html",
+  thumbnail_url:
+    "https://static01.nyt.com/images/2018/04/30/us/30globaltrade-1/30globaltrade-1-facebookJumbo.jpg",
+  thumbnail_width:  1050,
+  version:          "1.0",
+  provider_name:    "Nytimes",
+  type:             "link",
+  thumbnail_height: 549
+})
+
+export const makeImage = () => ({
+  provider_url:  "http://imgur.com",
+  url:           "http://imgur.com/Z0vhwxm.jpg",
+  height:        1152,
+  width:         863,
+  version:       "1.0",
+  provider_name: "Imgur",
+  type:          "photo"
+})
+
+export const makeYoutubeVideo = () => ({
+  provider_url: "https://www.youtube.com/",
+  description:
+    "This is one of our best dog compilations! Chihuahuas are sooo funny! The hardest TRY NOT TO LAUGH challenge in the World! Just look how all these chihuahuas behave, play, fail, make funny sounds, react to different things,... So ridiculous, funny and cute! What is your favorite clip?",
+  title:
+    "Are CHIHUAHUAS the FUNNIEST DOGS? - Funny CHIHUAHUA DOG videos that will make you LAUGH LIKE HELL",
+  url:              "http://www.youtube.com/watch?v=3z9gO6U5U2Y",
+  author_name:      "Tiger Productions",
+  height:           480,
+  thumbnail_width:  480,
+  width:            854,
+  html:             "<div>dummy html</div>",
+  author_url:       "https://www.youtube.com/user/wloltigerlolw2",
+  version:          "1.0",
+  provider_name:    "YouTube",
+  thumbnail_url:    "https://i.ytimg.com/vi/3z9gO6U5U2Y/hqdefault.jpg",
+  type:             "video",
+  thumbnail_height: 360
+})

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -27,6 +27,7 @@ import type {
   ReportRecord
 } from "../flow/discussionTypes"
 import type { NotificationSetting } from "../flow/settingsTypes"
+import type { EmbedlyResponse } from "../reducers/embedly"
 
 const paramsToQueryString = paramSelector =>
   R.compose(toQueryString, R.reject(R.isNil), paramSelector)
@@ -239,7 +240,10 @@ export const patchCommentSetting = (
       body:   JSON.stringify(setting)
     })
 
-export const getEmbedly = (url: string): Promise<Object> =>
-  fetchJSONWithAuthFailure(
+export const getEmbedly = async (url: string): Promise<EmbedlyResponse> => {
+  const response = await fetchJSONWithAuthFailure(
     `/api/v0/embedly/${encodeURIComponent(encodeURIComponent(url))}/`
   )
+
+  return { url, response }
+}

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -10,6 +10,7 @@ import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
 import { postRemovedEndpoint } from "../reducers/post_removed"
 import { reportsEndpoint } from "../reducers/reports"
 import { settingsEndpoint } from "../reducers/settings"
+import { embedlyEndpoint } from "../reducers/embedly"
 
 export const endpoints = [
   postsEndpoint,
@@ -23,5 +24,6 @@ export const endpoints = [
   postUpvotesEndpoint,
   postRemovedEndpoint,
   reportsEndpoint,
-  settingsEndpoint
+  settingsEndpoint,
+  embedlyEndpoint
 ]

--- a/static/js/reducers/embedly.js
+++ b/static/js/reducers/embedly.js
@@ -1,0 +1,25 @@
+// @flow
+import * as api from "../lib/api"
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
+
+export type EmbedlyResponse = {
+  url: string,
+  response: Object
+}
+
+type EmbedlyData = Map<string, Object>
+
+export const embedlyEndpoint = {
+  name:              "embedly",
+  verbs:             [GET],
+  getFunc:           api.getEmbedly,
+  getSuccessHandler: (
+    payload: EmbedlyResponse,
+    data: EmbedlyData
+  ): EmbedlyData => {
+    const update = new Map(data)
+    update.set(payload.url, payload.response)
+    return update
+  },
+  initialState: { ...INITIAL_STATE, data: new Map() }
+}

--- a/static/scss/_breakpoints.scss
+++ b/static/scss/_breakpoints.scss
@@ -3,6 +3,10 @@
     @media (min-width: 801px) {
       @content;
     }
+  } @else if $name == desktopwide {
+    @media (min-width: 1000px) {
+      @content;
+    }
   } @else if $name == mobile {
     @media (max-width: 800px) {
       @content;

--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -1,0 +1,68 @@
+.embedly {
+  .embed-container {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+  }
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .photo {
+    img {
+      max-height: 400px;
+      object-fit: scale-down;
+      width: 100%;
+    }
+  }
+
+  .link {
+    display: flex;
+    flex-direction: column;
+    color: $font-black;
+    font-weight: 400;
+
+    @include breakpoint(desktopwide) {
+      flex-direction: row;
+    }
+
+
+    .thumbnail {
+      display: flex;
+      overflow: hidden;
+      flex-direction: column;
+      max-height: 300px;
+      width: 100%;
+      justify-content: center;
+
+      @include breakpoint(desktopwide) {
+        height: 200px;
+        width: 300px;
+        flex: none;
+      }
+
+
+      img {
+        width: 100%;
+        height: auto;
+      }
+    }
+
+    .link-summary {
+      @include breakpoint(desktopwide) {
+        margin-left: 15px;
+      }
+
+
+      .description {
+        font-size: 15px;
+      }
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -33,6 +33,7 @@
 @import "sort-picker";
 @import "settings";
 @import "user-info";
+@import "embedly";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -74,11 +74,12 @@
   .summary {
     overflow: hidden;
 
-    img {
+    .profile-image {
       float: left;
       position: relative;
       top: 6px;
     }
+
   }
 
   .text-content {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #604 

#### What's this PR do?

When viewing a Link-type post this will make a request to the Embedly API and then display the results. Here's a few examples of what that looks like:

![nytimes_article](https://user-images.githubusercontent.com/6207644/39479561-a5e3b3da-4d33-11e8-970c-2a4f156475e9.png)
![nytimes_article_mob](https://user-images.githubusercontent.com/6207644/39479571-a94f7c20-4d33-11e8-973d-0e5007b028fe.png)
![chihuahuapic](https://user-images.githubusercontent.com/6207644/39479577-ab9e1040-4d33-11e8-92a8-9ab257c46efa.png)
![chihuahuapic_mob](https://user-images.githubusercontent.com/6207644/39479586-adfe0476-4d33-11e8-8133-9472bafdeaaa.png)
![youtube_vidv](https://user-images.githubusercontent.com/6207644/39479867-87726404-4d34-11e8-8560-c43990628f67.png)
![youtube_vidvmob](https://user-images.githubusercontent.com/6207644/39479870-8999b0ac-4d34-11e8-8c38-dd7987e69fe3.png)

#### How should this be manually tested?

You'll need an embedly API key set up to test this, and you'll need to set the `EMBEDLY_KEY` env var with it. Then, if you add a link post, you should see some sort of content get pulled out, as shown in the screenshots.

There are two small other tweaks which should be tested. From the post index (a channel or the frontpage) Link-type posts now link directly to the post detail view, not to the external resource. Also, the domain name of the external link is now put below the content, instead of up by the title, on the detail page.