### PR TITLE
Added password change UI

### DIFF
--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -8,9 +8,11 @@ from authentication.views import (
     RegisterEmailView,
     RegisterConfirmView,
     RegisterDetailsView,
+    get_social_auth_types,
     login_complete,
     CustomPasswordResetView,
     CustomPasswordResetConfirmView,
+    CustomSetPasswordView,
 )
 
 
@@ -26,6 +28,8 @@ urlpatterns = [
         CustomPasswordResetConfirmView.as_view(),
         name='password-reset-confirm-api'
     ),
+    url(r'^api/v0/set_password/$', CustomSetPasswordView.as_view(), name='set-password-api'),
+    url(r'^api/v0/auths/$', get_social_auth_types, name='get-auth-types-api'),
     url(r'^login/complete$', login_complete, name='login-complete'),
     url(r'^logout/$', auth_views.logout, name='logout')
 ]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,19 +1,24 @@
 """Authentication views"""
 from django.conf import settings
 from django.core import mail as django_mail
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.shortcuts import render, redirect
 from social_core.backends.email import EmailAuth
+from social_django.models import UserSocialAuth
 from social_django.utils import load_backend
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.settings import api_settings
 from anymail.message import AnymailMessage
 from djoser.views import (
     PasswordResetView as DjoserPasswordResetView,
-    PasswordResetConfirmView as DjoserPasswordResetConfirmView
+    PasswordResetConfirmView as DjoserPasswordResetConfirmView,
+    SetPasswordView as DjoserSetPasswordView
 )
+from djoser.utils import ActionViewMixin
 from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 
 from open_discussions import features
@@ -94,6 +99,34 @@ class RegisterDetailsView(SocialAuthAPIView):
         return RegisterDetailsSerializer
 
 
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_social_auth_types(request):
+    """
+    View that returns a serialized list of the logged-in user's UserSocialAuth types
+    """
+    if not features.is_enabled(features.EMAIL_AUTH):
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    social_auths = (
+        UserSocialAuth
+        .objects
+        .filter(user=request.user)
+        .values('provider', 'user__email')
+    )
+    serialized_social_auths = [
+        {
+            'provider': social_auth['provider'],
+            'email': social_auth['user__email']
+        }
+        for social_auth in social_auths
+    ]
+    return Response(
+        data=serialized_social_auths,
+        status=status.HTTP_200_OK
+    )
+
+
 def login_complete(request, **kwargs):  # pylint: disable=unused-argument
     """View that completes the login"""
     # redirect to home
@@ -137,18 +170,17 @@ class CustomPasswordResetEmail(DjoserPasswordResetEmail):
             send_messages([msg])
 
 
-class CustomPasswordResetView(DjoserPasswordResetView):
-    """Custom view to modify base functionality in Djoser's PasswordResetView class"""
-    def post(self, request):
-        """
-        Overrides djoser.views.PasswordResetView#post and adds two bits of logic:
+class CustomDjoserAPIView(ActionViewMixin):
+    """
+    Overrides the post method of a Djoser view and adds two bits of logic:
 
-        1. Returns 404 if the EMAIL_AUTH feature is not enabled
-        2. In version 0.30.0, the fetch function in redux-hammock does not handle responses
-        with empty response data. Djoser returns 204's with empty response data, so we are
-        coercing that to a 200 with an empty dict as the response data. This can be removed
-        when redux-hammock is changed to support 204's.
-        """
+    1. Returns 404 if the EMAIL_AUTH feature is not enabled
+    2. In version 0.30.0, the fetch function in redux-hammock does not handle responses
+    with empty response data. Djoser returns 204's with empty response data, so we are
+    coercing that to a 200 with an empty dict as the response data. This can be removed
+    when redux-hammock is changed to support 204's.
+    """
+    def post(self, request):  # pylint: disable=missing-docstring
         if not features.is_enabled(features.EMAIL_AUTH):
             return Response(status=status.HTTP_404_NOT_FOUND)
         response = super().post(request)
@@ -157,21 +189,27 @@ class CustomPasswordResetView(DjoserPasswordResetView):
         return response
 
 
-class CustomPasswordResetConfirmView(DjoserPasswordResetConfirmView):
+class CustomPasswordResetView(CustomDjoserAPIView, DjoserPasswordResetView):
+    """Custom view to modify base functionality in Djoser's PasswordResetView class"""
+    pass
+
+
+class CustomPasswordResetConfirmView(CustomDjoserAPIView, DjoserPasswordResetConfirmView):
     """Custom view to modify base functionality in Djoser's PasswordResetConfirmView class"""
+    pass
+
+
+class CustomSetPasswordView(CustomDjoserAPIView, DjoserSetPasswordView):
+    """Custom view to modify base functionality in Djoser's SetPasswordView class"""
+    permission_classes = (IsAuthenticated,)
+
     def post(self, request):
         """
-        Overrides djoser.views.PasswordResetView#post and adds two bits of logic:
-
-        1. Returns 404 if the EMAIL_AUTH feature is not enabled
-        2. In version 0.30.0, the fetch function in redux-hammock does not handle responses
-        with empty response data. Djoser returns 204's with empty response data, so we are
-        coercing that to a 200 with an empty dict as the response data. This can be removed
-        when redux-hammock is changed to support 204's.
+        Overrides CustomDjoserAPIView.post to update the session after a successful
+        password change. Without this explicit refresh, the user's session would be
+        invalid and they would be logged out.
         """
