### PR TITLE
Add preventDefault to toolbar click handler

### DIFF
--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -11,7 +11,7 @@ export default class Toolbar extends React.Component<*, void> {
   toolbar: Object
 
   props: {
-    toggleShowDrawer: (b: boolean) => void,
+    toggleShowDrawer: () => void,
     toggleShowUserMenu: Function,
     showUserMenu: boolean,
     profile: Profile
@@ -27,13 +27,14 @@ export default class Toolbar extends React.Component<*, void> {
     }
   }
 
+  toggleShowDrawer = (e: Event) => {
+    const { toggleShowDrawer } = this.props
+    e.preventDefault()
+    toggleShowDrawer()
+  }
+
   render() {
-    const {
-      toggleShowDrawer,
-      toggleShowUserMenu,
-      showUserMenu,
-      profile
-    } = this.props
+    const { toggleShowUserMenu, showUserMenu, profile } = this.props
 
     return (
       <div className="navbar">
@@ -43,7 +44,7 @@ export default class Toolbar extends React.Component<*, void> {
               <a
                 href="#"
                 className="material-icons mdc-toolbar__icon--menu"
-                onClick={toggleShowDrawer}
+                onClick={this.toggleShowDrawer}
               >
                 menu
               </a>

--- a/static/js/components/Toolbar_test.js
+++ b/static/js/components/Toolbar_test.js
@@ -32,7 +32,9 @@ describe("Toolbar", () => {
     renderToolbar()
       .find("a")
       .at(0)
-      .simulate("click")
+      .simulate("click", {
+        preventDefault: sandbox.stub()
+      })
     assert.ok(toggleShowDrawerStub.called)
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds a `preventDefault()` call to the click handler for the hamburger menu click handler

#### How should this be manually tested?
Click the menu. You should not see a `#` appear in the URL
