### PR TITLE
Set requestedAuthnContext to False for SAML

### DIFF
--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -384,6 +384,7 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
 
 SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
     "wantAssertionsEncrypted": SOCIAL_AUTH_SAML_SECURITY_ENCRYPTED,
+    "requestedAuthnContext": False
 }
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
#763

#### What's this PR do?
Adds `"requestedAuthnContext": False` to SAML configuration, which should cause Touchstone to show the 'login via certificate' option.

#### How should this be manually tested?
Nothing should break