-        if not features.is_enabled(features.EMAIL_AUTH):
-            return Response(status=status.HTTP_404_NOT_FOUND)
         response = super().post(request)
-        if response.status_code == status.HTTP_204_NO_CONTENT:
-            return Response({}, status=status.HTTP_200_OK)
+        if response.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT):
+            update_session_auth_hash(self.request, self.request.user)
         return response

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -692,7 +692,8 @@ PASSWORD_RESET_CONFIRM_URL = 'password_reset/confirm/{uid}/{token}/'
 # Djoser library settings (see: http://djoser.readthedocs.io/en/stable/settings.html)
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': PASSWORD_RESET_CONFIRM_URL,
-    'SET_PASSWORD_RETYPE': True,
+    'SET_PASSWORD_RETYPE': False,
+    'LOGOUT_ON_PASSWORD_CHANGE': False,
     'PASSWORD_RESET_CONFIRM_RETYPE': True,
     'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': True,
     'EMAIL': {

--- a/static/js/components/PasswordChangeForm.js
+++ b/static/js/components/PasswordChangeForm.js
@@ -1,0 +1,66 @@
+// @flow
+import React from "react"
+import { Link } from "react-router-dom"
+
+import { validationMessage } from "../lib/validation"
+import { ACCOUNT_SETTINGS_URL } from "../lib/url"
+
+import type { FormProps } from "../flow/formTypes"
+import type { PwChangeForm } from "../flow/authTypes"
+
+type PasswordChangeFormProps = {
+  invalidPwError: ?string
+} & FormProps<PwChangeForm>
+
+export default class PasswordChangeForm extends React.Component<*, void> {
+  props: PasswordChangeFormProps
+
+  render() {
+    const {
+      form,
+      validation,
+      onSubmit,
+      onUpdate,
+      processing,
+      invalidPwError
+    } = this.props
+
+    return (
+      <form onSubmit={onSubmit} className="form">
+        <div className="passwordfield row">
+          <label>Current Password</label>
+          <input
+            type="password"
+            name="current_password"
+            value={form.current_password}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.current_password)}
+          {validationMessage(invalidPwError)}
+        </div>
+        <div className="passwordfield row">
+          <label>New Password</label>
+          <input
+            type="password"
+            name="new_password"
+            value={form.new_password}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.new_password)}
+        </div>
+        <div className="actions row">
+          <Link to={ACCOUNT_SETTINGS_URL} className="buttonLink cancel">
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            className={`submit-password ${processing ? "disabled" : ""}`}
+            disabled={processing}
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    )
+  }
+}

