### PR TITLE
Added Elasticsearch document and added indexing handlers for posts

### DIFF
--- a/channels/constants.py
+++ b/channels/constants.py
@@ -1,4 +1,6 @@
 """Constants for channels"""
+from enum import Enum, auto
+
 
 CHANNEL_TYPE_PUBLIC = 'public'
 CHANNEL_TYPE_PRIVATE = 'private'
@@ -27,3 +29,14 @@ VALID_COMMENT_SORT_TYPES = (
     COMMENTS_SORT_NEW,
     COMMENTS_SORT_OLD,
 )
+
+POST_TYPE = 'post'
+COMMENT_TYPE = 'comment'
+
+
+class VoteActions(Enum):
+    """An enum indicating the valid vote actions that can be taken for a post or comment"""
+    UPVOTE = auto()
+    DOWNVOTE = auto()
+    CLEAR_UPVOTE = auto()
+    CLEAR_DOWNVOTE = auto()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - "8061:8061"
     links:
       - db
+      - elastic
       - redis
 
   watch:

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -1,9 +1,17 @@
 """Common config for pytest and friends"""
 # pylint: disable=unused-argument, redefined-outer-name
+import importlib
 import warnings
+from functools import wraps
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import factory
 import pytest
+
+import channels.api
+import channels.factories
+import channels.serializers
 
 
 @pytest.fixture(autouse=True)
@@ -38,3 +46,45 @@ def warnings_as_errors():
 def randomness():
     """Ensure a fixed seed for factoryboy"""
     factory.fuzzy.reseed_random("happy little clouds")
+
+
+@pytest.fixture(scope='session', autouse=True)
+def session_indexing_decorator():
+    """
+    Fixture that mocks the reddit object indexer for the test suite by default.
+
+    Decorators require some extra work to patch since they are already applied to functions
+    when a module is loaded. To get around this, we patch the decorator function then
+    reload the relevant modules via importlib.
+    """
+    mock_func = Mock()
+
+    def dummy_decorator(**kwargs):  # pylint: disable=unused-argument
+        """A decorator that calls a mock before calling the wrapped function"""
+        def dummy_decorator_inner(func):  # pylint: disable=missing-docstring
+            @wraps(func)
+            def wrapped_api_func(*args, **kwargs):  # pylint: disable=missing-docstring
+                mock_func(*args, **kwargs)
+                return func(*args, **kwargs)
+            return wrapped_api_func
+        return dummy_decorator_inner
+
+    patched_decorator = patch('search.task_helpers.reddit_object_indexer', dummy_decorator)
+    patched_decorator.start()
+    # Reload the modules that import and use the channels API. All methods decorated with
+    # reddit_object_indexer will now use the simple patched version that was created here.
+    importlib.reload(channels.factories)
+    importlib.reload(channels.api)
+    importlib.reload(channels.serializers)
+    yield SimpleNamespace(patch=patched_decorator, mock_indexing_func=mock_func)
+
+
+@pytest.fixture()
+def indexing_decorator(session_indexing_decorator):
+    """
+    Fixture that resets the indexing function mock and returns the indexing decorator fixture.
+    This can be used if there is a need to test whether or not a function is wrapped in the
+    indexing decorator.
+    """
+    session_indexing_decorator.mock_indexing_func.reset_mock()
+    yield session_indexing_decorator

--- a/open_discussions/features.py
+++ b/open_discussions/features.py
@@ -1,10 +1,12 @@
 """Discussions feature flags"""
+from functools import wraps
 from django.conf import settings
 
 EMAIL_NOTIFICATIONS = 'EMAIL_NOTIFICATIONS'
 FRONTPAGE_EMAIL_DIGESTS = 'FRONTPAGE_EMAIL_DIGESTS'
 COMMENT_NOTIFICATIONS = 'COMMENT_NOTIFICATIONS'
 ANONYMOUS_ACCESS = 'ANONYMOUS_ACCESS'
+INDEX_UPDATES = 'INDEX_UPDATES'
 
 
 def is_enabled(name, default=False):
