### PR TITLE
Fix for non-breaking code text in discussions

### DIFF
--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -106,6 +106,16 @@ $replyPaddingLeft: 8px;
         }
       }
 
+      tt, code, kbd, samp {
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        word-break: break-word;
+        -webkit-hyphens: auto;
+        -ms-hyphens: auto;
+        hyphens: auto;
+      }
+
       @include breakpoint(phone) {
         display: block;
       }

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -111,8 +111,6 @@ $replyPaddingLeft: 8px;
         overflow-wrap: break-word;
         word-wrap: break-word;
         word-break: break-word;
-        -webkit-hyphens: auto;
-        -ms-hyphens: auto;
         hyphens: auto;
       }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -57,8 +57,6 @@
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
-    -webkit-hyphens: auto;
-    -ms-hyphens: auto;
     hyphens: auto;
   }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -52,6 +52,16 @@
     }
   }
 
+  tt, code, kbd, samp {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+  }
+
   .post-links {
     display: flex;
     align-items: center;


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #754

#### What's this PR do?
Discussion posts and comments can be formatted as code elements using markdown. There is a bug where code elements are not wrapping, which causes all the other text to overflow.

#### How should this be manually tested?
Create a comment or a post and enter some code. Around the code add markdown for code which is ```.

The text should wrap normally.

For example:

```  
curl "$1" --max-time 30 -L \
-H 'Connection: keep-alive' \
-H 'Cache-Control: max-age=0' \
-H 'Upgrade-Insecure-Requests: 1' \
-H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3381.0 Safari/537.36' \
-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' \
-H 'Accept-Encoding: gzip, deflate, br' \
-H 'Accept-Language: en-US,en;q=0.9,en-GB;q=0.8,zh;q=0.7,zh-CN;q=0.6,zh-TW;q=0.5' \
-H 'Cookie: welcome-message-viewed=True; optimizelyEndUserId=...; ajs_group_id=null; ajs_anonymous_id=...; _ga=...; __cfduid=...; ajs_user_id=...; prod-edx-language-preference=en; prod-edx-csrftoken=...; video_player_volume_level=100; prod.edx.utm={...}}"' \
--compressed -w %{http_code} -o "$2"
```

