### PR TITLE
Fix comment serialization error, Celery error handling

### DIFF
--- a/open_discussions/utils.py
+++ b/open_discussions/utils.py
@@ -93,3 +93,34 @@ def chunks(iterable, chunk_size=20):
     while len(chunk) > 0:
         yield chunk
         chunk = list(islice(iterable, chunk_size))
+
+
+def merge_strings(list_or_str):
+    """
+    Recursively go through through nested lists of strings and merge into a flattened list.
+
+    Args:
+        list_or_str (any): A list of strings or a string
+
+    Returns:
+        list of str: A list of strings
+    """
+
+    list_to_return = []
+    _merge_strings(list_or_str, list_to_return)
+    return list_to_return
+
+
+def _merge_strings(list_or_str, list_to_return):
+    """
+    Recursively go through through nested lists of strings and merge into a flattened list.
+
+    Args:
+        list_or_str (any): A list of strings or a string
+        list_to_return (list of str): The list the strings will be added to
+    """
+    if isinstance(list_or_str, list):
+        for item in list_or_str:
+            _merge_strings(item, list_to_return)
+    elif list_or_str is not None:
+        list_to_return.append(list_or_str)

--- a/open_discussions/utils_test.py
+++ b/open_discussions/utils_test.py
@@ -2,6 +2,7 @@
 import datetime
 from math import ceil
 
+import pytest
 import pytz
 
 from open_discussions.utils import (
@@ -9,6 +10,7 @@ from open_discussions.utils import (
     is_near_now,
     normalize_to_start_of_day,
     chunks,
+    merge_strings,
 )
 
 
@@ -74,3 +76,15 @@ def test_chunks_iterable():
     for chunk in chunk_output:
         range_list += chunk
     assert range_list == list(range(count))
+
+
+@pytest.mark.parametrize("list_or_string,output", [
+    ['str', ['str']],
+    [['str', None, [None]], ['str']],
+    [[['a'], 'b', ['c', 'd'], 'e'], ['a', 'b', 'c', 'd', 'e']],
+])
+def test_merge_strings(list_or_string, output):
+    """
+    merge_strings should flatten a nested list of strings
+    """
+    assert merge_strings(list_or_string) == output

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -40,7 +40,7 @@ def serialize_post(post_obj):
     """
     return {
         'object_type': POST_TYPE,
-        'author': post_obj.author.name,
+        'author': post_obj.author.name if post_obj.author else None,
         'channel_title': post_obj.subreddit.display_name,
         'text': post_obj.selftext,
         'score': post_obj.score,
@@ -69,7 +69,7 @@ def serialize_comment(comment_obj):
 
     return {
         'object_type': COMMENT_TYPE,
-        'author': comment_obj.author.name,
+        'author': comment_obj.author.name if comment_obj.author else None,
         'channel_title': comment_obj.subreddit.display_name,
         'text': comment_obj.body,
         'score': comment_obj.score,

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -1,4 +1,10 @@
 """Tests for elasticsearch serializers"""
+import pytest
+
+from channels.constants import (
+    COMMENT_TYPE,
+    POST_TYPE,
+)
 from search.serializers import (
     serialize_comment,
     serialize_post,
@@ -22,3 +28,87 @@ def test_serialize_post_and_comments(mocker):
         serialize_comment(outer_comment_mock),
         serialize_comment(inner_comment_mock),
     ]
+
+
+@pytest.mark.parametrize("missing_author", [True, False])
+def test_serialize_comment(mocker, missing_author):
+    """serialize_comment should create a dict representation of a reddit comment to put in elasticsearch"""
+    author_name = 'author'
+    channel = 'channel'
+    comment_id = 'comment'
+    created = 'created'
+    parent = 'parent'
+    post_id = 'post id'
+    post_title = 'post title'
+    score = 'score'
+    text = 'text'
+
+    if missing_author:
+        author_obj = None
+    else:
+        author_obj = mocker.Mock()
+        author_obj.name = author_name
+
+    comment = mocker.Mock(
+        author=author_obj,
+        subreddit=mocker.Mock(display_name=channel),
+        id=comment_id,
+        created=created,
+        submission=mocker.Mock(id=post_id, title=post_title),
+        score=score,
+        body=text,
+    )
+    comment.parent = mocker.Mock(return_value=mocker.Mock(id=parent))
+    assert serialize_comment(comment) == {
+        'author': author_name if not missing_author else None,
+        'channel_title': channel,
+        'comment_id': comment_id,
+        'created': created,
+        'object_type': COMMENT_TYPE,
+        'parent_comment_id': parent,
+        'post_id': post_id,
+        'post_title': post_title,
+        'score': score,
+        'text': text,
+    }
+
+
+@pytest.mark.parametrize("missing_author", [True, False])
+def test_serialize_post(mocker, missing_author):
+    """serialize_post should create a dict representation of a post to put in elasticsearch"""
+    author_name = 'author_name'
+    channel_name = 'channel'
+    created = 'created'
+    num_comments = 'comments'
+    text = 'selftext'
+    score = 'score'
+    post_id = 'post_id'
+    post_title = 'post_title'
+
+    if missing_author:
+        author_obj = None
+    else:
+        author_obj = mocker.Mock()
+        author_obj.name = author_name
+
+    post = mocker.Mock(
+        author=author_obj,
+        subreddit=mocker.Mock(display_name=channel_name),
+        created=created,
+        num_comments=num_comments,
+        selftext=text,
+        score=score,
+        title=post_title,
+        id=post_id,
+    )
+    assert serialize_post(post) == {
+        'author': author_name if not missing_author else None,
+        'channel_title': channel_name,
+        'created': created,
+        'num_comments': num_comments,
+        'object_type': POST_TYPE,
+        'post_id': post_id,
+        'post_title': post_title,
+        'score': score,
+        'text': text,
+    }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #760 
Fixes #762 

#### What's this PR do?
Fixes a None error with missing reddit authors. Error handling for tasks is also refactored to not rely on Celery propagating the error correctly through groups.

#### How should this be manually tested?
In `serialize_comment` add some code which will fail for a particular comment. Something like `if comment.id == 'abc': raise Exception()` would work. Run `./manage.py recreate_index`. It should fail and show you the comment id on which it failed.

Remove the exception code and run it again. It should succeed.
