### PR TITLE
Touchstone login UI

### DIFF
--- a/authentication/templates/register.html
+++ b/authentication/templates/register.html
@@ -3,12 +3,14 @@
 
 {% block content %}
 <div id="login-page">
-  <h2>Register</h2>
+  <h2>Sign up for free to unlock more features.</h2>
   <form method="post" action="{% url 'social:complete' 'email' %}">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Register</button>
+    <button type="submit">Sign Up</button>
   </form>
+    <div class="text-divider">Or use</div>
+    <a class="touchstone-button" href="/login/saml?idp=default">Touchstone@MIT</a>
   <br>
 </div>
 {% endblock %}

--- a/authentication/templates/register.html
+++ b/authentication/templates/register.html
@@ -3,14 +3,12 @@
 
 {% block content %}
 <div id="login-page">
-  <h2>Sign up for free to unlock more features.</h2>
+  <h2>Register</h2>
   <form method="post" action="{% url 'social:complete' 'email' %}">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Sign Up</button>
+    <button type="submit">Register</button>
   </form>
-    <div class="text-divider">Or use</div>
-    <a class="touchstone-button" href="/login/saml?idp=default">Touchstone@MIT</a>
   <br>
 </div>
 {% endblock %}

--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -1,0 +1,19 @@
+// @flow
+import React from "react"
+import { TOUCHSTONE_URL } from "../lib/url"
+
+type ExternalLoginProps = {
+  className?: string
+}
+
+const ExternalLogins = ({ className }: ExternalLoginProps) => (
+  <div className={className ? `actions row ${className}` : "actions row"}>
+    <a className="link-button" href={TOUCHSTONE_URL}>
+      Touchstone
+      <span className="ampersand">@</span>
+      MIT
+    </a>
+  </div>
+)
+
+export default ExternalLogins

