### PR TITLE
Increased uwsgi buffer size

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -39,3 +39,4 @@ endif =
 if-not-env = UWSGI_SOCKET_TIMEOUT
 socket-timeout = 3
 endif =
+buffer-size = 65535


### PR DESCRIPTION
Fixes #529 

#### What's this PR do?
Increases the uwsgi buffer size. Same change we did over in MM: https://github.com/mitodl/micromasters/pull/3887/commits/91e820c5a3a14d9b0586fb3f5c8b127847c9e637

#### How should this be manually tested?
Ensure that uwsgi starts without error and that you can still use the app.