### PR TITLE
Add autouse fixture to prevent requests from executing during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,17 @@
 """Project conftest"""
 # pylint: disable=wildcard-import, unused-wildcard-import
+import pytest
+
 from fixtures.betamax import *
 from fixtures.common import *
 from fixtures.reddit import *
 from fixtures.users import *
+from open_discussions.exceptions import NoRequestException
+
+
+@pytest.fixture(autouse=True)
+def prevent_requests(mocker, request):
+    """Patch requests to error on request by default"""
+    if 'betamax' in request.keywords:
+        return
+    mocker.patch('requests.sessions.Session.request', autospec=True, side_effect=NoRequestException)

--- a/open_discussions/exceptions.py
+++ b/open_discussions/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions for open discussions"""
+
+
+class NoRequestException(Exception):
+    """This exception is raised during unit tests if an HTTP request is attempted"""


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds a fixture preventing HTTP requests from being made via the requests library when unit tests are running

#### How should this be manually tested?
Checkout `master`, go to `test_more_comments` in `channels/api_test.py` and remove `mock_client` from the list. Run that test, it should pass locally (or possibly fail due to some reddit error).

Check out this PR and run the same test, with `mock_client` removed. You should see a `NoRequestException` somewhere in the stack trace.