### PR TITLE
fix a stupid bug

### DIFF
--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -158,7 +158,7 @@ export default class ExpandedPostDisplay extends React.Component<*, void> {
             by <span className="author-name">{post.author_name}</span>,{" "}
             {formattedDate}
           </div>
-          <Embedly embedly={embedly} />
+          {post && post.url ? <Embedly embedly={embedly} /> : null}
         </div>
         {!showPermalinkUI && post.text ? this.renderTextContent() : null}
         {R.has(editPostKey(post), forms) ? null : this.postActionButtons()}

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -8,6 +8,7 @@ import R from "ramda"
 
 import ExpandedPostDisplay from "./ExpandedPostDisplay"
 import Router from "../Router"
+import Embedly from "./Embedly"
 
 import { wait } from "../lib/util"
 import { urlHostname } from "../lib/url"
@@ -83,6 +84,14 @@ describe("ExpandedPostDisplay", () => {
   it("should hide text content if passed showPermalinkUI", () => {
     const wrapper = renderPostDisplay({ post, showPermalinkUI: true })
     assert.isFalse(wrapper.find(ReactMarkdown).exists())
+  })
+
+  it("should show an embedly component, if a link post", () => {
+    [true, false].forEach(isLinkPost => {
+      post = makePost(isLinkPost)
+      const wrapper = renderPostDisplay({ post })
+      assert.equal(isLinkPost, wrapper.find(Embedly).exists())
+    })
   })
 
   it("should display post text", () => {


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

This makes sure we're dealing with a URL post before we display the Embedly component. I recently changed the Embedly component to include a loader placeholder. Previously, it had its own logic that would only display when it got a result, so it was safe to just leave it on the page at all times. After I changed it to have a 'loading' placeholder it was no longer safe! oops.

This just checks to make sure we're dealing with a link post before we put the component on the page.

#### How should this be manually tested?

You, uh, shouldn't see a link post loader on the text post page anymore...

Embed.ly link posts should work as normal.