### PR TITLE
Backpopulate MM social auths

### DIFF
--- a/authentication/api.py
+++ b/authentication/api.py
@@ -1,0 +1,82 @@
+"""Authentication api"""
+import logging
+
+from django.contrib.auth import get_user_model
+from django.db import transaction, IntegrityError
+from social_core.utils import get_strategy
+
+from authentication.backends.micromasters import MicroMastersAuth
+from channels import api as channels_api
+from notifications import api as notifications_api
+from profiles import api as profile_api
+
+User = get_user_model()
+
+log = logging.getLogger()
+
+
+def create_user(username, email, profile_data=None, user_extra=None):
+    """
+    Ensures the user exists
+
+    Args:
+        email (str): the user's email
+        profile (dic): the profile data for the user
+
+    Returns:
+        User: the user's profile
+    """
+    defaults = {}
+
+    if user_extra is not None:
+        defaults.update(user_extra)
+
+    # this takes priority over a passed in value
+    defaults.update({
+        'username': username,
+    })
+
+    with transaction.atomic():
+        user, _ = User.objects.get_or_create(email=email, defaults=defaults)
+
+        profile_api.ensure_profile(user, profile_data=profile_data)
+        notifications_api.ensure_notification_settings(user)
+
+    try:
+        # this could fail if the reddit backend is down
+        # but we don't want it to hard-fail the user creation process
+        channels_api.get_or_create_auth_tokens(user)
+    except:  # pylint: disable=bare-except
+        log.exception('Exception trying to create auth tokens')
+
+    return user
+
+
+def create_micromasters_social_auth(user):
+    """
+    Creates a MicroMasters social auth for a user
+
+    Args:
+        user(User): user to create the auth for
+
+    Returns:
+        UserSocialAuth: the created social auth record
+    """
+    # avoid a circular import
+    from social_django.utils import STORAGE, STRATEGY, load_backend
+    strategy = get_strategy(STRATEGY, STORAGE)
+    storage = strategy.storage
+    backend = load_backend(strategy, MicroMastersAuth.name, None)
+    try:
+        social = storage.user.create_social_auth(user, user.username, MicroMastersAuth.name)
+
+        extra_data = backend.extra_data(user, user.username, {
+            'email': user.email,
+            'username': str(user.username),
+        }, {})
+        social.set_extra_data(extra_data)
+        return social
+    except IntegrityError:
+        # if the user already has a social auth for MM, we don't want to fail
+        # so just return the existing one
+        return storage.user.get_social_auth_for_user(user, provider=MicroMastersAuth.name)

--- a/authentication/api_test.py
+++ b/authentication/api_test.py
@@ -1,0 +1,92 @@
+"""API tests"""
+from django.contrib.auth import get_user_model
+import pytest
+from social_django.models import UserSocialAuth
+
+from authentication import api
+from notifications.models import NotificationSettings
+from profiles.models import Profile
+from open_discussions.test_utils import any_instance_of
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize('profile_data', [
+    {'name': 'My Name', 'image': 'http://localhost/image.jpg'},
+    # {},
+    # None,
+])
+def test_create_user(profile_data):
+    """Tests that a user and associated objects are created"""
+    email = 'email@localhost'
+    username = 'username'
+    user = api.create_user(username, email, profile_data, {
+        'first_name': 'Bob',
+    })
+
+    assert isinstance(user, User)
+    assert user.email == email
+    assert user.username == username
+    assert user.first_name == 'Bob'
+    assert NotificationSettings.objects.count() == 2
+
+    if 'name' in profile_data:
+        assert user.profile.name == profile_data['name']
+    else:
+        assert user.profile.name is None
+
+
+@pytest.mark.parametrize('mock_method', [
+    'profiles.api.ensure_profile',
+    'notifications.api.ensure_notification_settings',
+])
+def test_create_user_errors(mocker, mock_method):
+    """Test that we don't end up in a partial state if there are errors"""
+    mocker.patch(mock_method, side_effect=Exception('error'))
+    auth_token_mock = mocker.patch('channels.api.get_or_create_auth_tokens')
+
+    with pytest.raises(Exception):
+        api.create_user('username', 'email@localhost', {
+            'name': 'My Name',
+            'image': 'http://localhost/image.jpg',
+        })
+
+    assert User.objects.all().count() == 0
+    assert Profile.objects.count() == 0
+    auth_token_mock.assert_not_called()
+
+
+def test_create_user_token_error(mocker):
+    """Test that an error creating a token does not fail the user creation"""
+    auth_token_mock = mocker.patch('channels.api.get_or_create_auth_tokens', side_effect=Exception('error'))
+
+    assert api.create_user('username', 'email@localhost', {
+        'name': 'My Name',
+        'image': 'http://localhost/image.jpg',
+    }) is not None
+
+    assert User.objects.all().count() == 1
+    assert Profile.objects.count() == 1
+    assert NotificationSettings.objects.count() == 2
+    auth_token_mock.assert_called_once()
+
+
+def test_create_micromasters_social_auth(user):
+    """Test that we create a MM social auth"""
+
+    assert UserSocialAuth.objects.count() == 0
+    assert api.create_micromasters_social_auth(user) is not None
+
+    assert UserSocialAuth.objects.count() == 1
+
+    social = UserSocialAuth.objects.first()
+    assert social.user == user
+    assert social.uid == user.username
+    assert social.provider == 'micromasters'
+    assert social.extra_data == {
+        'email': user.email,
+        'username': user.username,
+        'auth_time': any_instance_of(int),
+    }

