### PR TITLE
add user menu

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -80,6 +80,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         },
         "is_authenticated": bool(request.user.is_authenticated),
         "allow_anonymous": features.is_enabled(features.ANONYMOUS_ACCESS),
+        "allow_email_auth": features.is_enabled(features.EMAIL_AUTH),
     }
 
     return render(request, "index.html", context={

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -50,6 +50,7 @@ def test_webpack_url(settings, client, user, mocker, authenticated_site):
         },
         'is_authenticated': True,
         'allow_anonymous': 'access',
+        'allow_email_auth': False,
     }
 
 
@@ -89,6 +90,7 @@ def test_webpack_url_jwt(
         },
         'is_authenticated': False,
         'allow_anonymous': 'access',
+        'allow_email_auth': False,
     }
 
 
@@ -125,4 +127,5 @@ def test_webpack_url_anonymous(settings, client, mocker, authenticated_site):
         },
         'is_authenticated': False,
         'allow_anonymous': 'access',
+        'allow_email_auth': False,
     }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-ga": "^2.2.0",
     "react-hot-loader": "next",
     "react-markdown": "^3.1.5",
+    "react-onclickoutside": "^6.7.1",
     "react-redux": "^5.0.5",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -15,3 +15,6 @@ export const showDialog = createAction(SHOW_DIALOG)
 
 export const HIDE_DIALOG = "HIDE_DIALOG"
 export const hideDialog = createAction(HIDE_DIALOG)
+
+export const SET_SHOW_USER_MENU = "SET_SHOW_USER_MENU"
+export const setShowUserMenu = createAction(SET_SHOW_USER_MENU)

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -5,7 +5,11 @@ import { Link } from "react-router-dom"
 import SubscriptionsList from "./SubscriptionsList"
 import UserInfo from "./UserInfo"
 
-import { newPostURL, getChannelNameFromPathname } from "../lib/url"
+import {
+  newPostURL,
+  getChannelNameFromPathname,
+  FRONTPAGE_URL
+} from "../lib/url"
 import { userIsAnonymous } from "../lib/util"
 
 import type { Channel } from "../flow/discussionTypes"
@@ -31,6 +35,10 @@ const Navigation = (props: NavigationProps) => {
         >
             Submit a New Post
         </Link>}
+      <Link className="home-link" to={FRONTPAGE_URL}>
+        <i className="material-icons home">home</i>
+        Home
+      </Link>
       <SubscriptionsList
         currentChannel={channelName}
         subscribedChannels={subscribedChannels}

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -9,7 +9,7 @@ import Navigation from "./Navigation"
 import SubscriptionsList from "./SubscriptionsList"
 import UserInfo from "./UserInfo"
 
