### PR TITLE
Use feature flag to determine whether to show profile incompleteness red dot

### DIFF
--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -53,7 +53,7 @@ export default class UserMenu extends React.Component<*, *> {
           className="profile-image"
           src={makeProfileImageUrl(profile)}
         />
-        {!isProfileComplete(profile) ? (
+        {SETTINGS.profile_ui_enabled && !isProfileComplete(profile) ? (
           <div className="profile-incomplete" />
         ) : null}
         {showUserMenu ? (

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -70,12 +70,22 @@ describe("UserMenu", () => {
       }
     })
   })
-
-  it("should include a red dot if profile is incomplete", () => {
-    SETTINGS.profile_ui_enabled = true
-    sandbox.stub(utilFuncs, "isProfileComplete").returns(false)
-    const wrapper = renderUserMenu()
-    assert.isOk(wrapper.find(".profile-incomplete").exists())
+  ;[
+    [true, true, false],
+    [true, false, true],
+    [false, true, false],
+    [false, false, false]
+  ].forEach(([featureFlagEnabled, complete, shouldShowDot]) => {
+    it(`should ${
+      shouldShowDot ? "" : "not "
+    }include a red dot since the feature flag
+     is ${featureFlagEnabled ? "enabled" : "disabled"} and the profile is
+      ${complete ? "complete" : "incomplete"}`, () => {
+      SETTINGS.profile_ui_enabled = featureFlagEnabled
+      sandbox.stub(utilFuncs, "isProfileComplete").returns(complete)
+      const wrapper = renderUserMenu()
+      assert.equal(wrapper.find(".profile-incomplete").exists(), shouldShowDot)
+    })
   })
 
   it("should not include a red dot if profile is complete", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes a regression from #816. The feature flag for profile UI will be used to determine whether to show the red dot showing profile incompleteness

#### How should this be manually tested?
If your profile is incomplete and the `PROFILE_UI` feature flag is on, you should see the red dot in the profile icon. You should be able to turn off the feature flag and see the red dot go away.