### PR TITLE
update submit post form

### DIFF
--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -1,19 +1,29 @@
-// @flow
 import React from "react"
 import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 
 import CreatePostForm from "./CreatePostForm"
-import Embedly from "./Embedly"
+import Embedly, { EmbedlyLoader } from "./Embedly"
 
 import { LINK_TYPE_LINK, LINK_TYPE_TEXT } from "../lib/channels"
 import * as channels from "../lib/channels"
 import { makeChannel } from "../factories/channels"
 import { makeArticle } from "../factories/embedly"
+import { newPostForm } from "../lib/posts"
 
 describe("CreatePostForm", () => {
   let sandbox, isTextTabSelectedStub, isLinkTypeAllowedStub
+
+  const renderPostForm = (props = {}) =>
+    shallow(
+      <CreatePostForm
+        validation={{}}
+        channels={[]}
+        postForm={newPostForm()}
+        {...props}
+      />
+    )
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -27,84 +37,123 @@ describe("CreatePostForm", () => {
     sandbox.restore()
   })
 
-  describe("embedly preview link", () => {
-    const errorArticle = makeArticle()
-    errorArticle.type = "error"
-    ;[
-      [true, true, makeArticle(), "valid"],
-      [false, false, makeArticle(), "valid"],
-      [true, false, errorArticle, "errored"],
-      [true, false, undefined, "missing"],
-      [false, false, undefined, "missing"]
-    ].forEach(
-      ([linkPost, shouldShowEmbed, embedlyResponse, embedlyDescription]) => {
-        it(`should ${shouldShowEmbed ? " " : "not "}show the link for a ${
-          linkPost ? "link" : "text"
-        } post and a ${embedlyDescription} embedly response`, () => {
-          isTextTabSelectedStub.returns(!linkPost)
-          const form = {
-            title: "title"
-          }
-          const wrapper = shallow(
-            <CreatePostForm
-              postForm={form}
-              embedly={embedlyResponse}
-              validation={{}}
-              channels={[]}
-            />
-          )
-          assert.equal(shouldShowEmbed, wrapper.find(Embedly).exists())
-        })
-      }
+  it("should show post_type validation message", () => {
+    const wrapper = renderPostForm({
+      validation: { post_type: "HEY" }
+    })
+    assert.equal(
+      wrapper.find(".post-type-row .validation-message").text(),
+      "HEY"
     )
   })
 
-  it("uses isTextTabSelected to determine which tab to show", () => {
-    isTextTabSelectedStub.returns(false)
-    const form = {
-      postType: LINK_TYPE_LINK,
-      title:    "title"
-    }
-    const channel = makeChannel()
-    const wrapper = shallow(
-      <CreatePostForm
-        postForm={form}
-        validation={{}}
-        channel={channel}
-        channels={new Map([[channel.name, channel]])}
-      />
-    )
-    sinon.assert.calledWith(isTextTabSelectedStub, LINK_TYPE_LINK, channel)
-    assert.equal(wrapper.find(".active").text(), "New link post")
+  it("should show title validation message", () => {
+    const wrapper = renderPostForm({
+      validation: { title: "HEY" }
+    })
+    assert.equal(wrapper.find(".titlefield .validation-message").text(), "HEY")
   })
+
+  it("should show text validation message", () => {
+    const postForm = { ...newPostForm(), postType: LINK_TYPE_TEXT }
+    const wrapper = renderPostForm({
+      validation: { text: "HEY" },
+      postForm
+    })
+    assert.equal(wrapper.find(".text .validation-message").text(), "HEY")
+  })
+
+  it("should show url validation message", () => {
+    const postForm = { ...newPostForm(), postType: LINK_TYPE_LINK }
+    const wrapper = renderPostForm({
+      validation: { url: "HEY" },
+      postForm
+    })
+    assert.equal(wrapper.find(".url .validation-message").text(), "HEY")
+  })
+
+  it("should show channel validation message", () => {
+    const wrapper = renderPostForm({
+      validation: { channel: "HEY" }
+    })
+    assert.equal(
+      wrapper.find(".channel-select .validation-message").text(),
+      "HEY"
+    )
+  })
+
+  describe("embedly preview link", () => {
+    const postForm = { url: "some url", postType: LINK_TYPE_LINK }
+
+    it("should show embedly when a non-error response has arrived", () => {
+      const article = makeArticle()
+      const error = makeArticle()
+      error.type = "error"
+      ;[[article, true], [error, false]].forEach(
+        ([embedly, shouldRenderComponent]) => {
+          const wrapper = renderPostForm({
+            postForm,
+            embedly
+          })
+          if (shouldRenderComponent) {
+            assert.ok(wrapper.find(Embedly).exists())
+          } else {
+            assert.ok(wrapper.find("input", { name: "url" }).exists())
+          }
+        }
+      )
+    })
+
+    it("should show EmbedlyLoader when no embedly and embedlyInFlight", () => {
+      const article = makeArticle()
+      ;[
+        [article, true, false],
+        [article, false, false],
+        [undefined, true, true],
+        [undefined, false, false]
+      ].forEach(([embedly, embedlyInFlight, shouldRenderComponent]) => {
+        const wrapper = renderPostForm({
+          postForm,
+          embedly,
+          embedlyInFlight
+        })
+        assert.equal(
+          wrapper.find(EmbedlyLoader).exists(),
+          shouldRenderComponent
+        )
+      })
+    })
+  })
+
+  //
   ;[[true, false], [false, true], [true, true]].forEach(
     ([showLink, showText]) => {
       it(`shows ${
         showLink && showText
-          ? "both tabs"
+          ? "both buttons"
           : showText
-            ? "the text tab"
-            : "the link tab"
+            ? "the text button"
+            : "the link button"
       }`, () => {
         isLinkTypeAllowedStub.callsFake(
           (_, linkType) => (linkType === LINK_TYPE_TEXT ? showText : showLink)
         )
         const form = {
-          postType: LINK_TYPE_LINK,
-          title:    "title"
+          postType: null,
+          title:    "",
+          text:     ""
         }
         const channel = makeChannel()
-        const wrapper = shallow(
-          <CreatePostForm
-            postForm={form}
-            validation={{}}
-            channel={channel}
-            channels={new Map([[channel.name, channel]])}
-          />
-        )
+        const wrapper = renderPostForm({
+          channel,
+          postForm:        form,
+          channels:        new Map([[channel.name, channel]]),
+          embedlyInFlight: false,
+          embedly:         {}
+        })
 
-        assert.equal(wrapper.find(".new-text-post").length, showText ? 1 : 0)
-        assert.equal(wrapper.find(".new-link-post").length, showLink ? 1 : 0)
+        assert.equal(wrapper.find(".write-something").length, showText ? 1 : 0)
+        assert.equal(wrapper.find(".share-a-link").length, showLink ? 1 : 0)
       })
     }
   )

--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -3,6 +3,24 @@ import React from "react"
 
 import ContentLoader from "react-content-loader"
 
+export const EmbedlyLoader = (props: Object = {}) => (
+  <div className="content-loader">
+    <ContentLoader
+      speed={2}
+      style={{ width: "100%", height: "300px" }}
+      width="100%"
+      height={300}
+      {...props}
+    >
+      <rect x="0" y="0" rx="5" ry="5" width="100%" height="200" />
+      <rect x="0" y="220" rx="5" ry="5" width="65%" height="15" />
+      <rect x="0" y="250" rx="5" ry="5" width="93%" height="10" />
+      <rect x="0" y="265" rx="5" ry="5" width="95%" height="10" />
+      <rect x="0" y="280" rx="5" ry="5" width="90%" height="10" />
+    </ContentLoader>
+  </div>
+)
+
 export default class Embedly extends React.Component<*> {
   renderEmbed() {
     const { embedly } = this.props
@@ -55,32 +73,13 @@ export default class Embedly extends React.Component<*> {
     )
   }
 
-  renderContentLoader() {
-    return (
-      <div className="content-loader">
-        <ContentLoader
-          speed={2}
-          style={{ width: "100%", height: "300px" }}
-          width="100%"
-          height={300}
-        >
-          <rect x="0" y="0" rx="5" ry="5" width="100%" height="200" />
-          <rect x="0" y="220" rx="5" ry="5" width="65%" height="15" />
-          <rect x="0" y="250" rx="5" ry="5" width="93%" height="10" />
-          <rect x="0" y="265" rx="5" ry="5" width="95%" height="10" />
-          <rect x="0" y="280" rx="5" ry="5" width="90%" height="10" />
-        </ContentLoader>
-      </div>
-    )
-  }
-
   render() {
     const { embedly } = this.props
 
     return embedly && embedly.type !== "error" ? (
       <div className="embedly">{this.renderEmbed()}</div>
     ) : (
-      this.renderContentLoader()
+      <EmbedlyLoader />
     )
   }
 }

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -67,10 +67,11 @@ export type PostForm = {
 }
 
 export type PostValidation = {
-  text:   string,
-  url:    string,
-  title:  string,
-  channel:string,
+  text?:      string,
+  url?:       string,
+  title?:     string,
+  channel?:   string,
+  post_type?: string
 }
 
 export type CreatePostPayload = {

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -63,7 +63,7 @@ export const postUrlOrTextPresent = (postForm: { value: PostForm }) => {
     return S.Just(
       R.set(
         R.lensPath(["value", "post_type"]),
-        "One of text or post tabs must be selected"
+        "You must either add text or a link to your post"
       )
     )
   }

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -133,7 +133,7 @@ describe("validation library", () => {
       const post = { value: { postType: null, title: "potato" } }
       assert.deepEqual(validatePostCreateForm(post), {
         value: {
-          post_type: "One of text or post tabs must be selected"
+          post_type: "You must either add text or a link to your post"
         }
       })
     })

--- a/static/scss/createPost.scss
+++ b/static/scss/createPost.scss
@@ -1,55 +1,77 @@
-.new-post-card {
-  .card-contents {
-    .embedly-preview {
-      max-width: 770px;
+.new-post-form {
+  .channel-select {
+    max-width: 300px;
+  }
 
-      .preview-header {
-        font-size: 14px;
-        font-style: italic;
-        color: $font-grey;
-        padding-bottom: 10px;
+  .post-types {
+    display: flex;
+    flex-direction: row;
 
-        @include breakpoint(desktopwide) {
-          padding-bottom: 20px;
-        }
-      }
+    .write-something {
+      margin-right: 5px;
     }
 
-    .post-types {
+    .write-something,
+    .share-a-link {
+      font-weight: 400;
+      font-size: 14px;
       display: flex;
-      flex-direction: row;
-      box-shadow: 0px 7px 6px -3px rgba(0, 0, 0, 0.1);
-      margin: 0 -15px 33px -15px;
-      padding: 0 20px;
-
-      .new-text-post,
-      .new-link-post {
-        padding: 10px 29px 17px;
-        color: #585858;
-        text-transform: uppercase;
-        font-weight: 400;
-        font-size: 14px;
-
-        @include breakpoint(phone) {
-          padding: 10px 15px 17px;
-        }
-      }
-
-      & > div {
-        cursor: pointer;
-      }
-
-      .active {
-        border-bottom: 4px solid #0085df;
-        font-weight: 500;
-        color: #000;
-      }
-    }
-
-    .posting-to-channel,
-    .posting-policy {
-      font-size: 1rem;
+      align-items: center;
       color: $font-grey;
+      background-color: $app-background;
+      border: 1px solid $border-grey;
+      border-radius: 3px;
+      padding: 3px 10px;
+      cursor: pointer;
+
+      i {
+        font-size: 16px;
+        margin-right: 5px;
+      }
     }
+
+    & > div {
+      cursor: pointer;
+    }
+
+    .active {
+      border-bottom: 4px solid #0085df;
+      font-weight: 500;
+      color: #000;
+    }
+  }
+
+  .post-content {
+    position: relative;
+
+    .close-button {
+      background: white;
+      border-radius: 50%;
+      position: absolute;
+      top: -11px;
+      right: -11px;
+      border: 1px solid $border-grey;
+      height: 24px;
+      width: 24px;
+      display: flex;
+      cursor: pointer;
+
+      i {
+        font-size: 21px;
+        color: $font-grey;
+        margin: auto;
+      }
+    }
+  }
+
+  .posting-to-channel,
+  .posting-policy {
+    font-size: 1rem;
+    color: $font-grey;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #870 

#### What's this PR do?

This updates the submit post form to match the latest designs (see linked from the issue). There are a few changes which necessitated re-writing some of the logic.

the user interaction now looks like 'adding' a text or url component to the form, rather than select a text post or link post tab. this means that we don't default to having one of those two things selected anymore. before we always had to have one of the two selected, which meant some complicated logic (especially when dealing with changing between subreddits, which might have different posting poermissions). with the new design, though, we default to having neither of the options selected, so things got a little easier.

#### How should this be manually tested?

make sure that things work smoothly and there are not issues! especially test edge cases around starting to fill out the form, changing the subreddit selection, and so on, with a variety of different permissions settings. hopefully I prevented any weird things but I'm sure there is still a dark corner or two.