### PR TITLE
fix issue with large channel descriptions

### DIFF
--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -1,5 +1,6 @@
 .channel-about {
   position: relative;
+  max-width: 400px;
 
   @include breakpoint(desktop) {
     &:first-child {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #835 

#### What's this PR do?

This just puts a `max-width` on the description container to fix the layout bug.

#### How should this be manually tested?

Edit the channel description for one of your channels to be pretty long (a few paragraphs). Then confirm on master you see the layout bug. Then check out this branch and confirm it fixes it.