--- a/authentication/backends/base_jwt.py
+++ b/authentication/backends/base_jwt.py
@@ -9,7 +9,7 @@ from social_core.exceptions import AuthException
 class BaseJwtAuth(LegacyAuth):
     """Base implementation for JWT-based authentication"""
     ID_KEY = 'username'
-    EXTRA_DATA = ['username']
+    EXTRA_DATA = ['username', 'email']
 
     def auth_complete(self, *args, **kwargs):
         """Perform the authentication"""
@@ -41,4 +41,6 @@ class BaseJwtAuth(LegacyAuth):
 
     def get_user_details(self, response):
         """Get the user details"""
-        return {}
+        return {
+            'username': response['username'],
+        }

--- a/authentication/backends/base_jwt_test.py
+++ b/authentication/backends/base_jwt_test.py
@@ -23,7 +23,10 @@ def auth(mock_strategy):
 
 def test_user_details(auth):
     """Tests get_user_details"""
-    assert auth.get_user_details(None) == {}
+    assert auth.get_user_details({
+        'username': 'abc',
+        'other': 'missing',
+    }) == {'username': 'abc'}
 
 
 def test_auth_complete_no_auth_header(auth):

--- a/authentication/management/commands/backpopulate_social_auth.py
+++ b/authentication/management/commands/backpopulate_social_auth.py
@@ -1,0 +1,25 @@
+"""Command to populate UserSocialAuth for micromasters"""
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+from django.db.models import OuterRef, Exists
+from social_django.models import UserSocialAuth
+
+from authentication import api
+from authentication.backends.micromasters import MicroMastersAuth
+
+
+class Command(BaseCommand):
+    """Populates UserSocialAuth"""
+    help = 'Populates UserSocialAuth'
+
+    def handle(self, *args, **options):
+        micromasters_auths = UserSocialAuth.objects.filter(
+            provider=MicroMastersAuth.name,
+            user=OuterRef("pk"),
+        )
+        users = get_user_model().objects.annotate(
+            has_mm_auth=Exists(micromasters_auths)
+        ).filter(has_mm_auth=False)
+
+        for user in users.iterator():
+            api.create_micromasters_social_auth(user)

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -11,10 +11,8 @@ from authentication.exceptions import (
     RequireRegistrationException,
 )
 from authentication.utils import SocialAuthState
-from channels import api as channel_api
-from notifications import api as notifications_api
 from open_discussions.settings import SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME
-from profiles.models import Profile
+from profiles import api as profile_api
 from profiles.utils import update_full_name
 
 
