### PR TITLE
Apt buildpack should be first

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,6 +6,9 @@
   ],
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-nodejs"
     },
     {
@@ -16,9 +19,6 @@
     },
     {
       "url": "https://github.com/heroku/heroku-buildpack-nginx"
-    },
-    {
-      "url": "https://github.com/heroku/heroku-buildpack-apt"
     }
   ],
   "description": "open-discussions",


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Puts the apt buildpack first in the list in app.json

#### How should this be manually tested?
Heroku PR builds shouldn't break