### PR TITLE
Delete indices one by one to avoid use of _all

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -279,7 +279,9 @@ def create_backing_index():
     temp_alias = get_reindexing_alias_name()
     if conn.indices.exists_alias(name=temp_alias):
         # Deletes both alias and backing indexes
-        conn.indices.delete_alias(index="_all", name=temp_alias)
+        indices = conn.indices.get_alias(temp_alias).keys()
+        for index in indices:
+            conn.indices.delete_alias(index=index, name=temp_alias)
 
     # Point temp_alias toward new backing index
     conn.indices.put_alias(index=new_backing_index, name=temp_alias)


### PR DESCRIPTION
#### What are the relevant tickets?
https://sentry.io/mit-office-of-digital-learning/discussions/issues/585134656/?environment=production

#### What's this PR do?
Delete indices one by one instead of using `_all` in order to work around complications with readonlyrest Elasticsearch plugin

#### How should this be manually tested?
N/A, we will need to test this in CI