--- a/static/js/components/PasswordChangeForm_test.js
+++ b/static/js/components/PasswordChangeForm_test.js
@@ -1,0 +1,83 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { mount } from "enzyme"
+import { assert } from "chai"
+import { Router } from "react-router"
+import { createMemoryHistory } from "history"
+
+import PasswordChangeForm from "./PasswordChangeForm"
+
+describe("PasswordChangeForm component", () => {
+  let sandbox, onSubmitStub, onUpdateStub, form, browserHistory
+
+  beforeEach(() => {
+    browserHistory = createMemoryHistory()
+    sandbox = sinon.sandbox.create()
+    onSubmitStub = sandbox.stub()
+    onUpdateStub = sandbox.stub()
+    form = {
+      current_password: "",
+      new_password:     ""
+    }
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const getPasswordInput = wrapper =>
+    wrapper.find("input[name='current_password']")
+  const getNewPasswordInput = wrapper =>
+    wrapper.find("input[name='new_password']")
+
+  const mountForm = (props = {}) =>
+    mount(
+      <Router history={browserHistory}>
+        <PasswordChangeForm
+          onSubmit={onSubmitStub}
+          onUpdate={onUpdateStub}
+          form={form}
+          validation={{}}
+          processing={false}
+          {...props}
+        />
+      </Router>
+    )
+
+  it("should render an initial form", () => {
+    const wrapper = mountForm()
+
+    assert.equal(getPasswordInput(wrapper).props().value, "")
+    assert.equal(getNewPasswordInput(wrapper).props().value, "")
+    assert.equal(wrapper.find(".validation-message").exists(), false)
+    assert.equal(wrapper.find("button").props().disabled, false)
+  })
+
+  it("should disable the submit button if processing === true", () => {
+    const wrapper = mountForm({ processing: true })
+
+    assert.equal(wrapper.find("button").props().disabled, true)
+  })
+
+  it("should show error messages if there is a failure in validation or the API call", () => {
+    const wrapper = mountForm({
+      validation: {
+        current_password: "Password is required",
+        new_password:     "New password is required"
+      },
+      invalidPwError: "Invalid password"
+    })
+
+    const validationMessages = wrapper.find(".validation-message")
+    assert.equal(validationMessages.at(0).text(), "Password is required")
+    assert.equal(validationMessages.at(1).text(), "Invalid password")
+    assert.equal(validationMessages.at(2).text(), "New password is required")
+  })
+
+  it("should call onSubmit when the form is submitted", () => {
+    const wrapper = mountForm({ processing: true })
+    wrapper.find("form").simulate("submit")
+    sinon.assert.calledOnce(onSubmitStub)
+  })
+})

--- a/static/js/components/SettingsTabs.js
+++ b/static/js/components/SettingsTabs.js
@@ -1,0 +1,53 @@
+// @flow
+import React from "react"
+import { NavLink } from "react-router-dom"
+import { withRouter } from "react-router"
+
+import { NOTIFICATION_SETTINGS_URL, ACCOUNT_SETTINGS_URL } from "../lib/url"
+
+import type { Location } from "react-router"
+
+type LinkSpec = {
+  isDefault: boolean,
+  text: string
+}
+
+const activeClassName = "active"
+
+const renderNavLinks = (
+  location: Location,
+  linkSpecMap: { [to: string]: LinkSpec }
+) =>
+  Object.keys(linkSpecMap).map((to, i) => {
+    const linkSpec = linkSpecMap[to]
+    const isPathHandled = location.pathname in linkSpecMap
+    const extraClass =
+      !isPathHandled && linkSpec.isDefault ? activeClassName : ""
+    return (
+      <NavLink
+        key={i}
+        to={to}
+        className={`tab ${extraClass}`}
+        activeClassName={activeClassName}
+      >
+        {linkSpec.text}
+      </NavLink>
+    )
+  })
+
+export const SettingsTabs = ({ location }: { location: Location }) => (
+  <div className="tab-row">
+    {renderNavLinks(location, {
+      [NOTIFICATION_SETTINGS_URL]: {
+        isDefault: true,
+        text:      "Email Notifications"
+      },
+      [ACCOUNT_SETTINGS_URL]: {
+        isDefault: false,
+        text:      "Account"
+      }
+    })}
+  </div>
+)
+
+export default withRouter(SettingsTabs)

--- a/static/js/components/SettingsTabs_test.js
+++ b/static/js/components/SettingsTabs_test.js
@@ -1,0 +1,37 @@
+// @flow
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import { SettingsTabs } from "./SettingsTabs"
+
+const generateLocation = (pathname: ?string) => ({
+  pathname: pathname || "",
+  search:   "",
+  hash:     ""
+})
+
+describe("SettingsTabs", function() {
+  it("should render settings links", () => {
+    const mockLocation = generateLocation()
+    const wrapper = shallow(<SettingsTabs location={mockLocation} />)
+    const navLinks = wrapper.find("NavLink")
+    assert.equal(navLinks.length, 2)
+    const notificationsLink = navLinks.at(0)
+    const accountLink = navLinks.at(1)
+    assert.equal(notificationsLink.prop("children"), "Email Notifications")
+    assert.equal(accountLink.prop("children"), "Account")
+  })
+
+  it("should set a default active tab with an unhandled url", () => {
+    const mockLocation = generateLocation("/unhandled/url")
+    const wrapper = shallow(<SettingsTabs location={mockLocation} />)
+    assert.include(
+      wrapper
+        .find("NavLink")
+        .at(0)
+        .prop("className"),
+      "active"
+    )
+  })
+})

--- a/static/js/components/auth/PasswordResetForm.js
+++ b/static/js/components/auth/PasswordResetForm.js
@@ -25,7 +25,7 @@ export default class PasswordResetForm extends React.Component<*, void> {
     return (
       <form onSubmit={onSubmit} className="form">
         <div className="emailfield row">
-          <label>Email</label>
+          <label>We will send a reset email to:</label>
           <input
             type="email"
             name="email"
@@ -41,7 +41,7 @@ export default class PasswordResetForm extends React.Component<*, void> {
             className={`submit-password-reset ${processing ? "disabled" : ""}`}
             disabled={processing}
           >
-            Reset Password
+            Send Reset Email
           </button>
         </div>
       </form>

--- a/static/js/containers/AccountSettingsPage.js
+++ b/static/js/containers/AccountSettingsPage.js
@@ -1,0 +1,92 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import R from "ramda"
+import { connect } from "react-redux"
+import { MetaTags } from "react-meta-tags"
+import { Link } from "react-router-dom"
+
+import Card from "../components/Card"
+import SettingsTabs from "../components/SettingsTabs"
+
+import { actions } from "../actions"
+import { formatTitle } from "../lib/title"
+
+import type { SocialAuth } from "../flow/discussionTypes"
+
+class AccountSettingsPage extends React.Component<*, void> {
+  componentDidMount() {
+    this.loadData()
+  }
+
+  loadData = async () => {
+    const { dispatch } = this.props
+
+    try {
+      await dispatch(actions.accountSettings.get())
+    } catch (_) {} // eslint-disable-line no-empty
+  }
+
+  renderSocialAuthLine = (socialAuth: SocialAuth, index: number) => {
+    switch (socialAuth.provider) {
+    case "email":
+      return (
+        <div key={index}>
+          <h4>MIT Open</h4>
+          <div className="account-settings-row">
+            <div className="email">{socialAuth.email}</div>
+            <div className="action">
+              <Link to="/settings/password">Change Password</Link>
+            </div>
+          </div>
+        </div>
+      )
+    case "micromasters":
+      return (
+        <div key={index}>
+          <h4>MicroMasters</h4>
+          <div className="account-settings-row">
+            <div className="email">{socialAuth.email}</div>
+          </div>
+        </div>
+      )
+    default:
+      return null
+    }
+  }
+
+  render() {
+    const { socialAuths } = this.props
+
+    return (
+      <div className="content">
+        <MetaTags>
+          <title>{formatTitle("Account Settings")}</title>
+        </MetaTags>
+        <div className="main-content settings-page">
+          <SettingsTabs />
+          <Card>
+            <label>
+              You're logged in as
+              <span className="highlight"> {SETTINGS.user_full_name} </span>
+              using:
+            </label>
+            {R.compose(
+              R.addIndex(R.map)(this.renderSocialAuthLine),
+              // Show email auth before any other social auths
+              R.sortBy(x => (x.provider === "email" ? 0 : 1))
+            )(socialAuths)}
+          </Card>
+        </div>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  const socialAuths = state.accountSettings.data || []
+
+  return { socialAuths }
+}
+
+export default connect(mapStateToProps)(AccountSettingsPage)

--- a/static/js/containers/AccountSettingsPage_test.js
+++ b/static/js/containers/AccountSettingsPage_test.js
@@ -1,0 +1,89 @@
+// @flow
+/* global SETTINGS: false */
+import { assert } from "chai"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+describe("PasswordChangePage", () => {
+  let helper, renderComponent
+
+  const renderPage = async () => {
+    const [wrapper] = await renderComponent("/settings/account", [
+      actions.accountSettings.get.requestType,
+      actions.accountSettings.get.successType
+    ])
+    return wrapper.update()
+  }
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    renderComponent = helper.renderComponent.bind(helper)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders the account settings page with lines for each auth type", async () => {
+    SETTINGS.user_full_name = "Test User"
+    helper.getSocialAuthTypesStub.returns(
+      Promise.resolve([
+        { provider: "email", email: "test1@example.com" },
+        { provider: "micromasters", email: "test2@example.com" },
+        { provider: "unknown_provider", email: "test3@example.com" }
+      ])
+    )
+    const wrapper = await renderPage()
+
+    const card = wrapper.find("Card").at(0)
+    assert.equal(card.find(".account-settings-row").length, 2)
+    assert.equal(
+      card
+        .find(".email")
+        .at(0)
+        .text(),
+      "test1@example.com"
+    )
+    assert.equal(
+      card
+        .find(".email")
+        .at(1)
+        .text(),
+      "test2@example.com"
+    )
+    assert.equal(
+      card
+        .find(".highlight")
+        .at(0)
+        .text()
+        .trim(),
+      "Test User"
+    )
+  })
+
+  it("renders the email auth type first", async () => {
+    helper.getSocialAuthTypesStub.returns(
+      Promise.resolve([
+        { provider: "micromasters", email: "mm_auth@example.com" },
+        { provider: "email", email: "email_auth@example.com" }
+      ])
+    )
+    const wrapper = await renderPage()
+
+    assert.equal(
+      wrapper
+        .find(".email")
+        .at(0)
+        .text(),
+      "email_auth@example.com"
+    )
+    assert.equal(
+      wrapper
+        .find(".email")
+        .at(1)
+        .text(),
+      "mm_auth@example.com"
+    )
+  })
+})

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -1,7 +1,7 @@
 /* global SETTINGS: false */
 // @flow
 import React from "react"
-import { Route, Redirect } from "react-router-dom"
+import { Route, Redirect, Switch } from "react-router-dom"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
@@ -14,6 +14,8 @@ import AuthRequiredPage from "./auth/AuthRequiredPage"
 import CreatePostPage from "./CreatePostPage"
 import ChannelModerationPage from "./ChannelModerationPage"
 import SettingsPage from "./SettingsPage"
+import AccountSettingsPage from "./AccountSettingsPage"
+import PasswordChangePage from "./PasswordChangePage"
 import ProfilePage from "./ProfilePage"
 import ProfileEditPage from "./ProfileEditPage"
 import LoginPage from "./auth/LoginPage"
@@ -196,11 +198,28 @@ class App extends React.Component<*, void> {
             path={`${match.url}content_policy/`}
             component={ContentPolicyPage}
           />
-          <Route
-            exact
-            path={`${match.url}settings/:token?`}
-            component={SettingsPage}
-          />
+          <Switch>
+            <Route
+              exact
+              path={`${match.url}settings/notifications`}
+              component={SettingsPage}
+            />
+            <Route
+              exact
+              path={`${match.url}settings/account`}
+              component={AccountSettingsPage}
+            />
+            <Route
+              exact
+              path={`${match.url}settings/password`}
+              component={PasswordChangePage}
+            />
+            <Route
+              exact
+              path={`${match.url}settings/:token?`}
+              component={SettingsPage}
+            />
+          </Switch>
           <Route
             exact
             path={`${match.url}profile/:userName/edit`}

--- a/static/js/containers/PasswordChangePage.js
+++ b/static/js/containers/PasswordChangePage.js
@@ -1,0 +1,107 @@
+// @flow
+import React from "react"
+import R from "ramda"
+import { connect } from "react-redux"
+import { MetaTags } from "react-meta-tags"
+import { Link } from "react-router-dom"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+
+import Card from "../components/Card"
+import PasswordChangeForm from "../components/PasswordChangeForm"
+import withForm from "../hoc/withForm"
+
+import { actions } from "../actions"
+import { formatTitle } from "../lib/title"
+import { mergeAndInjectProps } from "../lib/redux_props"
+import { configureForm } from "../lib/forms"
+import { ACCOUNT_SETTINGS_URL } from "../lib/url"
+import { validatePasswordChangeForm as validateForm } from "../lib/validation"
+
+import type { PwChangeForm } from "../flow/authTypes"
+
+export class PasswordChangePage extends React.Component<*, void> {
+  componentWillUnmount() {
+    const { clearPasswordChange, successfullySubmitted } = this.props
+    // If the form has been successfully submitted and we are navigating away
+    // from this page, clear the password change request state so that the user
+    // will see the password change form (instead of the success message) the
+    // next time they visit this page.
+    if (successfullySubmitted) {
+      clearPasswordChange()
+    }
+  }
+
+  render() {
+    const { renderForm, successfullySubmitted, invalidPwError } = this.props
+    return (
+      <div className="content">
+        <MetaTags>
+          <title>{formatTitle("Change Password")}</title>
+        </MetaTags>
+        <div className="main-content settings-page">
+          <h4>Change Password</h4>
+          {successfullySubmitted ? (
+            <Card>
+              <h3>Your password has been changed successfully!</h3>
+              <Link to={ACCOUNT_SETTINGS_URL} className="buttonLink">
+                Back to Settings
+              </Link>
+            </Card>
+          ) : (
+            <Card>{renderForm({ invalidPwError })}</Card>
+          )}
+        </div>
+      </div>
+    )
+  }
+}
+
+const passwordChangeForm = () => ({
+  current_password: "",
+  new_password:     ""
+})
+
+export const FORM_KEY = "settings:password_change"
+const { getForm, actionCreators } = configureForm(FORM_KEY, passwordChangeForm)
+
+const onSubmit = (form: PwChangeForm) =>
+  actions.passwordChange.post(form.current_password, form.new_password)
+
+const clearPasswordChange = () => actions.passwordChange.clear()
+
+const mergeProps = mergeAndInjectProps((stateProps, { onSubmit }) => ({
+  onSubmit: form => onSubmit(form)
+}))
+
+const mapStateToProps = state => {
+  const form = getForm(state)
+  const passwordChange = state.passwordChange
+  const invalidPwError = R.view(R.lensPath(["error", "current_password"]))(
+    passwordChange
+  )
+  const successfullySubmitted =
+    passwordChange &&
+    passwordChange.loaded &&
+    !passwordChange.processing &&
+    passwordChange.postStatus === FETCH_SUCCESS
+
+  return {
+    form,
+    validateForm,
+    invalidPwError,
+    successfullySubmitted
+  }
+}
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    {
+      clearPasswordChange,
+      onSubmit,
+      ...actionCreators
+    },
+    mergeProps
+  ),
+  withForm(PasswordChangeForm)
+)(PasswordChangePage)

--- a/static/js/containers/PasswordChangePage_test.js
+++ b/static/js/containers/PasswordChangePage_test.js
@@ -1,0 +1,104 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+import { FETCH_SUCCESS } from "redux-hammock/constants"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import ConnectedPasswordChangePage, {
+  PasswordChangePage,
+  FORM_KEY
+} from "./PasswordChangePage"
+
+const DEFAULT_STATE = {
+  passwordChange: {
+    data:       {},
+    processing: false
+  },
+  forms: {
+    [FORM_KEY]: {
+      value: {
+        current_password: "asdfasdf",
+        new_password:     "asdfasdf"
+      },
+      errors: {}
+    }
+  }
+}
+
+describe("PasswordChangePage", () => {
+  let helper, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.postSetPasswordStub.returns(Promise.resolve())
+    renderPage = helper.configureHOCRenderer(
+      ConnectedPasswordChangePage,
+      PasswordChangePage,
+      DEFAULT_STATE
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render the password change form by default", async () => {
+    const { inner } = await renderPage()
+
+    const form = inner.find("PasswordChangeForm")
+    assert.ok(form.exists())
+    assert.isNotOk(form.prop("invalidPwError"))
+  })
+
+  it("should render a success message after the form submits successfully", async () => {
+    const { inner } = await renderPage({
+      passwordChange: {
+        loaded:     true,
+        processing: false,
+        postStatus: FETCH_SUCCESS
+      }
+    })
+
+    assert.isFalse(inner.find("PasswordChangeForm").exists())
+    assert.include(
+      inner
+        .find("h3")
+        .at(0)
+        .text(),
+      "Your password has been changed successfully!"
+    )
+  })
+
+  it("form onSubmit prop calls api correctly", async () => {
+    const { inner, store } = await renderPage()
+
+    const { onSubmit } = inner.find("PasswordChangeForm").props()
+
+    onSubmit()
+
+    const dispatchedActions = store.getActions()
+
+    assert.lengthOf(dispatchedActions, 3)
+    assert.equal(
+      dispatchedActions[2].type,
+      actions.passwordChange.post.requestType
+    )
+    sinon.assert.calledOnce(helper.postSetPasswordStub)
+    sinon.assert.calledWith(helper.postSetPasswordStub, "asdfasdf", "asdfasdf")
+  })
+
+  it("should pass an error object into the form when the API call fails", async () => {
+    const { inner } = await renderPage({
+      passwordChange: {
+        error: {
+          current_password: "Invalid password"
+        }
+      }
+    })
+
+    const form = inner.find("PasswordChangeForm")
+    assert.ok(form.exists())
+    assert.equal(form.prop("invalidPwError"), "Invalid password")
+  })
+})

--- a/static/js/containers/SettingsPage.js
+++ b/static/js/containers/SettingsPage.js
@@ -8,8 +8,10 @@ import Checkbox from "rmwc/Checkbox"
 import { FETCH_PROCESSING } from "redux-hammock/constants"
 
 import Card from "../components/Card"
+import SettingsTabs from "../components/SettingsTabs"
 
 import { formatTitle } from "../lib/title"
+import { getTokenFromUrl } from "../lib/util"
 import { actions } from "../actions"
 import {
   FRONTPAGE_FREQUENCY_CHOICES,
@@ -20,6 +22,7 @@ import {
   COMMENT_NOTIFICATION
 } from "../reducers/settings"
 import { setSnackbarMessage } from "../actions/ui"
+import { withRouter } from "react-router"
 
 export const SETTINGS_FORM_KEY = "SETTINGS_FORM_KEY"
 
@@ -108,8 +111,8 @@ class SettingsPage extends React.Component<*, *> {
           <title>{formatTitle("Settings")}</title>
         </MetaTags>
         <div className="main-content settings-page">
-          <div className="breadcrumbs">Email Settings</div>
-          <form onSubmit={this.onSubmit} className="form">
+          <SettingsTabs />
+          <form onSubmit={this.onSubmit}>
             <Card>
               <label htmlFor="frequency" className="label">
                 How often do you want to receive discussion digest emails?
@@ -151,12 +154,18 @@ class SettingsPage extends React.Component<*, *> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  settings: state.settings.data,
-  token:    ownProps.match.params.token || "",
-  form:     state.forms[SETTINGS_FORM_KEY],
-  saving:
-    state.settings.processing && state.settings.patchStatus === FETCH_PROCESSING
-})
+const mapStateToProps = (state, ownProps) => {
+  return {
+    settings: state.settings.data,
+    token:    getTokenFromUrl(ownProps),
+    form:     state.forms[SETTINGS_FORM_KEY],
+    saving:
+      state.settings.processing &&
+      state.settings.patchStatus === FETCH_PROCESSING
+  }
+}
 
-export default connect(mapStateToProps)(SettingsPage)
+export default R.compose(
+  connect(mapStateToProps),
+  withRouter
+)(SettingsPage)

--- a/static/js/containers/auth/PasswordResetPage.js
+++ b/static/js/containers/auth/PasswordResetPage.js
@@ -40,10 +40,10 @@ export const PasswordResetPage = ({
         </Card>
       ) : (
         <Card className="login-card">
-          <h3>Enter your email address</h3>
           <MetaTags>
             <title>{formatTitle("Password Reset")}</title>
           </MetaTags>
+          <h3>Forgot your password?</h3>
           {renderForm({ emailApiError })}
         </Card>
       )}

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -19,6 +19,11 @@ export type ResetConfirmForm = {
   re_new_password: string
 }
 
+export type PwChangeForm = {
+  current_password: string,
+  new_password: string
+}
+
 // API response types
 export type AuthStates =
   |"success"

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -219,3 +219,7 @@ export type ProfilePayload = {
   headline:                    ?string,
 }
 
+export type SocialAuth = {
+  provider: string,
+  email:    ?string
+}

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -20,6 +20,7 @@ const _createSettings = () => ({
   allow_anonymous:    false,
   is_authenticated:   true,
   username:           "greatusername",
+  user_full_name:     "Great User",
   profile_ui_enabled: false,
   support_email:      "support@fake.url",
   reactGaDebug:       true,

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -30,11 +30,12 @@ import type {
   MoreCommentsFromAPI,
   GenericReport,
   ReportRecord,
-  ProfilePayload
+  Profile,
+  ProfilePayload,
+  SocialAuth
 } from "../flow/discussionTypes"
 import type { NotificationSetting } from "../flow/settingsTypes"
 import type { EmbedlyResponse } from "../reducers/embedly"
-import type { Profile } from "../flow/discussionTypes"
 
 const paramsToQueryString = paramSelector =>
   R.compose(
@@ -424,5 +425,21 @@ export const postPasswordResetNewPassword = (
       re_new_password: reNewPassword,
       token,
       uid
+    })
+  })
+
+export function getSocialAuthTypes(): Promise<Array<SocialAuth>> {
+  return fetchJSONWithAuthFailure("/api/v0/auths/")
+}
+
+export const postSetPassword = (
+  currentPassword: string,
+  newPassword: string
+): Promise<*> =>
+  fetchJSONWithCSRF("/api/v0/set_password/", {
+    method: POST,
+    body:   JSON.stringify({
+      current_password: currentPassword,
+      new_password:     newPassword
     })
   })

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -40,6 +40,7 @@ import {
   postDetailsRegister,
   postPasswordResetEmail,
   postPasswordResetNewPassword,
+  postSetPassword,
   addChannelContributor,
   addChannelModerator,
   deleteChannelContributor,
@@ -775,6 +776,23 @@ describe("api", function() {
         assert.deepEqual(fetchJSONStub.args[0][1], {
           method: DELETE
         })
+      })
+    })
+
+    describe("postSetPassword", () => {
+      it("should pass a current and new password", async () => {
+        const currentPassword = "abcdefgh"
+        const newPassword = "abcdefgh"
+        await postSetPassword(currentPassword, newPassword)
+        assert.ok(
+          fetchJSONStub.calledWith("/api/v0/set_password/", {
+            method: POST,
+            body:   JSON.stringify({
+              current_password: currentPassword,
+              new_password:     newPassword
+            })
+          })
+        )
       })
     })
   })

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -11,10 +11,12 @@ import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
 import { postRemovedEndpoint } from "../reducers/post_removed"
 import { reportsEndpoint } from "../reducers/reports"
 import { settingsEndpoint } from "../reducers/settings"
