### PR TITLE
allow anonymous users to hit the embedly API

### DIFF
--- a/embedly/views.py
+++ b/embedly/views.py
@@ -1,15 +1,17 @@
 """Embed.ly views"""
 from urllib.parse import unquote
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
 from django.conf import settings
 
 from embedly.api import get_embedly
+from open_discussions.permissions import AnonymousAccessReadonlyPermission
 
 
 @api_view()
+@permission_classes([AnonymousAccessReadonlyPermission])
 def embedly_view(request, **kwargs):  # pylint: disable=unused-argument
     """get Embedly API, return the JSON"""
     if settings.EMBEDLY_KEY:

--- a/embedly/views_test.py
+++ b/embedly/views_test.py
@@ -1,6 +1,10 @@
 """tests for the embedly views"""
+import pytest
+
 from django.core.urlresolvers import reverse
 from rest_framework import status
+
+from open_discussions.features import ANONYMOUS_ACCESS
 
 
 def test_get_embedly(client, user, mocker, settings):
@@ -31,3 +35,26 @@ def test_get_embedly_no_key(client, user, settings):
     resp = client.get(embedly_url)
     assert resp.json() == {}
     assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("allow_anonymous", [True, False])
+def test_get_embedly_anon(client, mocker, settings, allow_anonymous):
+    """test that an anonymous user can get embedly"""
+    settings.FEATURES[ANONYMOUS_ACCESS] = allow_anonymous
+    settings.EMBEDLY_KEY = 'a great key'
+    embedly_url = reverse('embedly-detail', kwargs={
+        "url": "https%253A%252F%252Fen.wikipedia.org%252Fwiki%252FGiant_panda/"
+    })
+    embed_return_value = mocker.Mock()
+    embed_return_value.configure_mock(**{
+        'json.return_value': {'some': 'json'}
+    })
+    get_stub = mocker.patch('embedly.views.get_embedly', return_value=embed_return_value)
+    resp = client.get(embedly_url)
+
+    if allow_anonymous:
+        assert resp.json() == {'some': 'json'}
+        assert resp.status_code == status.HTTP_200_OK
+        get_stub.assert_called_once_with("https://en.wikipedia.org/wiki/Giant_panda/")
+    else:
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
#### What are the relevant tickets?

closes #703

#### What's this PR do?

This sets the permission class on the Embedly API to use the `AnonymousAccessReadonlyPermission` which we're using elsewhere.

#### How should this be manually tested?

If you're logged in, things should be normal. If you're not logged in, you should be able to view a link post on a public channel. It shouldn't redirect you to log-in (b/c of a 401) and you should be able to see the rich embed content.