### PR TITLE
add zendesk widget

### DIFF
--- a/open_discussions/templates/index.html
+++ b/open_discussions/templates/index.html
@@ -7,4 +7,5 @@
 <div id="container"></div>
 {% load render_bundle %}
 {% render_bundle 'root' %}
+{% render_bundle 'zendesk' %}
 {% endblock %}

--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -47,12 +47,14 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         raise ImproperlyConfigured("Unable to find site for site key: '{}'".format(site_key))
 
     user_full_name = None
+    user_email = None
     profile_image_small = None
 
     if username is not None:
         user = User.objects.get(username=username)
         user_full_name = user.profile.name
         profile_image_small = user.profile.image_small
+        user_email = user.email
 
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
@@ -60,6 +62,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "max_comment_depth": settings.OPEN_DISCUSSIONS_MAX_COMMENT_DEPTH,
         "username": username,
         "user_full_name": user_full_name,
+        "user_email": user_email,
         "profile_image_small": profile_image_small,
         "authenticated_site": {
             "title": site.title,

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -24,6 +24,7 @@ def test_webpack_url(settings, staff_client, mocker, authenticated_site):
         'common',
         'root',
         'style',
+        'zendesk',
     }
     js_settings = json.loads(response.context['js_settings_json'])
     assert js_settings == {
@@ -31,6 +32,7 @@ def test_webpack_url(settings, staff_client, mocker, authenticated_site):
         'public_path': '/static/bundles/',
         'max_comment_depth': 6,
         'username': None,
+        'user_email': None,
         'profile_image_small': None,
         'user_full_name': None,
         'authenticated_site': {

--- a/static/js/entry/zendesk.js
+++ b/static/js/entry/zendesk.js
@@ -1,0 +1,184 @@
+/* global SETTINGS:false zE:false _:false */
+__webpack_public_path__ = `${SETTINGS.public_path}` // eslint-disable-line no-undef, camelcase
+import _ from "lodash"
+
+// Start of odl Zendesk Widget script
+/* eslint-disable no-sequences, prefer-const */
+/*<![CDATA[*/
+window.zEmbed ||
+  (function(e, t) {
+    let n,
+      o,
+      d,
+      i,
+      s,
+      a = [],
+      r = document.createElement("iframe")
+    ;(window.zEmbed = function() {
+      a.push(arguments)
+    }), (window.zE = window.zE || window.zEmbed), (r.src =
+      "javascript:false"), (r.title = ""), (r.role =
+      "presentation"), ((r.frameElement || r).style.cssText =
+      "display: none"), (d = document.getElementsByTagName("script")), (d =
+      d[d.length - 1]), d.parentNode.insertBefore(r, d), (i =
+      r.contentWindow), (s = i.document)
+    try {
+      o = s
+    } catch (e) {
+      (n =
+        document.domain), (r.src = `javascript:var d=document.open();d.domain="${n}";void(0);`), (o = s)
+    }
+    (o.open()._l = function() {
+      const o = this.createElement("script")
+      n && (this.domain = n), (o.id =
+        "js-iframe-async"), (o.src = e), (this.t = +new Date()), (this.zendeskHost = t), (this.zEQueue = a), this.body.appendChild(
+        o
+      )
+    }), o.write('<body onload="document._l();">'), o.close()
+  })(
+    "https://assets.zendesk.com/embeddable_framework/main.js",
+    "odl.zendesk.com"
+  )
+
+// This will execute when Zendesk's Javascript is finished executing, and the
+// Web Widget API is available to be used. Zendesk's various iframes may *not*
+// have been inserted into the DOM yet.
+zE(function() {
+  // pre-populate feedback form
+  if (SETTINGS.user_full_name) {
+    zE.identify({ name: SETTINGS.user_full_name, email: SETTINGS.user_email })
+  }
+
+  zendeskPollForExistence("launcher")
+  zendeskPollForExistence("webWidget")
+})
+
+const zendeskCallbacks = {
+  // This object supports the following functions:
+  //   launcherLoaded: runs when the launcher iframe's content is loaded
+  //   webWidgetLoaded: runs when the submission form is loaded
+  //
+  // The `zendeskPollForExistence()` function will ensure that these functions
+  // are called at the appropriate time. We have to ensure that the iframe
+  // exists before we can start polling to see if the content has loaded
+  // (so that we can call functions to fiddle with the HTML and styling inside
+  // of it).
+
+  launcherLoaded: () => {
+    const iframe = document.querySelector("iframe.zEWidget-launcher")
+    if (_.isNull(iframe)) {
+      return
+    }
+
+    const btn = iframe.contentDocument.querySelector(".u-userLauncherColor")
+    if (_.isNull(btn)) {
+      return
+    }
+
+    const regularBackgroundColor = "rgba(0, 0, 0, .14)"
+    const defaultHoverBackgroundColor = "#a31f34" // fall back color
+    const hoverBackgroundColor = window.getComputedStyle(
+      btn,
+      defaultHoverBackgroundColor
+    ).backgroundColor
+    // We need to set a new background color, and unfortunately,
+    // the existing background color is set with "!important".
+    // As a result, the only way to override this existing color is to
+    // *also* use "!important".
+    const setHover = () => {
+      btn.style.setProperty(
+        "background-color",
+        hoverBackgroundColor,
+        "important"
+      )
+    }
+    const unsetHover = () => {
+      btn.style.setProperty(
+        "background-color",
+        regularBackgroundColor,
+        "important"
+      )
+    }
+    btn.onmouseenter = setHover
+    btn.onmouseleave = unsetHover
+    unsetHover()
+  },
+  webWidgetLoaded: () => {
+    const iframe = document.querySelector("iframe.zEWidget-webWidget")
+
+    // this is Zendesk's ID for the program selector field
+    // which we want to hide in Discussions
+    const programFieldName = "24690866"
+
+    let tries = 0
+    let programEl
+
+    const intervalID = setInterval(() => {
+      tries++
+
+      programEl = iframe.contentDocument.querySelector(
+        `input[name="${programFieldName}"]`
+      )
+
+      if (programEl) {
+        programEl.parentNode.parentNode.style.setProperty(
+          "display",
+          "none",
+          "important"
+        )
+        clearInterval(intervalID)
+      } else if (tries > 100) {
+        console.error("couldn't find program selector") // eslint-disable-line no-console
+        clearInterval(intervalID)
+      }
+    }, 100)
+  }
+}
+
+const zendeskPollForExistence = name => {
+  let tries = 0
+  const intervalID = setInterval(() => {
+    tries += 1
+    const iframe = document.querySelector(`iframe.zEWidget-${name}`)
+    if (iframe) {
+      clearInterval(intervalID)
+      zendeskPollForLoaded(name)
+    } else if (tries > 100) {
+      // max 100 tries (10 seconds)
+      console.error(`couldn't find Zendesk iframe: ${name}`) // eslint-disable-line no-console
+      clearInterval(intervalID)
+    }
+  }, 100) // check every 100 milliseconds
+}
+
+const zendeskPollForLoaded = name => {
+  let tries = 0
+  let iframeDocument = null
+  const intervalID = setInterval(() => {
+    tries += 1
+    const iframe = document.querySelector(`iframe.zEWidget-${name}`)
+    try {
+      iframeDocument = iframe.contentDocument
+    } catch (err) {
+      // cross-domain exception: can't continue
+    }
+    if (!iframeDocument) {
+      console.error(`Can't access content of Zendesk iframe: ${name}`) // eslint-disable-line no-console
+      clearInterval(intervalID)
+      return
+    }
+
+    const div = iframeDocument.querySelector("div")
+    if (div) {
+      clearInterval(intervalID)
+      const callback = zendeskCallbacks[`${name}Loaded`]
+      if (callback) {
+        callback()
+      }
+    } else if (tries > 100) {
+      // max 100 tries (10 seconds)
+      console.error(`couldn't load Zendesk iframe: ${name}`) // eslint-disable-line no-console
+      clearInterval(intervalID)
+    }
+  }, 100) // check every 100 milliseconds
+}

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -5,6 +5,7 @@ module.exports = {
   config: {
     entry: {
       'root': ['babel-polyfill', './static/js/entry/root'],
+      'zendesk': './static/js/entry/zendesk',
       'style': './static/js/entry/style',
     },
     module: {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #549 

#### What's this PR do?

This adds the Zendesk support widget to open discussions. I copied the implementation we have in MM over, and removed the parts which it didn't seem to me like we would need over here. I also added a little thing to hide the MM program selector, and also added the user's email address to the SETTINGS object in order to fully pre-fill the widget form.

#### How should this be manually tested?

Make sure that the widget shows up. It should look roughly the same as in MM. Your user's name and email should be pre-filled in the form, and the form shouldn't have a (visible) drop-down for selecting the program. Also, there shouldn't be any zendesk-related console errors.