### PR TITLE
Don't fetch from moderators list to check whether user is mod

### DIFF
--- a/static/js/containers/ChannelModerationPage.js
+++ b/static/js/containers/ChannelModerationPage.js
@@ -37,7 +37,6 @@ class ChannelModerationPage extends React.Component<*, *> {
 
     try {
       await dispatch(actions.channels.get(channelName))
-      await dispatch(actions.channelModerators.get(channelName))
       await dispatch(actions.reports.get(channelName))
     } catch (_) {} // eslint-disable-line no-empty
   }

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -21,7 +21,6 @@ import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
 import { safeBulkGet } from "../lib/maps"
 import { getChannelName } from "../lib/util"
-import { isModerator } from "../lib/channels"
 import { getPostIds } from "../lib/posts"
 import { channelURL } from "../lib/url"
 import { toggleUpvote } from "../util/api_actions"
@@ -101,7 +100,6 @@ class ChannelPage extends React.Component<*, void> {
 
     try {
       await dispatch(actions.channels.get(channelName))
-      await dispatch(actions.channelModerators.get(channelName))
 
       this.fetchPostsForChannel()
     } catch (_) {} // eslint-disable-line no-empty
@@ -181,7 +179,6 @@ const mapStateToProps = (state, ownProps) => {
   const postsForChannel = state.postsForChannel.data.get(channelName) || {}
   const channel = channels.data.get(channelName)
   const postIds = getPostIds(postsForChannel)
-  const channelModerators = state.channelModerators.data.get(channelName) || []
   // NOTE: postsForChannel.postIds cannot be `postIds` because that never evals to a Nil value
   const loaded = channels.error
     ? true
@@ -193,7 +190,7 @@ const mapStateToProps = (state, ownProps) => {
     ? channels.error && channels.error.errorStatusCode === 403
     : false
 
-  const userIsModerator = isModerator(channelModerators, SETTINGS.username)
+  const userIsModerator = channel && channel.user_is_moderator
 
   return {
     ...postModerationSelector(state, ownProps),

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -79,6 +79,8 @@ describe("ChannelPage", () => {
   })
 
   it("pin post link should just post what's necessary", async () => {
+    currentChannel.user_is_moderator = true
+
     SETTINGS.username = "username"
     const post = makePost()
     helper.editPostStub.returns(

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -11,11 +11,7 @@ import { NotFound, NotAuthorized } from "../components/ErrorPages"
 import ChannelPage from "./ChannelPage"
 import DropdownMenu from "../components/DropdownMenu"
 
-import {
-  makeChannel,
-  makeChannelList,
-  makeModerators
-} from "../factories/channels"
+import { makeChannel, makeChannelList } from "../factories/channels"
 import { makeChannelPostList, makePost } from "../factories/posts"
 import { actions } from "../actions"
 import { SET_POST_DATA, CLEAR_POST_ERROR } from "../actions/post"
@@ -40,19 +36,16 @@ describe("ChannelPage", () => {
     channels,
     currentChannel,
     otherChannel,
-    postList,
-    moderators
+    postList
 
   beforeEach(() => {
     channels = makeChannelList(10)
     currentChannel = channels[3]
     otherChannel = channels[4]
-    moderators = makeModerators()
     postList = makeChannelPostList()
     helper = new IntegrationTestHelper()
     helper.getChannelStub.returns(Promise.resolve(currentChannel))
     helper.getChannelsStub.returns(Promise.resolve(channels))
-    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
     helper.getPostsForChannelStub.returns(Promise.resolve({ posts: postList }))
     helper.getReportsStub.returns(Promise.resolve(R.times(makeReportRecord, 4)))
     helper.getProfileStub.returns(Promise.resolve(""))
@@ -74,8 +67,6 @@ describe("ChannelPage", () => {
       actions.postsForChannel.get.successType,
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
-      actions.channelModerators.get.requestType,
-      actions.channelModerators.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA
     ])
@@ -89,9 +80,6 @@ describe("ChannelPage", () => {
 
   it("pin post link should just post what's necessary", async () => {
     SETTINGS.username = "username"
-    helper.getChannelModeratorsStub.returns(
-      Promise.resolve(makeModerators(SETTINGS.username))
-    )
     const post = makePost()
     helper.editPostStub.returns(
       Promise.resolve(
@@ -114,8 +102,6 @@ describe("ChannelPage", () => {
       actions.postsForChannel.get.successType,
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
-      actions.channelModerators.get.requestType,
-      actions.channelModerators.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA
     ])
@@ -147,8 +133,6 @@ describe("ChannelPage", () => {
           actions.channels.get.successType,
           actions.postsForChannel.get.requestType,
           actions.postsForChannel.get.successType,
-          actions.channelModerators.get.requestType,
-          actions.channelModerators.get.successType,
           SET_POST_DATA
         ],
         () => {
@@ -194,8 +178,6 @@ describe("ChannelPage", () => {
         actions.channels.get.successType,
         actions.postsForChannel.get.requestType,
         actions.postsForChannel.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         EVICT_POSTS_FOR_CHANNEL
       ],
       () => {
@@ -220,8 +202,6 @@ describe("ChannelPage", () => {
       actions.postsForChannel.get.successType,
       actions.subscribedChannels.get.requestType,
       actions.subscribedChannels.get.successType,
-      actions.channelModerators.get.requestType,
-      actions.channelModerators.get.successType,
       SET_POST_DATA,
       SET_CHANNEL_DATA,
       CLEAR_CHANNEL_ERROR,

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -4,7 +4,7 @@ import sinon from "sinon"
 
 import { CreatePostPage as InnerCreatePostPage } from "../containers/CreatePostPage"
 
-import { makeModerators, makeChannelList } from "../factories/channels"
+import { makeChannelList } from "../factories/channels"
 import { makeCommentsResponse } from "../factories/comments"
 import { makePost, makeChannelPostList } from "../factories/posts"
 import { newPostURL } from "../lib/url"
@@ -65,7 +65,6 @@ describe("CreatePostPage", () => {
     )
     helper.getChannelsStub.returns(Promise.resolve(channels))
     helper.getPostStub.returns(Promise.resolve(post))
-    helper.getChannelModeratorsStub.returns(Promise.resolve(makeModerators()))
     helper.getCommentsStub.returns(Promise.resolve(commentsResponse))
     helper.getEmbedlyStub.returns(
       Promise.resolve({ url: post.url, response: article })

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -17,7 +17,7 @@ import {
   makeCommentsResponse,
   makeMoreComments
 } from "../factories/comments"
-import { makeChannel, makeModerators } from "../factories/channels"
+import { makeChannel } from "../factories/channels"
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
 import { SET_CHANNEL_DATA } from "../actions/channel"
@@ -51,7 +51,6 @@ describe("PostPage", function() {
     post,
     comments,
     channel,
-    moderators,
     twitterEmbedStub
 
   this.timeout(5000)
@@ -61,7 +60,6 @@ describe("PostPage", function() {
     const commentsResponse = makeCommentsResponse(post, 3)
     comments = createCommentTree(commentsResponse)
     channel = makeChannel()
-    moderators = makeModerators()
 
     helper = new IntegrationTestHelper()
     helper.getPostStub.returns(Promise.resolve(post))
@@ -72,7 +70,6 @@ describe("PostPage", function() {
     helper.getCommentStub.returns(
       Promise.resolve(R.slice(0, 1, commentsResponse))
     )
-    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
     helper.getPostsForChannelStub.returns(
       Promise.resolve({
         posts: makeChannelPostList()
@@ -101,8 +98,6 @@ describe("PostPage", function() {
     actions.subscribedChannels.get.successType,
     actions.channels.get.requestType,
     actions.channels.get.successType,
-    actions.channelModerators.get.requestType,
-    actions.channelModerators.get.successType,
     SET_CHANNEL_DATA
   ]
 
@@ -313,8 +308,6 @@ describe("PostPage", function() {
         actions.channels.get.requestType,
         actions.channels.get.successType,
         actions.postsForChannel.get.requestType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         SET_SNACKBAR_MESSAGE
       ],
       () => {
@@ -332,12 +325,6 @@ describe("PostPage", function() {
   })
 
   describe("as a moderator user", () => {
-    beforeEach(() => {
-      helper.getChannelModeratorsStub.returns(
-        Promise.resolve(makeModerators(SETTINGS.username))
-      )
-    })
-
     it("should remove the post", async () => {
       post.removed = false
       const wrapper = await renderPage()

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -325,6 +325,10 @@ describe("PostPage", function() {
   })
 
   describe("as a moderator user", () => {
+    beforeEach(() => {
+      channel.user_is_moderator = true
+    })
+
     it("should remove the post", async () => {
       post.removed = false
       const wrapper = await renderPage()

--- a/static/js/containers/admin/EditChannelAppearancePage_test.js
+++ b/static/js/containers/admin/EditChannelAppearancePage_test.js
@@ -17,7 +17,6 @@ describe("EditChannelAppearancePage", () => {
     helper = new IntegrationTestHelper()
     helper.getChannelStub.returns(Promise.resolve(channel))
     helper.getChannelsStub.returns(Promise.resolve([channel]))
-    helper.getChannelModeratorsStub.returns(Promise.resolve([]))
     helper.getPostsForChannelStub.returns(
       Promise.resolve({
         pagination: {},
@@ -85,8 +84,6 @@ describe("EditChannelAppearancePage", () => {
         actions.channels.patch.successType,
         actions.channels.get.requestType,
         actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         actions.postsForChannel.get.requestType,
         actions.postsForChannel.get.successType,
         FORM_END_EDIT

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -18,7 +18,6 @@ describe("EditChannelBasicPage", () => {
     helper = new IntegrationTestHelper()
     helper.getChannelStub.returns(Promise.resolve(channel))
     helper.getChannelsStub.returns(Promise.resolve([channel]))
-    helper.getChannelModeratorsStub.returns(Promise.resolve([]))
     helper.getPostsForChannelStub.returns(
       Promise.resolve({
         pagination: {},
@@ -90,8 +89,6 @@ describe("EditChannelBasicPage", () => {
         actions.channels.patch.successType,
         actions.channels.get.requestType,
         actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
         actions.postsForChannel.get.requestType,
         actions.postsForChannel.get.successType,
         FORM_END_EDIT

--- a/static/js/hoc/withPostModeration.js
+++ b/static/js/hoc/withPostModeration.js
@@ -16,7 +16,6 @@ import {
 } from "../actions/ui"
 import { setFocusedPost, clearFocusedPost } from "../actions/focus"
 import { getChannelName } from "../lib/util"
-import { isModerator } from "../lib/channels"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { anyErrorExcept404 } from "../util/rest"
 import {
@@ -195,9 +194,8 @@ export const postModerationSelector = (state: Object, ownProps: Object) => {
   const { channels, reports, ui, focus, forms } = state
   const channelName = getChannelName(ownProps)
   const channel = channels.data.get(channelName)
-  const channelModerators = state.channelModerators.data.get(channelName) || []
 
-  const userIsModerator = isModerator(channelModerators, SETTINGS.username)
+  const userIsModerator = channel && channel.user_is_moderator
 
   const loaded =
     channels.error || reports.error ? true : channels.loaded && reports.loaded

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -1,11 +1,7 @@
 //@flow
 import R from "ramda"
 
-import type {
-  Channel,
-  ChannelForm,
-  ChannelModerators
-} from "../flow/discussionTypes"
+import type { Channel, ChannelForm } from "../flow/discussionTypes"
 
 export const CHANNEL_TYPE_PUBLIC = "public"
 export const CHANNEL_TYPE_RESTRICTED = "restricted"
@@ -37,11 +33,6 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
     ],
     channel
   )
-
-export const isModerator = (
-  moderators: ChannelModerators,
-  username: ?string
-): boolean => R.any(R.propEq("moderator_name", username), moderators || [])
 
 export const userCanPost = (channel: Channel) =>
   channel.channel_type === CHANNEL_TYPE_PUBLIC ||

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -7,7 +7,6 @@ import {
   CHANNEL_TYPE_PRIVATE,
   newChannelForm,
   editChannelForm,
-  isModerator,
   userCanPost,
   LINK_TYPE_ANY,
   LINK_TYPE_TEXT,
@@ -17,7 +16,7 @@ import {
   isLinkTypeChecked,
   isTextTabSelected
 } from "./channels"
-import { makeModerators, makeChannel } from "../factories/channels"
+import { makeChannel } from "../factories/channels"
 
 describe("Channel utils", () => {
   it("newChannelForm should return a new channel form with empty values and public type", () => {
@@ -41,16 +40,6 @@ describe("Channel utils", () => {
       public_description: channel.public_description,
       channel_type:       channel.channel_type,
       link_type:          channel.link_type
-    })
-  })
-
-  describe("isModerator", () => {
-    it("should return true for a moderator user", () => {
-      assert.isTrue(isModerator(makeModerators("username"), "username"))
-    })
-
-    it("should return false for a regular user", () => {
-      assert.isFalse(isModerator(makeModerators(), "username"))
     })
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #900 

#### What's this PR do?
Removes requests that fetch the moderators list. To check if the user is a moderator `user_is_moderator` is used instead.

#### How should this be manually tested?
Log in as a regular user and verify that you don't see the edit channel button on the channel page. Log in as a mod and verify that you do see this button. Also verify that the moderation tools in the post page look correct.


#### Any background context you want to provide?
I didn't delete the reducer or API functions because we will need this soon for the moderator list page.
