### PR TITLE
Added ES comment document indexing

### DIFF
--- a/channels/views/comments.py
+++ b/channels/views/comments.py
@@ -171,10 +171,14 @@ class CommentDetailView(APIView):
             'view': self,
         }
 
+    @property
+    def api(self):
+        """Returns a Channel API object"""
+        return Api(user=self.request.user)
+
     def get_object(self):
         """Get the comment object"""
-        api = Api(user=self.request.user)
-        return api.get_comment(self.kwargs['comment_id'])
+        return self.api.get_comment(self.kwargs['comment_id'])
 
     def get(self, request, *args, **kwargs):
         """GET a single comment and it's children"""
@@ -223,5 +227,5 @@ class CommentDetailView(APIView):
 
     def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Delete the comment"""
-        self.get_object().delete()
+        self.api.delete_comment(self.kwargs['comment_id'])
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/channels/views/posts.py
+++ b/channels/views/posts.py
@@ -77,10 +77,14 @@ class PostDetailView(APIView):
             'view': self,
         }
 
+    @property
+    def api(self):
+        """Returns a Channel API object"""
+        return Api(user=self.request.user)
+
     def get_object(self):
         """Get post"""
-        api = Api(user=self.request.user)
-        return api.get_post(self.kwargs['post_id'])
+        return self.api.get_post(self.kwargs['post_id'])
 
     def get(self, request, *args, **kwargs):
         """Get post"""
@@ -103,7 +107,7 @@ class PostDetailView(APIView):
 
     def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Delete a post"""
-        self.get_object().delete()
+        self.api.delete_post(self.kwargs['post_id'])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def patch(self, request, *args, **kwargs):  # pylint: disable=unused-argument

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -1,5 +1,6 @@
 """Reddit fixtures"""
 # pylint: disable=redefined-outer-name, unused-argument
+from types import SimpleNamespace
 import pytest
 
 from channels import api
@@ -78,3 +79,33 @@ def private_channel_and_contributor(private_channel, staff_api, user):
     staff_api.add_contributor(user.username, private_channel.name)
     staff_api.add_subscriber(user.username, private_channel.name)
     return (private_channel, user)
+
+
+@pytest.fixture()
+def reddit_submission_obj():
+    """A dummy Post object"""
+    return SimpleNamespace(
+        author=SimpleNamespace(name='Test User'),
+        subreddit=SimpleNamespace(display_name='channel_1'),
+        selftext='Body text',
+        score=1,
+        created=12345,
+        id='a',
+        title='Post Title',
+        num_comments=1
+    )
+
+
+@pytest.fixture()
+def reddit_comment_obj(mocker, reddit_submission_obj):
+    """A dummy Comment object"""
+    return SimpleNamespace(
+        parent=mocker.Mock(return_value=reddit_submission_obj),
+        submission=reddit_submission_obj,
+        author=SimpleNamespace(name='Some Name'),
+        subreddit=reddit_submission_obj.subreddit,
+        body='Comment text',
+        id='b',
+        score=1,
+        created=12345,
+    )

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -10,32 +10,6 @@ from search.api import (
 )
 
 