--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -7,7 +7,7 @@ type ExternalLoginProps = {
 }
 
 const ExternalLogins = ({ className }: ExternalLoginProps) => (
-  <div className={className ? `actions row ${className}` : "actions row"}>
+  <div className={`actions row ${className || ""}`}>
     <a className="link-button" href={TOUCHSTONE_URL}>
       Touchstone
       <span className="ampersand">@</span>

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -7,8 +7,8 @@ import { TOUCHSTONE_URL } from "../lib/url"
 import ExternalLogins from "./ExternalLogins"
 
 describe("ExternalLogins component", () => {
-  const mountExternalLogins = (children, props = {}) =>
-    shallow(<ExternalLogins {...props}>{children}</ExternalLogins>)
+  const mountExternalLogins = (props = {}) =>
+    shallow(<ExternalLogins {...props} />)
 
   it("should have a link to Touchstone", () => {
     const wrapper = mountExternalLogins()
@@ -18,7 +18,7 @@ describe("ExternalLogins component", () => {
   })
 
   it("should put className, if passed one", () => {
-    const wrapper = mountExternalLogins(<div />, { className: "custom-class" })
+    const wrapper = mountExternalLogins({ className: "custom-class" })
     assert.equal(wrapper.props().className, "actions row custom-class")
   })
 })

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -1,0 +1,24 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import { TOUCHSTONE_URL } from "../lib/url"
+import ExternalLogins from "./ExternalLogins"
+
+describe("ExternalLogins component", () => {
+  const mountExternalLogins = (children, props = {}) =>
+    shallow(<ExternalLogins {...props}>{children}</ExternalLogins>)
+
+  it("should have a link to Touchstone", () => {
+    const wrapper = mountExternalLogins()
+    const link = wrapper.find(".link-button")
+    assert.ok(link.exists())
+    assert.equal(link.props().href, TOUCHSTONE_URL)
+  })
+
+  it("should put className, if passed one", () => {
+    const wrapper = mountExternalLogins(<div />, { className: "custom-class" })
+    assert.equal(wrapper.props().className, "actions row custom-class")
+  })
+})

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -12,6 +12,7 @@ import { actions } from "../../actions"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
+import { TOUCHSTONE_URL } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
@@ -35,7 +36,14 @@ export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
         <h3>Log In</h3>
         <DocumentTitle title={formatTitle("Log In")} />
         {renderForm({ formError })}
-        <hr />
+        <div className="textline">Or use</div>
+        <div className="actions row">
+          <a className="link-button" href={TOUCHSTONE_URL}>
+            Touchstone
+            <span className="ampersand">@</span>
+            MIT
+          </a>
+        </div>
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -12,7 +12,6 @@ import { actions } from "../../actions"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
-import { TOUCHSTONE_URL } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
@@ -23,6 +22,7 @@ import {
 
 import type { EmailForm } from "../../flow/authTypes"
 import type { WithFormProps } from "../../flow/formTypes"
+import ExternalLogins from "../../components/ExternalLogins"
 
 type LoginPageProps = {
   history: Object,
@@ -37,13 +37,7 @@ export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
         <DocumentTitle title={formatTitle("Log In")} />
         {renderForm({ formError })}
         <div className="textline">Or use</div>
-        <div className="actions row">
-          <a className="link-button" href={TOUCHSTONE_URL}>
-            Touchstone
-            <span className="ampersand">@</span>
-            MIT
-          </a>
-        </div>
+        <ExternalLogins />
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -3,7 +3,6 @@ import { assert } from "chai"
 import sinon from "sinon"
 
 import { actions } from "../../actions"
-import { TOUCHSTONE_URL } from "../../lib/url"
 import { FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedLoginPage, { LoginPage, FORM_KEY } from "./LoginPage"
@@ -59,7 +58,7 @@ describe("LoginPage", () => {
     assert.equal(form.props().formError, "error")
   })
 
-  it("should render a Touchstone login link", async () => {
+  it("should render an ExternalLogins component", async () => {
     const { inner } = await renderPage({
       auth: {
         data: {
@@ -68,9 +67,8 @@ describe("LoginPage", () => {
       }
     })
 
-    const link = inner.find(".link-button")
+    const link = inner.find("ExternalLogins")
     assert.ok(link.exists())
-    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 
   it("form onSubmit prop calls api correctly", async () => {

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 import sinon from "sinon"
 
 import { actions } from "../../actions"
+import { TOUCHSTONE_URL } from "../../lib/url"
 import { FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedLoginPage, { LoginPage, FORM_KEY } from "./LoginPage"
@@ -56,6 +57,20 @@ describe("LoginPage", () => {
     const form = inner.find("AuthEmailForm")
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
+  })
+
+  it("should render a Touchstone login link", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
+    })
+
+    const link = inner.find(".link-button")
+    assert.ok(link.exists())
+    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 
   it("form onSubmit prop calls api correctly", async () => {

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -13,7 +13,6 @@ import { setSnackbarMessage } from "../../actions/ui"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
-import { TOUCHSTONE_URL } from "../../lib/url"
 import { preventDefaultAndInvoke } from "../../lib/util"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
@@ -28,6 +27,7 @@ import {
 
 import type { EmailForm, AuthResponse } from "../../flow/authTypes"
 import type { WithFormProps } from "../../flow/formTypes"
+import ExternalLogins from "../../components/ExternalLogins"
 
 type RegisterPageProps = {
   history: Object,
@@ -72,13 +72,7 @@ export const RegisterPage = ({
           renderForm({ formError })
         )}
         <div className="textline">Or use</div>
-        <div className="actions row">
-          <a className="link-button" href={TOUCHSTONE_URL}>
-            Touchstone
-            <span className="ampersand">@</span>
-            MIT
-          </a>
-        </div>
+        <ExternalLogins />
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -13,6 +13,7 @@ import { setSnackbarMessage } from "../../actions/ui"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
+import { TOUCHSTONE_URL } from "../../lib/url"
 import { preventDefaultAndInvoke } from "../../lib/util"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
@@ -51,7 +52,7 @@ export const RegisterPage = ({
         <h3>
           {partialToken && email
             ? `We could not find an account with the email: ${email}`
-            : "Register"}
+            : "Sign up for free to unlock more features."}
         </h3>
         <DocumentTitle title={formatTitle("Register")} />
         {partialToken && email ? (
@@ -70,7 +71,14 @@ export const RegisterPage = ({
         ) : (
           renderForm({ formError })
         )}
-        <hr />
+        <div className="textline">Or use</div>
+        <div className="actions row">
+          <a className="link-button" href={TOUCHSTONE_URL}>
+            Touchstone
+            <span className="ampersand">@</span>
+            MIT
+          </a>
+        </div>
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -6,6 +6,7 @@ import { actions } from "../../actions"
 import { FLOW_REGISTER, STATE_REGISTER_CONFIRM_SENT } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedRegisterPage, { RegisterPage, FORM_KEY } from "./RegisterPage"
+import { TOUCHSTONE_URL } from "../../lib/url"
 
 const email = "test@example.com"
 
@@ -58,6 +59,20 @@ describe("RegisterPage", () => {
     const form = inner.find("AuthEmailForm")
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
+  })
+
+  it("should render a Touchstone login link", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
+    })
+
+    const link = inner.find(".link-button")
+    assert.ok(link.exists())
+    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 
   it("should show a different header if tried to login", async () => {

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -6,7 +6,6 @@ import { actions } from "../../actions"
 import { FLOW_REGISTER, STATE_REGISTER_CONFIRM_SENT } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedRegisterPage, { RegisterPage, FORM_KEY } from "./RegisterPage"
-import { TOUCHSTONE_URL } from "../../lib/url"
 
 const email = "test@example.com"
 
@@ -61,7 +60,7 @@ describe("RegisterPage", () => {
     assert.equal(form.props().formError, "error")
   })
 
-  it("should render a Touchstone login link", async () => {
+  it("should render an ExternalLogins component", async () => {
     const { inner } = await renderPage({
       auth: {
         data: {
@@ -70,9 +69,8 @@ describe("RegisterPage", () => {
       }
     })
 
-    const link = inner.find(".link-button")
+    const link = inner.find("ExternalLogins")
     assert.ok(link.exists())
-    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 
   it("should show a different header if tried to login", async () => {

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -64,6 +64,8 @@ export const REGISTER_DETAILS_URL = "/register/details/"
 
 export const INACTIVE_USER_URL = "/account/inactive/"
 
+export const TOUCHSTONE_URL = "/login/saml/?idp=default"
+
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`
 

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -47,6 +47,11 @@ export const validEmail = R.compose(
   R.trim
 )
 
+export const validNotMIT = R.compose(
+  R.not,
+  R.test(/[.@]mit\.edu$/i) // matches any mit.edu email
+)
+
 // POST CREATE VALIDATION
 export const postUrlOrTextPresent = (postForm: { value: PostForm }) => {
   if (R.isEmpty(postForm)) {
@@ -144,6 +149,11 @@ export const validateEmailForm = validate([
     R.complement(validEmail),
     R.lensPath(["value", "email"]),
     "Email is not formatted correctly"
+  ),
+  validation(
+    R.complement(validNotMIT),
+    R.lensPath(["value", "email"]),
+    "MIT users please login with Touchstone below"
   ),
   validation(emptyOrNil, R.lensPath(["value", "email"]), "Email is required")
 ])

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -49,7 +49,7 @@ export const validEmail = R.compose(
 
 export const validNotMIT = R.compose(
   R.not,
-  R.test(/[.@]mit\.edu$/i) // matches any mit.edu email
+  R.test(/^.*@(((?!alum\.).)+\.)*mit.edu$/i) // matches any mit.edu email except alum.mit.edu
 )
 
 // POST CREATE VALIDATION

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -146,14 +146,14 @@ export const validationMessage = (message: ?string) =>
 
 export const validateEmailForm = validate([
   validation(
-    R.complement(validEmail),
-    R.lensPath(["value", "email"]),
-    "Email is not formatted correctly"
-  ),
-  validation(
     R.complement(validNotMIT),
     R.lensPath(["value", "email"]),
     "MIT users please login with Touchstone below"
+  ),
+  validation(
+    R.complement(validEmail),
+    R.lensPath(["value", "email"]),
+    "Email is not formatted correctly"
   ),
   validation(emptyOrNil, R.lensPath(["value", "email"]), "Email is required")
 ])

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -237,13 +237,14 @@ describe("validation library", () => {
     it("should complain about an MIT email", () => {
       [
         ["user@mit.edu", true],
+        ["user@MIT.EDU", true],
         ["user@test.mit.edu", true],
         ["user@TEST.MIT.edu", true],
         ["user@amit.edu", false],
         ["user@mit.eduu", false],
         ["user@mit.com", false]
       ].forEach(([email, invalid]) => {
-        const form = { value: { email: email } }
+        const form = { value: { email } }
         assert.deepEqual(
           validateEmailForm(form),
           invalid

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -233,6 +233,27 @@ describe("validation library", () => {
         }
       })
     })
+
+    it("should complain about an MIT email", () => {
+      [
+        ["user@mit.edu", true],
+        ["user@test.mit.edu", true],
+        ["user@TEST.MIT.edu", true],
+        ["user@amit.edu", false],
+        ["user@mit.eduu", false],
+        ["user@mit.com", false]
+      ].forEach(([email, invalid]) => {
+        const form = { value: { email: email } }
+        assert.deepEqual(
+          validateEmailForm(form),
+          invalid
+            ? {
+              value: { email: "MIT users please login with Touchstone below" }
+            }
+            : {}
+        )
+      })
+    })
   })
 
   describe("validatePasswordForm", () => {

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -234,12 +234,17 @@ describe("validation library", () => {
       })
     })
 
-    it("should complain about an MIT email", () => {
+    it("should complain about an MIT email except alum.mit.edu", () => {
       [
         ["user@mit.edu", true],
         ["user@MIT.EDU", true],
         ["user@test.mit.edu", true],
         ["user@TEST.MIT.edu", true],
+        ["user@ALUM.MIT.edu", false],
+        ["user@alum.mit.edu", false],
+        ["user@other.alum.mit.edu", false],
+        ["user@other.school.mit.edu", true],
+        ["user@aluminum.mit.edu", true],
         ["user@amit.edu", false],
         ["user@mit.eduu", false],
         ["user@mit.com", false]

--- a/static/scss/basic.scss
+++ b/static/scss/basic.scss
@@ -13,3 +13,34 @@ a.button {
   font-weight: 300;
   margin: 10px 0 20px;
 }
+
+.link-button {
+  display: block;
+  padding: 17px 40px;
+  color: $font-grey;
+  border: 1px solid $bg-grey;
+  text-align: center;
+  font-size: 17px;
+  font-weight: 400;
+  margin: 10px 0 20px;
+
+  .ampersand {
+    color: #68b90f;
+  }
+}
+
+.textline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $font-grey;
+}
+
+.textline:after,
+.textline:before {
+  content: "";
+  width: 150px;
+  height: 2px;
+  background: $bg-grey;
+  margin: 0 10px;
+}

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -32,6 +32,7 @@
   vertical-align: middle;
 }
 
+input[type="email"],
 input[type="text"],
 input[type="url"],
 input[type="password"] {


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #672 
- Partially addresses #771

#### What's this PR do?
- Adds Touchstone login buttons to the Login and Register pages
- Requires users with MIT email addresses to use that button on both pages
- Tweaks the login/register form a bit to more closely resemble the Invision design:
  - https://projects.invisionapp.com/d/main#/console/14224393/298626344/preview
  - https://projects.invisionapp.com/d/main#/console/14224393/298626353/preview

#### How should this be manually tested?
- Go to `/register`.  Click the `Touchstone@mit.edu` button and you should be redirected to `/login/saml?idp=default` (and then, [depending on your `.env` setup](https://github.com/mitodl/open-discussions/#7-testing-integration-with-saml-via-ssocircle), perhaps to SSOCircle or TestShib).
- Go back to `/register`.  Enter an MIT email (try a combo of lower and uppercase in the domain part) and click Next.  You should get a validation message telling you to use Touchstone instead.
- Enter a non-MIT email address and click Next.  The email registration should proceed with no validation messages.
- Go to `/login`, click the Touchstone button, it should work as above.
- Go to `/login`, enter an MIT email, the same validation message as before should appear, telling you to use Touchstone instead,
- Go to `/login`, enter a non-MIT email, you should not get a validation message about using Touchstone.
