### PR TITLE
Backend modifications for resizing an uploaded image

### DIFF
--- a/fixtures/users.py
+++ b/fixtures/users.py
@@ -1,6 +1,9 @@
 """User fixtures"""
 # pylint: disable=unused-argument, redefined-outer-name
+from io import BytesIO
+
 import pytest
+from PIL import Image
 from rest_framework.test import APIClient
 from rest_framework_jwt.settings import api_settings
 
@@ -85,3 +88,13 @@ def staff_client(client, staff_user):
 def authenticated_site(db, settings):
     """The authenticated site"""
     return AuthenticatedSiteFactory.create(key=settings.OPEN_DISCUSSIONS_DEFAULT_SITE_KEY)
+
+
+@pytest.fixture
+def profile_image():
+    """ Create a PNG image """
+    image_file = BytesIO()
+    image = Image.new('RGBA', size=(250, 250), color=(256, 0, 0))
+    image.save(image_file, 'png')
+    image_file.seek(0)
+    return image_file

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -9,7 +9,7 @@ from profiles.utils import (
     profile_image_upload_uri,
     profile_image_upload_uri_medium,
     profile_image_upload_uri_small,
-    default_profile_image, image_uri)
+    default_profile_image, image_uri,
     make_thumbnail)
 
 # Max dimension of either height or width for small and medium images

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -80,7 +80,7 @@ class Profile(models.Model):
         """Update thumbnails if necessary"""
         if update_image:
             if self.image_file:
-                small_thumbnail = make_thumbnail(self.image_file.file, IMAGE_SMALL_MAX_DIMENSION)
+                small_thumbnail = make_thumbnail(self.image_file, IMAGE_SMALL_MAX_DIMENSION)
                 medium_thumbnail = make_thumbnail(self.image_file, IMAGE_MEDIUM_MAX_DIMENSION)
 
                 # name doesn't matter here, we use upload_to to produce that

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -1,7 +1,10 @@
 """ Tests for profile model """
 import pytest
-
+from django.core.files.uploadedfile import UploadedFile
 from open_discussions import features
+
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(['image_field', 'image_url', 'bio', 'headline', 'name'], [
@@ -33,3 +36,36 @@ def test_profile_complete_feature_enabled(feature_enabled, user, settings):
     """ Tests that profile.is_complete returns True if the PROFILE_UI feature is disabled """
     settings.FEATURES[features.PROFILE_UI] = feature_enabled
     assert user.profile.is_complete is not feature_enabled
+
+
+@pytest.mark.parametrize('update_image', [True, False])
+def test_image_update(user, profile_image, update_image):
+    """
+    Test that small and medium images are created only when update_image is True
+    """
+    profile = user.profile
+    image_size = len(profile_image.getvalue())
+    profile.image_file = UploadedFile(profile_image, "filename.png", "image/png", image_size)
+    profile.image_small_file = None
+    profile.image_medium_file = None
+    profile.save(update_image=update_image)
+    assert (profile.image_medium_file.name is not None) is update_image
+    medium_size = len(profile.image_medium_file.read()) if update_image else 1
+    assert medium_size != image_size
+    assert (profile.image_small_file.name is not None) is update_image
+    small_size = len(profile.image_small_file.read()) if update_image else 0
+    assert small_size < medium_size
+
+
+def test_null_image(user):
+    """
+    If the main image is null the thumbnails should be too
+    """
+    profile = user.profile
+    assert profile.image_small_file is not None
+    assert profile.image_medium_file is not None
+    profile.image_file = None
+    profile.save(update_image=True)
+    assert not profile.image_file
+    assert not profile.image_medium_file
+    assert not profile.image_small_file

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -17,11 +17,24 @@ class ProfileSerializer(serializers.ModelSerializer):
     email_optin = serializers.BooleanField(write_only=True, required=False)
     toc_optin = serializers.BooleanField(write_only=True, required=False)
 
+    def update(self, instance, validated_data):
+        with transaction.atomic():
+            for attr, value in validated_data.items():
+                setattr(instance, attr, value)
+
+            update_image = 'image_file' in validated_data
+            instance.save(update_image=update_image)
+            return instance
+
     class Meta:
         model = Profile
         fields = ('name', 'image', 'image_small', 'image_medium',
                   'image_file', 'image_small_file', 'image_medium_file',
                   'email_optin', 'toc_optin', 'bio', 'headline')
+        read_only_fields = (
+            'image_file_small',
+            'image_file_medium'
+        )
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -183,14 +183,23 @@ def test_patch_profile_by_user(client, logged_in_profile):
     """
     url = reverse('profile_api-detail', kwargs={'user__username': logged_in_profile.user.username})
     # create a dummy image file in memory for upload
-    with make_temp_image_file(width=50, height=50) as image_file:
+    with make_temp_image_file(width=250, height=250) as image_file:
         # format patch using multipart upload
         resp = client.patch(url, data={
             'bio': 'updated_bio_value',
-            'image_small_file': image_file
+            'image_file': image_file
         }, format='multipart')
     filename, ext = splitext(image_file.name)
     assert resp.status_code == 200
     assert resp.json()['bio'] == 'updated_bio_value'
-    assert basename(filename) in resp.json()['image_small_file']
-    assert resp.json()['image_small_file'].endswith(ext)
+    assert basename(filename) in resp.json()['image_file']
+    assert resp.json()['image_file'].endswith(ext)
+    assert resp.json()['image_small_file'].endswith('.jpg')
+
+    logged_in_profile.refresh_from_db()
+    assert logged_in_profile.image_file.height == 250
+    assert logged_in_profile.image_file.width == 250
+    assert logged_in_profile.image_small_file.height == 64
+    assert logged_in_profile.image_small_file.width == 64
+    assert logged_in_profile.image_medium_file.height == 128
+    assert logged_in_profile.image_medium_file.width == 128


### PR DESCRIPTION
#### What are the relevant tickets?
- Makes some backend modifications to prepare for #682

#### What's this PR do?
- Modifies the Profile model/serializer/api to resize an uploaded image to different sizes.

#### How should this be manually tested?
- Use the API to update the `image_file` field of your profile:
  - Get a `jwt_token`:
    ```python
    from fixtures.users import staff_jwt_token
    from django.contrib.auth.models import User
    user = User.objects.get(username=<your_username>)
    staff_jwt_token(None, user)
    ```
  - Send an API PATCH request to update your profile image:
    ```
    curl --request PATCH -H "Authorization: Bearer  <jwt_token>" -F 'image_file=@<image_name.jpg>'  http://od.odl.local:8063/api/v0/profiles/<username>/
    ```
 -  The response JSON should include populated URL's for `image_file`, `image_small_file`, and `image_medium_file`.  Open them in a browser to verify that the images load and are correctly sized (max 64x64 pixels for small, 128x128 for medium).
- The `image_small_file` photo should appear as your profile image in OD.