### PR TITLE
Remove authentication requirement for viewing SAML metadata

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -96,7 +96,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
 
 def saml_metadata(request):
     """ Display SAML configuration metadata as XML """
-    if not request.user.is_superuser or not features.is_enabled(features.SAML_AUTH):
+    if not features.is_enabled(features.SAML_AUTH):
         raise Http404("Page not found")
     complete_url = reverse('social:complete', args=("saml", ))
     saml_backend = load_backend(

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -5,7 +5,6 @@ import json
 import xml.etree.ElementTree as etree
 
 import pytest
-from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework_jwt.settings import api_settings
 
@@ -137,8 +136,7 @@ def test_webpack_url_anonymous(settings, client, mocker, authenticated_site):
 
 
 @pytest.mark.parametrize('is_enabled', [True, False])
-@pytest.mark.parametrize('is_superuser', [True, False])
-def test_saml_metadata(settings, client, is_enabled, is_superuser):
+def test_saml_metadata(settings, client, user, is_enabled):
     """Test that SAML metadata page renders or returns a 404"""
     settings.FEATURES[SAML_AUTH] = is_enabled
     if is_enabled:
@@ -150,11 +148,10 @@ def test_saml_metadata(settings, client, is_enabled, is_superuser):
         settings.SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {"givenName": "TestName", "emailAddress": "test@example.com"}
         settings.SOCIAL_AUTH_SAML_SP_EXTRA = {"assertionConsumerService": {"url": "http://mit.edu"}}
 
-    user = User.objects.create(is_superuser=is_superuser)
     client.force_login(user)
     response = client.get(reverse("saml-metadata"))
 
-    if is_enabled and is_superuser:
+    if is_enabled:
         root = etree.fromstring(response.content)
         assert root.tag == '{urn:oasis:names:tc:SAML:2.0:metadata}EntityDescriptor'
         assert response.status_code == 200


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #772 

#### What's this PR do?
Removes the superuser authentication requirement for viewing the SAML metadata URL.

#### How should this be manually tested?
Go to http://localhost:8063/saml/metadata without being logged in, you should see some XML.
