### PR TITLE
Moved channel API imports out of channel serializers

### DIFF
--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -47,7 +47,7 @@ def mock_client(mock_get_client):
     return mock_get_client.return_value
 
 
-@pytest.mark.parametrize('vote_func', [api.apply_post_vote, api.apply_comment_vote])
+@pytest.mark.parametrize('vote_func', [api.Api.apply_post_vote, api.Api.apply_comment_vote])
 @pytest.mark.parametrize('request_data,likes_value,expected_instance_vote_func', [
     ({'upvoted': True}, None, 'upvote'),
     ({'upvoted': True}, False, 'upvote'),
@@ -76,8 +76,8 @@ def test_apply_vote(mocker, vote_func, request_data, likes_value, expected_insta
 
 
 @pytest.mark.parametrize('vote_func,expected_allowed_downvote,expected_instance_type', [
-    (api.apply_post_vote, False, POST_TYPE),
-    (api.apply_comment_vote, True, COMMENT_TYPE),
+    (api.Api.apply_post_vote, False, POST_TYPE),
+    (api.Api.apply_comment_vote, True, COMMENT_TYPE),
 ])
 def test_vote_indexing(mocker, vote_func, expected_allowed_downvote, expected_instance_type):
     """Test that an upvote/downvote calls a function to update the index"""

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.functional import SimpleLazyObject
+from praw.config import Config
 from praw.exceptions import APIException
 from praw.models import Comment
 from prawcore.exceptions import (
@@ -220,3 +221,13 @@ def lookup_subscriptions_for_comments(comments, user):
         list of int: list of integer ids of comments the user is subscribed to
     """
     return SimpleLazyObject(lambda: _lookup_subscriptions_for_comments(comments, user))
+
+
+def get_kind_mapping():
+    """
+    Get a mapping of kinds
+
+    Returns:
+        dict: A map of the kind name to the kind prefix (ie t1)
+    """
+    return Config('DEFAULT').kinds

--- a/channels/views/channels.py
+++ b/channels/views/channels.py
@@ -24,6 +24,13 @@ class ChannelListView(ListCreateAPIView):
     permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffOrReadonlyPermission,)
     serializer_class = ChannelSerializer
 
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
+
     def get_queryset(self):
         """Get generator for channels list"""
         api = Api(user=self.request.user)
@@ -40,6 +47,13 @@ class ChannelDetailView(RetrieveUpdateAPIView):
     """
     permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffModeratorOrReadonlyPermission,)
     serializer_class = ChannelSerializer
+
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
 
     def get_object(self):
         """Get channel referenced by API"""

--- a/channels/views/comments.py
+++ b/channels/views/comments.py
@@ -68,6 +68,7 @@ class CommentListView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
             'view': self,
@@ -119,6 +120,7 @@ class MoreCommentsView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
             'view': self,
@@ -166,6 +168,7 @@ class CommentDetailView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
             'view': self,

--- a/channels/views/contributors.py
+++ b/channels/views/contributors.py
@@ -20,6 +20,13 @@ class ContributorListView(ListCreateAPIView):
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
     serializer_class = ContributorSerializer
 
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
+
     def get_queryset(self):
         """Get generator for contributors in channel"""
         api = Api(user=self.request.user)
@@ -31,6 +38,13 @@ class ContributorDetailView(APIView):
     View to retrieve and remove contributors in channels
     """
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
+
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
 
     def get(self, request, *args, **kwargs):
         """Get contributor in channel"""

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -22,6 +22,13 @@ class ModeratorListView(ListCreateAPIView):
     permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffOrReadonlyPermission,)
     serializer_class = ModeratorSerializer
 
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
+
     def get_queryset(self):
         """Get a list of moderators for channel"""
         api = Api(user=self.request.user)
@@ -34,6 +41,13 @@ class ModeratorDetailView(APIView):
     View to retrieve and remove moderators
     """
     permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffOrReadonlyPermission,)
+
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
 
     def get(self, request, *args, **kwargs):
         """Get moderator for the channel"""

--- a/channels/views/posts.py
+++ b/channels/views/posts.py
@@ -26,6 +26,7 @@ class PostListView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
             'view': self,
@@ -72,6 +73,7 @@ class PostDetailView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
             'view': self,

--- a/channels/views/reports.py
+++ b/channels/views/reports.py
@@ -20,8 +20,10 @@ class ReportContentView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
+            'view': self,
         }
 
     def post(self, request, *args, **kwargs):  # pylint: disable=unused-argument
@@ -49,8 +51,10 @@ class ChannelReportListView(APIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {
+            'channel_api': self.request.channel_api,
             'current_user': self.request.user,
             'request': self.request,
+            'view': self,
         }
 
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument

--- a/channels/views/subscribers.py
+++ b/channels/views/subscribers.py
@@ -20,12 +20,26 @@ class SubscriberListView(CreateAPIView):
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
     serializer_class = SubscriberSerializer
 
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
+
 
 class SubscriberDetailView(APIView):
     """
     View to retrieve and remove subscribers in channels
     """
     permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
+
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            'channel_api': self.request.channel_api,
+            'view': self,
+        }
 
     def get(self, request, *args, **kwargs):
         """Get subscriber for the channel"""

--- a/open_discussions/middleware/channel_api.py
+++ b/open_discussions/middleware/channel_api.py
@@ -1,0 +1,17 @@
+"""Channel API middleware"""
+from django.utils.functional import SimpleLazyObject
+
+from channels.api import Api
+
+
+class ChannelApiMiddleware:
+    """
+    Middleware that makes a channel API object available to views
+    via a lazy object attached to the request
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.channel_api = SimpleLazyObject(lambda: Api(request.user))
+        return self.get_response(request)

--- a/open_discussions/middleware/channel_api_test.py
+++ b/open_discussions/middleware/channel_api_test.py
@@ -1,0 +1,23 @@
+"""Tests for channel API middleware"""
+from django.utils.functional import SimpleLazyObject
+
+from open_discussions.middleware.channel_api import ChannelApiMiddleware
+
+
+def test_channel_api_middleware(settings, mocker, jwt_token, rf, user):
+    """Tests that the middleware makes a channel API object available on the request"""
+    api_mock_obj = mocker.Mock(some_api_method=mocker.Mock(return_value='result'))
+    patched_api_cls = mocker.patch('open_discussions.middleware.channel_api.Api', return_value=api_mock_obj)
+    rf.cookies.load({
+        settings.OPEN_DISCUSSIONS_COOKIE_NAME: jwt_token,
+    })
+    request = rf.get('/')
+    request.user = user
+    get_request_mock = mocker.Mock()
+    middleware = ChannelApiMiddleware(get_request_mock)
+    middleware(request)
+    assert hasattr(request, 'channel_api')
+    assert isinstance(request.channel_api, SimpleLazyObject)
+    result = request.channel_api.some_api_method()
+    patched_api_cls.assert_called_with(user)
+    assert result == 'result'

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -110,6 +110,7 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'open_discussions.middleware.user_activity.UserActivityMiddleware',
+    'open_discussions.middleware.channel_api.ChannelApiMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #790 (this essentially addresses some tech debt behind that tech debt)

#### What's this PR do?
Moves channel API imports out of channel serializers. Channel API is now attached to each request as a lazy object

#### How should this be manually tested?
Tests should pass, normal app functionality should work
