### PR TITLE
add little 'sign in' tooltips on voting buttons for anons

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "react-test-renderer": "^15.6.1",
+    "react-tooltip": "^3.6.0",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-asserts": "^0.0.10",

--- a/static/js/components/CommentVoteForm.js
+++ b/static/js/components/CommentVoteForm.js
@@ -1,5 +1,8 @@
 // @flow
 import React from "react"
+import ReactTooltip from "react-tooltip"
+
+import { userIsAnonymous, votingTooltipText } from "../lib/util"
 
 import type { CommentInTree } from "../flow/discussionTypes"
 
@@ -67,10 +70,17 @@ export default class CommentVoteForm extends React.Component<*, *> {
         <div className="score">
           {comment.score}
         </div>
+        {userIsAnonymous()
+          ? <ReactTooltip id="comment-upvote-button">
+            {votingTooltipText}
+          </ReactTooltip>
+          : null}
         <button
           className={`vote upvote-button ${upvoted ? "upvoted" : ""}`}
-          onClick={this.upvote}
+          onClick={userIsAnonymous() ? null : this.upvote}
           disabled={disabled}
+          data-tip
+          data-for="comment-upvote-button"
         >
           <img
             className="vote-arrow"
@@ -83,10 +93,17 @@ export default class CommentVoteForm extends React.Component<*, *> {
           />
         </button>
         <span className="pipe">|</span>
+        {userIsAnonymous()
+          ? <ReactTooltip id="comment-downvote-button">
+            {votingTooltipText}
+          </ReactTooltip>
+          : null}
         <button
           className={`vote downvote-button ${downvoted ? "downvoted" : ""}`}
-          onClick={this.downvote}
+          onClick={userIsAnonymous() ? null : this.downvote}
           disabled={disabled}
+          data-tip
+          data-for="comment-downvote-button"
         >
           <img
             className="vote-arrow"

--- a/static/js/components/CommentVoteForm_test.js
+++ b/static/js/components/CommentVoteForm_test.js
@@ -3,11 +3,14 @@ import React from "react"
 import sinon from "sinon"
 import { mount } from "enzyme"
 import { assert } from "chai"
+import ReactTooltip from "react-tooltip"
 
-import { wait } from "../lib/util"
+import { wait, votingTooltipText } from "../lib/util"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
 import CommentVoteForm from "./CommentVoteForm"
+
+import * as utilFuncs from "../lib/util"
 
 describe("CommentVoteForm", () => {
   let sandbox, upvoteStub, downvoteStub, comment, resolveUpvote, resolveDownvote
@@ -81,6 +84,21 @@ describe("CommentVoteForm", () => {
       otherVoteClass
     )
   }
+
+  it("should have tooltips, if the user is anonymous", () => {
+    sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    const wrapper = renderForm()
+    wrapper.find(ReactTooltip).forEach(tooltip => {
+      assert.equal(tooltip.text(), votingTooltipText)
+    })
+  })
+
+  it("should not have any tooltips, if the user is not anonymous", () => {
+    sandbox.stub(utilFuncs, "userIsAnonymous").returns(false)
+    assert.isNotOk(renderForm().find(ReactTooltip).exists())
+  })
+
+  //
   ;[true, false].forEach(isUpvote => {
     describe(`clicks the ${isUpvote ? "upvote" : "downvote"} button`, () => {
       it("when the previous state was clear", async () => {
@@ -110,6 +128,8 @@ describe("CommentVoteForm", () => {
         await wait(10)
         assertButtons(wrapper, isUpvote, false, false)
       })
+
+      //
       ;[true, false].forEach(wasUpvote => {
         it(`when the previous state was ${wasUpvote
           ? "upvote"

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -2,8 +2,10 @@
 import React from "react"
 import R from "ramda"
 import { Link } from "react-router-dom"
+import ReactTooltip from "react-tooltip"
 
-import { postDetailURL, urlHostname } from "../lib/url"
+import { postDetailURL, urlHostname } from "./url"
+import { userIsAnonymous, votingTooltipText } from "./util"
 
 import type {
   PostForm,
@@ -99,10 +101,17 @@ export class PostVotingButtons extends React.Component<*, *> {
 
     return (
       <div className={`upvotes ${className || ""} ${upvoteClass}`}>
+        {userIsAnonymous()
+          ? <ReactTooltip id="post-upvote-button">
+            {votingTooltipText}
+          </ReactTooltip>
+          : null}
         <button
           className="upvote-button"
-          onClick={this.onToggleUpvote}
+          onClick={userIsAnonymous() ? null : this.onToggleUpvote}
           disabled={upvoting}
+          data-tip
+          data-for="post-upvote-button"
         >
           <img
             className="vote-arrow"

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -1,8 +1,14 @@
 // @flow
+import React from "react"
 import { assert } from "chai"
+import { mount } from "enzyme"
+import sinon from "sinon"
+import ReactTooltip from "react-tooltip"
 
-import { newPostForm, formatCommentsCount } from "./posts"
+import { newPostForm, formatCommentsCount, PostVotingButtons } from "./posts"
 import { makePost } from "../factories/posts"
+import { votingTooltipText } from "./util"
+import * as utilFuncs from "./util"
 
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
@@ -23,6 +29,33 @@ describe("Post utils", () => {
     ].forEach(([num, expectation]) => {
       post.num_comments = num
       assert.equal(formatCommentsCount(post), expectation)
+    })
+  })
+
+  describe("PostVotingButtons", () => {
+    let sandbox
+
+    const renderButtons = () => mount(<PostVotingButtons post={makePost()} />)
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create()
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+    })
+
+    it("should include tooltips if user is anonymous", () => {
+      sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+      const tooltip = renderButtons().find(ReactTooltip)
+      assert.isOk(tooltip.exists())
+      assert.equal(tooltip.text(), votingTooltipText)
+    })
+
+    it("should not include tooltips if the user is not anonymous", () => {
+      sandbox.stub(utilFuncs, "userIsAnonymous").returns(false)
+      const tooltip = renderButtons().find(ReactTooltip)
+      assert.isNotOk(tooltip.exists())
     })
   })
 })

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -49,3 +49,5 @@ export const preventDefaultAndInvoke = R.curry(
 )
 
 export const userIsAnonymous = () => R.isNil(SETTINGS.username)
+
+export const votingTooltipText = "Sign Up or Login to vote"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5925,6 +5925,13 @@ react-test-renderer@^15.6.1:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react-tooltip@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.6.0.tgz#61fd8502540d91fb3397e3fc90b487c0842c4189"
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #687 

#### What's this PR do?

This PR basically adds a little tooltip to the post and comment voting buttons, which we show when an anonymous user clicks on or hovers over the voting buttons.

#### How should this be manually tested?

If you're not anonymous, then voting on posts and comments (in the post detail view and the channel / frontpage views) should work as normal.

If you're anonymous, you should instead see a friendly lil' tooltip, like this one:

![sign-in-channel](https://user-images.githubusercontent.com/6207644/40323613-e5cfe948-5d03-11e8-9e09-323a988a1255.png)

The buttons also shouldn't do anything when you click them, if you're anonymous (previously you would get redirected to the 'auth required' page).