### PR TITLE
add link preview to link post creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-asserts": "^0.0.10",
+    "redux-debounced": "^0.5.0",
     "redux-hammock": "^0.2.3",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom"
 
 import Card from "../components/Card"
 import { ChannelBreadcrumbs } from "../components/ChannelBreadcrumbs"
+import Embedly from "./Embedly"
 
 import { CONTENT_POLICY_URL } from "../lib/url"
 import { goBackAndHandleEvent } from "../lib/util"
@@ -21,7 +22,8 @@ type CreatePostFormProps = {
   history: Object,
   processing: boolean,
   channels: Map<string, Channel>,
-  updateChannelSelection: Function
+  updateChannelSelection: Function,
+  embedly: Object
 }
 
 const channelOptions = (channels: Map<string, Channel>) =>
@@ -45,7 +47,8 @@ export default class CreatePostForm extends React.Component<*, void> {
       processing,
       channels,
       updateChannelSelection,
-      validation
+      validation,
+      embedly
     } = this.props
     if (!postForm) {
       return null
@@ -107,6 +110,14 @@ export default class CreatePostForm extends React.Component<*, void> {
                 />
                 {validationMessage(validation.url)}
               </div>}
+            {!isText && embedly
+              ? <div className="embedly-preview row">
+                <div className="preview-header">
+                    this is a preview of your post
+                </div>
+                <Embedly embedly={embedly} />
+              </div>
+              : null}
             <div className="row channel-select">
               <label>Channel</label>
               <select

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -1,0 +1,34 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import CreatePostForm from "./CreatePostForm"
+import Embedly from "./Embedly"
+
+import { makeArticle } from "../factories/embedly"
+
+describe("CreatePostForm", () => {
+  it("should show an embedly preview when link post and passed an embedly object", () => {
+    [
+      [true, true, makeArticle()],
+      [false, false, makeArticle()],
+      [true, false, undefined],
+      [false, false, undefined]
+    ].forEach(([linkPost, shouldShowEmbed, embedlyResponse]) => {
+      const form = {
+        isText: !linkPost,
+        title:  "title"
+      }
+      const wrapper = shallow(
+        <CreatePostForm
+          postForm={form}
+          embedly={embedlyResponse}
+          validation={{}}
+          channels={[]}
+        />
+      )
+      assert.equal(shouldShowEmbed, wrapper.find(Embedly).exists())
+    })
+  })
+})

--- a/static/js/reducers/embedly.js
+++ b/static/js/reducers/embedly.js
@@ -12,7 +12,7 @@ type EmbedlyData = Map<string, Object>
 export const embedlyEndpoint = {
   name:              "embedly",
   verbs:             [GET],
-  getFunc:           api.getEmbedly,
+  getFunc:           (url: string) => api.getEmbedly(url),
   getSuccessHandler: (
     payload: EmbedlyResponse,
     data: EmbedlyData

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -2,19 +2,20 @@
 import { compose, createStore, applyMiddleware } from "redux"
 import thunkMiddleware from "redux-thunk"
 import { createLogger } from "redux-logger"
+import createDebounce from "redux-debounced"
 
 import rootReducer from "../reducers"
 
 let createStoreWithMiddleware
 if (process.env.NODE_ENV !== "production") {
   createStoreWithMiddleware = compose(
-    applyMiddleware(thunkMiddleware, createLogger()),
+    applyMiddleware(createDebounce(), thunkMiddleware, createLogger()),
     window.devToolsExtension ? window.devToolsExtension() : f => f
   )(createStore)
 } else {
-  createStoreWithMiddleware = compose(applyMiddleware(thunkMiddleware))(
-    createStore
-  )
+  createStoreWithMiddleware = compose(
+    applyMiddleware(createDebounce(), thunkMiddleware)
+  )(createStore)
 }
 
 export default function configureStore(initialState: Object) {

--- a/static/scss/createPost.scss
+++ b/static/scss/createPost.scss
@@ -1,5 +1,19 @@
 .new-post-card {
   .card-contents {
+    .embedly-preview {
+      max-width: 770px;
+
+      .preview-header {
+        font-size: 14px;
+        font-style: italic;
+        color: $font-grey;
+        padding-bottom: 10px;
+
+        @include breakpoint(desktopwide) {
+          padding-bottom: 0;
+        }
+      }
+    }
 
     .post-types {
       display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6060,6 +6060,10 @@ redux-asserts@^0.0.10:
     redux "^3.3.1"
     redux-thunk "^2.0.1"
 
+redux-debounced@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/redux-debounced/-/redux-debounced-0.5.0.tgz#4dde27a3e66ea428afe78215f30a27f22714605b"
+
 redux-hammock@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/redux-hammock/-/redux-hammock-0.2.3.tgz#0235e8657d4808c6a9c9d25bdf367b2e3f0714f2"


### PR DESCRIPTION
#### What are the relevant tickets?

part of #604 
closes #694 

#### What's this PR do?

This adds a preview display to the link post creation form, which shows you what the embedly embed (ha) for your link will look like when it's posted.

#### How should this be manually tested?

Making a text post should work like normal. If you make a link post, when you add a URL to the form, or change the URL, a rich embed thingy like this should pop up:

![fjfjasdfasdf](https://user-images.githubusercontent.com/6207644/39777520-bca6d37e-52d1-11e8-9c52-ac090a0ee1a2.png)

changing the URL should cause the preview to change.