### PR TITLE
remove flow workaround

### DIFF
--- a/static/js/hoc/withCommentModeration.js
+++ b/static/js/hoc/withCommentModeration.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS: false */
-import React, { Fragment } from "react"
+import React from "react"
 import { Dialog } from "@mitodl/mdl-react-components"
 
 import { actions } from "../actions"
@@ -87,7 +87,7 @@ export const withCommentModeration = (
       const { showRemoveCommentDialog } = this.props
 
       return (
-        <Fragment>
+        <React.Fragment>
           <Dialog
             id="remove-comment-dialog"
             open={showRemoveCommentDialog}
@@ -107,7 +107,7 @@ export const withCommentModeration = (
             approveComment={this.approveComment}
             ignoreCommentReports={this.ignoreReports}
           />
-        </Fragment>
+        </React.Fragment>
       )
     }
   }

--- a/static/js/hoc/withPostModeration.js
+++ b/static/js/hoc/withPostModeration.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS: false */
-import React, { Fragment } from "react"
+import React from "react"
 import { Dialog } from "@mitodl/mdl-react-components"
 import R from "ramda"
 
@@ -143,7 +143,7 @@ export const withPostModeration = (
       const reportForm = getReportForm(forms)
 
       return (
-        <Fragment>
+        <React.Fragment>
           <Dialog
             open={reportPostDialogVisible}
             hideDialog={preventDefaultAndInvoke(this.hideReportPostDialog)}
@@ -184,7 +184,7 @@ export const withPostModeration = (
             ignorePostReports={this.ignoreReports}
             reportPost={this.openReportPostDialog}
           />
-        </Fragment>
+        </React.Fragment>
       )
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

I needed to use `React.Fragment` before, but with the version of flow we were on threw an error if you just used `<React.Fragment>` directly in JSX. To get around the error I added a qualified import, like `import React, { Fragment } from "react"`, which silenced the error. The newer version of flow we recently upgraded to no longer has this issue, so we can remove the workaround now.

#### How should this be manually tested?

Everything should work as before.