### PR TITLE
Added user full name to ES document

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -32,7 +32,8 @@ SCRIPTING_LANG = 'painless'
 UPDATE_CONFLICT_SETTING = 'proceed'
 COMBINED_MAPPING = {
     'object_type': {'type': 'keyword'},
-    'author': {'type': 'keyword'},
+    'author_id': {'type': 'keyword'},
+    'author_name': {'type': 'keyword'},
     'channel_title': {'type': 'keyword'},
     'text': {'type': 'text'},
     'score': {'type': 'long'},

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -1,4 +1,6 @@
 """Serializers for elasticsearch data"""
+from django.contrib.auth import get_user_model
+
 from channels.constants import (
     POST_TYPE,
     COMMENT_TYPE,
@@ -9,6 +11,25 @@ from search.api import (
     gen_comment_id,
 )
 
+User = get_user_model()
+
+
+def _get_user_from_reddit_object(reddit_obj):
+    """
+    Gets the User that corresponds to a given reddit object
+
+    Args:
+        reddit_obj (praw.models.Submission|praw.models.Comment):
+            A post or comment object
+
+    Returns:
+        User|None: A User object (or None if author information is missing from the instance)
+    """
+    if reddit_obj.author is None:
+        return None
+    else:
+        return User.objects.filter(username=reddit_obj.author.name).select_related('profile').first()
+
 
 def serialize_post(post_obj):
     """
@@ -17,9 +38,12 @@ def serialize_post(post_obj):
     Args:
         post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
     """
+    author_user = _get_user_from_reddit_object(post_obj)
+    author_name = author_user.profile.name if author_user else None
     return {
         'object_type': POST_TYPE,
-        'author': post_obj.author.name if post_obj.author else None,
+        'author_id': post_obj.author.name if post_obj.author else None,
+        'author_name': author_name,
         'channel_title': post_obj.subreddit.display_name,
         'text': post_obj.selftext,
         'score': post_obj.score,
@@ -37,13 +61,17 @@ def serialize_comment(comment_obj):
     Args:
         comment_obj (Comment): A PRAW comment
     """
+    author_user = _get_user_from_reddit_object(comment_obj)
+    author_name = author_user.profile.name if author_user else None
+
     post_obj = comment_obj.submission
     parent_comment = comment_obj.parent()
     parent_comment_id = None if get_reddit_object_type(parent_comment) != COMMENT_TYPE else parent_comment.id
 
     return {
         'object_type': COMMENT_TYPE,
-        'author': comment_obj.author.name if comment_obj.author else None,
+        'author_id': comment_obj.author.name if comment_obj.author else None,
+        'author_name': author_name,
         'channel_title': comment_obj.subreddit.display_name,
         'text': comment_obj.body,
         'score': comment_obj.score,


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #787 

#### What's this PR do?
Adds a user's name to the ES index and renames the existing `author` field to `author_id`

#### How should this be manually tested?
- Restart your `celery` container at the very least after you check out this branch
- Run `docker-compose run web ./manage.py recreate_index`
- Check the search index to make sure that `author_id` and `author_name` are in the indexed documents and that the values are what you expect.

Easy curl command to look at documents in the index: `curl -XGET -H "Content-Type: application/json" -s 'http://localhost:9101/discussions_local_default/_search?pretty=true'`

#### Any background context you want to provide?
Two things to note:
1. Unsurprisingly, some code was added that is very similar to `PostSerializer` and `CommentSerializer`. There is an open tech debt issue to use those classes when serializing for the ES index (#790)
1. For every post and comment we want to add/update in the index, a query will be made to fetch the associated `User`. This will result in a lot of queries when we fully reindex from data. Not perfect, but I wouldn't expect this to cause any intolerable performance penalties for quite a while.
