### PR TITLE
hide reporting UI for anonymous users

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -12,7 +12,7 @@ import CommentVoteForm from "./CommentVoteForm"
 import CommentRemovalForm from "./CommentRemovalForm"
 import { renderTextContent } from "./Markdown"
 
-import { preventDefaultAndInvoke } from "../lib/util"
+import { preventDefaultAndInvoke, userIsAnonymous } from "../lib/util"
 import {
   replyToCommentKey,
   editCommentKey,
@@ -188,7 +188,7 @@ export default class CommentTree extends React.Component<*, *> {
               approve={approve}
               isModerator={isModerator}
             />
-            {moderationUI
+            {moderationUI || userIsAnonymous()
               ? null
               : <div
                 className="comment-action-button report-button"

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -154,6 +154,13 @@ describe("CommentTree", () => {
     assert.ok(reportCommentStub.calledWith(comments[0]))
   })
 
+  it('should hide the "report" button for anons', () => {
+    SETTINGS.username = null
+    assert.isNotOk(
+      renderCommentTree().find(".comment-action-button.report-button").exists()
+    )
+  })
+
   it('should include an "Edit" button, if the user wrote the comment', () => {
     SETTINGS.username = comments[0].author_id
     const wrapper = renderCommentTree()

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -10,6 +10,7 @@ import {
   formatPostTitle,
   PostVotingButtons
 } from "../lib/posts"
+import { userIsAnonymous } from "../lib/util"
 
 import type { Post } from "../flow/discussionTypes"
 
@@ -86,7 +87,9 @@ class CompactPostDisplay extends React.Component<*, void> {
                   ignore all reports
               </a>
               : null}
-            <a onClick={() => reportPost(post)}>report</a>
+            {!userIsAnonymous()
+              ? <a onClick={() => reportPost(post)}>report</a>
+              : null}
           </div>
         </div>
       </div>

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { assert } from "chai"
 import { mount } from "enzyme"
@@ -98,6 +99,13 @@ describe("CompactPostDisplay", () => {
     const link = wrapper.find({ children: "report" })
     link.props().onClick()
     assert.ok(reportPost.called)
+  })
+
+  it("should hide the report link for anon users", () => {
+    SETTINGS.username = null
+    const wrapper = renderPostDisplay({ post })
+    const link = wrapper.find({ children: "report" })
+    assert.isNotOk(link.exists())
   })
 
   it("should set a class if stickied and showing pin ui", () => {

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -9,7 +9,7 @@ import { renderTextContent } from "./Markdown"
 import Embedly from "./Embedly"
 
 import { formatPostTitle, PostVotingButtons } from "../lib/posts"
-import { preventDefaultAndInvoke } from "../lib/util"
+import { preventDefaultAndInvoke, userIsAnonymous } from "../lib/util"
 import { editPostKey } from "../components/CommentForms"
 
 import type { Post } from "../flow/discussionTypes"
@@ -127,12 +127,14 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             <a href="#">approve</a>
           </div>
           : null}
-        <div
-          className="comment-action-button report-post"
-          onClick={showPostReportDialog}
-        >
-          <a href="#">report</a>
-        </div>
+        {!userIsAnonymous()
+          ? <div
+            className="comment-action-button report-post"
+            onClick={showPostReportDialog}
+          >
+            <a href="#">report</a>
+          </div>
+          : null}
       </div>
     )
   }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -13,7 +13,8 @@ const _createSettings = () => ({
     session_url: "http://fake.session.url",
     tos_url:     "http://fake.tos.url/"
   },
-  allow_anonymous: false
+  allow_anonymous: false,
+  username:        "greatusername"
 })
 
 global.SETTINGS = _createSettings()


### PR DESCRIPTION
#### What are the relevant tickets?

closes #686 

#### What's this PR do?

This hides the report buttons for comments and posts for anonymous users.

#### How should this be manually tested?

Check that a report button shows up when you're logged in, and is absent when you're not, in these three places:

- a post in an index view (frontpage or channel view)
- a post in a detail view
- a comment on a post