### PR TITLE
hide reply and follow buttons for anonymous users

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -54,6 +54,27 @@ type CommentTreeProps = {
 export default class CommentTree extends React.Component<*, *> {
   props: CommentTreeProps
 
+  renderFollowButton = (comment: CommentInTree) => {
+    const { toggleFollowComment } = this.props
+    return comment.subscribed
+      ? <div
+        className="comment-action-button subscribe-comment subscribed"
+        onClick={preventDefaultAndInvoke(() => {
+          toggleFollowComment(comment)
+        })}
+      >
+        <a href="#">unfollow</a>
+      </div>
+      : <div
+        className="comment-action-button subscribe-comment unsubscribed"
+        onClick={preventDefaultAndInvoke(() => {
+          toggleFollowComment(comment)
+        })}
+      >
+        <a href="#">follow</a>
+      </div>
+  }
+
   renderComment = (depth: number, comment: CommentInTree) => {
     const {
       forms,
@@ -68,8 +89,7 @@ export default class CommentTree extends React.Component<*, *> {
       reportComment,
       commentPermalink,
       moderationUI,
-      ignoreCommentReports,
-      toggleFollowComment
+      ignoreCommentReports
     } = this.props
     const formKey = replyToCommentKey(comment)
     const editFormKey = editCommentKey(comment)
@@ -117,7 +137,7 @@ export default class CommentTree extends React.Component<*, *> {
               upvote={upvote}
               downvote={downvote}
             />
-            {atMaxDepth || moderationUI || comment.deleted
+            {atMaxDepth || moderationUI || comment.deleted || userIsAnonymous()
               ? null
               : <div
                 className="comment-action-button reply-button"
@@ -127,23 +147,7 @@ export default class CommentTree extends React.Component<*, *> {
               >
                 <a href="#">reply</a>
               </div>}
-            {comment.subscribed
-              ? <div
-                className="comment-action-button subscribe-comment subscribed"
-                onClick={preventDefaultAndInvoke(() => {
-                  toggleFollowComment(comment)
-                })}
-              >
-                <a href="#">unfollow</a>
-              </div>
-              : <div
-                className="comment-action-button subscribe-comment unsubscribed"
-                onClick={preventDefaultAndInvoke(() => {
-                  toggleFollowComment(comment)
-                })}
-              >
-                <a href="#">follow</a>
-              </div>}
+            {userIsAnonymous() ? null : this.renderFollowButton(comment)}
             {comment.num_reports
               ? <div className="comment-action-button report-count">
                   Reports: {comment.num_reports}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -22,6 +22,7 @@ import { makeCommentsResponse, makeMoreComments } from "../factories/comments"
 import { makePost } from "../factories/posts"
 import { createCommentTree } from "../reducers/comments"
 import { makeCommentReport } from "../factories/reports"
+import * as utilFuncs from "../lib/util"
 
 describe("CommentTree", () => {
   let comments,
@@ -154,10 +155,24 @@ describe("CommentTree", () => {
     assert.ok(reportCommentStub.calledWith(comments[0]))
   })
 
+  it("should hide the report button if userIsAnonymous", () => {
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    assert.isNotOk(renderCommentTree().find(".report-button").exists())
+  })
+
   it('should hide the "report" button for anons', () => {
-    SETTINGS.username = null
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
     assert.isNotOk(
       renderCommentTree().find(".comment-action-button.report-button").exists()
+    )
+  })
+
+  it("should hide the 'follow' button for anons", () => {
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    assert.isNotOk(
+      renderCommentTree()
+        .find(".comment-action-button.subscribe-comment")
+        .exists()
     )
   })
 

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -55,10 +55,30 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
     removePost(post)
   }
 
+  postSubscriptionButton = () => {
+    const { toggleFollowPost, post } = this.props
+    return post.subscribed
+      ? <div
+        className="comment-action-button subscribe-post subscribed"
+        onClick={preventDefaultAndInvoke(() => {
+          toggleFollowPost(post)
+        })}
+      >
+        <a href="#">unfollow</a>
+      </div>
+      : <div
+        className="comment-action-button subscribe-post unsubscribed"
+        onClick={preventDefaultAndInvoke(() => {
+          toggleFollowPost(post)
+        })}
+      >
+        <a href="#">follow</a>
+      </div>
+  }
+
   postActionButtons = () => {
     const {
       toggleUpvote,
-      toggleFollowPost,
       post,
       beginEditing,
       isModerator,
@@ -94,23 +114,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             <a href="#">delete</a>
           </div>
           : null}
-        {post.subscribed
-          ? <div
-            className="comment-action-button subscribe-post subscribed"
-            onClick={preventDefaultAndInvoke(() => {
-              toggleFollowPost(post)
-            })}
-          >
-            <a href="#">unfollow</a>
-          </div>
-          : <div
-            className="comment-action-button subscribe-post unsubscribed"
-            onClick={preventDefaultAndInvoke(() => {
-              toggleFollowPost(post)
-            })}
-          >
-            <a href="#">follow</a>
-          </div>}
+        {userIsAnonymous() ? null : this.postSubscriptionButton()}
         {isModerator && !post.removed
           ? <div
             className="comment-action-button remove-post"

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -15,6 +15,7 @@ import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
 import { editPostKey } from "../components/CommentForms"
+import * as utilFuncs from "../lib/util"
 
 describe("ExpandedPostDisplay", () => {
   let helper,
@@ -186,6 +187,22 @@ describe("ExpandedPostDisplay", () => {
     const wrapper = renderPostDisplay({ post })
     wrapper.find(".edit-post").at(0).simulate("click")
     assert.ok(beginEditingStub.called)
+  })
+
+  it("should hide the report link for anonymous users", () => {
+    const post = makePost()
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    const wrapper = renderPostDisplay({ post })
+    assert.isNotOk(wrapper.find(".comment-action-button.report-post").exists())
+  })
+
+  it("should hide the follow link for anonymous users", () => {
+    const post = makePost()
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    const wrapper = renderPostDisplay({ post })
+    assert.isNotOk(
+      wrapper.find(".comment-action-button.subscribe-post").exists()
+    )
   })
 
   it("should hide post action buttons when editing", () => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #689 
closes #690 

#### What's this PR do?

This hides the follow / unfollow and reply buttons if the user is anonymous. I decided to just throw those in one PR since they were both very small changes.

#### How should this be manually tested?

Make sure that you can follow / unfollow a comment or post as normal, and that the reply button allows you to reply to a comment. Then make sure that the follow and reply buttons are hidden, on both posts and comments.