### PR TITLE
add a fancy loading animation to the post detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ramda": "^0.24.1",
     "react": "^16.4.0",
     "react-addons-shallow-compare": "^15.6.0",
+    "react-content-loader": "^3.1.2",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.4.0",
     "react-ga": "^2.2.0",

--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -1,6 +1,8 @@
 // @flow
 import React from "react"
 
+import ContentLoader from "react-content-loader"
+
 export default class Embedly extends React.Component<*> {
   renderEmbed() {
     const { embedly } = this.props
@@ -48,13 +50,32 @@ export default class Embedly extends React.Component<*> {
     )
   }
 
+  renderContentLoader() {
+    return (
+      <div className="content-loader">
+        <ContentLoader
+          speed={2}
+          style={{ width: "100%", height: "300px" }}
+          width="100%"
+          height={300}
+        >
+          <rect x="0" y="0" rx="5" ry="5" width="100%" height="200" />
+          <rect x="0" y="220" rx="5" ry="5" width="65%" height="15" />
+          <rect x="0" y="250" rx="5" ry="5" width="93%" height="10" />
+          <rect x="0" y="265" rx="5" ry="5" width="95%" height="10" />
+          <rect x="0" y="280" rx="5" ry="5" width="90%" height="10" />
+        </ContentLoader>
+      </div>
+    )
+  }
+
   render() {
     const { embedly } = this.props
 
-    return (
-      <div className="embedly">
-        {embedly && embedly.type !== "error" ? this.renderEmbed() : null}
-      </div>
+    return embedly && embedly.type !== "error" ? (
+      <div className="embedly">{this.renderEmbed()}</div>
+    ) : (
+      this.renderContentLoader()
     )
   }
 }

--- a/static/js/components/Embedly_test.js
+++ b/static/js/components/Embedly_test.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { mount } from "enzyme"
 import { assert } from "chai"
+import ContentLoader from "react-content-loader"
 
 import Embedly from "./Embedly"
 
@@ -52,5 +53,11 @@ describe("Embedly", () => {
     article.type = "error"
     const wrapper = renderEmbedly(article)
     assert.lengthOf(wrapper.children().at(1), 0)
+  })
+
+  it("should show a loading animation thing if embedly response hasn't come back yet", () => {
+    const wrapper = renderEmbedly()
+    assert.isOk(wrapper.find(".content-loader"))
+    assert.isOk(wrapper.find(ContentLoader))
   })
 })

--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -1,3 +1,8 @@
+.content-loader {
+  width: 100%;
+  height: 300px;
+}
+
 .embedly {
   .video-container {
     padding: 15px 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,6 +6125,10 @@ react-addons-shallow-compare@^15.6.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
+react-content-loader@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-3.1.2.tgz#98230b4604b4b744eaa2d3fc88917dd988df6766"
+
 react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"


### PR DESCRIPTION
#### What are the relevant tickets?

part of #777 

#### What's this PR do?

This adds a fancy animated placeholder loading UI element, which we show on link posts while awaiting a response from Embed.ly. It looks like this:

![loading_thing](https://user-images.githubusercontent.com/6207644/41251674-abe2913c-6d88-11e8-9567-bc150935296b.png)

![loading_thing_mobile](https://user-images.githubusercontent.com/6207644/41251680-aee1a918-6d88-11e8-9b8d-83b39b6c0766.png)

I'm using this thing: http://danilowoz.com/create-content-loader/ to make it.

#### How should this be manually tested?

You'll need to have the embedly API key set up on your machine. Once you've got that, you'll need to just try to look at a link post. You should see the animation thingy for just like half a second or so when the embedly response is still loading. It should display ok on both desktop and mobile views.
