### PR TITLE
Added password reset UI

### DIFF
--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,6 +1,5 @@
 """URL configurations for authentication"""
 from django.conf.urls import url
-from django.contrib.auth import views as auth_views
 
 from authentication.views import (
     LoginEmailView,
@@ -9,6 +8,8 @@ from authentication.views import (
     RegisterConfirmView,
     RegisterDetailsView,
     login_complete,
+    CustomPasswordResetView,
+    CustomPasswordResetConfirmView,
 )
 
 
@@ -18,6 +19,11 @@ urlpatterns = [
     url(r'^api/v0/register/email/$', RegisterEmailView.as_view(), name='psa-register-email'),
     url(r'^api/v0/register/confirm/$', RegisterConfirmView.as_view(), name='psa-register-confirm'),
     url(r'^api/v0/register/details/$', RegisterDetailsView.as_view(), name='psa-register-details'),
+    url(r'^api/v0/password_reset/$', CustomPasswordResetView.as_view(), name='password-reset-api'),
+    url(
+        r'^api/v0/password_reset/confirm/$',
+        CustomPasswordResetConfirmView.as_view(),
+        name='password-reset-confirm-api'
+    ),
     url(r'^login/complete$', login_complete, name='login-complete'),
-    url(r'^logout/$', auth_views.logout, name='logout'),
 ]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,15 +1,22 @@
 """Authentication views"""
 from django.conf import settings
-from django.shortcuts import redirect
+from django.core import mail as django_mail
+from django.contrib.auth import get_user_model
+from django.shortcuts import render, redirect
+from social_core.backends.email import EmailAuth
+from social_django.utils import load_backend
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework_jwt.settings import api_settings
-from social_core.backends.email import EmailAuth
-from social_django.utils import load_backend
+from anymail.message import AnymailMessage
+from djoser.views import (
+    PasswordResetView as DjoserPasswordResetView,
+    PasswordResetConfirmView as DjoserPasswordResetConfirmView
+)
+from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 
 from open_discussions import features
-
 from authentication.serializers import (
     LoginEmailSerializer,
     LoginPasswordSerializer,
@@ -18,6 +25,9 @@ from authentication.serializers import (
     RegisterDetailsSerializer,
 )
 from authentication.utils import load_drf_strategy
+from mail.api import render_email_templates, send_messages
+
+User = get_user_model()
 
 
 class SocialAuthAPIView(APIView):
@@ -99,3 +109,69 @@ def login_complete(request, **kwargs):  # pylint: disable=unused-argument
         )
 
     return response
+
+
+def confirmation_sent(request, **kwargs):  # pylint: disable=unused-argument
+    """The confirmation of an email being sent"""
+    return render(request, "confirmation_sent.html")
+
+
+class CustomPasswordResetEmail(DjoserPasswordResetEmail):
+    """Custom class to modify base functionality in Djoser's PasswordResetEmail class"""
+    def send(self, to, *args, **kwargs):
+        """
+        Overrides djoser.email.PasswordResetEmail#send to use our mail API.
+        """
+        context = super().get_context_data()
+        context.update(self.context)
+        with django_mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
+            subject, text_body, html_body = render_email_templates('password_reset', context)
+            msg = AnymailMessage(
+                subject=subject,
+                body=text_body,
+                to=to,
+                from_email=settings.MAILGUN_FROM_EMAIL,
+                connection=connection,
+            )
+            msg.attach_alternative(html_body, "text/html")
+            send_messages([msg])
+
+
+class CustomPasswordResetView(DjoserPasswordResetView):
+    """Custom view to modify base functionality in Djoser's PasswordResetView class"""
+    def post(self, request):
+        """
+        Overrides djoser.views.PasswordResetView#post and adds two bits of logic:
+
+        1. Returns 404 if the EMAIL_AUTH feature is not enabled
+        2. In version 0.30.0, the fetch function in redux-hammock does not handle responses
+        with empty response data. Djoser returns 204's with empty response data, so we are
+        coercing that to a 200 with an empty dict as the response data. This can be removed
+        when redux-hammock is changed to support 204's.
+        """
+        if not features.is_enabled(features.EMAIL_AUTH):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        response = super().post(request)
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            return Response({}, status=status.HTTP_200_OK)
+        return response
+
+
+class CustomPasswordResetConfirmView(DjoserPasswordResetConfirmView):
+    """Custom view to modify base functionality in Djoser's PasswordResetConfirmView class"""
+    def post(self, request):
+        """
+        Overrides djoser.views.PasswordResetView#post and adds two bits of logic:
+
+        1. Returns 404 if the EMAIL_AUTH feature is not enabled
+        2. In version 0.30.0, the fetch function in redux-hammock does not handle responses
+        with empty response data. Djoser returns 204's with empty response data, so we are
+        coercing that to a 200 with an empty dict as the response data. This can be removed
+        when redux-hammock is changed to support 204's.
+        """
+        if not features.is_enabled(features.EMAIL_AUTH):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        response = super().post(request)
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            return Response({}, status=status.HTTP_200_OK)
+        return response

--- a/mail/templates/password_reset/body.html
+++ b/mail/templates/password_reset/body.html
@@ -1,0 +1,21 @@
+{% extends "email_base.html" %}
+
+{% block title %}Open Discussions - Reset Password{% endblock %}
+
+{% block content %}
+{% autoescape off %}
+
+<p>
+    You're receiving this email because you requested a password reset for your
+    user account at {{ site_name }}.
+</p>
+
+<p>
+    Please go to the following page and choose a new password:
+    {% block reset_link %}
+    {{ protocol }}://{{ domain }}{% url 'password-reset-confirm' uid=uid token=token %}
+    {% endblock %}
+</p>
+
+{% endautoescape %}
+{% endblock %}

--- a/mail/templates/password_reset/subject.txt
+++ b/mail/templates/password_reset/subject.txt
@@ -1,0 +1,1 @@
+Your Password Reset Link

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -684,3 +684,18 @@ REST_FRAMEWORK = {
 
 USE_X_FORWARDED_PORT = get_bool('USE_X_FORWARDED_PORT', False)
 USE_X_FORWARDED_HOST = get_bool('USE_X_FORWARDED_HOST', False)
+
+# Relative URL to be used by Djoser for the link in the password reset email
+# (see: http://djoser.readthedocs.io/en/stable/settings.html#password-reset-confirm-url)
+PASSWORD_RESET_CONFIRM_URL = 'password_reset/confirm/{uid}/{token}/'
+
+# Djoser library settings (see: http://djoser.readthedocs.io/en/stable/settings.html)
+DJOSER = {
+    'PASSWORD_RESET_CONFIRM_URL': PASSWORD_RESET_CONFIRM_URL,
+    'SET_PASSWORD_RETYPE': True,
+    'PASSWORD_RESET_CONFIRM_RETYPE': True,
+    'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': True,
+    'EMAIL': {
+        'password_reset': 'authentication.views.CustomPasswordResetEmail',
+    }
+}

--- a/open_discussions/settings_test.py
+++ b/open_discussions/settings_test.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+from django.urls import reverse
 import semantic_version
 
 
@@ -160,3 +161,20 @@ class TestSettings(TestCase):
             with mock.patch.dict('os.environ', required_settings, clear=True):
                 with self.assertRaises(ImproperlyConfigured):
                     self.reload_settings()
+
+    def test_djoser_confirm_url(self):
+        """
+        Assert that the PASSWORD_RESET_CONFIRM_URL setting value produces a
+        URL that
+        """
+        token = '4xj-8aa0d06b40f1c067b464'
+        uid = 'AA'
+        template_generated_url = settings.PASSWORD_RESET_CONFIRM_URL.format(
+            uid=uid,
+            token=token
+        )
+        reverse_url = reverse('password-reset-confirm', kwargs=dict(
+            uid=uid,
+            token=token
+        ))
+        assert reverse_url == '/{}'.format(template_generated_url)

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -61,10 +61,18 @@ urlpatterns = [
     url(r'^settings/', index),
     url(r'^saml/metadata/', saml_metadata, name='saml-metadata'),
     url(r'^profile/[A-Za-z0-9_]+/', index, name='profile'),
+
     url(r'^login/', index),
     url(r'^register/', index),
     url(r'^register/confirm/$', index, name='register-confirm'),
     url(r'^account/inactive/$', index),
+
+    url(r'^password_reset/', index, name='password-reset'),
+    url(
+        r'^password_reset/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        index,
+        name='password-reset-confirm'
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ django-webpack-loader==0.5.0
 django-anymail[mailgun]
 djangorestframework==3.7.7
 djangorestframework-jwt==1.11.0
+djoser
 elasticsearch-dsl==6.1.0
 elasticsearch==6.2.0
 factory_boy

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,10 +25,12 @@ django-cors-headers==2.1.0
 django-redis==4.7.0
 django-server-status==0.5.0
 django-storages==1.6.6
+django-templated-mail==1.1.1  # via djoser
 django-webpack-loader==0.5.0
 django==1.11.10
 djangorestframework-jwt==1.11.0
 djangorestframework==3.7.7
+djoser==1.1.5
 elasticsearch-dsl==6.1.0
 elasticsearch==6.2.0
 factory-boy==2.10.0

--- a/static/js/components/auth/AuthPasswordForm.js
+++ b/static/js/components/auth/AuthPasswordForm.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react"
 import R from "ramda"
+import { Link } from "react-router-dom"
 
 import { validationMessage } from "../../lib/validation"
 
@@ -34,6 +35,9 @@ const AuthPasswordForm = ({
       {!processing && R.isEmpty(validation)
         ? validationMessage(formError)
         : null}
+    </div>
+    <div className="row">
+      <Link to="/password_reset">Forgot your password?</Link>
     </div>
     <div className="actions row">
       <button

--- a/static/js/components/auth/PasswordResetConfirmForm.js
+++ b/static/js/components/auth/PasswordResetConfirmForm.js
@@ -1,0 +1,60 @@
+// @flow
+import React from "react"
+
+import { validationMessage } from "../../lib/validation"
+import type { FormProps } from "../../flow/formTypes"
+import type { ResetConfirmForm } from "../../flow/authTypes"
+
+type PasswordResetConfirmFormProps = {
+  tokenApiError: ?string
+} & FormProps<ResetConfirmForm>
+
+export default class PasswordResetConfirmForm extends React.Component<*, void> {
+  props: PasswordResetConfirmFormProps
+
+  render() {
+    const {
+      form,
+      validation,
+      tokenApiError,
+      onSubmit,
+      onUpdate,
+      processing
+    } = this.props
+
+    return (
+      <form onSubmit={onSubmit} className="form">
+        <div className="passwordfield row">
+          <label>New Password</label>
+          <input
+            type="password"
+            name="new_password"
+            value={form.new_password}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.new_password)}
+        </div>
+        <div className="passwordfield row">
+          <label>Confirm Password</label>
+          <input
+            type="password"
+            name="re_new_password"
+            value={form.re_new_password}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.re_new_password)}
+        </div>
+        <div className="actions row">
+          <button
+            type="submit"
+            className={`submit-password ${processing ? "disabled" : ""}`}
+            disabled={processing}
+          >
+            Submit
+          </button>
+          {validationMessage(tokenApiError)}
+        </div>
+      </form>
+    )
+  }
+}

--- a/static/js/components/auth/PasswordResetConfirmForm_test.js
+++ b/static/js/components/auth/PasswordResetConfirmForm_test.js
@@ -1,0 +1,76 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { mount } from "enzyme"
+import { assert } from "chai"
+
+import PasswordResetConfirmForm from "./PasswordResetConfirmForm"
+
+describe("PasswordResetConfirmForm component", () => {
+  let sandbox, onSubmitStub, onUpdateStub, form
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    onSubmitStub = sandbox.stub()
+    onUpdateStub = sandbox.stub()
+    form = {
+      new_password:    "",
+      re_new_password: ""
+    }
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const getPasswordInput = wrapper => wrapper.find("input[name='new_password']")
+  const getConfirmPasswordInput = wrapper =>
+    wrapper.find("input[name='re_new_password']")
+
+  const mountForm = (props = {}) =>
+    mount(
+      <PasswordResetConfirmForm
+        onSubmit={onSubmitStub}
+        onUpdate={onUpdateStub}
+        form={form}
+        validation={{}}
+        processing={false}
+        {...props}
+      />
+    )
+
+  it("should render an initial form", () => {
+    const wrapper = mountForm()
+
+    assert.equal(getPasswordInput(wrapper).props().value, "")
+    assert.equal(getConfirmPasswordInput(wrapper).props().value, "")
+    assert.equal(wrapper.find(".validation-message").exists(), false)
+    assert.equal(wrapper.find("button").props().disabled, false)
+  })
+
+  it("should disable the submit button if processing === true", () => {
+    const wrapper = mountForm({ processing: true })
+
+    assert.equal(wrapper.find("button").props().disabled, true)
+  })
+
+  it("should show error messages if there is a failure in validation or the API call", () => {
+    const wrapper = mountForm({
+      validation: {
+        new_password:    "Password is required",
+        re_new_password: "Passwords must match"
+      },
+      tokenApiError: "Token is invalid"
+    })
+
+    const validationMessages = wrapper.find(".validation-message")
+    assert.equal(validationMessages.at(0).text(), "Password is required")
+    assert.equal(validationMessages.at(1).text(), "Passwords must match")
+    assert.equal(validationMessages.at(2).text(), "Token is invalid")
+  })
+
+  it("should call onSubmit when the form is submitted", () => {
+    const wrapper = mountForm({ processing: true })
+    wrapper.find("form").simulate("submit")
+    sinon.assert.calledOnce(onSubmitStub)
+  })
+})

--- a/static/js/components/auth/PasswordResetForm.js
+++ b/static/js/components/auth/PasswordResetForm.js
@@ -1,0 +1,50 @@
+// @flow
+import React from "react"
+
+import { validationMessage } from "../../lib/validation"
+import type { FormProps } from "../../flow/formTypes"
+import type { EmailForm } from "../../flow/authTypes"
+
+type PasswordResetFormProps = {
+  emailApiError: ?string
+} & FormProps<EmailForm>
+
+export default class PasswordResetForm extends React.Component<*, void> {
+  props: PasswordResetFormProps
+
+  render() {
+    const {
+      form,
+      validation,
+      emailApiError,
+      onSubmit,
+      onUpdate,
+      processing
+    } = this.props
+
+    return (
+      <form onSubmit={onSubmit} className="form">
+        <div className="emailfield row">
+          <label>Email</label>
+          <input
+            type="email"
+            name="email"
+            value={form.email}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.email)}
+          {validationMessage(emailApiError)}
+        </div>
+        <div className="actions row">
+          <button
+            type="submit"
+            className={`submit-password-reset ${processing ? "disabled" : ""}`}
+            disabled={processing}
+          >
+            Reset Password
+          </button>
+        </div>
+      </form>
+    )
+  }
+}