+import { accountSettingsEndpoint } from "../reducers/account_settings"
 import { embedlyEndpoint } from "../reducers/embedly"
 import { profilesEndpoint } from "../reducers/profiles"
 import { authEndpoint } from "../reducers/auth"
 import { passwordResetEndpoint } from "../reducers/password_reset"
+import { passwordChangeEndpoint } from "../reducers/password_change"
 
 import type { Dispatch } from "redux"
 
@@ -32,10 +34,12 @@ export const endpoints = [
   postRemovedEndpoint,
   reportsEndpoint,
   settingsEndpoint,
+  accountSettingsEndpoint,
   embedlyEndpoint,
   profilesEndpoint,
   authEndpoint,
-  passwordResetEndpoint
+  passwordResetEndpoint,
+  passwordChangeEndpoint
 ]
 
 /**

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -52,7 +52,10 @@ export const FRONTPAGE_URL = "/"
 export const AUTH_REQUIRED_URL = "/auth_required/"
 export const CONTENT_POLICY_URL = "/content_policy/"
 export const SETTINGS_URL = "/settings/"
+export const NOTIFICATION_SETTINGS_URL = "/settings/notifications"
+export const ACCOUNT_SETTINGS_URL = "/settings/account"
 export const PASSWORD_RESET_URL = "/password_reset/"
+export const PASSWORD_CHANGE_URL = "/settings/password"
 
 // auth urls
 export const LOGIN_URL = "/login/"

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -2,6 +2,7 @@
 /* global SETTINGS:false */
 import R from "ramda"
 import _ from "lodash"
