### PR TITLE
Fix logging of errors and exceptions to sentry

### DIFF
--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -454,7 +454,7 @@ LOGGING = {
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,
-            'handlers': ['console', 'syslog'],
+            'handlers': ['console', 'syslog', 'sentry'],
         },
         'django.request': {
             'handlers': ['mail_admins'],
@@ -474,7 +474,7 @@ LOGGING = {
         }
     },
     'root': {
-        'handlers': ['console', 'syslog'],
+        'handlers': ['console', 'syslog', 'sentry'],
         'level': LOG_LEVEL,
     },
 }
@@ -488,14 +488,6 @@ RAVEN_CONFIG = {
     'release': VERSION
 }
 
-# to run the app locally on mac you need to bypass syslog
-if get_bool('OPEN_DISCUSSIONS_BYPASS_SYSLOG', False):
-    LOGGING['handlers'].pop('syslog')
-    LOGGING['loggers']['root']['handlers'] = ['console']
-    LOGGING['loggers']['ui']['handlers'] = ['console']
-    LOGGING['loggers']['django']['handlers'] = ['console']
-
-# server-status
 STATUS_TOKEN = get_string("STATUS_TOKEN", "")
 HEALTH_CHECK = ['CELERY', 'REDIS', 'POSTGRES', 'ELASTIC_SEARCH']
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ beautifulsoup4==4.6.0
 betamax
 betamax_serializers
 boto==2.39.0
-celery==4.2.0rc2
+celery==4.2.0
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
@@ -30,7 +30,7 @@ praw==4.5.1
 premailer==3.1.1
 python-dateutil
 python3-saml==1.4.1
-raven
+raven==6.9.0
 redis==2.10.5
 requests
 social-auth-app-django==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,15 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 amqp==2.1.4               # via kombu
-appnope==0.1.0            # via ipython
 base36==0.1.1
 beautifulsoup4==4.6.0
 betamax-serializers==0.2.0
 betamax==0.8.0
 billiard==3.5.0.2         # via celery
 boto==2.39.0
-celery==4.2.0rc2
+celery==4.2.0
 certifi==2017.4.17        # via requests
 chardet==3.0.4            # via requests
-contextlib2==0.5.5        # via raven
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.0.11         # via ipython, traitlets
@@ -42,7 +40,7 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.1.0
 isodate==0.6.0            # via python3-saml
 jedi==0.10.2              # via ipython
-kombu==4.0.2              # via celery, django-server-status
+kombu==4.2.1              # via celery, django-server-status
 lxml==4.1.1               # via premailer, xmlsec
 markdown2==2.3.5
 newrelic==2.86.3.70
@@ -64,7 +62,7 @@ python3-openid==3.1.0     # via social-auth-core
 python3-saml==1.4.1
 pytz==2017.2              # via celery, django
 pyyaml==3.11
-raven==6.1.0
+raven==6.9.0
 redis==2.10.5
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.18.1

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -1,9 +1,9 @@
 """Indexing tasks"""
 from contextlib import contextmanager
+import logging
 
 import celery
 from celery.exceptions import Ignore
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from elasticsearch.exceptions import NotFoundError
@@ -22,7 +22,7 @@ from search.exceptions import (
 
 
 User = get_user_model()
-log = get_task_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 # For our tasks that attempt to partially update a document, there's a chance that


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #811 

#### What's this PR do?
 - Adds `sentry` to the list of logging handlers and to the root logger so that all `log.error` or `log.exception` are logged correctly from the web server
 - Replace `get_task_logger` with `logging.getLogger` because the celery one doesn't work and I can't figure out what I need to change to fix it.
 - Upgrade some dependencies

#### How should this be manually tested?
You can shell into the PR build and run `logging.getLogger().error("test error")` to test that the error gets reported to sentry.

For celery you can shell into heroku and run `search.tasks.index_post_with_comments.delay(123456)` (123456 is invalid). You should see an error appear in sentry.