### PR TITLE
hide comment UI from anonymous users

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -39,7 +39,12 @@ import {
   toggleFollowPost,
   toggleFollowComment
 } from "../util/api_actions"
-import { getChannelName, getPostID, getCommentID } from "../lib/util"
+import {
+  getChannelName,
+  getPostID,
+  getCommentID,
+  userIsAnonymous
+} from "../lib/util"
 import { isModerator } from "../lib/channels"
 import {
   anyErrorExcept404,
@@ -389,7 +394,7 @@ class PostPage extends React.Component<*, void> {
               toggleFollowPost={toggleFollowPost(dispatch)}
               embedly={embedly}
             />
-            {showPermalinkUI
+            {showPermalinkUI || userIsAnonymous()
               ? null
               : <ReplyToPostForm
                 forms={forms}


### PR DESCRIPTION
#### What are the relevant tickets?

closes #688 

#### What's this PR do?

This PR hides the comment form (`ReplyToPostForm`) when the user is anonymous.

#### How should this be manually tested?

Ensure that logged-in users get the normal experience. Ensure that anonymous users don't see a form for leaving a comment under the post, so it should look like this:

![nocomm](https://user-images.githubusercontent.com/6207644/40131239-7005624c-5907-11e8-92b8-ae1b180e5f51.png)