### PR TITLE
Simplified layout for notification email

### DIFF
--- a/mail/templates/comments/body.html
+++ b/mail/templates/comments/body.html
@@ -15,7 +15,7 @@
     <tr>
       <td>
         <div>
-          <h3>{{ comment.author_name }}:</h3>
+          <p>From {{ comment.author_name }}:</p>
           <p class="comment-content">
             {{ comment.text|truncatewords:100 }}
             {% if is_comment_reply %}
@@ -29,11 +29,11 @@
     </tr>
   </tbody>
 </table>
-<div class="read-more">
+<div class="read-more alignleft" style="margin-left: 13px; margin-top: 13px;">
   {% if is_comment_reply %}
-  <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id comment_id=comment.id %}" class="btn-primary ghost-button">View on Open Discussions</a>
+  <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id comment_id=comment.id %}" class="btn-primary">View on Open Discussions</a>
   {% else %}
-  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}" class="btn-primary ghost-button">View on Open Discussions</a>
+  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}" class="btn-primary">View on Open Discussions</a>
   {% endif %}
 </div>
 {% endblock %}
@@ -43,8 +43,6 @@
   You are receiving this email because you are following a post on Open Discussions.
   <br/>
   If you don't want to receive these emails in the future, you can
-  <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">edit your settings</a>
-  or
-  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">unfollow from this post</a>.
+  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">unfollow this post</a>.
 </p>
 {% endblock %}

--- a/mail/templates/comments/subject.txt
+++ b/mail/templates/comments/subject.txt
@@ -1,1 +1,1 @@
-[{{ post.channel_title }}] {% if is_comment_reply %}Reply to your comment "{{ parent.text|truncatechars:20 }}"{% else %} Re: {{ post.title }}{% endif %}
+[{{ post.channel_title }}] {% if is_comment_reply %}Reply to your comment "{{ parent.text|truncatechars:20 }}"{% else %} Reply to {{ post.title }}{% endif %}

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -12,7 +12,7 @@
 * {
   font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
   box-sizing: border-box;
-  font-size: 16px;
+  font-size: 16px !important;
 }
 
 img {
@@ -136,6 +136,7 @@ h4 {
 p, ul, ol {
   margin: 15px 0 15px;
   font-weight: normal;
+  font-size: 15px;
 }
 p li, ul li, ol li {
   margin-left: 5px;
@@ -161,9 +162,11 @@ a {
   background-color: #348eda;
   border: solid #348eda;
   border-width: 10px 20px;
-  line-height: 2;
-  font-weight: bold;
+  line-height: 1;
+  font-weight: 500;
+  font-size: 15px;
   text-align: center;
+  padding: 8px 4px;
   cursor: pointer;
   display: inline-block;
   border-radius: 5px;
@@ -173,23 +176,23 @@ a {
 
 .ghost-button {
   background: none;
-  border-width: 3px;
+  border-width: 2px;
   color: #348eda;
-  padding: 2px 20px;
+  padding: 6px 20px;
   text-decoration: none;
   border: solid #348eda;
   line-height: 2;
-  font-weight: bold;
   text-align: center;
   cursor: pointer;
   display: inline-block;
   border-radius: 5px;
   text-transform: capitalize;
   margin: 15px 0 15px;
+  font-weight: 500;
+  font-size: 15px;
 }
 
 .read-more {
-  text-align: center;
   margin: 30px 0;
 }
 
@@ -284,39 +287,37 @@ a {
   <tbody>
     <tr>
     <td width="1%" style="width: 1%"></td>
-      <td class="container" width="98%" style="width: 98%">
-        <div class="content">
-          <table class="main" width="100%" cellpadding="0" cellspacing="0">
-            <tbody>
-              <tr>
-                <td class="content-wrap">
-                  {% block logo %}<div class="aligncenter">
-                    <img src="{{ base_url }}/static/images/mit-logo-micromasters.jpg" width="241" style="margin-bottom: 27px" />
-                  </div>{% endblock %}
+    <td class="container" width="98%" style="width: 98%">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tbody>
+            <tr>
+              <td class="content-wrap">
 
-                  {% block content %}{% endblock %}
+                {% block content %}{% endblock %}
 
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="footer aligncenter">
-            {% block footer %}<p>
-              You are receiving this email because you signed up for Open Discussions.
-              <br/>
-              If you don't want to receive these emails in the future, you can
-              <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">edit your settings</a>
-              or
-              <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">unsubscribe</a>.
-            </p>{% endblock %}
-            <p>
-              MIT Office of Digital Learning
-              <br/>
-              600 Technology Square, 2nd Floor, Cambridge, MA 02139
-            </p>
-          </div>
+                        <div class="footer">
+          {% block footer %}<p>
+            You are receiving this email because you signed up for Open Discussions.
+            <br/>
+            If you don't want to receive these emails in the future, you can
+            <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">edit your settings</a>
+            or
+            <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">unsubscribe</a>.
+          </p>{% endblock %}
+          <p>
+             MIT Office of Digital Learning
+            <br/>
+            600 Technology Square, 2nd Floor, Cambridge, MA 02139
+          </p>
         </div>
-      </td>
+
+              </td>
+            </tr>
+          </tbody
+        </table>
+      </div>
+    </td>
       <td width="1%" style="width: 1%"></td>
     </tr>
   </tbody>

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -296,22 +296,21 @@ a {
 
                 {% block content %}{% endblock %}
 
-                        <div class="footer">
-          {% block footer %}<p>
-            You are receiving this email because you signed up for Open Discussions.
-            <br/>
-            If you don't want to receive these emails in the future, you can
-            <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">edit your settings</a>
-            or
-            <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">unsubscribe</a>.
-          </p>{% endblock %}
-          <p>
-             MIT Office of Digital Learning
-            <br/>
-            600 Technology Square, 2nd Floor, Cambridge, MA 02139
-          </p>
-        </div>
-
+                <div class="footer">
+                  {% block footer %}<p>
+                  You are receiving this email because you signed up for Open Discussions.
+                  <br/>
+                  If you don't want to receive these emails in the future, you can
+                  <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">edit your settings</a>
+                  or
+                  <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}">unsubscribe</a>.
+                  </p>{% endblock %}
+                  <p>
+                  MIT Office of Digital Learning
+                  <br/>
+                  600 Technology Square, 2nd Floor, Cambridge, MA 02139
+                  </p>
+                </div>
               </td>
             </tr>
           </tbody

--- a/mail/templates/frontpage/body.html
+++ b/mail/templates/frontpage/body.html
@@ -37,6 +37,9 @@ p.comments {
 
 {% block content %}
 
+{% block logo %}<div class="aligncenter">
+  <img src="{{ base_url }}/static/images/mit-logo-micromasters.jpg" width="241" style="margin-bottom: 27px" />
+</div>{% endblock %}
 <div class="section">
   <p class="lead-in">Here are some recent posts you might have missed</p>
 </div>
@@ -56,7 +59,7 @@ p.comments {
     {% endfor %}
   </tbody>
 </table>
-<div class="read-more">
+<div class="read-more aligncenter">
   <a href="{{ base_url }}" class="ghost-button">Read More</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
#### What are the relevant tickets?
closes #633

#### What's this PR do?
This PR removes the MIT and Micromasters logos, and left aligns the notification email.

#### How should this be manually tested?
Test it in various email clients

#### Screenshots (if appropriate)
(Optional)
![image](https://user-images.githubusercontent.com/20047260/39589193-835f708a-4ecb-11e8-9205-0f915fe099b8.png)

