### PR TITLE
Hide user menu if user is not logged in

### DIFF
--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -57,13 +57,15 @@ export default class Toolbar extends React.Component<*, void> {
                 </a>{" "}
               </span>
             </section>
-            <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
-              <UserMenu
-                toggleShowUserMenu={toggleShowUserMenu}
-                showUserMenu={showUserMenu}
-                profile={profile}
-              />
-            </section>
+            {SETTINGS.username ? (
+              <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
+                <UserMenu
+                  toggleShowUserMenu={toggleShowUserMenu}
+                  showUserMenu={showUserMenu}
+                  profile={profile}
+                />
+              </section>
+            ) : null}
           </div>
         </header>
       </div>

--- a/static/js/components/Toolbar_test.js
+++ b/static/js/components/Toolbar_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import sinon from "sinon"
 import { assert } from "chai"
@@ -36,5 +37,20 @@ describe("Toolbar", () => {
         preventDefault: sandbox.stub()
       })
     assert.ok(toggleShowDrawerStub.called)
+  })
+
+  //
+  ;[true, false].forEach(isLoggedIn => {
+    it(`should ${isLoggedIn ? "" : "not"} display UserMenu if user is logged ${
+      isLoggedIn ? "in" : "out"
+    }`, () => {
+      SETTINGS.username = isLoggedIn ? "username" : null
+      assert.equal(
+        renderToolbar()
+          .find("UserMenu")
+          .exists(),
+        isLoggedIn
+      )
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #885 

#### What's this PR do?
Hides this ui if you're logged out

#### How should this be manually tested?
Test that you still see it if logged in and don't if logged out.