@@ -78,21 +76,17 @@ def require_password_and_profile_via_email(
         return {}
 
     data = strategy.request_data()
-    profile = None
+    profile = user.profile
 
     if 'name' in data:
-        profile, _ = Profile.objects.update_or_create(
-            user=user,
-            defaults={
-                'name': data['name'],
-            },
-        )
+        profile.name = data['name']
+        profile.save()
 
     if 'password' in data:
         user.set_password(data['password'])
         user.save()
 
-    if not user.password or not hasattr(user, 'profile') or not user.profile.name:
+    if not user.password or not user.profile.name:
         raise RequirePasswordAndProfileException(backend, current_partial)
 
     return {
@@ -119,18 +113,17 @@ def require_profile_update_user_via_saml(
     if backend.name != SAMLAuth.name or not is_new:
         return {}
 
+    profile_api.ensure_profile(user)
+
     try:
         update_full_name(user, kwargs['response']['attributes'][SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME][0])
     except (KeyError, IndexError):
         # No name information passed, skipping
         pass
 
-    profile, _ = Profile.objects.update_or_create(
-        user=user,
-        defaults={
-            'name': user.get_full_name()
-        },
-    )
+    profile = user.profile
+    profile.name = user.get_full_name()
+    profile.save()
 
     return {
         'user': user,
@@ -169,23 +162,5 @@ def validate_password(
 
     if not user or not user.check_password(password):
         raise InvalidPasswordException(backend, current_partial)
-
-    return {}
-
-
-def initialize_user(user, is_new=False, *args, **kwargs):  # pylint: disable=unused-argument
-    """
-    Performs first-time initialization of the user
-
-    Args:
-        user (User): the current user
-        is_new (bool): True if the user just got created
-    """
-    if not is_new:
-        return {}
-
-    notifications_api.ensure_notification_settings(user)
-
-    channel_api.get_or_create_auth_tokens(user)
 
     return {}

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -3,8 +3,6 @@ from django.contrib.sessions.middleware import SessionMiddleware
 import pytest
 from social_django.utils import load_strategy, load_backend
 
-from channels.models import RedditAccessToken, RedditRefreshToken
-from notifications.models import NotificationSettings
 from open_discussions.factories import UserFactory
 from authentication.pipeline import user as user_actions
 from authentication.exceptions import (
@@ -166,8 +164,7 @@ def test_validate_require_password_and_profile_via_email_exit(mocker, backend_na
 @pytest.mark.django_db
 def test_validate_require_password_and_profile_via_email(mocker):
     """Tests that require_password_and_profile_via_email processes the request"""
-    mocker.patch('profiles.models.requests.get')
-    user = UserFactory(profile=None)
+    user = UserFactory.create(profile__name='')
     mock_strategy = mocker.Mock()
     mock_strategy.request_data.return_value = {
         'name': 'Jane Doe',
@@ -188,7 +185,7 @@ def test_validate_require_password_and_profile_via_email(mocker):
 @pytest.mark.django_db
 def test_validate_require_password_and_profile_via_email_no_data(mocker):
     """Tests that require_password_and_profile_via_email raises an error if no data for name and password provided"""
-    user = UserFactory(profile=None)
+    user = UserFactory.create(profile__name='')
     mock_strategy = mocker.Mock()
     mock_strategy.request_data.return_value = {}
     mock_backend = mocker.Mock()
@@ -226,10 +223,11 @@ def test_validate_require_password_and_profile_via_email_password_set(mocker):
 ])
 def test_validate_require_profile_update_user_via_saml(mocker, backend_name, is_new):
     """Tests that require_profile_update_user_via_saml returns {} if not using the saml backend"""
-    user = UserFactory(first_name='Jane', last_name='Doe', profile=None)
-    mocker.patch('profiles.models.requests.get')
+    user = UserFactory(first_name='Jane', last_name='Doe', profile__name='')
     mock_strategy = mocker.Mock()
     mock_backend = mocker.Mock()
+    # don't test this, so mock an empty return
+    mocker.patch('profiles.api._get_gravatar_urls_properties', return_value={})
     mock_backend.name = backend_name
     response = user_actions.require_profile_update_user_via_saml(  # pylint:disable=redundant-keyword-arg
         mock_strategy, mock_backend, 0, user=user, is_new=is_new
@@ -244,21 +242,3 @@ def test_validate_require_profile_update_user_via_saml(mocker, backend_name, is_
     assert response == expected
     if 'user' in response:
         assert response['profile'].name == 'Jane Doe'
-
-
-@pytest.mark.parametrize('is_new', [True, False])
-@pytest.mark.django_db
-@pytest.mark.betamax
-def test_initialize_user(is_new):
-    """Tests that a new users is initialized"""
-    # don't use the user fixture because it creates Reddit*Token objects implicitly
-    user = UserFactory.create()
-    assert NotificationSettings.objects.filter(user=user).count() == 0
-    assert RedditAccessToken.objects.filter(user=user).count() == 0
-    assert RedditRefreshToken.objects.filter(user=user).count() == 0
-
-    assert user_actions.initialize_user(user=user, is_new=is_new) == {}
-
-    assert RedditAccessToken.objects.filter(user=user).count() == (1 if is_new else 0)
-    assert RedditRefreshToken.objects.filter(user=user).count() == (1 if is_new else 0)
-    assert NotificationSettings.objects.filter(user=user).count() == (2 if is_new else 0)

--- a/authentication/strategy.py
+++ b/authentication/strategy.py
@@ -2,8 +2,23 @@
 from rest_framework.request import Request
 from social_django.strategy import DjangoStrategy
 
+from authentication import api as auth_api
 
-class DjangoRestFrameworkStrategy(DjangoStrategy):
+
+class OpenDiscussionsStrategy(DjangoStrategy):
+    """A custom strategy for open"""
+
+    def create_user(self, *args, **kwargs):
+        """Creates the user during the pipeline execution"""
+        # this is normally delegated to the storage mechanism,
+        # specifically social_django.storage.DjangoUserMixin.create_user
+        # but we want to call our own method to create the user so we override at the strategy level
+        username = kwargs.pop('username')
+        email = kwargs.pop('email')
+        return auth_api.create_user(username, email, user_extra=kwargs)
+
+
+class DjangoRestFrameworkStrategy(OpenDiscussionsStrategy):
     """Strategy specific to handling DRF requests"""
 
     def __init__(self, storage, drf_request=None, tpl=None):

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -3,7 +3,7 @@ Factory for Users
 """
 import ulid
 from django.contrib.auth.models import User
-from factory import LazyFunction, RelatedFactory
+from factory import LazyFunction, RelatedFactory, Trait
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
@@ -19,3 +19,6 @@ class UserFactory(DjangoModelFactory):
 
     class Meta:
         model = User
+
+    class Params:
+        no_profile = Trait(profile=None)

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -204,6 +204,8 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+SOCIAL_AUTH_STRATEGY = 'authentication.strategy.OpenDiscussionsStrategy'
+
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = 'login-complete'
 SOCIAL_AUTH_LOGIN_ERROR_URL = 'login'
 
@@ -269,9 +271,6 @@ SOCIAL_AUTH_PIPELINE = (
 
     # require a profile if they're not set via SAML
     'authentication.pipeline.user.require_profile_update_user_via_saml',
-
-    # initialize the user, must happen after we're sure who the user is
-    'authentication.pipeline.user.initialize_user',
 
     # Create the record that associates the social account with the user.
     'social_core.pipeline.social_auth.associate_user',

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -1,0 +1,56 @@
+"""Profile API"""
+import hashlib
+
+import requests
+
+from profiles.models import (
+    IMAGE_MEDIUM_MAX_DIMENSION,
+    IMAGE_SMALL_MAX_DIMENSION,
+    Profile,
+    filter_profile_props,
+)
+
+GRAVATAR_IMAGE_URL = "https://www.gravatar.com/avatar/{}.jpg"
+
+
+def ensure_profile(user, profile_data=None):
+    """
+    Ensures the user has a profile
+
+    Args:
+        user (User): the user to ensure a profile for
+        profile (dic): the profile data for the user
+
+    Returns:
+        Profile: the user's profile
+    """
+    defaults = filter_profile_props(profile_data) if profile_data else {}
+
+    # if we weren't provided an image for the new user, fetch defaults from gravatar
+    if 'image' not in defaults and 'image_file' not in defaults:
+        defaults.update(_get_gravatar_urls_properties(user))
+
+    profile, _ = Profile.objects.get_or_create(user=user, defaults=defaults)
+    return profile
+
+
+def _get_gravatar_urls_properties(user):
+    """
+    Query gravatar for an image and return those image properties
+
+    Args:
+        user (User): the user to compute gravatar image urls for
+
+    Returns:
+        dict: additional properties for the profile
+    """
+    gravatar_hash = hashlib.md5(user.email.lower().encode('utf-8')).hexdigest()
+    gravatar_image_url = GRAVATAR_IMAGE_URL.format(gravatar_hash)
+    if requests.get("{}?d=404".format(gravatar_image_url), timeout=5).status_code == 200:
+        return {
+            'image': gravatar_image_url,
+            'image_small': '{}?s={}'.format(gravatar_image_url, IMAGE_SMALL_MAX_DIMENSION),
+            'image_medium': '{}?s={}'.format(gravatar_image_url, IMAGE_MEDIUM_MAX_DIMENSION)
+        }
+
+    return {}

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -1,0 +1,56 @@
+"""Profile API tests"""
+import pytest
+
+from open_discussions.factories import UserFactory
+from profiles import api
+from profiles.models import (
+    IMAGE_SMALL_MAX_DIMENSION,
+    IMAGE_MEDIUM_MAX_DIMENSION,
+    Profile,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize('profile_data', [
+    {
+        'image': 'http://localhost:image.jpg'
+    },
+    {},
+    None
+])
+@pytest.mark.parametrize('no_profile', [True, False])
+def test_ensure_profile(mocker, profile_data, no_profile):
+    """Test that it creates a profile form the data"""
+    mock_requests = mocker.patch('profiles.api.requests')
+    mock_requests.get.return_value.status_code = 200
+    user = UserFactory.create(email='testuser@example.com', no_profile=no_profile)
+    profile = api.ensure_profile(user, profile_data=profile_data)
+
+    assert isinstance(profile, Profile)
+
+    if no_profile:
+        if profile_data and 'image' in profile_data:
+            assert profile.image == profile_data['image']
+        else:
+            base_img_url = 'https://www.gravatar.com/avatar/7ec7606c46a14a7ef514d1f1f9038823.jpg'
+            assert profile.image == base_img_url
+            assert profile.image_small == '{}?s={}'.format(base_img_url, IMAGE_SMALL_MAX_DIMENSION)
+            assert profile.image_medium == '{}?s={}'.format(base_img_url, IMAGE_MEDIUM_MAX_DIMENSION)
+    else:
+        assert 'gravatar.com' not in profile.image
+        assert 'gravatar.com' not in profile.image_small
+        assert 'gravatar.com' not in profile.image_medium
+
+
+@pytest.mark.parametrize('status_code', [404, 500])
+def test_ensure_profile_error_codes(mocker, status_code):
+    """Test that it doesn't set gravatar images if gravatar errors"""
+    mock_requests = mocker.patch('profiles.api.requests')
+    mock_requests.get.return_value.status_code = status_code
+    user = UserFactory.create(no_profile=True)
+    profile = api.ensure_profile(user)
+
+    assert profile.image is None
+    assert profile.image_small is None
+    assert profile.image_medium is None

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,8 +1,6 @@
 """Profile models"""
-import hashlib
 from uuid import uuid4
 
-import requests
 from django.db import models, transaction
 from django.conf import settings
 
@@ -10,7 +8,8 @@ from profiles.utils import (
     profile_image_upload_uri,
     profile_image_upload_uri_medium,
     profile_image_upload_uri_small,
-    make_thumbnail)
+    make_thumbnail
+)
 
 # Max dimension of either height or width for small and medium images
 IMAGE_SMALL_MAX_DIMENSION = 64
@@ -28,6 +27,19 @@ PROFILE_PROPS = (
     'headline',
     'bio',
 )
+
+
+def filter_profile_props(data):
+    """
+    Filters the passed profile data to valid profile fields
+
+    Args:
+        data (dict): profile data
+
+    Return:
+        dict: filtered dict
+    """
+    return {key: value for key, value in data.items() if key in PROFILE_PROPS}
 
 
 class Profile(models.Model):
@@ -52,17 +64,6 @@ class Profile(models.Model):
     headline = models.TextField(blank=True, null=True)
     bio = models.TextField(blank=True, null=True)
 
-    def set_gravatar(self):
-        """
-        Query gravatar for an image and set user's profile image fields to it if found.
-        """
-        gravatar_hash = hashlib.md5(self.user.email.lower().encode('utf-8')).hexdigest()
-        gravatar_base_url = "https://www.gravatar.com/avatar/{}.jpg".format(gravatar_hash)
-        if requests.get("{}?d=404".format(gravatar_base_url), timeout=5).status_code == 200:
-            self.image = gravatar_base_url
-            self.image_small = '{}?s={}'.format(gravatar_base_url, IMAGE_SMALL_MAX_DIMENSION)
-            self.image_medium = '{}?s={}'.format(gravatar_base_url, IMAGE_MEDIUM_MAX_DIMENSION)
-
     @transaction.atomic
     def save(self, *args, update_image=False, **kwargs):  # pylint: disable=arguments-differ
         """Update thumbnails if necessary"""
@@ -77,8 +78,6 @@ class Profile(models.Model):
             else:
                 self.image_small_file = None
                 self.image_medium_file = None
-        elif not self.pk and not self.image_file and not self.image:
-            self.set_gravatar()
         super(Profile, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -2,12 +2,6 @@
 import pytest
 from django.core.files.uploadedfile import UploadedFile
 
-from open_discussions.factories import UserFactory
-from open_discussions.test_utils import MockResponse
-from profiles.models import Profile, IMAGE_SMALL_MAX_DIMENSION, IMAGE_MEDIUM_MAX_DIMENSION
-
-pytestmark = pytest.mark.django_db
-
 
 @pytest.mark.parametrize('update_image', [True, False])
 def test_image_update(user, profile_image, update_image):
@@ -40,56 +34,3 @@ def test_null_image(user):
     assert not profile.image_file
     assert not profile.image_medium_file
     assert not profile.image_small_file
-
-
-def test_save_with_gravatar_image(mocker):
-    """
-    An empty image should be replaced with a gravatar URL if found
-    """
-    new_user = UserFactory(email='testuser@example.com')
-    new_user.profile.delete()
-    base_img_url = 'https://www.gravatar.com/avatar/7ec7606c46a14a7ef514d1f1f9038823.jpg'
-    mocker.patch('profiles.models.requests.get', return_value=MockResponse("", 200))
-    profile = Profile(user=new_user, image=None, image_file=None)
-    profile.save()
-    assert profile.image == base_img_url
-    assert profile.image_small == '{}?s={}'.format(base_img_url, IMAGE_SMALL_MAX_DIMENSION)
-    assert profile.image_medium == '{}?s={}'.format(base_img_url, IMAGE_MEDIUM_MAX_DIMENSION)
-
-
-def test_save_no_gravatar(mocker):
-    """
-    An empty image should not be replaced with a gravatar URL if the URL request returns a 404
-    """
-    new_user = UserFactory(email='testuser@example.com')
-    new_user.profile.delete()
-    mocker.patch('profiles.models.requests.get', return_value=MockResponse("", 404))
-    profile = Profile(user=new_user, image=None, image_file=None)
-    profile.save()
-    assert profile.image is None
-    assert profile.image_small is None
-    assert profile.image_medium is None
-
-
-def test_existing_image_not_replaced(mocker):
-    """
-    A non-empty image URL should not be replaced with a gravatar URL
-    """
-    new_user = UserFactory(email='testuser@example.com')
-    new_user.profile.delete()
-    original_url = 'https://example.cloudront.com/0.jpg'
-    mocker.patch('profiles.models.requests.get', return_value=MockResponse("", 200))
-    profile = Profile(user=new_user, image=original_url)
-    profile.save()
-    assert profile.image == original_url
-
-
-def test_no_gravatar_for_updated_profile(mocker, user):
-    """
-    An empty image URL should not be replaced with a gravatar URL if the profile is not new.
-    """
-    mocker.patch('profiles.models.requests.get', return_value=MockResponse("", 200))
-    profile = user.profile
-    profile.image = None
-    profile.save()
-    assert profile.image is None

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -4,12 +4,13 @@ Serializers for profile REST APIs
 from django.contrib.auth import get_user_model
 from django.db import transaction
 
-import ulid
 from rest_framework import serializers
+import ulid
 
-from channels.api import get_or_create_auth_tokens
-from notifications.api import ensure_notification_settings
+from authentication import api as auth_api
 from profiles.models import Profile, PROFILE_PROPS
+
+User = get_user_model()
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -50,24 +51,25 @@ class UserSerializer(serializers.ModelSerializer):
         read_only=True,
         default=serializers.CreateOnlyDefault(ulid.new)
     )
-    email = serializers.CharField(write_only=True, required=False)
+    email = serializers.CharField(write_only=True)
     profile = ProfileSerializer()
 
     def create(self, validated_data):
         profile_data = validated_data.pop('profile') or {}
-        with transaction.atomic():
-            user = get_user_model().objects.create(**validated_data)
-            Profile.objects.create(user=user, **profile_data)
-            ensure_notification_settings(user)
+        username = validated_data.get('username')
+        email = validated_data.get('email')
 
-        get_or_create_auth_tokens(user)
+        with transaction.atomic():
+            user = auth_api.create_user(username, email, profile_data)
+
+            auth_api.create_micromasters_social_auth(user)
+
         return user
 
     def update(self, instance, validated_data):
         profile_data = validated_data.pop('profile', None)
 
         with transaction.atomic():
-
             instance.email = validated_data.pop('email', instance.email)
             instance.save()
 
@@ -80,6 +82,6 @@ class UserSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        model = get_user_model()
+        model = User
         fields = ('id', 'username', 'profile', 'email')
-        read_only_fields = ('id',)
+        read_only_fields = ('id', 'username')

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -47,10 +47,13 @@ def test_serialize_create_user(db, mocker):
         'headline': 'headline',
     }
 
-    get_or_create_auth_tokens_stub = mocker.patch('profiles.serializers.get_or_create_auth_tokens')
-    user = UserSerializer().create({
-        'profile': profile
+    get_or_create_auth_tokens_stub = mocker.patch('channels.api.get_or_create_auth_tokens')
+    serializer = UserSerializer(data={
+        'email': 'test@localhost',
+        'profile': profile,
     })
+    serializer.is_valid(raise_exception=True)
+    user = serializer.save()
     get_or_create_auth_tokens_stub.assert_called_once_with(user)
 
     del profile['email_optin']  # is write-only
@@ -105,7 +108,7 @@ def test_update_user_profile(user, key, value):
         'profile': {
             key: value,
         }
-    })
+    }, partial=True)
     serializer.is_valid(raise_exception=True)
     serializer.save()
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,5 +1,4 @@
 """Views for REST APIs for channels"""
-
 from django.contrib.auth import get_user_model
 
 from rest_framework import viewsets, mixins


### PR DESCRIPTION
Based on #887, so it includes code form that, but the code for this is https://github.com/mitodl/open-discussions/pull/899/commits/9ad761b21e3ad28919b8725dabec55a6dedc78d1

#### What are the relevant tickets?
Fixes #840 

#### What's this PR do?
Adds a command to backpopulate MM social auth for all users who don't have it. This code assumes (as is the case in production), that all users who exist only came in through MM up until now.

#### How should this be manually tested?
Run `./manage.py backpopulate_social_auth` and verify it creates `UserSocialAuth` records for those that don't have it.
