### PR TITLE
Hide post button for channels not allowing it

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -31,6 +31,22 @@ class ChannelSerializer(serializers.Serializer):
         source="subreddit_type",
         choices=VALID_CHANNEL_TYPES,
     )
+    user_is_contributor = serializers.SerializerMethodField()
+    user_is_moderator = serializers.SerializerMethodField()
+
+    def get_user_is_contributor(self, channel):
+        """
+        Get is_contributor from reddit object.
+        For some reason reddit returns None instead of False so an explicit conversion is done here.
+        """
+        return bool(channel.user_is_contributor)
+
+    def get_user_is_moderator(self, channel):
+        """
+        Get is_moderator from reddit object.
+        For some reason reddit returns None instead of False so an explicit conversion is done here.
+        """
+        return bool(channel.user_is_moderator)
 
     def create(self, validated_data):
         api = self.context['channel_api']

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -43,6 +43,8 @@ def test_serialize_channel(user):
         'channel_type': 'public',
         'description': 'description',
         'public_description': 'public_description',
+        'user_is_moderator': True,
+        'user_is_contributor': True,
     }
 
 

--- a/channels/views/channels_test.py
+++ b/channels/views/channels_test.py
@@ -26,6 +26,8 @@ def test_list_channels(client, jwt_header, private_channel_and_contributor, requ
             'description': channel.description,
             'public_description': channel.public_description,
             'channel_type': channel.channel_type,
+            'user_is_contributor': True,
+            'user_is_moderator': False,
         }
     ]
 
@@ -60,8 +62,13 @@ def test_create_channel(client, staff_user, staff_jwt_header, reddit_factories):
         'public_description': channel.public_description,
     }
     resp = client.post(url, data=payload, **staff_jwt_header)
+    expected = {
+        **payload,
+        'user_is_contributor': True,
+        'user_is_moderator': True,
+    }
     assert resp.status_code == status.HTTP_201_CREATED
-    assert resp.json() == payload
+    assert resp.json() == expected
 
 
 def test_create_channel_no_descriptions(client, staff_user, staff_jwt_header, reddit_factories):
@@ -76,7 +83,13 @@ def test_create_channel_no_descriptions(client, staff_user, staff_jwt_header, re
         'title': channel.title,
     }
     resp = client.post(url, data=payload, **staff_jwt_header)
-    expected = dict(payload, description='', public_description='')
+    expected = {
+        **payload,
+        'description': '',
+        'public_description': '',
+        'user_is_contributor': True,
+        'user_is_moderator': True,
+    }
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == expected
 
@@ -144,6 +157,8 @@ def test_get_channel(client, jwt_header, private_channel_and_contributor):
         'title': channel.title,
         'description': channel.description,
         'public_description': channel.public_description,
+        'user_is_contributor': True,
+        'user_is_moderator': False,
     }
 
 
@@ -163,6 +178,8 @@ def test_get_channel_anonymous(client, public_channel, settings, allow_anonymous
             'title': public_channel.title,
             'description': public_channel.description,
             'public_description': public_channel.public_description,
+            'user_is_contributor': False,
+            'user_is_moderator': False,
         }
     else:
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
@@ -212,6 +229,8 @@ def test_patch_channel(client, staff_jwt_header, private_channel):
         'title': private_channel.title,
         'description': private_channel.description,
         'public_description': private_channel.public_description,
+        'user_is_contributor': True,
+        'user_is_moderator': True,
     }
 
 
@@ -232,6 +251,8 @@ def test_patch_channel_moderator(client, jwt_header, staff_api, private_channel_
         'title': private_channel.title,
         'description': private_channel.description,
         'public_description': private_channel.public_description,
+        'user_is_contributor': True,
+        'user_is_moderator': True,
     }
 
 

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -6,6 +6,7 @@ import Card from "../components/Card"
 import { ChannelBreadcrumbs } from "../components/ChannelBreadcrumbs"
 import Embedly from "./Embedly"
 