-import { newPostURL } from "../lib/url"
+import { newPostURL, FRONTPAGE_URL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 import * as util from "../lib/util"
 
@@ -32,7 +32,7 @@ describe("Navigation", () => {
 
   it("create post link should not have channel name if channelName is not in URL", () => {
     const wrapper = renderComponent()
-    assert.lengthOf(wrapper.find(Link), 2)
+    assert.lengthOf(wrapper.find(Link), 3)
     const props = wrapper.find(Link).at(0).props()
     assert.equal(props.to, "/create_post/")
     assert.equal(props.children, "Submit a New Post")
@@ -84,10 +84,20 @@ describe("Navigation", () => {
 
   it("should have a link to the settings", () => {
     const wrapper = renderComponent()
-    const { children, to, className } = wrapper.find(Link).at(1).props()
+    const { children, to, className } = wrapper.find(Link).at(2).props()
     assert.equal(children, "Settings")
     assert.equal(className, "settings-link")
     assert.equal(to, "/settings")
+  })
+
+  it("should have to link to home", () => {
+    const { to, className, children } = renderComponent()
+      .find(Link)
+      .at(1)
+      .props()
+    assert.equal(children[1], "Home")
+    assert.equal(className, "home-link")
+    assert.equal(to, FRONTPAGE_URL)
   })
 
   it("should hide the link to settings, if the user is anonymous", () => {

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -1,13 +1,19 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { FRONTPAGE_URL } from "../lib/url"
-import { Link } from "react-router-dom"
 import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
+
+import UserMenu from "./UserMenu"
 
 export default class Toolbar extends React.Component<*, void> {
   toolbarRoot: HTMLElement | null
   toolbar: Object
+
+  props: {
+    toggleShowSidebar: Function,
+    toggleShowUserMenu: Function,
+    showUserMenu: boolean
+  }
 
   componentDidMount() {
     this.toolbar = new MDCToolbar(this.toolbarRoot)
@@ -20,7 +26,7 @@ export default class Toolbar extends React.Component<*, void> {
   }
 
   render() {
-    const { toggleShowSidebar } = this.props
+    const { toggleShowSidebar, toggleShowUserMenu, showUserMenu } = this.props
 
     return (
       <div className="navbar">
@@ -41,8 +47,13 @@ export default class Toolbar extends React.Component<*, void> {
                 <a href={SETTINGS.authenticated_site.base_url}>
                   {SETTINGS.authenticated_site.title}
                 </a>{" "}
-                > <Link to={FRONTPAGE_URL}>Discussion</Link>
               </span>
+            </section>
+            <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
+              <UserMenu
+                toggleShowUserMenu={toggleShowUserMenu}
+                showUserMenu={showUserMenu}
+              />
             </section>
           </div>
         </header>

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -1,0 +1,55 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import { Link } from "react-router-dom"
+import onClickOutside from "react-onclickoutside"
+
+import { SETTINGS_URL } from "../lib/url"
+
+export class Dropdown extends React.Component<*, *> {
+  handleClickOutside = () => {
+    const { toggleShowUserMenu } = this.props
+
+    toggleShowUserMenu()
+  }
+
+  render() {
+    const { toggleShowUserMenu } = this.props
+
+    return (
+      <ul className="user-menu-dropdown">
+        <li>
+          <Link onClick={toggleShowUserMenu} to={SETTINGS_URL}>
+            Settings
+          </Link>
+        </li>
+        {SETTINGS.allow_email_auth
+          ? <li>
+            <a href="/logout">Sign Out</a>
+          </li>
+          : null}
+      </ul>
+    )
+  }
+}
+
+export const DropdownWithClickOutside = onClickOutside(Dropdown)
+
+export default class UserMenu extends React.Component<*, *> {
+  render() {
+    const { toggleShowUserMenu, showUserMenu } = this.props
+
+    return (
+      <div className="user-menu">
+        <img
+          onClick={toggleShowUserMenu}
+          className="profile-image"
+          src={SETTINGS.profile_image_small}
+        />
+        {showUserMenu
+          ? <DropdownWithClickOutside toggleShowUserMenu={toggleShowUserMenu} />
+          : null}
+      </div>
+    )
+  }
+}

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -1,0 +1,70 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+import sinon from "sinon"
+import { Link } from "react-router-dom"
+
+import UserMenu from "./UserMenu"
+import { DropdownWithClickOutside, Dropdown } from "./UserMenu"
+
+import { SETTINGS_URL } from "../lib/url"
+
+describe("UserMenu", () => {
+  let toggleShowUserMenuStub, showUserMenu
+
+  beforeEach(() => {
+    toggleShowUserMenuStub = sinon.stub()
+    showUserMenu = false
+  })
+
+  const renderUserMenu = () =>
+    shallow(
+      <UserMenu
+        toggleShowUserMenu={toggleShowUserMenuStub}
+        showUserMenu={showUserMenu}
+      />
+    )
+
+  const renderDropdown = () =>
+    shallow(<Dropdown toggleShowUserMenu={toggleShowUserMenuStub} />)
+
+  it("should include the profile image with onclick handler", () => {
+    const wrapper = renderUserMenu()
+    const { className, onClick, src } = wrapper.find("img").props()
+    assert.equal(className, "profile-image")
+    onClick()
+    assert.isOk(toggleShowUserMenuStub.called)
+    assert.equal(src, SETTINGS.profile_image_small)
+  })
+
+  it("should render the dropdown if showUserMenu", () => {
+    [true, false].forEach(showUserMenuValue => {
+      showUserMenu = showUserMenuValue
+      const wrapper = renderUserMenu()
+      if (showUserMenu) {
+        assert.isOk(wrapper.find(DropdownWithClickOutside).exists())
+      } else {
+        assert.isNotOk(wrapper.find(DropdownWithClickOutside).exists())
+      }
+    })
+  })
+
+  it("dropdown menu should have a settings link", () => {
+    const wrapper = renderDropdown()
+    const { onClick, to, children } = wrapper.find(Link).props()
+    onClick()
+    assert.isOk(toggleShowUserMenuStub.called)
+    assert.equal(to, SETTINGS_URL)
+    assert.equal(children, "Settings")
+  })
+
+  it("should include a logout link, if feature is enabled", () => {
+    SETTINGS.allow_email_auth = true
+    const wrapper = renderDropdown()
+    const { href, children } = wrapper.find("a").props()
+    assert.equal(href, "/logout")
+    assert.equal(children, "Sign Out")
+  })
+})

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -20,7 +20,7 @@ import Drawer from "../containers/Drawer"
 import Footer from "../components/Footer"
 
 import { actions } from "../actions"
-import { setShowDrawer } from "../actions/ui"
+import { setShowDrawer, setShowUserMenu } from "../actions/ui"
 import { setChannelData } from "../actions/channel"
 import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
 
@@ -34,12 +34,18 @@ class App extends React.Component<*, void> {
     location: Location,
     showDrawer: boolean,
     snackbar: SnackbarState,
-    dispatch: Dispatch
+    dispatch: Dispatch,
+    showUserMenu: boolean
   }
 
   toggleShowSidebar = () => {
     const { dispatch, showDrawer } = this.props
     dispatch(setShowDrawer(!showDrawer))
+  }
+
+  toggleShowUserMenu = () => {
+    const { dispatch, showUserMenu } = this.props
+    dispatch(setShowUserMenu(!showUserMenu))
   }
 
   componentWillMount() {
@@ -77,7 +83,7 @@ class App extends React.Component<*, void> {
   }
 
   render() {
-    const { match, location: { pathname }, snackbar } = this.props
+    const { match, location: { pathname }, snackbar, showUserMenu } = this.props
 
     if (
       !SETTINGS.authenticated_site.session_url &&
@@ -94,7 +100,11 @@ class App extends React.Component<*, void> {
         <div className="app">
           <DocumentTitle title="MIT Open Discussions" />
           <Snackbar snackbar={snackbar} />
-          <Toolbar toggleShowSidebar={this.toggleShowSidebar} />
+          <Toolbar
+            toggleShowSidebar={this.toggleShowSidebar}
+            toggleShowUserMenu={this.toggleShowUserMenu}
+            showUserMenu={showUserMenu}
+          />
           <Drawer />
           <Route exact path={match.url} component={HomePage} />
           <Route
@@ -142,6 +152,6 @@ class App extends React.Component<*, void> {
 }
 
 export default connect(state => {
-  const { ui: { showDrawer, snackbar } } = state
-  return { showDrawer, snackbar }
+  const { ui: { showDrawer, snackbar, showUserMenu } } = state
+  return { showDrawer, snackbar, showUserMenu }
 })(App)

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -20,6 +20,7 @@ declare var SETTINGS: {
   },
   is_authenticated: boolean,
   allow_anonymous: boolean,
+  allow_email_auth: boolean,
 }
 
 // mocha

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -13,9 +13,10 @@ const _createSettings = () => ({
     session_url: "http://fake.session.url",
     tos_url:     "http://fake.tos.url/"
   },
-  allow_anonymous:  false,
-  is_authenticated: true,
-  username:         "greatusername"
+  allow_anonymous:     false,
+  is_authenticated:    true,
+  username:            "greatusername",
+  profile_image_small: "https://example.com/my/profile/image"
 })
 
 global.SETTINGS = _createSettings()

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -5,7 +5,8 @@ import {
   SET_SHOW_DRAWER,
   SET_SNACKBAR_MESSAGE,
   SHOW_DIALOG,
-  HIDE_DIALOG
+  HIDE_DIALOG,
+  SET_SHOW_USER_MENU
 } from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
@@ -20,13 +21,15 @@ export type SnackbarState = {
 export type UIState = {
   showDrawer: boolean,
   snackbar: ?SnackbarState,
-  dialogs: Set<string>
+  dialogs: Set<string>,
+  showUserMenu: boolean
 }
 
 export const INITIAL_UI_STATE: UIState = {
-  showDrawer: false,
-  snackbar:   null,
-  dialogs:    new Set()
+  showDrawer:   false,
+  snackbar:     null,
+  dialogs:      new Set(),
+  showUserMenu: false
 }
 
 // this generates a new sequential id for each snackbar state that is pushed
@@ -64,6 +67,8 @@ export const ui = (
       ...state,
       dialogs: updateDialog(state.dialogs, action.payload, false)
     }
+  case SET_SHOW_USER_MENU:
+    return { ...state, showUserMenu: action.payload }
   }
   return state
 }

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -8,10 +8,12 @@ import {
   SET_SNACKBAR_MESSAGE,
   SHOW_DIALOG,
   HIDE_DIALOG,
+  SET_SHOW_USER_MENU,
   setShowDrawer,
   setSnackbarMessage,
   showDialog,
-  hideDialog
+  hideDialog,
+  setShowUserMenu
 } from "../actions/ui"
 
 describe("ui reducer", () => {
@@ -76,5 +78,14 @@ describe("ui reducer", () => {
     })
     const dialogs = store.getState().ui.dialogs
     assert.deepEqual(keys, [...dialogs.keys()])
+  })
+
+  it("should let you toggle show user menu", async () => {
+    for (const open of [true, false]) {
+      const state = await dispatchThen(setShowUserMenu(open), [
+        SET_SHOW_USER_MENU
+      ])
+      assert.equal(state.showUserMenu, open)
+    }
   })
 })

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -34,6 +34,7 @@
 @import "settings";
 @import "user-info";
 @import "embedly";
+@import "user-menu";
 
 body {
   font-family: 'Roboto', helvetica, arial, sans-serif !important;

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -21,6 +21,10 @@
     color: #a31f34;
   }
 
+  .user-menu-section {
+    flex-grow: unset;
+    height: 49px;
+  }
 
   @include breakpoint(desktop) {
     .mdc-toolbar__icon--menu {
@@ -44,7 +48,7 @@
     margin-left: 36px;
   }
 
-  .mdc-button {
+  .mdc-button, .home-link {
     width: 87%;
     height: 43px;
     line-height: 43px;
@@ -56,6 +60,17 @@
     margin-left: 14px;
   }
 
+  .home-link {
+    display: flex;
+    align-items: center;
+    margin-top: 10px;
+    color: $navigation-text;
+
+    i {
+      margin-right: 10px;
+    }
+  }
+
   .mdc-button:hover {
     box-shadow: 2px 3px 5px 0px rgba(0, 0, 0, 0.2);
     transition: none;
@@ -63,7 +78,7 @@
 }
 
 .subscriptions {
-  margin: 30px 0 20px;
+  margin: 15px 0 20px;
   width: 100%;
   padding: 16px 0 18px 0;
   box-sizing: border-box;
@@ -81,7 +96,7 @@
     }
 
     a:hover {
-      background: rgba(0,0,0,.05);
+      background: rgba(0, 0, 0, 0.05);
     }
 
     &.current-location {

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -1,0 +1,39 @@
+.user-menu {
+  position: relative;
+  cursor: pointer;
+
+  @include breakpoint(mobile) {
+    margin-right: 15px;
+  }
+
+
+  @include breakpoint(desktop) {
+    margin-right: 150px;
+  }
+
+
+  ul.user-menu-dropdown {
+    margin: 0;
+    padding: 10px;
+    position: absolute;
+    top: 46px;
+    right: 24px;
+    background-color: $card-background;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    list-style: none;
+
+    a {
+      text-decoration: none;
+      color: $navigation-text;
+      white-space: nowrap;
+    }
+
+    li {
+      margin-bottom: 14px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5872,6 +5872,10 @@ react-markdown@^3.1.5:
     unist-util-visit "^1.1.3"
     xtend "^4.0.1"
 
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"


### PR DESCRIPTION
#### What are the relevant tickets?

closes #679 

#### What's this PR do?

This adds a little user menu in the upper right of the toolbar. It looks like this:

![usermenufasdf](https://user-images.githubusercontent.com/6207644/40503822-5afceddc-5f5d-11e8-8a30-d585b97b4008.png)

mobile view:

![fodfodfaj4rere](https://user-images.githubusercontent.com/6207644/40503861-6f8c072e-5f5d-11e8-93b3-644ba7f08df7.png)

If you click on the profile image it will open a little dropdown:

![usermenufasdfffffasdfasdfasdffasdfasdfasdfasdf](https://user-images.githubusercontent.com/6207644/40503808-570d3ede-5f5d-11e8-9721-03537fc466cd.png)


If the email auth feature flag is on it will include a logout link too. I also went ahead and remove the `> Discussions` from the toolbar and added a basic 'home' link in the sidebar, because without doing that the user menu was cutting off the text on mobile.

#### How should this be manually tested?

The user menu should open when you click on the profile image, and it should close when you click outside. If you click on a link in the menu, the menu should close too. There should be a 'Home' link in the sidebar, adn teh `> Discussions` link should be gone from the toolbar.

Also, if you have the email auth feature flag enabled you should see a 'Sign Out' thing which links to `/logout`.

