### PR TITLE
don't show the 'this is a preview' message if embedly returns an error

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -112,7 +112,7 @@ export default class CreatePostForm extends React.Component<*, void> {
                 {validationMessage(validation.url)}
               </div>
             )}
-            {!isText && embedly ? (
+            {!isText && embedly && embedly.type !== "error" ? (
               <div className="embedly-preview row">
                 <div className="preview-header">
                   this is a preview of your post

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -9,10 +9,13 @@ import Embedly from "./Embedly"
 import { makeArticle } from "../factories/embedly"
 
 describe("CreatePostForm", () => {
-  it("should show an embedly preview when link post and passed an embedly object", () => {
-    [
+  it("should show an embedly preview when link post and non-error embedly object", () => {
+    const errorArticle = makeArticle()
+    errorArticle.type = "error"
+    ;[
       [true, true, makeArticle()],
       [false, false, makeArticle()],
+      [true, false, errorArticle],
       [true, false, undefined],
       [false, false, undefined]
     ].forEach(([linkPost, shouldShowEmbed, embedlyResponse]) => {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #734 

#### What's this PR do?

If we get an error response from Embedly we don't want to show the little 'this is a preview of your post' message that we normally shown above the embedly preview on the post create screen.

#### How should this be manually tested?

Go to the link post creation screen and try to make a post with a URL that won't work, like 'http://localhost/foo/bar' or something. You shouldn't see the 'this is a preview...' message. If you do a twitter or youtube url or something you should see it as normal.