### PR TITLE
Don't HTML escape subject lines for frontpage emails

### DIFF
--- a/mail/templates/comments/subject.txt
+++ b/mail/templates/comments/subject.txt
@@ -1,1 +1,1 @@
-[{{ post.channel_title }}] {% if is_comment_reply %}Reply to your comment "{{ parent.text|truncatechars:20 }}"{% else %} Reply to {{ post.title }}{% endif %}
+[{{ post.channel_title|safe }}] {% if is_comment_reply %}Reply to your comment "{{ parent.text|truncatechars:20|safe }}"{% else %} Reply to {{ post.title|safe }}{% endif %}

--- a/mail/templates/frontpage/subject.txt
+++ b/mail/templates/frontpage/subject.txt
@@ -1,1 +1,1 @@
-{{ posts.0.title }}
+{{ posts.0.title|safe }}

--- a/notifications/notifiers/frontpage_test.py
+++ b/notifications/notifiers/frontpage_test.py
@@ -103,7 +103,7 @@ def test_send_notification(mocker):
     serializer_mock = mocker.patch('channels.serializers.PostSerializer')
     serializer_mock.return_value.data = {
         'id': 1,
-        'title': 'post title',
+        'title': 'post\'s title',
         'channel_name': 'micromasters',
         'channel_title': 'MicroMasters',
         'created': now_in_utc().isoformat(),
@@ -127,6 +127,7 @@ def test_send_notification(mocker):
     })
 
     send_messages_mock.assert_called_once_with([any_instance_of(EmailMessage)])
+    assert send_messages_mock.call_args[0][0][0].subject == 'post\'s title'
 
 
 def test_send_notification_no_posts(mocker):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #611 

#### What's this PR do?
Ensures the frontpage digest subject lines aren't html escaped

#### How should this be manually tested?
This is pretty simple so the test coverage should be sufficient (the `'` would be escaped to `&apos;` in master branch).