### PR TITLE
Pin dockerfile python version to 3.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.4
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Pins this to 3.6.4 since we've seen broken pack issues in micromasters with 3.6.5. See mitodl/micromasters#4031

#### How should this be manually tested?
`docker-compose build --no-cache web` should work