+import qs from "query-string"
 
 import type { Match } from "react-router"
 import type { Profile } from "../flow/discussionTypes"
@@ -105,3 +106,16 @@ export const isMobileWidth = () => getViewportWidth() < DRAWER_BREAKPOINT
 
 export const truncate = (text: ?string, length: number): string =>
   text ? _.truncate(text, { length: length, separator: " " }) : ""
+
+export const getTokenFromUrl = (props: Object): string => {
+  const urlMatchPath = ["match", "params", "token"],
+    querystringPath = ["location", "search"]
+
+  let token = R.view(R.lensPath(urlMatchPath))(props)
+  if (token) return token
+
+  const querystring = R.view(R.lensPath(querystringPath))(props)
+  const parsedQuerystring = qs.parse(querystring)
+  token = parsedQuerystring.token
+  return token || ""
+}

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -13,7 +13,8 @@ import {
   defaultProfileImageUrl,
   makeProfileImageUrl,
   notNil,
-  truncate
+  truncate,
+  getTokenFromUrl
 } from "./util"
 
 describe("utility functions", () => {
@@ -161,6 +162,29 @@ describe("utility functions", () => {
       ["abc", true]
     ].forEach(([val, exp]) => {
       assert.equal(notNil(val), exp)
+    })
+  })
+
+  it("getTokenFromUrl gets a token value from a url match or the querystring", () => {
+    [
+      ["url_token", undefined, "url_token"],
+      [undefined, "?token=querystring_token", "querystring_token"],
+      ["url_token", "?token=querystring_token", "url_token"],
+      [undefined, "?not_token=whatever", ""],
+      [undefined, undefined, ""]
+    ].forEach(([urlMatchTokenValue, querystringValue, exp]) => {
+      const props = {
+        match: {
+          params: {
+            token: urlMatchTokenValue
+          }
+        },
+        location: {
+          search: querystringValue
+        }
+      }
+      const token = getTokenFromUrl(props)
+      assert.equal(token, exp)
     })
   })
 })

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -186,12 +186,7 @@ export const validateRegisterDetailsForm = validate([
   )
 ])
 