-def _serialize_comment_tree(comments):
-    """
-    Serialize an iterable of Comment and their replies
-
-    Args:
-        comments (iterable of Comment): An iterable of comments
-
-    Yields:
-        dict: Documents suitable for indexing in Elasticsearch
-    """
-    for comment in comments:
-        yield serialize_comment(comment)
-        yield from _serialize_comment_tree(comment.replies)
-
-
-def serialize_post_and_comments(post_obj):
-    """
-    Index comments for a post and recurse to deeper level comments
-
-    Args:
-        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
-    """
-    yield serialize_post(post_obj)
-    yield from _serialize_comment_tree(post_obj.comments)
-
-
 def serialize_post(post_obj):
     """
     Serialize a reddit Submission
@@ -44,7 +18,6 @@ def serialize_post(post_obj):
         post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
     """
     return {
-        '_id': gen_post_id(post_obj.id),
         'object_type': POST_TYPE,
         'author': post_obj.author.name if post_obj.author else None,
         'channel_title': post_obj.subreddit.display_name,
@@ -69,7 +42,6 @@ def serialize_comment(comment_obj):
     parent_comment_id = None if get_reddit_object_type(parent_comment) != COMMENT_TYPE else parent_comment.id
 
     return {
-        '_id': gen_comment_id(comment_obj.id),
         'object_type': COMMENT_TYPE,
         'author': comment_obj.author.name if comment_obj.author else None,
         'channel_title': comment_obj.subreddit.display_name,
@@ -80,4 +52,56 @@ def serialize_comment(comment_obj):
         'post_title': post_obj.title,
         'comment_id': comment_obj.id,
         'parent_comment_id': parent_comment_id,
+    }
+
+
+def _serialize_comment_tree_for_bulk(comments):
+    """
+    Serialize an iterable of Comment and their replies for a bulk API request
+
+    Args:
+        comments (iterable of Comment): An iterable of comments
+
+    Yields:
+        dict: Documents suitable for indexing in Elasticsearch
+    """
+    for comment in comments:
+        yield serialize_comment_for_bulk(comment)
+        yield from _serialize_comment_tree_for_bulk(comment.replies)
+
+
+def serialize_bulk_post_and_comments(post_obj):
+    """
+    Index comments for a post and recurse to deeper level comments for a bulk API request
+
+    Args:
+        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
+    """
+    yield serialize_post_for_bulk(post_obj)
+    yield from _serialize_comment_tree_for_bulk(post_obj.comments)
+
+
+def serialize_post_for_bulk(post_obj):
+    """
+    Serialize a reddit Submission for a bulk API request
+
+    Args:
+        post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
+    """
+    return {
+        '_id': gen_post_id(post_obj.id),
+        **serialize_post(post_obj),
+    }
+
+
+def serialize_comment_for_bulk(comment_obj):
+    """
+    Serialize a comment for a bulk API request
+
+    Args:
+        comment_obj (Comment): A PRAW comment
+    """
+    return {
+        '_id': gen_comment_id(comment_obj.id),
+        **serialize_comment(comment_obj),
     }

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -56,19 +56,27 @@ def wrap_retry_exception(*exception_classes):
 @app.task
 def create_document(doc_id, data):
     """Task that makes a request to create an ES document"""
-    api.create_document(doc_id, data)
+    return api.create_document(doc_id, data)
 
 
 @app.task(**PARTIAL_UPDATE_TASK_SETTINGS)
 def update_document_with_partial(doc_id, partial_data):
     """Task that makes a request to update an ES document with a partial document"""
-    api.update_document_with_partial(doc_id, partial_data)
+    return api.update_document_with_partial(doc_id, partial_data)
 
 
 @app.task(**PARTIAL_UPDATE_TASK_SETTINGS)
 def increment_document_integer_field(doc_id, field_name, incr_amount):
     """Task that makes a request to increment some integer field in an ES document"""
     api.increment_document_integer_field(doc_id, field_name, incr_amount)
+
+
+@app.task
+def update_field_values_by_query(query, field_name, field_value):
+    """
+    Task that makes a request to update a field value for all ES documents that match some query.
+    """
+    return api.update_field_values_by_query(query, field_name, field_value)
 
 
 @app.task(autoretry_for=(RetryException, ), retry_backoff=True, rate_limit='600/m')

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -18,6 +18,7 @@ from search.tasks import (
     update_document_with_partial,
     finish_recreate_index,
     increment_document_integer_field,
+    update_field_values_by_query,
     index_channel,
     index_post_with_comments,
     start_recreate_index,
@@ -86,6 +87,17 @@ def test_increment_document_integer_field_task(mocked_api):
     increment_document_integer_field(*indexing_api_args)
     assert mocked_api.increment_document_integer_field.call_count == 1
     assert mocked_api.increment_document_integer_field.call_args[0] == indexing_api_args
+
+
+def test_update_field_values_by_query(mocked_api):
+    """
+    Test that the update_field_values_by_query task calls the indexing
+    API function with the right args
+    """
+    indexing_api_args = ({'query': {}}, 'field1', 'value1')
+    update_field_values_by_query(*indexing_api_args)
+    assert mocked_api.update_field_values_by_query.call_count == 1
+    assert mocked_api.update_field_values_by_query.call_args[0] == indexing_api_args
 
 
 def test_wrap_retry_exception():


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #606

#### What's this PR do?
Adds logic to create/update comment documents in Elasticsearch

#### How should this be manually tested?
- Set `FEATURE_INDEX_UPDATES=True` in your `.env`
- Create/update comments and check to see if those changes are reflected in the ES index
- Set a post to removed, then check to see that all comments associated with that post are also set to removed
- Delete a comment and check to see that the parent post's `num_comments` is decremented

#### Where should the reviewer start?
Probably `search/task_helpers.py`

#### Any background context you want to provide?
There are comments that say as much, but we are going ahead with an approach where we will log information about version conflicts in document updates and let the app continue to function as normal.

