### PR TITLE
a few CSS tweaks for the post detail page

### DIFF
--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -158,12 +158,6 @@
 
   .summary {
     overflow: hidden;
-
-    .profile-image {
-      float: left;
-      position: relative;
-      top: 6px;
-    }
   }
 
   .text-content {
@@ -216,6 +210,10 @@
 
         &.share-action {
           position: relative;
+
+          i {
+            transform: scaleX(-1);
+          }
 
           > div:not(.share-popup) {
             display: flex;


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

two things:

- tighten up the profile image and name display:

before:

![name_before](https://user-images.githubusercontent.com/6207644/42515602-2b3172d4-842a-11e8-90e3-2e6eca39f060.png)


after:

![name_after](https://user-images.githubusercontent.com/6207644/42515606-30570c56-842a-11e8-9c78-872befb90942.png)


- flip the icon for the 'share' button to match the mocks:

before:

![share_before](https://user-images.githubusercontent.com/6207644/42515614-35823804-842a-11e8-9384-ae5408914488.png)


after:

![share_after](https://user-images.githubusercontent.com/6207644/42515623-397d0a74-842a-11e8-88bd-64adb8a9b294.png)


#### How should this be manually tested?

just check that it looks good and nothing is weird