-export const validatePasswordResetForm = validate([
-  validation(
-    (reNewPassword, form) => reNewPassword !== form.value.new_password,
-    R.lensPath(["value", "re_new_password"]),
-    "Passwords must match"
-  ),
+const newPasswordValidations = [
   validation(
     R.compose(
       R.gt(PASSWORD_LENGTH_MINIMUM),
@@ -203,6 +198,28 @@ export const validatePasswordResetForm = validate([
   validation(
     emptyOrNil,
     R.lensPath(["value", "new_password"]),
-    "Password is required"
+    "New password is required"
   )
-])
+]
+
+export const validatePasswordResetForm = validate(
+  R.prepend(
+    validation(
+      (reNewPassword, form) => reNewPassword !== form.value.new_password,
+      R.lensPath(["value", "re_new_password"]),
+      "Passwords must match"
+    ),
+    newPasswordValidations
+  )
+)
+
+export const validatePasswordChangeForm = validate(
+  R.append(
+    validation(
+      emptyOrNil,
+      R.lensPath(["value", "current_password"]),
+      "Current password is required"
+    ),
+    newPasswordValidations
+  )
+)

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -14,6 +14,7 @@ import {
   validateEmailForm,
   validatePasswordForm,
   validatePasswordResetForm,
+  validatePasswordChangeForm,
   PASSWORD_LENGTH_MINIMUM
 } from "./validation"
 
@@ -280,7 +281,7 @@ describe("validation library", () => {
       }
       assert.deepEqual(validatePasswordResetForm(form), {
         value: {
-          new_password: "Password is required"
+          new_password: "New password is required"
         }
       })
     })
@@ -301,6 +302,29 @@ describe("validation library", () => {
       assert.deepEqual(validatePasswordResetForm(form), {
         value: {
           re_new_password: "Passwords must match"
+        }
+      })
+    })
+  })
+
+  describe("validatePasswordChangeForm", () => {
+    it("should complain about no password", () => {
+      const form = {
+        value: { current_password: "", new_password: "" }
+      }
+      assert.deepEqual(validatePasswordChangeForm(form), {
+        value: {
+          current_password: "Current password is required",
+          new_password:     "New password is required"
+        }
+      })
+    })
+
+    it("should complain about password length", () => {
+      const form = { value: { current_password: "a", new_password: "a" } }
+      assert.deepEqual(validatePasswordChangeForm(form), {
+        value: {
+          new_password: `Password must be at least ${PASSWORD_LENGTH_MINIMUM} characters`
         }
       })
     })

--- a/static/js/reducers/account_settings.js
+++ b/static/js/reducers/account_settings.js
@@ -1,0 +1,10 @@
+// @flow
+import * as api from "../lib/api"
+import { INITIAL_STATE, GET } from "redux-hammock/constants"
+
+export const accountSettingsEndpoint = {
+  name:         "accountSettings",
+  initialState: { ...INITIAL_STATE, data: [] },
+  verbs:        [GET],
+  getFunc:      () => api.getSocialAuthTypes()
+}

--- a/static/js/reducers/password_change.js
+++ b/static/js/reducers/password_change.js
@@ -1,0 +1,11 @@
+// @flow
+import * as api from "../lib/api"
+import { INITIAL_STATE, POST } from "redux-hammock/constants"
+
+export const passwordChangeEndpoint = {
+  name:         "passwordChange",
+  verbs:        [POST],
+  initialState: { ...INITIAL_STATE },
+  postFunc:     (currentPassword: string, newPassword: string) =>
+    api.postSetPassword(currentPassword, newPassword)
+}

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -74,6 +74,10 @@ label {
   font-weight: 400;
   font-size: 15px;
   color: #777;
+
+  .highlight {
+    color: #000;
+  }
 }
 
 label.radiolabel {
@@ -86,17 +90,18 @@ label.radiolabel {
 
 input[type="submit"],
 button[type="submit"],
-button.cancel {
+button.cancel,
+a.buttonLink {
   background-color: $button-blue;
-  border: none;
   color: white;
-  text-decoration: none;
   margin: 0 10px 5px 0;
-  cursor: pointer;
+  padding: 9px 16px;
+  border: none;
   border-radius: 2px;
   font-weight: 400;
-  padding: 9px 16px;
   font-size: 14px;
+  text-decoration: none;
+  cursor: pointer;
 
   &:hover {
     box-shadow: 2px 3px 5px 0px rgba(0, 0, 0, 0.2);
@@ -105,7 +110,8 @@ button.cancel {
 }
 
 button.cancel,
-button.disabled {
+button.disabled,
+a.buttonLink.cancel {
   background: #cecece;
 }
 
@@ -141,4 +147,18 @@ textarea::placeholder {
 
 .actions {
   margin-top: 20px;
+}
+
+.account-settings-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  color: #777;
+  border-bottom: 1px solid #777;
+  padding: 0 0 8px 0;
+
+  a:link {
+    font-weight: bold;
+  }
 }

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -73,6 +73,33 @@ a.mitlogo {
   }
 }
 
+.tab-row {
+  display: flex;
+  flex-direction: row;
+
+  .tab {
+    padding: 10px 29px 17px;
+    color: #585858;
+    text-transform: uppercase;
+    font-weight: 400;
+    font-size: 14px;
+
+    @include breakpoint(phone) {
+      padding: 10px 15px 17px;
+    }
+  }
+
+  & > div {
+    cursor: pointer;
+  }
+
+  .active {
+    border-bottom: 4px solid #0085df;
+    font-weight: 500;
+    color: #000;
+  }
+}
+
 .subscriptions {
   margin: 15px 0 20px;
   width: 100%;

--- a/static/scss/settings.scss
+++ b/static/scss/settings.scss
@@ -1,4 +1,22 @@
+.app .settings-page form {
+  @include breakpoint(desktop) {
+    width: inherit;
+  }
+}
+
 .settings-page {
+  .card {
+    width: 500px;
+
+    @include breakpoint(mobile) {
+      width: 350px;
+    }
+  }
+
+  .tab-row {
+    margin: 0 0 20px 0;
+  }
+
   button {
     margin-left: 15px;
   }
@@ -21,5 +39,9 @@
     label {
       margin: 0;
     }
+  }
+
+  a.buttonLink {
+    display: inline-block;
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #827 

#### What's this PR do?
Adds the password change UI

#### How should this be manually tested?
With an email-authenticated user, go to the settings page, click the "Account" tab, click "Change Password", then use the form to change your password

#### Where should the reviewer start?
Probably `static/js/containers/AccountSettingsPage.js` and `static/js/containers/PasswordChangePage.js`

#### Any background context you want to provide?
The designs for the account settings page are incomplete. The output for Micromasters-authenticated users is just a placeholder for now.

#### Screenshots

![ss 2018-07-11 at 10 42 48](https://user-images.githubusercontent.com/14932219/42580153-ea928c12-84f7-11e8-8f15-a13fe297b1f5.png)
![ss 2018-07-11 at 10 42 59](https://user-images.githubusercontent.com/14932219/42580162-ed35cf6a-84f7-11e8-95c0-d40dead6e3a3.png)
![ss 2018-07-11 at 10 47 45](https://user-images.githubusercontent.com/14932219/42580165-ef096ff4-84f7-11e8-8e49-1d67e390cfe5.png)