@@ -19,3 +21,25 @@ def is_enabled(name, default=False):
         bool: True if the feature flag is enabled
     """
     return settings.FEATURES.get(name, default)
+
+
+def if_feature_enabled(name, default=False):
+    """
+    Wrapper that results in a no-op if the given feature isn't enabled, and otherwise
+    runs the wrapped function as normal.
+
+    Args:
+        name (str): Feature flag name
+        default (bool): default value if not set in settings
+    """
+    def if_feature_enabled_inner(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):  # pylint: disable=missing-docstring
+            if not is_enabled(name, default):
+                # If the given feature name is not enabled, do nothing (no-op).
+                return
+            else:
+                # If the given feature name is enabled, call the function and return as normal.
+                return func(*args, **kwargs)
+        return wrapped_func
+    return if_feature_enabled_inner

--- a/open_discussions/features_test.py
+++ b/open_discussions/features_test.py
@@ -19,3 +19,27 @@ def test_is_enabled(settings, value_in_settings, default, expected):
         settings.FEATURES[key] = value_in_settings
 
     assert features.is_enabled(key, default=default) is expected
+
+
+# pylint: disable=too-many-arguments
+@pytest.mark.parametrize('feature_enabled,initial_value,update_value,expected_result_value', [
+    (True, None, 'new value', 'new value'),
+    (False, None, 'new value', None),
+])
+def test_if_feature_enabled(
+        mocker, settings, feature_enabled, initial_value, update_value, expected_result_value
+):
+    """
+    Tests that if_feature_enabled turns a decorated function into a no-op if the
+    given feature flag is disabled.
+    """
+    key = 'feature_key'
+    settings.FEATURES[key] = feature_enabled
+    some_mock = mocker.Mock(value=initial_value)
+
+    @features.if_feature_enabled(key)
+    def mock_editing_func(value):  # pylint: disable=missing-docstring
+        some_mock.value = value
+
+    mock_editing_func(update_value)
+    assert some_mock.value == expected_result_value

--- a/search/connection.py
+++ b/search/connection.py
@@ -1,0 +1,59 @@
+"""
+Elasticsearch connection functionality
+"""
+from django.conf import settings
+from elasticsearch_dsl.connections import connections
+
+
+_CONN = None
+# When we create the connection, check to make sure all appropriate mappings exist
+_CONN_VERIFIED = False
+
+
+def get_conn(*, verify=True):
+    """
+    Lazily create the connection.
+
+    Args:
+        verify (bool): If true, check the presence of indices and mappings
+
+    Returns:
+        elasticsearch.client.Elasticsearch: An Elasticsearch client
+    """
+    # pylint: disable=global-statement
+    global _CONN
+    global _CONN_VERIFIED
+
+    do_verify = False
+    if _CONN is None:
+        http_auth = settings.ELASTICSEARCH_HTTP_AUTH
+        use_ssl = http_auth is not None
+        _CONN = connections.create_connection(
+            hosts=[settings.ELASTICSEARCH_URL],
+            http_auth=http_auth,
+            use_ssl=use_ssl,
+            # make sure we verify SSL certificates (off by default)
+            verify_certs=use_ssl
+        )
+        # Verify connection on first connect if verify=True.
+        do_verify = verify
+
+    if verify and not _CONN_VERIFIED:
+        # If we have a connection but haven't verified before, do it now.
+        do_verify = True
+
+    if not do_verify:
+        if not verify:
+            # We only skip verification if we're reindexing or
+            # deleting the index. Make sure we verify next time we connect.
+            _CONN_VERIFIED = False
+        return _CONN
+
+    index_to_verify = settings.ELASTICSEARCH_INDEX
+    if not _CONN.indices.exists(index_to_verify):
+        raise Exception("Unable to find index {index_name}".format(
+            index_name=index_to_verify
+        ))
+
+    _CONN_VERIFIED = True
+    return _CONN

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -1,0 +1,124 @@
+"""
+Functions and constants for Elasticsearch indexing
+"""
+from functools import partial
+from django.conf import settings
+
+from search.connection import get_conn
+
+
+GLOBAL_DOC_TYPE = '_doc'
+COMBINED_MAPPING = {
+    'object_type': {'type': 'keyword'},
+    'author': {'type': 'keyword'},
+    'channel_title': {'type': 'keyword'},
+    'text': {'type': 'text'},
+    'score': {'type': 'long'},
+    'created': {'type': 'date'},
+    'deleted': {'type': 'boolean'},
+    'removed': {'type': 'boolean'},
+    'post_id': {'type': 'keyword'},
+    'post_title': {'type': 'text'},
+    'post_link_url': {'type': 'text'},
+    'num_comments': {'type': 'long'},
+    'comment_id': {'type': 'keyword'},
+    'parent_comment_id': {'type': 'keyword'},
+}
+
+
+def gen_post_id(reddit_obj_id):
+    """Generates the Elasticsearch document id for a post"""
+    return 'p_{}'.format(reddit_obj_id)
+
+
+def clear_and_create_index(skip_mapping=False):
+    """
+    Wipe and recreate index and mapping. No indexing is done.
+
+    Args:
+        skip_mapping (bool): If true, don't set any mapping
+    """
+    conn = get_conn(verify=False)
+    index_name = settings.ELASTICSEARCH_INDEX
+    if conn.indices.exists(index_name):
+        conn.indices.delete(index_name)
+    index_create_data = {
+        'settings': {
+            'analysis': {
+                'analyzer': {
+                    'folding': {
+                        'type': 'custom',
+                        'tokenizer': 'standard',
+                        'filter': [
+                            'lowercase',
+                            'asciifolding',  # remove accents if we use folding analyzer
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    if not skip_mapping:
+        index_create_data['mappings'] = {
+            GLOBAL_DOC_TYPE: {
+                "properties": COMBINED_MAPPING
+            }
+        }
+    # from https://www.elastic.co/guide/en/elasticsearch/guide/current/asciifolding-token-filter.html
+    conn.indices.create(index_name, body=index_create_data)
+
+
+def create_document(doc_id, data):
+    """
+    Makes a request to ES to create a new document
+
+    Args:
+        doc_id (str): The ES document id
+        data (dict): Full ES document data
+    """
+    conn = get_conn(verify=True)
+    return conn.create(
+        index=settings.ELASTICSEARCH_INDEX,
+        doc_type=GLOBAL_DOC_TYPE,
+        body=data,
+        id=doc_id,
+    )
+
+
+def _update_document(doc_id, data, update_key=None):
+    """
+    Makes a request to ES to update an existing document
+
+    Args:
+        doc_id (str): The ES document id
+        data (dict): Full ES document data
+    """
+    conn = get_conn(verify=True)
+    return conn.update(
+        index=settings.ELASTICSEARCH_INDEX,
+        doc_type=GLOBAL_DOC_TYPE,
+        body={update_key: data},
+        id=doc_id,
+    )
+
+
+update_document_with_partial = partial(_update_document, update_key='doc')
+
+
+def increment_document_integer_field(doc_id, field_name, incr_amount):
+    """
+    Makes a request to ES to increment some integer field in a document
+
+    Args:
+        doc_id (str): The ES document id
+        field_name (str): The name of the field to increment
+        incr_amount (int): The amount to increment by
+    """
+    return _update_document(
+        doc_id,
+        {
+            "source": "ctx._source.{} += {}".format(field_name, incr_amount),
+            "lang": "painless",
+        },
+        update_key='script'
+    )

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -1,0 +1,75 @@
+"""
+Tests for the indexing API
+"""
+# pylint: disable=redefined-outer-name
+from types import SimpleNamespace
+import pytest
+
+from search.indexing_api import (
+    create_document,
+    update_document_with_partial,
+    increment_document_integer_field,
+    GLOBAL_DOC_TYPE,
+)
+
+
+@pytest.fixture()
+def mocked_es(mocker, settings):
+    """Mocked ES client objects/functions"""
+    index_name = 'test'
+    settings.ELASTICSEARCH_INDEX = index_name
+    conn = mocker.Mock()
+    get_conn_patch = mocker.patch('search.indexing_api.get_conn', return_value=conn)
+    yield SimpleNamespace(get_conn=get_conn_patch, conn=conn, index_name=index_name)
+    get_conn_patch.reset_mock()
+
+
+def test_create_document(mocked_es):
+    """
+    Test that create_document gets a connection and calls the correct elasticsearch-dsl function
+    """
+    doc_id, data = ('doc_id', {'key1': 'value1'})
+    create_document(doc_id, data)
+    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.conn.create.assert_called_once_with(
+        index=mocked_es.index_name,
+        doc_type=GLOBAL_DOC_TYPE,
+        body=data,
+        id=doc_id,
+    )
+
+
+def test_partially_update_document(mocked_es):
+    """
+    Test that partially_update_document gets a connection and calls the correct elasticsearch-dsl function
+    """
+    doc_id, data = ('doc_id', {'key1': 'value1'})
+    update_document_with_partial(doc_id, data)
+    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.conn.update.assert_called_once_with(
+        index=mocked_es.index_name,
+        doc_type=GLOBAL_DOC_TYPE,
+        body={'doc': data},
+        id=doc_id,
+    )
+
+
+def test_increment_document_integer_field(mocked_es):
+    """
+    Test that increment_document_integer_field gets a connection and calls the
+    correct elasticsearch-dsl function
+    """
+    doc_id, field_name, incr_amount = ('doc_id', 'some_field_name', 1)
+    increment_document_integer_field(doc_id, field_name, incr_amount)
+    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.conn.update.assert_called_once_with(
+        index=mocked_es.index_name,
+        doc_type=GLOBAL_DOC_TYPE,
+        body={
+            "script": {
+                "source": "ctx._source.{} += {}".format(field_name, incr_amount),
+                "lang": "painless",
+            }
+        },
+        id=doc_id,
+    )

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -1,0 +1,144 @@
+"""
+Functions that execute search-related asynchronous tasks
+"""
+import logging
+from functools import wraps, partial
+
+from open_discussions.features import (
+    INDEX_UPDATES,
+    if_feature_enabled,
+)
+from channels.constants import (
+    POST_TYPE,
+    VoteActions,
+)
+from search.indexing_api import gen_post_id
+from search.tasks import (
+    create_document,
+    update_document_with_partial,
+    increment_document_integer_field,
+)
+
+log = logging.getLogger()
+
+
+def reddit_object_indexer(indexing_func=None):
+    """
+    Decorator that passes a PRAW object to a function that will perform some indexing action.
+    The decorated function must return a PRAW object
+    (e.g.: praw.models.reddit.submission.Submission, praw.models.reddit.comment.Comment)
+    """
+    def api_indexing_listener_inner(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapped_api_func(*args, **kwargs):  # pylint: disable=missing-docstring
+            reddit_obj = func(*args, **kwargs)
+            try:
+                indexing_func(reddit_obj)
+            except Exception:  # pylint: disable=broad-except
+                log.exception('Error occurred while trying to serialize and index PRAW object')
+            return reddit_obj
+        return wrapped_api_func
+    return api_indexing_listener_inner
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def index_full_post(post_obj):
+    """
+    Serializes a post object and runs a task to create an ES document for it.
+
+    Args:
+        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
+    """
+    data = {
+        'object_type': POST_TYPE,
+        'author': post_obj.author.name,
+        'channel_title': post_obj.subreddit.display_name,
+        'text': post_obj.selftext,
+        'score': post_obj.score,
+        'created': post_obj.created,
+        'post_id': post_obj.id,
+        'post_title': post_obj.title,
+        'num_comments': post_obj.num_comments,
+    }
+    return create_document.delay(
+        gen_post_id(post_obj.id),
+        data
+    )
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def update_post_text(post_obj):
+    """
+    Serializes post object text and runs a task to update the text for the associated ES document.
+
+    Args:
+        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
+    """
+    return update_document_with_partial.delay(
+        gen_post_id(post_obj.id),
+        {'text': post_obj.selftext}
+    )
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def update_post_removal_status(post_obj):
+    """
+    Serializes the removal status for a post object and runs a task to update that status
+    for the associated ES document.
+
+    Args:
+        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
+    """
+    return update_document_with_partial.delay(
+        gen_post_id(post_obj.id),
+        {'removed': bool(post_obj.banned_by) and not post_obj.approved_by}
+    )
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def _update_post_comment_count(comment_obj, incr_amount=1):
+    """
+    Updates the comment count for a post object (retrieved via a comment object)
+    and runs a task to update that count for the associated ES document.
+
+    Args:
+        comment_obj (praw.models.reddit.comment.Comment): A PRAW comment object
+        incr_amount (int): The amount to increment to count
+    """
+    post_obj = comment_obj.submission
+    return increment_document_integer_field.delay(
+        gen_post_id(post_obj.id),
+        field_name='num_comments',
+        incr_amount=incr_amount
+    )
+
+
+increment_post_comment_count = partial(_update_post_comment_count, incr_amount=1)
+decrement_post_comment_count = partial(_update_post_comment_count, incr_amount=-1)
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def update_indexed_score(instance, instance_type, vote_action):
+    """
+    Serializes the score for a PRAW object (comment or post) and runs a task to update
+    that score for the associated ES document.
+
+    Args:
+        instance: A PRAW Comment or Submission (a.k.a. post) object
+        instance_type (str): A string indicating the type of object being passed in
+        vote_action (VoteActions): A value indicating what kind of vote action was taken
+    """
+    if vote_action in (VoteActions.UPVOTE, VoteActions.CLEAR_DOWNVOTE):
+        vote_increment = 1
+    elif vote_action in (VoteActions.DOWNVOTE, VoteActions.CLEAR_UPVOTE):
+        vote_increment = -1
+    else:
+        raise ValueError('Received an invalid vote action value: %s', vote_action)
+
+    if instance_type != POST_TYPE:
+        return
+    return increment_document_integer_field.delay(
+        gen_post_id(instance.id),
+        field_name='score',
+        incr_amount=vote_increment
+    )

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -1,0 +1,160 @@
+"""Task helper tests"""
+# pylint: disable=redefined-outer-name
+from types import SimpleNamespace
+import pytest
+
+from open_discussions.features import INDEX_UPDATES
+from channels.constants import (
+    POST_TYPE,
+    VoteActions,
+)
+from search.task_helpers import (
+    reddit_object_indexer,
+    index_full_post,
+    update_post_text,
+    update_post_removal_status,
+    increment_post_comment_count,
+    decrement_post_comment_count,
+    update_indexed_score,
+)
+from search.indexing_api import gen_post_id
+
+
+@pytest.fixture(autouse=True)
+def enable_index_update_feature(settings):
+    """Enables the INDEX_UPDATES feature by default"""
+    settings.FEATURES[INDEX_UPDATES] = True
+
+
+@pytest.fixture()
+def reddit_submission_obj():  # pylint: disable=missing-docstring
+    return SimpleNamespace(
+        author=SimpleNamespace(name='Test User'),
+        subreddit=SimpleNamespace(display_name='channel_1'),
+        selftext='Body text',
+        score=1,
+        created=12345,
+        id='a',
+        title='Post Title',
+        num_comments=1
+    )
+
+
+@pytest.fixture()
+def reddit_comment_obj():  # pylint: disable=missing-docstring
+    return SimpleNamespace(
+        submission=SimpleNamespace(id=1)
+    )
+
+
+def test_reddit_object_indexer(mocker):
+    """
+    Test that a function decorated with reddit_object_indexer receives the return value
+    of the decorated function, passes it to a provided function, and returns the value
+    as normal.
+    """
+    def mock_indexer(reddit_obj):  # pylint: disable=missing-docstring
+        reddit_obj.changed = True
+
+    @reddit_object_indexer(indexing_func=mock_indexer)
+    def decorated_api_func(mock_reddit_obj):  # pylint: disable=missing-docstring
+        return mock_reddit_obj
+
+    mock_reddit_obj = mocker.Mock()
+    reddit_obj = decorated_api_func(mock_reddit_obj)
+    assert reddit_obj.changed is True
+    assert reddit_obj == mock_reddit_obj
+
+
+def test_index_full_post(mocker, reddit_submission_obj):
+    """
+    Test that index_full_post calls the indexing task with the right parameters
+    """
+    patched_task = mocker.patch('search.task_helpers.create_document')
+    index_full_post(reddit_submission_obj)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[0] == (
+        gen_post_id(reddit_submission_obj.id),
+        {
+            'object_type': POST_TYPE,
+            'post_id': reddit_submission_obj.id,
+            'author': reddit_submission_obj.author.name,
+            'channel_title': reddit_submission_obj.subreddit.display_name,
+            'text': reddit_submission_obj.selftext,
+            'score': reddit_submission_obj.score,
+            'created': reddit_submission_obj.created,
+            'post_title': reddit_submission_obj.title,
+            'num_comments': reddit_submission_obj.num_comments,
+        }
+    )
+
+
+def test_update_post_text(mocker, reddit_submission_obj):
+    """
+    Test that update_post_text calls the indexing task with the right parameters
+    """
+    patched_task = mocker.patch('search.task_helpers.update_document_with_partial')
+    update_post_text(reddit_submission_obj)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[0] == (
+        gen_post_id(reddit_submission_obj.id),
+        {'text': reddit_submission_obj.selftext}
+    )
+
+
+@pytest.mark.parametrize('banned_by,approved_by,expected_removed', [
+    ('some_username', None, True),
+    (None, 'some_username', False),
+    ('some_username', 'some_username', False),
+])
+def test_update_post_removal_status(mocker, reddit_submission_obj, banned_by, approved_by, expected_removed):
+    """
+    Test that update_post_removal_status calls the indexing task with the right parameters
+    """
+    patched_task = mocker.patch('search.task_helpers.update_document_with_partial')
+    reddit_submission_obj.banned_by = banned_by
+    reddit_submission_obj.approved_by = approved_by
+    update_post_removal_status(reddit_submission_obj)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[0] == (
+        gen_post_id(reddit_submission_obj.id),
+        {'removed': expected_removed}
+    )
+
+
+@pytest.mark.parametrize('update_comment_count_func,expected_increment', [
+    (increment_post_comment_count, 1),
+    (decrement_post_comment_count, -1),
+])
+def test_update_post_comment_count(mocker, reddit_comment_obj, update_comment_count_func, expected_increment):
+    """
+    Test that update_post_removal_status calls the indexing task with the right parameters
+    """
+    patched_task = mocker.patch('search.task_helpers.increment_document_integer_field')
+    update_comment_count_func(reddit_comment_obj)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[0] == (gen_post_id(reddit_comment_obj.submission.id), )
+    assert patched_task.delay.call_args[1] == {
+        'field_name': 'num_comments',
+        'incr_amount': expected_increment
+    }
+
+
+@pytest.mark.parametrize('vote_action,expected_increment', [
+    (VoteActions.UPVOTE, 1),
+    (VoteActions.CLEAR_DOWNVOTE, 1),
+    (VoteActions.DOWNVOTE, -1),
+    (VoteActions.CLEAR_UPVOTE, -1),
+])
+def test_update_indexed_score(mocker, reddit_submission_obj, vote_action, expected_increment):
+    """
+    Test that update_indexed_score calls the indexing task with the right parameters
+    """
+    patched_task = mocker.patch('search.task_helpers.increment_document_integer_field')
+    update_indexed_score(reddit_submission_obj, POST_TYPE, vote_action=vote_action)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[0] == (gen_post_id(reddit_submission_obj.id), )
+    assert patched_task.delay.call_args[1] == {
+        'field_name': 'score',
+        'incr_amount': expected_increment
+    }

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -1,0 +1,37 @@
+"""Indexing tasks"""
+import logging
+from elasticsearch.exceptions import NotFoundError
+
+from search import indexing_api as api
+from open_discussions.celery import app
+
+
+log = logging.getLogger(__name__)
+
+# For our tasks that attempt to partially update a document, there's a chance that
+# the document has not yet been created. When we get an error that indicates that the
+# document doesn't exist for the given ID, we will retry a few times in case there is
+# a waiting task to create the document.
+PARTIAL_UPDATE_TASK_SETTINGS = dict(
+    autoretry_for=(NotFoundError,),
+    retry_kwargs={'max_retries': 5},
+    default_retry_delay=2
+)
+
+
+@app.task
+def create_document(doc_id, data):
+    """Task that makes a request to create an ES document"""
+    api.create_document(doc_id, data)
+
+
+@app.task(**PARTIAL_UPDATE_TASK_SETTINGS)
+def update_document_with_partial(doc_id, partial_data):
+    """Task that makes a request to update an ES document with a partial document"""
+    api.update_document_with_partial(doc_id, partial_data)
+
+
+@app.task(**PARTIAL_UPDATE_TASK_SETTINGS)
+def increment_document_integer_field(doc_id, field_name, incr_amount):
+    """Task that makes a request to increment some integer field in an ES document"""
+    api.increment_document_integer_field(doc_id, field_name, incr_amount)

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -1,0 +1,42 @@
+"""Search task tests"""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from search.tasks import (
+    create_document,
+    update_document_with_partial,
+    increment_document_integer_field,
+)
+
+
+@pytest.fixture()
+def mocked_api(mocker):
+    """Mock object that patches the channels API"""
+    return mocker.patch('search.tasks.api')
+
+
+def test_create_document_task(mocked_api):
+    """Test that the create_document task calls the indexing API function with the right args"""
+    indexing_api_args = ('doc_id', {'test': 'data'})
+    create_document(*indexing_api_args)
+    assert mocked_api.create_document.call_count == 1
+    assert mocked_api.create_document.call_args[0] == indexing_api_args
+
+
+def test_update_document_with_partial_task(mocked_api):
+    """Test that the create_document task calls the indexing API function with the right args"""
+    indexing_api_args = ('doc_id', {'test': 'data'})
+    update_document_with_partial(*indexing_api_args)
+    assert mocked_api.update_document_with_partial.call_count == 1
+    assert mocked_api.update_document_with_partial.call_args[0] == indexing_api_args
+
+
+def test_increment_document_integer_field_task(mocked_api):
+    """
+    Test that the increment_document_integer_field task calls the indexing
+    API function with the right args
+    """
+    indexing_api_args = ('doc_id', {'test': 'data'}, 1)
+    increment_document_integer_field(*indexing_api_args)
+    assert mocked_api.increment_document_integer_field.call_count == 1
+    assert mocked_api.increment_document_integer_field.call_args[0] == indexing_api_args


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #605

#### What's this PR do?
- Adds the elasticsearch document mapping, as well as a function that clears and creates the index in ES
- Wraps various channel API methods to make changes to the index when there are changes made to the information that we index for posts (and only posts)

#### How should this be manually tested?
- Enable the `INDEX_UPDATES` feature (i.e.: add `FEATURE_INDEX_UPDATES=true` to your `.env`)
- Run `search.indexing_api.clear_and_create_index` in a Django shell
- Create posts and alter posts in different ways (changing text, adding comments, upvoting/downvoting)
- Query the index and confirm that those changes are reflected in the indexed document (or that the document was created if it's a new post)

An easy curl command to inspect the documents in the index:
```bash
curl -XGET -s 'http://localhost:9101/discussions_local/_search?pretty=true&filter_path=hits.hits._id,hits.hits._source&sort=created:desc'
```

#### Where should the reviewer start?
Probably `channels/api.py`

#### Any background context you want to provide?
- This PR does not add a search UI or add any querying capability. That can and should be done in a separate issue.
- This PR does not index changes to comments. That can also be done in a separate PR.
- `search/connection.py` was copied from Micromasters. If we want to make any changes to that connection logic we can, but worth pointing out that it's copied
