### PR TITLE
Use keyword so post_link_url won't be tokenized

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -19,7 +19,7 @@ COMBINED_MAPPING = {
     'removed': {'type': 'boolean'},
     'post_id': {'type': 'keyword'},
     'post_title': {'type': 'text'},
-    'post_link_url': {'type': 'text'},
+    'post_link_url': {'type': 'keyword'},
     'num_comments': {'type': 'long'},
     'comment_id': {'type': 'keyword'},
     'parent_comment_id': {'type': 'keyword'},


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Switches mapping for post_link_url from `text` to `keyword` since `text` will assume its input is tokenizable, disrupting search

#### How should this be manually tested?
N/A
