### PR TITLE
add a unique CSS class for every page in the app

### DIFF
--- a/static/js/containers/AuthRequiredPage.js
+++ b/static/js/containers/AuthRequiredPage.js
@@ -10,7 +10,7 @@ import { formatTitle } from "../lib/title"
 export default class AuthRequiredPage extends React.Component<*, void> {
   render() {
     return (
-      <div className="content">
+      <div className="content auth-required-page">
         <DocumentTitle title={formatTitle("Login Required")} />
         <div className="main-content">
           <Card className="auth-required">

--- a/static/js/containers/ChannelModerationPage.js
+++ b/static/js/containers/ChannelModerationPage.js
@@ -114,6 +114,6 @@ export default R.compose(
   connect(mapStateToProps),
   withPostModeration,
   withCommentModeration,
-  withNavAndChannelSidebars,
+  withNavAndChannelSidebars("channel-moderation-page"),
   withLoading
 )(ChannelModerationPage)

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -219,6 +219,6 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withPostModeration,
-  withNavAndChannelSidebars,
+  withNavAndChannelSidebars("channel-page"),
   withLoading
 )(ChannelPage)

--- a/static/js/containers/ContentPolicyPage.js
+++ b/static/js/containers/ContentPolicyPage.js
@@ -10,7 +10,7 @@ import { formatTitle } from "../lib/title"
 export default class ContentPolicyPage extends React.Component<*, void> {
   render() {
     return (
-      <div className="content">
+      <div className="content content-policy-page">
         <DocumentTitle
           title={formatTitle("MicroMasters Discussions Community Guidelines")}
         />

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -151,7 +151,7 @@ class CreatePostPage extends React.Component<*, void> {
     }
 
     return (
-      <div className="content">
+      <div className="content create-post-page">
         <DocumentTitle title={formatTitle("Submit a Post")} />
         <div className="main-content">
           <CreatePostForm

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -120,6 +120,6 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withPostModeration,
-  withNavSidebar,
+  withNavSidebar("home-page"),
   withLoading
 )(HomePage)

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -500,6 +500,6 @@ export default R.compose(
   connect(mapStateToProps),
   withPostModeration,
   withCommentModeration,
-  withNavSidebar,
+  withNavSidebar("post-page"),
   withLoading
 )(PostPage)

--- a/static/js/hoc/withNavAndChannelSidebars.js
+++ b/static/js/hoc/withNavAndChannelSidebars.js
@@ -1,31 +1,34 @@
 // @flow
 import React from "react"
+import R from "ramda"
 
 import ChannelSidebar from "../components/ChannelSidebar"
 import NavSidebar from "../components/NavSidebar"
 import Sidebar from "../components/Sidebar"
 
-const withNavAndChannelSidebars = (
-  WrappedComponent: Class<React.Component<*, *>>
-) => {
-  class WithNavAndChannelSidebars extends React.Component<*, *> {
-    render() {
-      return (
-        <div className="content has-left-sidebar has-right-sidebar">
-          <Sidebar className="sidebar-left">
-            <NavSidebar {...this.props} />
-          </Sidebar>
-          <div className="main-content">
-            <WrappedComponent {...this.props} />
+const withNavAndChannelSidebars = R.curry(
+  (className: string, WrappedComponent: Class<React.Component<*, *>>) => {
+    class WithNavAndChannelSidebars extends React.Component<*, *> {
+      render() {
+        return (
+          <div
+            className={`content has-left-sidebar has-right-sidebar ${className}`}
+          >
+            <Sidebar className="sidebar-left">
+              <NavSidebar {...this.props} />
+            </Sidebar>
+            <div className="main-content">
+              <WrappedComponent {...this.props} />
+            </div>
+            <Sidebar className="sidebar-right">
+              <ChannelSidebar {...this.props} />
+            </Sidebar>
           </div>
-          <Sidebar className="sidebar-right">
-            <ChannelSidebar {...this.props} />
-          </Sidebar>
-        </div>
-      )
+        )
+      }
     }
+    return WithNavAndChannelSidebars
   }
-  return WithNavAndChannelSidebars
-}
+)
 
 export default withNavAndChannelSidebars

--- a/static/js/hoc/withNavSidebar.js
+++ b/static/js/hoc/withNavSidebar.js
@@ -1,25 +1,28 @@
 // @flow
 import React from "react"
+import R from "ramda"
 
 import NavSidebar from "../components/NavSidebar"
 import Sidebar from "../components/Sidebar"
 
-const withNavSidebar = (WrappedComponent: Class<React.Component<*, *>>) => {
-  class WithNavSidebar extends React.Component<*, *> {
-    render() {
-      return (
-        <div className="content has-left-sidebar">
-          <Sidebar className="sidebar-left">
-            <NavSidebar {...this.props} />
-          </Sidebar>
-          <div className="main-content">
-            <WrappedComponent {...this.props} />
+const withNavSidebar = R.curry(
+  (className: string, WrappedComponent: Class<React.Component<*, *>>) => {
+    class WithNavSidebar extends React.Component<*, *> {
+      render() {
+        return (
+          <div className={`content has-left-sidebar ${className}`}>
+            <Sidebar className="sidebar-left">
+              <NavSidebar {...this.props} />
+            </Sidebar>
+            <div className="main-content">
+              <WrappedComponent {...this.props} />
+            </div>
           </div>
-        </div>
-      )
+        )
+      }
     }
+    return WithNavSidebar
   }
-  return WithNavSidebar
-}
+)
 
 export default withNavSidebar


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

just adds a unique CSS class (like `.post-page`, `.channel-page`, etc) to each page, so we can do page-specific styling if we want.

#### How should this be manually tested?

Read the code, make sure it makes sense. Check that on each page in the SPA there's a unique class applied to the `.main-content` div.