--- a/static/js/components/auth/PasswordResetForm_test.js
+++ b/static/js/components/auth/PasswordResetForm_test.js
@@ -3,21 +3,17 @@ import React from "react"
 import sinon from "sinon"
 import { mount } from "enzyme"
 import { assert } from "chai"
-import { Router } from "react-router"
-import { createMemoryHistory } from "history"
 
-import AuthPasswordForm from "./AuthPasswordForm"
+import PasswordResetForm from "./PasswordResetForm"
 
-describe("AuthPasswordForm component", () => {
-  let sandbox, onSubmitStub, onUpdateStub, form, browserHistory
-
+describe("PasswordResetForm component", () => {
+  let sandbox, onSubmitStub, onUpdateStub, form
   beforeEach(() => {
-    browserHistory = createMemoryHistory()
     sandbox = sinon.sandbox.create()
     onSubmitStub = sandbox.stub()
     onUpdateStub = sandbox.stub()
     form = {
-      password: ""
+      email: ""
     }
   })
 
@@ -25,30 +21,26 @@ describe("AuthPasswordForm component", () => {
     sandbox.restore()
   })
 
-  const getPasswordInput = wrapper => wrapper.find("input[name='password']")
+  const getEmailInput = wrapper => wrapper.find("input[name='email']")
 
   const mountForm = (props = {}) =>
     mount(
-      <Router history={browserHistory}>
-        <AuthPasswordForm
-          onSubmit={onSubmitStub}
-          onUpdate={onUpdateStub}
-          form={form}
-          validation={{}}
-          processing={false}
-          formError={""}
-          {...props}
-        />
-      </Router>
+      <PasswordResetForm
+        onSubmit={onSubmitStub}
+        onUpdate={onUpdateStub}
+        form={form}
+        validation={{}}
+        processing={false}
+        {...props}
+      />
     )
 
   it("should render an initial form", () => {
     const wrapper = mountForm()
 
-    assert.equal(getPasswordInput(wrapper).props().value, "")
+    assert.equal(getEmailInput(wrapper).props().value, "")
     assert.equal(wrapper.find(".validation-message").exists(), false)
     assert.equal(wrapper.find("button").props().disabled, false)
-    assert.equal(wrapper.find("Link").prop("to"), "/password_reset")
   })
 
   it("should disable the submit button if processing === true", () => {
@@ -57,31 +49,27 @@ describe("AuthPasswordForm component", () => {
     assert.equal(wrapper.find("button").props().disabled, true)
   })
 
-  it("should show validation", () => {
+  it("should show an error message if validation fails", () => {
     const wrapper = mountForm({
       validation: {
-        password: "Password is required"
-      },
-      formError: "error"
+        email: "Email is required"
+      }
     })
 
     assert.equal(
       wrapper.find(".validation-message").text(),
-      "Password is required"
+      "Email is required"
     )
-
-    // form level error shouldn't show
-    assert.isNotOk(wrapper.find(".row.error .validation-message").exists())
   })
 
-  it("should show a form level error", () => {
-    const wrapper = mountForm({ formError: "backend error" })
+  it("should show an error message if the API call fails", () => {
+    const wrapper = mountForm({
+      emailApiError: "Email does not exist"
+    })
+
     assert.equal(
-      wrapper
-        .find(".validation-message")
-        .at(0)
-        .text(),
-      "backend error"
+      wrapper.find(".validation-message").text(),
+      "Email does not exist"
     )
   })
 
@@ -89,11 +77,11 @@ describe("AuthPasswordForm component", () => {
     const wrapper = mountForm({ processing: true })
     const event = {
       target: {
-        name:  "password",
-        value: "password1"
+        name:  "email",
+        value: "user@localhost"
       }
     }
-    getPasswordInput(wrapper).simulate("change", event)
+    getEmailInput(wrapper).simulate("change", event)
     sinon.assert.calledOnce(onUpdateStub)
     const eventArg = onUpdateStub.firstCall.args[0]
     assert.equal(eventArg.target.name, event.target.name)

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -22,6 +22,8 @@ import RegisterPage from "./auth/RegisterPage"
 import RegisterConfirmPage from "./auth/RegisterConfirmPage"
 import RegisterDetailsPage from "./auth/RegisterDetailsPage"
 import InactiveUserPage from "./auth/InactiveUserPage"
+import PasswordResetPage from "./auth/PasswordResetPage"
+import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
 import Snackbar from "../components/material/Snackbar"
 import Drawer from "../containers/Drawer"
 import Toolbar from "../components/Toolbar"
@@ -232,6 +234,16 @@ class App extends React.Component<*, void> {
             exact
             path={`${match.url}account/inactive/`}
             component={InactiveUserPage}
+          />
+          <Route
+            exact
+            path={`${match.url}password_reset/`}
+            component={PasswordResetPage}
+          />
+          <Route
+            exact
+            path={`${match.url}password_reset/confirm/:uid/:token`}
+            component={PasswordResetConfirmPage}
           />
           <Footer />
         </div>

--- a/static/js/containers/auth/PasswordResetConfirmPage.js
+++ b/static/js/containers/auth/PasswordResetConfirmPage.js
@@ -1,0 +1,109 @@
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
+import { Link } from "react-router-dom"
+import R from "ramda"
+
+import Card from "../../components/Card"
+import PasswordResetConfirmForm from "../../components/auth/PasswordResetConfirmForm"
+import withForm from "../../hoc/withForm"
+
+import { actions } from "../../actions"
+import { configureForm } from "../../lib/forms"
+import { formatTitle } from "../../lib/title"
+import { validatePasswordResetForm as validateForm } from "../../lib/validation"
+import { mergeAndInjectProps } from "../../lib/redux_props"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+
+import type { WithFormProps } from "../../flow/formTypes"
+import type { ResetConfirmForm } from "../../flow/authTypes"
+
+type PasswordResetConfirmPageProps = {
+  tokenApiError: ?Object,
+  successfullySubmitted: boolean
+} & WithFormProps<ResetConfirmForm>
+
+export const PasswordResetConfirmPage = ({
+  renderForm,
+  tokenApiError,
+  successfullySubmitted
+}: PasswordResetConfirmPageProps) => (
+  <div className="content auth-page password-reset-confirm-page">
+    <div className="main-content">
+      {successfullySubmitted ? (
+        <Card className="login-card">
+          <h3>Your password has been reset</h3>
+          <p>
+            You can use <Link to="/login">this link</Link> to log in.
+          </p>
+        </Card>
+      ) : (
+        <Card className="login-card">
+          <h3>Enter your new password</h3>
+          <DocumentTitle title={formatTitle("Password Reset")} />
+          {renderForm({ tokenApiError })}
+        </Card>
+      )}
+    </div>
+  </div>
+)
+
+const passwordResetConfirmForm = () => ({
+  new_password:    "",
+  re_new_password: ""
+})
+
+export const FORM_KEY = "login:password_reset_confirm"
+const { getForm, actionCreators } = configureForm(
+  FORM_KEY,
+  passwordResetConfirmForm
+)
+
+const onSubmit = (form: ResetConfirmForm, match: Object) =>
+  actions.passwordReset.postNewPassword(
+    form.new_password,
+    form.re_new_password,
+    match.params.token,
+    match.params.uid
+  )
+
+const mergeProps = mergeAndInjectProps(
+  (stateProps, { onSubmit }, { match }) => {
+    return {
+      onSubmit: form => onSubmit(form, match)
+    }
+  }
+)
+
+const mapStateToProps = state => {
+  const form = getForm(state)
+  const passwordReset = state.passwordReset
+  const tokenApiError = R.view(R.lensPath(["error", "non_field_errors"]))(
+    passwordReset
+  )
+  const successfullySubmitted =
+    passwordReset &&
+    passwordReset.loaded &&
+    !passwordReset.processing &&
+    passwordReset.postNewPasswordStatus === FETCH_SUCCESS
+
+  return {
+    form,
+    validateForm,
+    tokenApiError,
+    successfullySubmitted
+  }
+}
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    {
+      onSubmit,
+      ...actionCreators
+    },
+    mergeProps
+  ),
+  withForm(PasswordResetConfirmForm)
+)(PasswordResetConfirmPage)

--- a/static/js/containers/auth/PasswordResetConfirmPage_test.js
+++ b/static/js/containers/auth/PasswordResetConfirmPage_test.js
@@ -1,0 +1,113 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+
+import { actions } from "../../actions"
+import IntegrationTestHelper from "../../util/integration_test_helper"
+import ConnectedPasswordResetConfirmPage, {
+  PasswordResetConfirmPage,
+  FORM_KEY
+} from "./PasswordResetConfirmPage"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+
+const DEFAULT_STATE = {
+  passwordReset: {
+    data:       {},
+    processing: false
+  },
+  forms: {
+    [FORM_KEY]: {
+      value: {
+        new_password:    "abcdefgh",
+        re_new_password: "abcdefgh"
+      },
+      errors: {}
+    }
+  }
+}
+
+describe("PasswordResetConfirmPage", () => {
+  let helper, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.postPasswordResetNewPasswordStub.returns(Promise.resolve())
+    renderPage = helper.configureHOCRenderer(
+      ConnectedPasswordResetConfirmPage,
+      PasswordResetConfirmPage,
+      DEFAULT_STATE
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render the password reset form by default", async () => {
+    const { inner } = await renderPage()
+
+    const form = inner.find("PasswordResetConfirmForm")
+    assert.ok(form.exists())
+    assert.isNotOk(form.prop("tokenApiError"))
+  })
+
+  it("should render a success message after the form submits successfully", async () => {
+    const { inner } = await renderPage({
+      passwordReset: {
+        loaded:                true,
+        processing:            false,
+        postNewPasswordStatus: FETCH_SUCCESS
+      }
+    })
+
+    assert.isFalse(inner.find("PasswordResetConfirmForm").exists())
+    assert.include(
+      inner
+        .find("h3")
+        .at(0)
+        .text(),
+      "Your password has been reset"
+    )
+  })
+
+  it("form onSubmit prop calls api correctly", async () => {
+    const { inner, store } = await renderPage(
+      {},
+      { match: { params: { token: "1234567890", uid: "ABC" } } }
+    )
+
+    const { onSubmit } = inner.find("PasswordResetConfirmForm").props()
+
+    onSubmit()
+
+    const dispatchedActions = store.getActions()
+
+    assert.lengthOf(dispatchedActions, 3)
+    assert.equal(
+      dispatchedActions[2].type,
+      actions.passwordReset.postNewPassword.requestType
+    )
+    sinon.assert.calledOnce(helper.postPasswordResetNewPasswordStub)
+    sinon.assert.calledWith(
+      helper.postPasswordResetNewPasswordStub,
+      "abcdefgh",
+      "abcdefgh",
+      "1234567890",
+      "ABC"
+    )
+  })
+
+  it("should pass an error object into the form when the API call fails", async () => {
+    const { inner } = await renderPage({
+      passwordReset: {
+        error: {
+          non_field_errors: "Invalid token"
+        }
+      }
+    })
+
+    const form = inner.find("PasswordResetConfirmForm")
+    assert.ok(form.exists())
+    assert.equal(form.prop("tokenApiError"), "Invalid token")
+  })
+})

--- a/static/js/containers/auth/PasswordResetPage.js
+++ b/static/js/containers/auth/PasswordResetPage.js
@@ -1,0 +1,94 @@
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import DocumentTitle from "react-document-title"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+import R from "ramda"
+
+import Card from "../../components/Card"
+import PasswordResetForm from "../../components/auth/PasswordResetForm"
+import withForm from "../../hoc/withForm"
+
+import { actions } from "../../actions"
+import { configureForm } from "../../lib/forms"
+import { formatTitle } from "../../lib/title"
+import { validateEmailForm as validateForm } from "../../lib/validation"
+import { mergeAndInjectProps } from "../../lib/redux_props"
+
+import type { WithFormProps } from "../../flow/formTypes"
+import type { EmailForm } from "../../flow/authTypes"
+
+type PasswordResetPageProps = {
+  emailApiError: ?Object,
+  successfullySubmitted: boolean
+} & WithFormProps<EmailForm>
+
+export const PasswordResetPage = ({
+  renderForm,
+  emailApiError,
+  successfullySubmitted
+}: PasswordResetPageProps) => (
+  <div className="content auth-page password-reset-page">
+    <div className="main-content">
+      {successfullySubmitted ? (
+        <Card className="login-card">
+          <h3>Thank you!</h3>
+          <p>
+            We've emailed you instructions for setting your password. You should
+            receive them shortly.
+          </p>
+        </Card>
+      ) : (
+        <Card className="login-card">
+          <h3>Enter your email address</h3>
+          <DocumentTitle title={formatTitle("Password Reset")} />
+          {renderForm({ emailApiError })}
+        </Card>
+      )}
+    </div>
+  </div>
+)
+
+const passwordResetForm = () => ({ email: "" })
+
+export const FORM_KEY = "login:email"
+const { getForm, actionCreators } = configureForm(FORM_KEY, passwordResetForm)
+
+const onSubmit = (form: EmailForm) =>
+  actions.passwordReset.postEmail(form.email)
+
+const mergeProps = mergeAndInjectProps((stateProps, { onSubmit }) => {
+  return {
+    onSubmit: form => onSubmit(form)
+  }
+})
+
+const mapStateToProps = state => {
+  const form = getForm(state)
+  const passwordReset = state.passwordReset
+  const emailApiError = R.view(R.lensPath(["error", "email"]))(passwordReset)
+  const successfullySubmitted =
+    passwordReset &&
+    passwordReset.loaded &&
+    !passwordReset.processing &&
+    passwordReset.postEmailStatus === FETCH_SUCCESS
+
+  return {
+    form,
+    validateForm,
+    emailApiError,
+    successfullySubmitted
+  }
+}
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    {
+      onSubmit,
+      ...actionCreators
+    },
+    mergeProps
+  ),
+  withForm(PasswordResetForm)
+)(PasswordResetPage)

--- a/static/js/containers/auth/PasswordResetPage_test.js
+++ b/static/js/containers/auth/PasswordResetPage_test.js
@@ -1,0 +1,106 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+
+import { actions } from "../../actions"
+import IntegrationTestHelper from "../../util/integration_test_helper"
+import ConnectedPasswordResetPage, {
+  PasswordResetPage,
+  FORM_KEY
+} from "./PasswordResetPage"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+
+const DEFAULT_STATE = {
+  passwordReset: {
+    data:       {},
+    processing: false
+  },
+  forms: {
+    [FORM_KEY]: {
+      value: {
+        email: "test@example.com"
+      },
+      errors: {}
+    }
+  }
+}
+
+describe("PasswordResetPage", () => {
+  let helper, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.postPasswordResetEmailStub.returns(Promise.resolve())
+    renderPage = helper.configureHOCRenderer(
+      ConnectedPasswordResetPage,
+      PasswordResetPage,
+      DEFAULT_STATE
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render the password reset email form by default", async () => {
+    const { inner } = await renderPage()
+
+    const form = inner.find("PasswordResetForm")
+    assert.ok(form.exists())
+    assert.isNotOk(form.prop("emailApiError"))
+  })
+
+  it("should render a success message after the form submits successfully", async () => {
+    const { inner } = await renderPage({
+      passwordReset: {
+        loaded:          true,
+        processing:      false,
+        postEmailStatus: FETCH_SUCCESS
+      }
+    })
+
+    assert.isFalse(inner.find("PasswordResetForm").exists())
+    assert.include(
+      inner
+        .find("h3")
+        .at(0)
+        .text(),
+      "Thank you!"
+    )
+  })
+
+  it("form onSubmit prop calls api correctly", async () => {
+    const { inner, store } = await renderPage()
+
+    const { onSubmit } = inner.find("PasswordResetForm").props()
+
+    onSubmit()
+
+    const dispatchedActions = store.getActions()
+
+    assert.lengthOf(dispatchedActions, 3)
+    assert.equal(
+      dispatchedActions[2].type,
+      actions.passwordReset.postEmail.requestType
+    )
+    sinon.assert.calledOnce(helper.postPasswordResetEmailStub)
+    sinon.assert.calledWith(
+      helper.postPasswordResetEmailStub,
+      "test@example.com"
+    )
+  })
+
+  it("should pass an error object into the form when the API call fails", async () => {
+    const { inner } = await renderPage({
+      passwordReset: {
+        error: {
+          email: "This email doesn't exist"
+        }
+      }
+    })
+
+    const form = inner.find("PasswordResetForm")
+    assert.ok(form.exists())
+    assert.equal(form.prop("emailApiError"), "This email doesn't exist")
+  })
+})

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -14,6 +14,10 @@ export type DetailsForm = {
   name: string
 } & PasswordForm
 
+export type ResetConfirmForm = {
+  new_password: string,
+  re_new_password: string
+}
 
 // API response types
 export type AuthStates =

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -347,3 +347,25 @@ export const postDetailsRegister = (
     method: POST,
     body:   JSON.stringify({ flow, partial_token: partialToken, name, password })
   })
+
+export const postPasswordResetEmail = (email: string): Promise<*> =>
+  fetchJSONWithCSRF("/api/v0/password_reset/", {
+    method: POST,
+    body:   JSON.stringify({ email })
+  })
+
+export const postPasswordResetNewPassword = (
+  newPassword: string,
+  reNewPassword: string,
+  token: string,
+  uid: string
+): Promise<*> =>
+  fetchJSONWithCSRF("/api/v0/password_reset/confirm/", {
+    method: POST,
+    body:   JSON.stringify({
+      new_password:    newPassword,
+      re_new_password: reNewPassword,
+      token,
+      uid
+    })
+  })

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -37,7 +37,9 @@ import {
   postPasswordLogin,
   postEmailRegister,
   postConfirmRegister,
-  postDetailsRegister
+  postDetailsRegister,
+  postPasswordResetEmail,
+  postPasswordResetNewPassword
 } from "./api"
 import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
@@ -590,6 +592,45 @@ describe("api", function() {
               partial_token: partialToken,
               name,
               password
+            })
+          })
+        )
+      })
+    })
+
+    describe("postPasswordResetEmail", () => {
+      it("should pass email", async () => {
+        const email = "test@example.com"
+        await postPasswordResetEmail(email)
+        assert.ok(
+          fetchJSONStub.calledWith("/api/v0/password_reset/", {
+            method: POST,
+            body:   JSON.stringify({ email })
+          })
+        )
+      })
+    })
+
+    describe("postPasswordResetNewPassword", () => {
+      it("should pass password with confirmation, token, and uid", async () => {
+        const newPassword = "abcdefgh"
+        const reNewPassword = "abcdefgh"
+        const token = "4xe-88789b25f477a553b150"
+        const uid = "AA"
+        await postPasswordResetNewPassword(
+          newPassword,
+          reNewPassword,
+          token,
+          uid
+        )
+        assert.ok(
+          fetchJSONStub.calledWith("/api/v0/password_reset/confirm/", {
+            method: POST,
+            body:   JSON.stringify({
+              new_password:    newPassword,
+              re_new_password: reNewPassword,
+              token,
+              uid
             })
           })
         )

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -13,6 +13,7 @@ import { settingsEndpoint } from "../reducers/settings"
 import { embedlyEndpoint } from "../reducers/embedly"
 import { profilesEndpoint } from "../reducers/profiles"
 import { authEndpoint } from "../reducers/auth"
+import { passwordResetEndpoint } from "../reducers/password_reset"
 
 import type { Dispatch } from "redux"
 
@@ -31,7 +32,8 @@ export const endpoints = [
   settingsEndpoint,
   embedlyEndpoint,
   profilesEndpoint,
-  authEndpoint
+  authEndpoint,
+  passwordResetEndpoint
 ]
 
 /**

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -52,6 +52,7 @@ export const FRONTPAGE_URL = "/"
 export const AUTH_REQUIRED_URL = "/auth_required/"
 export const CONTENT_POLICY_URL = "/content_policy/"
 export const SETTINGS_URL = "/settings/"
+export const PASSWORD_RESET_URL = "/password_reset/"
 
 // auth urls
 export const LOGIN_URL = "/login/"

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -42,6 +42,8 @@ export const isEmptyText = R.compose(
   R.defaultTo("")
 )
 
+export const notNil = R.complement(R.isNil)
+
 export const goBackAndHandleEvent = R.curry((history, e) => {
   e.preventDefault()
   history.goBack()

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -11,7 +11,8 @@ import {
   userIsAnonymous,
   isProfileComplete,
   defaultProfileImageUrl,
-  makeProfileImageUrl
+  makeProfileImageUrl,
+  notNil
 } from "./util"
 
 describe("utility functions", () => {
@@ -136,6 +137,18 @@ describe("utility functions", () => {
           assert.equal(makeProfileImageUrl(profile, isSmall), expectedImageUrl)
         }
       )
+    })
+  })
+
+  it("notNil works as expected", () => {
+    [
+      [null, false],
+      [undefined, false],
+      [0, true],
+      ["", true],
+      ["abc", true]
+    ].forEach(([val, exp]) => {
+      assert.equal(notNil(val), exp)
     })
   })
 })

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -7,6 +7,8 @@ import { S } from "./sanctuary"
 import { isTextTabSelected } from "../lib/channels"
 import type { PostForm } from "../flow/discussionTypes"
 
+export const PASSWORD_LENGTH_MINIMUM = 8
+
 // this function checks that a given object fails validation (validator function returns true)
 // if it fails, it returns a setter (R.set) which which set the appropirate
 // validation message in an object. Else, it returns nothing.
@@ -16,7 +18,7 @@ import type { PostForm } from "../flow/discussionTypes"
 // to validate.
 export const validation = R.curry(
   (validator: Function, lens: Function, message: string, toValidate: Object) =>
-    validator(R.view(lens, toValidate))
+    validator(R.view(lens, toValidate), toValidate)
       ? S.Just(R.set(lens, message))
       : S.Nothing
 )
@@ -166,10 +168,31 @@ export const validateRegisterDetailsForm = validate([
   ),
   validation(
     R.compose(
-      R.gt(8),
+      R.gt(PASSWORD_LENGTH_MINIMUM),
       R.length
     ),
     R.lensPath(["value", "password"]),
-    "Password must be at least 8 characters"
+    `Password must be at least ${PASSWORD_LENGTH_MINIMUM} characters`
+  )
+])
+
+export const validatePasswordResetForm = validate([
+  validation(
+    (reNewPassword, form) => reNewPassword !== form.value.new_password,
+    R.lensPath(["value", "re_new_password"]),
+    "Passwords must match"
+  ),
+  validation(
+    R.compose(
+      R.gt(PASSWORD_LENGTH_MINIMUM),
+      R.length
+    ),
+    R.lensPath(["value", "new_password"]),
+    `Password must be at least ${PASSWORD_LENGTH_MINIMUM} characters`
+  ),
+  validation(
+    emptyOrNil,
+    R.lensPath(["value", "new_password"]),
+    "Password is required"
   )
 ])

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -12,7 +12,9 @@ import {
   validateChannelBasicEditForm,
   validateContentReportForm,
   validateEmailForm,
-  validatePasswordForm
+  validatePasswordForm,
+  validatePasswordResetForm,
+  PASSWORD_LENGTH_MINIMUM
 } from "./validation"
 
 describe("validation library", () => {
@@ -239,6 +241,39 @@ describe("validation library", () => {
       assert.deepEqual(validatePasswordForm(form), {
         value: {
           password: "Password must be at least 8 characters"
+        }
+      })
+    })
+  })
+
+  describe("validatePasswordResetForm", () => {
+    it("should complain about no password", () => {
+      const form = {
+        value: { new_password: "", re_new_password: "" }
+      }
+      assert.deepEqual(validatePasswordResetForm(form), {
+        value: {
+          new_password: "Password is required"
+        }
+      })
+    })
+
+    it("should complain about password length", () => {
+      const form = { value: { new_password: "a", re_new_password: "a" } }
+      assert.deepEqual(validatePasswordResetForm(form), {
+        value: {
+          new_password: `Password must be at least ${PASSWORD_LENGTH_MINIMUM} characters`
+        }
+      })
+    })
+
+    it("should complain about non-matching passwords", () => {
+      const form = {
+        value: { new_password: "abcdefgh", re_new_password: "01234567" }
+      }
+      assert.deepEqual(validatePasswordResetForm(form), {
+        value: {
+          re_new_password: "Passwords must match"
         }
       })
     })

--- a/static/js/reducers/password_reset.js
+++ b/static/js/reducers/password_reset.js
@@ -1,0 +1,19 @@
+// @flow
+import * as api from "../lib/api"
+import { INITIAL_STATE } from "redux-hammock/constants"
+import { deriveVerbFuncs } from "redux-hammock/hammock"
+
+export const passwordResetEndpoint = {
+  name:         "passwordReset",
+  initialState: { ...INITIAL_STATE },
+  ...deriveVerbFuncs({
+    postEmail:       (email: string) => api.postPasswordResetEmail(email),
+    postNewPassword: (
+      newPassword: string,
+      reNewPassword: string,
+      token: string,
+      uid: string
+    ) =>
+      api.postPasswordResetNewPassword(newPassword, reNewPassword, token, uid)
+  })
+}

--- a/webpack_dev_server.sh
+++ b/webpack_dev_server.sh
@@ -13,12 +13,12 @@ WEBPACK_PORT='8062'
 #       the webpack server on the host machine rather than the container.
 # If neither of those are true, running this script is basically a no-op.
 
-if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
-  echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
-else
-  if [[ "$1" == "--install" ]] ; then
+#if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
+#  echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
+#else
+if [[ "$1" == "--install" ]] ; then
     yarn install --frozen-lockfile --ignore-engines && echo "Finished yarn install"
-  fi
-  # Start the webpack dev server on the appropriate host and port
-  node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"
 fi
+# Start the webpack dev server on the appropriate host and port
+node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"
+#fi


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #721

#### What's this PR do?
Adds the password reset UI for users that have logged in via email

#### How should this be manually tested?
- Create an account via the email registration flow
- Visit /password_reset
- Go through the password reset flow as you would with any other app
- Try out bad token values, non-existent email addresses, etc.

#### Where should the reviewer start?
Probably `authentication/views.py`

#### Any background context you want to provide?
- This adds the [djoser](http://djoser.readthedocs.io/en/stable/index.html) library, which implements password reset endpoints via REST API
- The email template is a rough draft. There is no final design for that yet
- There is a very minor bug with front end validation. When one of these forms gets a bad input and a front end validation message, that validation message is not cleared if the form input is good but there is a error on the form submission (bad token, non-existent email, etc)

#### Screenshots (if appropriate)

![ss 2018-06-29 at 18 15 20](https://user-images.githubusercontent.com/14932219/42117073-ae692940-7bc8-11e8-9d16-f7b6712e0118.png)
![ss 2018-06-29 at 18 15 35](https://user-images.githubusercontent.com/14932219/42117076-b2608020-7bc8-11e8-8d16-fd5be430478d.png)
![ss 2018-06-29 at 18 16 58](https://user-images.githubusercontent.com/14932219/42117083-b6d25250-7bc8-11e8-8055-f6bbaa133c8e.png)
![ss 2018-06-29 at 18 16 38](https://user-images.githubusercontent.com/14932219/42117088-baa6869e-7bc8-11e8-931b-71cc48fa3c2b.png)

