### PR TITLE
Fix heroku deploy

### DIFF
--- a/open_discussions/test_utils.py
+++ b/open_discussions/test_utils.py
@@ -1,5 +1,9 @@
 """Testing utils"""
 import abc
+from contextlib import contextmanager
+import traceback
+
+import pytest
 
 
 def any_instance_of(*cls):
@@ -19,3 +23,14 @@ def any_instance_of(*cls):
     for c in cls:
         AnyInstanceOf.register(c)
     return AnyInstanceOf()
+
+
+@contextmanager
+def assert_not_raises():
+    """Used to assert that the context does not raise an exception"""
+    try:
+        yield
+    except AssertionError:
+        raise
+    except:  # pylint: disable=bare-except
+        pytest.fail(f'An exception was not raised: {traceback.format_exc()}')

--- a/open_discussions/test_utils_test.py
+++ b/open_discussions/test_utils_test.py
@@ -1,4 +1,6 @@
 """Tests for test utils"""
+import pytest
+
 from open_discussions.test_utils import any_instance_of, assert_not_raises
 
 

--- a/open_discussions/test_utils_test.py
+++ b/open_discussions/test_utils_test.py
@@ -1,5 +1,5 @@
 """Tests for test utils"""
-from open_discussions.test_utils import any_instance_of
+from open_discussions.test_utils import any_instance_of, assert_not_raises
 
 
 def test_any_instance_of():
@@ -11,3 +11,27 @@ def test_any_instance_of():
     assert any_number != 'not a number'
     assert any_number != {}
     assert any_number != []
+
+
+def test_assert_not_raises_none():
+    """
+    assert_not_raises should do nothing if no exception is raised
+    """
+    with assert_not_raises():
+        pass
+
+
+def test_assert_not_raises_exception(mocker):
+    """assert_not_raises should fail the test"""
+    # Here there be dragons
+    fail_mock = mocker.patch('pytest.fail', autospec=True)
+    with assert_not_raises():
+        raise TabError()
+    assert fail_mock.called is True
+
+
+def test_assert_not_raises_failure():
+    """assert_not_raises should reraise an AssertionError"""
+    with pytest.raises(AssertionError):
+        with assert_not_raises():
+            assert 1 == 2

--- a/open_discussions/utils.py
+++ b/open_discussions/utils.py
@@ -1,5 +1,4 @@
 """open_discussions utilities"""
-from contextlib import contextmanager
 import datetime
 from enum import (
     auto,
@@ -7,11 +6,9 @@ from enum import (
 )
 from itertools import islice
 import logging
-import traceback
 
 import pytz
 from django.conf import settings
-import pytest
 
 
 log = logging.getLogger(__name__)
@@ -96,14 +93,3 @@ def chunks(iterable, chunk_size=20):
     while len(chunk) > 0:
         yield chunk
         chunk = list(islice(iterable, chunk_size))
-
-
-@contextmanager
-def assert_not_raises():
-    """Used to assert that the context does not raise an exception"""
-    try:
-        yield
-    except AssertionError:
-        raise
-    except:  # pylint: disable=bare-except
-        pytest.fail(f'An exception was not raised: {traceback.format_exc()}')

--- a/open_discussions/utils_test.py
+++ b/open_discussions/utils_test.py
@@ -6,7 +6,6 @@ import pytest
 import pytz
 
 from open_discussions.utils import (
-    assert_not_raises,
     now_in_utc,
     is_near_now,
     normalize_to_start_of_day,
@@ -76,27 +75,3 @@ def test_chunks_iterable():
     for chunk in chunk_output:
         range_list += chunk
     assert range_list == list(range(count))
-
-
-def test_assert_not_raises_none():
-    """
-    assert_not_raises should do nothing if no exception is raised
-    """
-    with assert_not_raises():
-        pass
-
-
-def test_assert_not_raises_exception(mocker):
-    """assert_not_raises should fail the test"""
-    # Here there be dragons
-    fail_mock = mocker.patch('pytest.fail', autospec=True)
-    with assert_not_raises():
-        raise TabError()
-    assert fail_mock.called is True
-
-
-def test_assert_not_raises_failure():
-    """assert_not_raises should reraise an AssertionError"""
-    with pytest.raises(AssertionError):
-        with assert_not_raises():
-            assert 1 == 2

--- a/open_discussions/utils_test.py
+++ b/open_discussions/utils_test.py
@@ -2,7 +2,6 @@
 import datetime
 from math import ceil
 
-import pytest
 import pytz
 
 from open_discussions.utils import (

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -8,7 +8,7 @@ import pytest
 
 from channels.constants import POSTS_SORT_NEW
 from channels.utils import ListingParams
-from open_discussions.utils import assert_not_raises
+from open_discussions.test_utils import assert_not_raises
 from search.exceptions import RetryException
 from search.tasks import (
     create_document,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes invalid import caused by #651 which was blocking the heroku deploy. Heroku does not install test_requirements.txt so files using pytest were failing to import.

#### How should this be manually tested?
N/A
