### PR TITLE
fix html embeds

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -7,10 +7,19 @@ export default class Embedly extends React.Component<*> {
 
     // the response includes HTML which can be used to load a rich embed
     // (either a video or the 'rich' type)
-    if (embedly.html) {
+    if (embedly.type === "video") {
       return (
         <div
-          className="embed-container"
+          className="video-container"
+          dangerouslySetInnerHTML={{ __html: embedly.html }}
+        />
+      )
+    }
+
+    if (embedly.type === "rich" || embedly.html) {
+      return (
+        <div
+          className="rich"
           dangerouslySetInnerHTML={{ __html: embedly.html }}
         />
       )

--- a/static/js/components/Embedly_test.js
+++ b/static/js/components/Embedly_test.js
@@ -13,6 +13,7 @@ describe("Embedly", () => {
   it("should render the returned HTML for a video", () => {
     const wrapper = renderEmbedly(makeYoutubeVideo())
     assert.equal(wrapper.text(), "dummy html")
+    assert.ok(wrapper.find(".video-container").exists())
   })
 
   it("should render an image sensibly", () => {
@@ -36,6 +37,14 @@ describe("Embedly", () => {
       wrapper.find(".link-summary .description").text(),
       article.description
     )
+  })
+
+  it("should render a link which returns HTML sensibly", () => {
+    const article = makeArticle()
+    article.html = "<span>beep boop beepity boop</span>"
+    const wrapper = renderEmbedly(article)
+    assert.ok(wrapper.find(".rich").exists())
+    assert.equal(wrapper.text(), "beep boop beepity boop")
   })
 
   it("shouldnt render anything if embedly had some kind of error", () => {

--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -1,5 +1,5 @@
 .embedly {
-  .embed-container {
+  .video-container {
     position: relative;
     width: 100%;
     height: 0;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #717 

#### What's this PR do?

This just makes the embedly rendering code a little more foolproof. It turns out that embedly will sometimes (not realiably) return an 'html' value on link-type posts. Previously, the code assumed that the 'html' key would only have a usable value in it on video-type posts, so if a link returned html it would display in a weird squished video aspect-ratio box. This fixes that, so that we only put videos in the `.video-container` div, and we render the `.html` content for links if it's there.

#### How should this be manually tested?

You may have to try a few different links before you get one that returns `html` with the `link` type. Wikipedia pages sometimes do, but for reasons I don't understand sometimes the same page will return different things two times in a row.

Anyway, on master a wikipedia link that returns html should look strange, like this:

![tototototototto](https://user-images.githubusercontent.com/6207644/40244635-5c665ca6-5a91-11e8-9b84-7223e9b45d4e.png)

note all the excess whitespace. If you inspect the html you should see that it's being rendered inside of a `div.embed-container`:

![embed-container](https://user-images.githubusercontent.com/6207644/40244669-71f8ce46-5a91-11e8-830c-dafd3fb3732a.png)

On this branch it should look like this instead:

![noebmed](https://user-images.githubusercontent.com/6207644/40244703-8e8640d4-5a91-11e8-8e3d-07eefa63d312.png)

and if you inspect the html it should not be rendered inside of a `div.embed-container`. Videos and other things should still work as normal.
