### PR TITLE
Add MAILGUN_SENDER_DOMAIN to app.json so it gets used by review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -65,6 +65,9 @@
       "description": "Email address used with bcc email",
       "required": false
     },
+    "MAILGUN_SENDER_DOMAIN": {
+      "description": "Domain used for emails sent via mailgun"
+    },
     "OPEN_DISCUSSIONS_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to."
     },


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds `MAILGUN_SENDER_DOMAIN` to environment variables listed in app.json so it gets used by the review app

#### How should this be manually tested?
N/A
