### PR TITLE
remove settings and post link for anonymous users

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -6,6 +6,7 @@ import SubscriptionsList from "./SubscriptionsList"
 import UserInfo from "./UserInfo"
 
 import { newPostURL, getChannelNameFromPathname } from "../lib/url"
+import { userIsAnonymous } from "../lib/util"
 
 import type { Channel } from "../flow/discussionTypes"
 
@@ -22,19 +23,23 @@ const Navigation = (props: NavigationProps) => {
   return (
     <div className="navigation">
       <UserInfo />
-      <Link
-        className="mdc-button mdc-button--raised blue-button"
-        to={newPostURL(channelName)}
-      >
-        Submit a New Post
-      </Link>
+      {userIsAnonymous()
+        ? null
+        : <Link
+          className="mdc-button mdc-button--raised blue-button"
+          to={newPostURL(channelName)}
+        >
+            Submit a New Post
+        </Link>}
       <SubscriptionsList
         currentChannel={channelName}
         subscribedChannels={subscribedChannels}
       />
-      <Link className="settings-link" to="/settings">
-        Settings
-      </Link>
+      {userIsAnonymous()
+        ? null
+        : <Link className="settings-link" to="/settings">
+            Settings
+        </Link>}
     </div>
   )
 }

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -3,6 +3,7 @@ import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 import { Link } from "react-router-dom"
+import sinon from "sinon"
 
 import Navigation from "./Navigation"
 import SubscriptionsList from "./SubscriptionsList"
@@ -10,8 +11,21 @@ import UserInfo from "./UserInfo"
 
 import { newPostURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
+import * as util from "../lib/util"
 
 describe("Navigation", () => {
+  let sandbox, userIsAnonymousStub
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    userIsAnonymousStub = sandbox.stub(util, "userIsAnonymous")
+    userIsAnonymousStub.returns(false)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   const defaultProps = { pathname: "/", subscribedChannels: [] }
   const renderComponent = (props = defaultProps) =>
     shallow(<Navigation {...props} />)
@@ -32,6 +46,12 @@ describe("Navigation", () => {
     const link = wrapper.find(Link).first()
     assert.equal(link.props().to, newPostURL("foobar"))
     assert.equal(link.props().children, "Submit a New Post")
+  })
+
+  it("should not show the create post link if an anonymous user", () => {
+    userIsAnonymousStub.returns(true)
+    const wrapper = renderComponent()
+    assert.isNotOk(wrapper.find(".mdc-button").exists())
   })
 
   it("should show a SubscriptionsList", () => {
@@ -68,5 +88,11 @@ describe("Navigation", () => {
     assert.equal(children, "Settings")
     assert.equal(className, "settings-link")
     assert.equal(to, "/settings")
+  })
+
+  it("should hide the link to settings, if the user is anonymous", () => {
+    userIsAnonymousStub.returns(true)
+    const wrapper = renderComponent()
+    assert.isNotOk(wrapper.find(".settings-link").exists())
   })
 })

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -8,7 +8,7 @@ declare var SETTINGS: {
   FEATURES: {
     [key: string]: boolean,
   },
-  username: string,
+  username: ?string,
   user_full_name: ?string,
   profile_image_small: ?string,
   authenticated_site: {

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -26,5 +26,5 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
 
 export const isModerator = (
   moderators: ChannelModerators,
-  username: string
+  username: ?string
 ): boolean => R.any(R.propEq("moderator_name", username), moderators || [])

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import R from "ramda"
 
 import type { Match } from "react-router"
@@ -46,3 +47,5 @@ export const preventDefaultAndInvoke = R.curry(
     invokee()
   }
 )
+
+export const userIsAnonymous = () => R.isNil(SETTINGS.username)

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -1,8 +1,15 @@
 // @flow
+/* global SETTINGS:false */
 import sinon from "sinon"
 import { assert } from "chai"
 
-import { wait, enumerate, isEmptyText, preventDefaultAndInvoke } from "./util"
+import {
+  wait,
+  enumerate,
+  isEmptyText,
+  preventDefaultAndInvoke,
+  userIsAnonymous
+} from "./util"
 
 describe("utility functions", () => {
   it("waits some milliseconds", done => {
@@ -59,5 +66,12 @@ describe("utility functions", () => {
 
     sinon.assert.calledWith(invokee)
     sinon.assert.calledWith(event.preventDefault)
+  })
+
+  it("should check if SETTINGS.username is nil", () => {
+    [[null, true], ["username", false]].forEach(([username, expectation]) => {
+      SETTINGS.username = username
+      assert.equal(userIsAnonymous(), expectation)
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #659 
closes #657

#### What's this PR do?

This hides the settings link in the navigation component if the user is anonymous.

#### How should this be manually tested?

If you're not an anonymous user you should see the settings link in the left-hand-side nav, as before. If you are anonymous, you shouldn't see it!