### PR TITLE
fix issue with twitter embeds

### DIFF
--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -12,6 +12,7 @@ import { postDetailURL } from "../lib/url"
 import { getChannelName } from "../lib/util"
 import { formatTitle } from "../lib/title"
 import { validatePostCreateForm } from "../lib/validation"
+import { ensureTwitterEmbedJS, handleTwitterWidgets } from "../lib/embed"
 
 import type { FormValue } from "../flow/formTypes"
 import type { Channel, CreatePostPayload } from "../flow/discussionTypes"
@@ -49,6 +50,7 @@ class CreatePostPage extends React.Component<*, void> {
         value: newPostForm()
       })
     )
+    ensureTwitterEmbedJS()
   }
 
   componentWillUnmount() {
@@ -56,7 +58,7 @@ class CreatePostPage extends React.Component<*, void> {
     dispatch(actions.forms.formEndEdit(CREATE_POST_PAYLOAD))
   }
 
-  onUpdate = (e: Object) => {
+  onUpdate = async (e: Object) => {
     const { dispatch } = this.props
     const { name, value } = e.target
 
@@ -76,7 +78,8 @@ class CreatePostPage extends React.Component<*, void> {
           key:  actions.embedly.get.requestType
         }
       }
-      dispatch(embedlyGetFunc)
+      const embedlyResponse = await dispatch(embedlyGetFunc)
+      handleTwitterWidgets(embedlyResponse)
     }
   }
 

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -64,6 +64,7 @@ import {
   REPORT_CONTENT_NEW_FORM,
   REPORT_CONTENT_PAYLOAD
 } from "../lib/reports"
+import { ensureTwitterEmbedJS, handleTwitterWidgets } from "../lib/embed"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -130,6 +131,8 @@ class PostPage extends React.Component<*, void> {
 
   componentWillMount() {
     this.loadData()
+
+    ensureTwitterEmbedJS()
   }
 
   componentWillUnmount() {
@@ -178,7 +181,8 @@ class PostPage extends React.Component<*, void> {
       ])
 
       if (post.url) {
-        await dispatch(actions.embedly.get(post.url))
+        const embedlyResponse = await dispatch(actions.embedly.get(post.url))
+        handleTwitterWidgets(embedlyResponse)
       }
 
       if (!channel) {

--- a/static/js/factories/embedly.js
+++ b/static/js/factories/embedly.js
@@ -27,6 +27,23 @@ export const makeImage = () => ({
   type:          "photo"
 })
 
+export const makeTweet = () => ({
+  provider_url:    "http://twitter.com",
+  description:     "just setting up my twttr",
+  title:           "jack on Twitter",
+  author_name:     "jack",
+  thumbnail_width: 400,
+  html:
+    '<blockquote class="twitter-tweet"><a href="https://twitter.com/jack/status/20?ref_src=embedly"></a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>',
+  author_url:    "http://twitter.com/jack",
+  version:       "1.0",
+  provider_name: "Twitter",
+  thumbnail_url:
+    "https://pbs.twimg.com/profile_images/839863609345794048/mkpdB9Tf_400x400.jpg",
+  type:             "rich",
+  thumbnail_height: 400
+})
+
 export const makeYoutubeVideo = () => ({
   provider_url: "https://www.youtube.com/",
   description:

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -1,0 +1,29 @@
+// @flow
+import type { EmbedlyResponse } from "../reducers/embedly"
+
+export const ensureTwitterEmbedJS = () => {
+  if (!window.twttr) {
+    window.twttr = (function(d, s, id) {
+      const fjs: any = d.getElementsByTagName(s)[0]
+      const t = window.twttr || {}
+      if (d.getElementById(id)) return t
+      const js = d.createElement(s)
+      js.id = id
+      js.src = "https://platform.twitter.com/widgets.js"
+      fjs.parentNode.insertBefore(js, fjs)
+
+      t._e = []
+      t.ready = function(f) {
+        t._e.push(f)
+      }
+
+      return t
+    })(document, "script", "twitter-wjs")
+  }
+}
+
+export const handleTwitterWidgets = (embedlyResponse: EmbedlyResponse) => {
+  if (embedlyResponse && embedlyResponse.response.provider_name === "Twitter") {
+    window.twttr.widgets.load()
+  }
+}

--- a/static/js/lib/embed_test.js
+++ b/static/js/lib/embed_test.js
@@ -1,0 +1,28 @@
+import { assert } from "chai"
+import sinon from "sinon"
+
+import { handleTwitterWidgets } from "./embed"
+
+describe("embed utils", () => {
+  let twitterLoadStub
+
+  beforeEach(() => {
+    twitterLoadStub = sinon.stub()
+    window.twttr = {
+      widgets: { load: twitterLoadStub }
+    }
+  })
+
+  //
+  ;[
+    [{ response: { provider_name: "Facebook" } }, false],
+    [{ response: { provider_name: "Twitter" } }, true]
+  ].forEach(([response, shouldCall]) => {
+    it(`should ${
+      shouldCall ? "" : "not "
+    }call the load func when appropriate`, () => {
+      handleTwitterWidgets(response)
+      assert.equal(shouldCall, twitterLoadStub.called)
+    })
+  })
+})


### PR DESCRIPTION
#### What are the relevant tickets?

closes #744

#### What's this PR do?

This fixes the bug with embedded tweets not showing up, but ensuring that the twitter JS is on the page and calling its little bootstrap function when necessary.

I think the issue came about because we don't put the twitter HTML on the page at page-load, but afterwards, whenever the embedly request comes back. 

#### How should this be manually tested?

Make sure that if you embed a tweet it will show up in a nice normal tweet embed sort of fashion.