### PR TITLE
Use gravatar for new profiles without images

### DIFF
--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -179,6 +179,7 @@ def test_validate_require_password_and_profile_via_email_exit(mocker, backend_na
 @pytest.mark.django_db
 def test_validate_require_password_and_profile_via_email(mocker):
     """Tests that require_password_and_profile_via_email processes the request"""
+    mocker.patch('profiles.models.requests.get')
     user = UserFactory(profile=None)
     mock_strategy = mocker.Mock()
     mock_strategy.request_data.return_value = {
@@ -239,6 +240,7 @@ def test_validate_require_password_and_profile_via_email_password_set(mocker):
 def test_validate_require_profile_update_user_via_saml(mocker, backend_name, is_new):
     """Tests that require_profile_update_user_via_saml returns {} if not using the saml backend"""
     user = UserFactory(first_name='Jane', last_name='Doe', profile=None)
+    mocker.patch('profiles.models.requests.get')
     mock_strategy = mocker.Mock()
     mock_backend = mocker.Mock()
     mock_backend.name = backend_name

--- a/open_discussions/test_utils.py
+++ b/open_discussions/test_utils.py
@@ -34,3 +34,12 @@ def assert_not_raises():
         raise
     except Exception:  # pylint: disable=broad-except
         pytest.fail(f'An exception was not raised: {traceback.format_exc()}')
+
+
+class MockResponse:
+    """
+    Mock requests.Response
+    """
+    def __init__(self, content, status_code):
+        self.content = content
+        self.status_code = status_code

--- a/open_discussions/test_utils_test.py
+++ b/open_discussions/test_utils_test.py
@@ -1,7 +1,7 @@
 """Tests for test utils"""
 import pytest
 
-from open_discussions.test_utils import any_instance_of, assert_not_raises
+from open_discussions.test_utils import any_instance_of, assert_not_raises, MockResponse
 
 
 def test_any_instance_of():
@@ -37,3 +37,11 @@ def test_assert_not_raises_failure():
     with pytest.raises(AssertionError):
         with assert_not_raises():
             assert 1 == 2
+
+
+def test_mock_response():
+    """ assert MockResponse returns correct values """
+    content = 'test'
+    response = MockResponse(content, 404)
+    assert response.status_code == 404
+    assert response.content == content

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -14,11 +14,6 @@ from open_discussions.utils import now_in_utc
 
 # This is the Django ImageField max path size
 IMAGE_PATH_MAX_LENGTH = 100
-
-# Max dimension of either height or width for small and medium images
-IMAGE_SMALL_MAX_DIMENSION = 64
-IMAGE_MEDIUM_MAX_DIMENSION = 128
-
 IMAGE_PATH_PREFIX = 'profile'
 
 default_profile_image = urljoin(settings.STATIC_URL, "images/avatar_default.png")

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -77,19 +77,21 @@ class ProfileImage extends React.Component<*> {
     return (
       <div className="profile-image-container">
         <div className="avatar" onClick={onClick}>
-          {imageUrl === defaultProfileImageUrl && profile ? (
-            <div className={`profile-image ${imageSizeClass}`}>
-              <div className={`profile-initials ${imageSizeClass}`}>
-                {initials(profile.name)}
+          {imageUrl.endsWith(defaultProfileImageUrl) &&
+          profile &&
+          profile.name ? (
+              <div className={`profile-image ${imageSizeClass}`}>
+                <div className={`profile-initials ${imageSizeClass}`}>
+                  {initials(profile.name)}
+                </div>
               </div>
-            </div>
-          ) : (
-            <img
-              src={imageUrl}
-              alt={`Profile image for ${profile ? profile.name : "anonymous"}`}
-              className={`profile-image ${imageSizeClass}`}
-            />
-          )}
+            ) : (
+              <img
+                src={imageUrl}
+                alt={`Profile image for ${profile ? profile.name : "anonymous"}`}
+                className={`profile-image ${imageSizeClass}`}
+              />
+            )}
           {editable ? (
             <span>
               <ProfileImageUploader

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -7,6 +7,7 @@ import ProfileImage from "./ProfileImage"
 import { actions } from "../actions"
 import { initials } from "../lib/profile"
 import { formatTitle } from "../lib/title"
+import { defaultProfileImageUrl } from "../lib/util"
 
 describe("ProfilePage", function() {
   let helper, renderComponent, profile
@@ -77,6 +78,19 @@ describe("ProfilePage", function() {
         .at(0)
         .text(),
       initials(profile.name)
+    )
+  })
+
+  it("should include a ProfileImage and default image when no profile name exists", async () => {
+    profile.name = ""
+    const wrapper = await renderPage()
+    assert.equal(
+      wrapper
+        .find(ProfileImage)
+        .find("img")
+        .at(1)
+        .props().src,
+      defaultProfileImageUrl
     )
   })
 

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -2,19 +2,21 @@
   border-radius: 100%;
   background-color: #579cf9;
   color: #fff;
-  max-width: 45px;
-  max-height: 45px;
+  width: 45px;
+  height: 45px;
+  display: block;
+  overflow: hidden;
 }
 
 .small {
-  max-width: 45px;
-  max-height: 45px;
+  width: 45px;
+  height: 45px;
   font-size: 16px;
 }
 
 .medium {
-  max-width: 109px;
-  max-height: 109px;
+  width: 109px;
+  height: 109px;
   font-size: 36px;
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #833 

#### What's this PR do?
- Checks the user's gravatar URL when a new profile is saved without images; if found the image fields are updated with the gravatar URL's.

#### How should this be manually tested?
- Login/Register with a new user that has a gravatar account associated with the user's email.  The profile image should be the same as the gravatar image.
- Go to the profile page, and upload an image.  The uploaded image should replace the gravatar.
- Login/Register with a new user that does not have a gravatar account associated with the user's email.  The profile "image" should be a circle with the user's initials.