+import { userCanPost } from "../lib/channels"
 import { CONTENT_POLICY_URL } from "../lib/url"
 import { goBackAndHandleEvent } from "../lib/util"
 import { validationMessage } from "../lib/validation"
@@ -27,11 +28,13 @@ type CreatePostFormProps = {
 }
 
 const channelOptions = (channels: Map<string, Channel>) =>
-  Array.from(channels).map(([key, value], index) => (
-    <option label={value.title} value={key} key={index}>
-      {value.title}
-    </option>
-  ))
+  Array.from(channels)
+    .filter(([, channel]) => userCanPost(channel))
+    .map(([key, value], index) => (
+      <option label={value.title} value={key} key={index}>
+        {value.title}
+      </option>
+    ))
 
 export default class CreatePostForm extends React.Component<*, void> {
   props: CreatePostFormProps

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -1,9 +1,11 @@
 // @flow
 import React from "react"
+import R from "ramda"
 import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
 
+import { userCanPost } from "../lib/channels"
 import {
   newPostURL,
   getChannelNameFromPathname,
@@ -14,25 +16,33 @@ import { userIsAnonymous } from "../lib/util"
 import type { Channel } from "../flow/discussionTypes"
 
 type NavigationProps = {
+  channels: Map<string, Channel>,
   pathname: string,
   subscribedChannels: Array<Channel>
 }
 
 const Navigation = (props: NavigationProps) => {
-  const { subscribedChannels, pathname } = props
+  const { channels, subscribedChannels, pathname } = props
 
   const channelName = getChannelNameFromPathname(pathname)
 
+  const currentChannel = channels.get(channelName)
+  const showPostButton =
+    !userIsAnonymous() &&
+    (currentChannel
+      ? userCanPost(currentChannel)
+      : R.any(channel => userCanPost(channel), Array.from(channels.values())))
+
   return (
     <div className="navigation">
-      {userIsAnonymous() ? null : (
+      {showPostButton ? (
         <Link
           className="mdc-button mdc-button--raised blue-button"
           to={newPostURL(channelName)}
         >
           Submit a New Post
         </Link>
-      )}
+      ) : null}
       <Link className="home-link" to={FRONTPAGE_URL}>
         <i className="material-icons home">home</i>
         Home

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -31,7 +31,7 @@ const Navigation = (props: NavigationProps) => {
     !userIsAnonymous() &&
     (currentChannel
       ? userCanPost(currentChannel)
-      : R.any(channel => userCanPost(channel), Array.from(channels.values())))
+      : R.any(userCanPost, [...channels.values()]))
 
   return (
     <div className="navigation">

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -68,7 +68,7 @@ describe("Navigation", () => {
       assert.isNotOk(wrapper.find(".mdc-button").exists())
     })
 
-    it("should not show the create post link if the channel can't be shown to the user", () => {
+    it("should not show the create post link if the user can't post in the channel", () => {
       userCanPostStub.returns(false)
       const channel = defaultProps.subscribedChannels[3]
       const wrapper = renderComponent({
@@ -80,7 +80,7 @@ describe("Navigation", () => {
       sinon.assert.calledWith(userCanPostStub, channel)
     })
 
-    it("should not show the create post link if no channel can be shown to the user", () => {
+    it("should not show the create post link if the user can't post in any channel", () => {
       userCanPostStub.returns(false)
       const wrapper = renderComponent()
       assert.isNotOk(wrapper.find(".mdc-button").exists())

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -8,6 +8,7 @@ import { makePost, makeChannelPostList } from "../factories/posts"
 import { newPostURL } from "../lib/url"
 import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
+import { userCanPost } from "../lib/channels"
 import { formatTitle } from "../lib/title"
 import { makeArticle, makeTweet } from "../factories/embedly"
 import { wait } from "../lib/util"
@@ -258,7 +259,8 @@ describe("CreatePostPage", () => {
   it("should render a select with all subreddits", async () => {
     const wrapper = await renderPage()
     const select = wrapper.find("select")
-    assert.lengthOf(select.find("option"), channels.length + 1)
+    const allowedChannels = channels.filter(channel => userCanPost(channel))
+    assert.lengthOf(select.find("option"), allowedChannels.length + 1)
     assert.deepEqual(
       select.find("option").map(option => {
         const props = option.props()
@@ -266,12 +268,12 @@ describe("CreatePostPage", () => {
       }),
       [
         ["", "Select a channel"],
-        ...channels.map(channel => [channel.name, channel.title])
+        ...allowedChannels.map(channel => [channel.name, channel.title])
       ]
     )
     assert.deepEqual(select.find("option").map(option => option.text()), [
       "Select a channel",
-      ...channels.map(channel => channel.title)
+      ...allowedChannels.map(channel => channel.title)
     ])
   })
 

--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -19,7 +19,8 @@ import type { Location } from "react-router"
 type DrawerPropsFromState = {
   showDrawerDesktop: boolean,
   showDrawerMobile: boolean,
-  subscribedChannels: Array<Channel>
+  subscribedChannels: Array<Channel>,
+  channels: Map<string, Channel>
 }
 
 type DrawerProps = DrawerPropsFromState & {
@@ -71,6 +72,7 @@ export class ResponsiveDrawer extends React.Component<DrawerProps, *> {
 
   render() {
     const {
+      channels,
       showDrawerDesktop,
       showDrawerMobile,
       subscribedChannels,
@@ -108,6 +110,7 @@ export class ResponsiveDrawer extends React.Component<DrawerProps, *> {
               <Navigation
                 subscribedChannels={subscribedChannels}
                 pathname={pathname}
+                channels={channels}
               />
             </DrawerContent>
           </Drawer>
@@ -120,7 +123,8 @@ export class ResponsiveDrawer extends React.Component<DrawerProps, *> {
 export const mapStateToProps = (state: Object): DrawerPropsFromState => ({
   subscribedChannels: getSubscribedChannels(state),
   showDrawerDesktop:  state.ui.showDrawerDesktop,
-  showDrawerMobile:   state.ui.showDrawerMobile
+  showDrawerMobile:   state.ui.showDrawerMobile,
+  channels:           state.channels.data
 })
 
 export default R.compose(

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -9,12 +9,14 @@ const incr = incrementer()
 
 export const makeChannel = (privateChannel: boolean = false): Channel => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
-  name:               `channel_${incr.next().value}`,
-  title:              casual.title,
-  channel_type:       privateChannel ? "private" : "public",
-  description:        casual.description,
-  public_description: casual.description,
-  num_users:          casual.integer(0, 500)
+  name:                `channel_${incr.next().value}`,
+  title:               casual.title,
+  channel_type:        privateChannel ? "private" : "public",
+  description:         casual.description,
+  public_description:  casual.description,
+  num_users:           casual.integer(0, 500),
+  user_is_contributor: casual.coin_flip,
+  user_is_moderator:   casual.coin_flip
 })
 
 export const makeChannelList = (numChannels: number = 20) => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -2,12 +2,14 @@
 export type ChannelType = "private" | "public";
 
 export type Channel = {
-  name:               string,
-  title:              string,
-  description:        string,
-  public_description: string,
-  channel_type:       ChannelType,
-  num_users:          number,
+  name:                string,
+  title:               string,
+  description:         string,
+  public_description:  string,
+  channel_type:        ChannelType,
+  num_users:           number,
+  user_is_contributor: boolean,
+  user_is_moderator:   boolean,
 }
 
 export type ChannelForm = {

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -29,3 +29,8 @@ export const isModerator = (
   moderators: ChannelModerators,
   username: ?string
 ): boolean => R.any(R.propEq("moderator_name", username), moderators || [])
+
+export const userCanPost = (channel: Channel) =>
+  channel.channel_type === CHANNEL_TYPE_PUBLIC ||
+  channel.user_is_moderator ||
+  channel.user_is_contributor

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -51,12 +51,14 @@ describe("Channel utils", () => {
       [CHANNEL_TYPE_RESTRICTED, false, false, false],
       [CHANNEL_TYPE_PRIVATE, false, false, false],
       [CHANNEL_TYPE_PRIVATE, true, false, true],
-      [CHANNEL_TYPE_PRIVATE, false, true, true]
+      [CHANNEL_TYPE_PRIVATE, false, true, true],
+      [CHANNEL_TYPE_RESTRICTED, true, true, true]
     ].forEach(([channelType, isModerator, isContributor, expected]) => {
-      it(`${expected ? "shows" : "doesn't show"} the submit button when
-       channelType is ${channelType}${
-  isModerator ? "and the user is a moderator " : ""
-}${isContributor ? "and the user is a contributor" : ""}`, () => {
+      it(`${
+        expected ? "shows" : "doesn't show"
+      } the submit button when channelType is ${channelType}${
+        isModerator ? "and the user is a moderator " : ""
+      }${isContributor ? "and the user is a contributor" : ""}`, () => {
         const channel: Object = {
           ...makeChannel(),
           channel_type:        channelType,

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -3,9 +3,12 @@ import { assert } from "chai"
 
 import {
   CHANNEL_TYPE_PUBLIC,
+  CHANNEL_TYPE_RESTRICTED,
+  CHANNEL_TYPE_PRIVATE,
   newChannelForm,
   editChannelForm,
-  isModerator
+  isModerator,
+  userCanPost
 } from "./channels"
 import { makeModerators, makeChannel } from "../factories/channels"
 
@@ -32,11 +35,36 @@ describe("Channel utils", () => {
     })
   })
 
-  it("isModerator should return true for a moderator user", () => {
-    assert.isTrue(isModerator(makeModerators("username"), "username"))
+  describe("isModerator", () => {
+    it("should return true for a moderator user", () => {
+      assert.isTrue(isModerator(makeModerators("username"), "username"))
+    })
+
+    it("should return false for a regular user", () => {
+      assert.isFalse(isModerator(makeModerators(), "username"))
+    })
   })
 
-  it("isModerator should return false for a regular user", () => {
-    assert.isFalse(isModerator(makeModerators(), "username"))
+  describe("userCanPost", () => {
+    [
+      [CHANNEL_TYPE_PUBLIC, false, false, true],
+      [CHANNEL_TYPE_RESTRICTED, false, false, false],
+      [CHANNEL_TYPE_PRIVATE, false, false, false],
+      [CHANNEL_TYPE_PRIVATE, true, false, true],
+      [CHANNEL_TYPE_PRIVATE, false, true, true]
+    ].forEach(([channelType, isModerator, isContributor, expected]) => {
+      it(`${expected ? "shows" : "doesn't show"} the submit button when
+       channelType is ${channelType}${
+  isModerator ? "and the user is a moderator " : ""
+}${isContributor ? "and the user is a contributor" : ""}`, () => {
+        const channel: Object = {
+          ...makeChannel(),
+          channel_type:        channelType,
+          user_is_moderator:   isModerator,
+          user_is_contributor: isContributor
+        }
+        assert.equal(userCanPost(channel), expected)
+      })
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #832 

#### What's this PR do?
Adds moderator and contributor status to the channel API, then uses it to determine whether the post button is displayed, or whether the channel is shown in the list of options in the create post page.

#### How should this be manually tested?
Create a new public channel and subscribe the user to it. Unsubscribe the user from all other channels.

In the home page you should see a submit post button. Click on the channel in the sidebar. You should still see a create post button. Click on the button and verify that there is one channel in the channel list, the one you created for testing this PR.

Alter the channel to be `restricted` via Django shell then refresh the page. There should be no options in the channel dropdown. Go to the homepage. There should be no button shown. Click on the channel tab. You should still see no channel.