### PR TITLE
fix issue with not fetching subscriptions when navigating from settings

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -58,6 +58,17 @@ class App extends React.Component<*, void> {
     this.loadData()
   }
 
+  componentDidUpdate(prevProps) {
+    const { location: { pathname } } = this.props
+
+    if (
+      !pathname.startsWith(SETTINGS_URL) &&
+      prevProps.location.pathname.startsWith(SETTINGS_URL)
+    ) {
+      this.loadData()
+    }
+  }
+
   loadData = async () => {
     const { dispatch } = this.props
 


### PR DESCRIPTION
#### What are the relevant tickets?

closes #684 

#### What's this PR do?

This fixes an issue with the logic (in `App.js`) for when to fetch the channel subscriptions. The way this affected the user was that, if you entered the site from the `/settings` page and then navigated, without doing a full-page refresh, from there to the homepage the channel subscriptions would not be fetched, so the UI would look like this:

![missingchannels](https://user-images.githubusercontent.com/6207644/40187989-e6a0b356-59c6-11e8-9c46-97cf0f099909.png)

You can reproduce this by:

1. visiting `/settings`
2. clicking on the 'Discussions' link in the top bar

The issue was because we don't want to fetch the channels on `/settings`, because on `/settings` we allow the user to authenticate with a token as well as a normal JWT session. So in `App.js` we had logic to not fetch the subscribed channels if we were on the settings page. I added a bit of logic which runs on `componentDidUpdate` and just basically checks for the case where we've just navigated away from the settings page and, if so, we fetch the channel subscriptions.

#### How should this be manually tested?

Confirm on master that you can reproduce the issue via the steps above. Then confirm that this change fixes it. If possible, it would be good to confirm that by logging in with a token in the URL and also by the normal method.