### PR TITLE
Add readonly moderator and contributor tabs

### DIFF
--- a/static/js/components/admin/EditChannelContributorsForm.js
+++ b/static/js/components/admin/EditChannelContributorsForm.js
@@ -1,0 +1,49 @@
+// @flow
+import React from "react"
+import { Link } from "react-router-dom"
+
+import Card from "../Card"
+import MembersNavbar from "./MembersNavbar"
+
+import { profileURL } from "../../lib/url"
+
+import type { ChannelContributorsForm } from "../../flow/discussionTypes"
+
+export default class EditChannelContributorsForm extends React.Component<
+  *,
+  void
+> {
+  props: {
+    form: ChannelContributorsForm
+  }
+
+  render() {
+    const { form } = this.props
+    return (
+      <form className="form contributors-form">
+        <Card>
+          <MembersNavbar channelName={form.channel.name} />
+          <div className="contributors">
+            {form.contributors.map((contributor, index) => (
+              <div key={index} className="row">
+                {contributor.full_name ? (
+                  <Link
+                    className="name"
+                    to={profileURL(contributor.contributor_name)}
+                  >
+                    {contributor.full_name}
+                  </Link>
+                ) : (
+                  <span className="name">{"<missing>"}</span>
+                )}
+                <span className="email">
+                  {contributor.email || "<missing>"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </form>
+    )
+  }
+}

--- a/static/js/components/admin/EditChannelContributorsForm.js
+++ b/static/js/components/admin/EditChannelContributorsForm.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 import Card from "../Card"
 import MembersNavbar from "./MembersNavbar"
 
+import { MISSING_TEXT } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 
 import type { ChannelContributors } from "../../flow/discussionTypes"
@@ -34,9 +35,9 @@ export default class EditChannelContributorsForm extends React.Component<
                   {contributor.full_name}
                 </Link>
               ) : (
-                <span className="name">{"<missing>"}</span>
+                <span className="name">{MISSING_TEXT}</span>
               )}
-              <span className="email">{contributor.email || "<missing>"}</span>
+              <span className="email">{contributor.email || MISSING_TEXT}</span>
             </div>
           ))}
         </div>

--- a/static/js/components/admin/EditChannelContributorsForm.js
+++ b/static/js/components/admin/EditChannelContributorsForm.js
@@ -7,43 +7,40 @@ import MembersNavbar from "./MembersNavbar"
 
 import { profileURL } from "../../lib/url"
 
-import type { ChannelContributorsForm } from "../../flow/discussionTypes"
+import type { ChannelContributors } from "../../flow/discussionTypes"
 
 export default class EditChannelContributorsForm extends React.Component<
   *,
   void
 > {
   props: {
-    form: ChannelContributorsForm
+    channelName: string,
+    contributors: ChannelContributors
   }
 
   render() {
-    const { form } = this.props
+    const { channelName, contributors } = this.props
     return (
-      <form className="form contributors-form">
-        <Card>
-          <MembersNavbar channelName={form.channel.name} />
-          <div className="contributors">
-            {form.contributors.map((contributor, index) => (
-              <div key={index} className="row">
-                {contributor.full_name ? (
-                  <Link
-                    className="name"
-                    to={profileURL(contributor.contributor_name)}
-                  >
-                    {contributor.full_name}
-                  </Link>
-                ) : (
-                  <span className="name">{"<missing>"}</span>
-                )}
-                <span className="email">
-                  {contributor.email || "<missing>"}
-                </span>
-              </div>
-            ))}
-          </div>
-        </Card>
-      </form>
+      <Card>
+        <MembersNavbar channelName={channelName} />
+        <div className="contributors">
+          {contributors.map((contributor, index) => (
+            <div key={index} className="row">
+              {contributor.full_name ? (
+                <Link
+                  className="name"
+                  to={profileURL(contributor.contributor_name)}
+                >
+                  {contributor.full_name}
+                </Link>
+              ) : (
+                <span className="name">{"<missing>"}</span>
+              )}
+              <span className="email">{contributor.email || "<missing>"}</span>
+            </div>
+          ))}
+        </div>
+      </Card>
     )
   }
 }

--- a/static/js/components/admin/EditChannelContributorsForm_test.js
+++ b/static/js/components/admin/EditChannelContributorsForm_test.js
@@ -3,25 +3,28 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 
 import EditChannelContributorsForm from "./EditChannelContributorsForm"
-import { newContributorsForm } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 import { makeChannel, makeContributors } from "../../factories/channels"
 
-import type { ChannelForm } from "../../flow/discussionTypes"
-
 describe("EditChannelContributorsForm", () => {
-  const renderForm = (form: ChannelForm) =>
-    shallow(<EditChannelContributorsForm form={form} />)
-  let form
+  const renderForm = (channel, contributors) =>
+    shallow(
+      <EditChannelContributorsForm
+        channelName={channel.name}
+        contributors={contributors}
+      />
+    )
+  let channel, contributors
 
   beforeEach(() => {
-    form = newContributorsForm(makeChannel(), makeContributors())
+    channel = makeChannel()
+    contributors = makeContributors()
   })
 
   it("should render names and emails", () => {
-    const wrapper = renderForm(form)
+    const wrapper = renderForm(channel, contributors)
     const rows = wrapper.find(".contributors .row")
-    form.contributors.forEach((contributor, i) => {
+    contributors.forEach((contributor, i) => {
       const row = rows.at(i)
       const link = row.find(".name")
       assert.equal(link.children().text(), contributor.full_name)
@@ -36,11 +39,10 @@ describe("EditChannelContributorsForm", () => {
       full_name: null,
       email:     null
     }))
-    form = newContributorsForm(makeChannel(), contributors)
 
-    const wrapper = renderForm(form)
+    const wrapper = renderForm(channel, contributors)
     const rows = wrapper.find(".contributors .row")
-    form.contributors.forEach((contributor, i) => {
+    contributors.forEach((contributor, i) => {
       const row = rows.at(i)
       assert.equal(row.find(".name").text(), "<missing>")
       assert.equal(row.find(".email").text(), "<missing>")

--- a/static/js/components/admin/EditChannelContributorsForm_test.js
+++ b/static/js/components/admin/EditChannelContributorsForm_test.js
@@ -3,6 +3,8 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 
 import EditChannelContributorsForm from "./EditChannelContributorsForm"
+
+import { MISSING_TEXT } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 import { makeChannel, makeContributors } from "../../factories/channels"
 
@@ -44,8 +46,8 @@ describe("EditChannelContributorsForm", () => {
     const rows = wrapper.find(".contributors .row")
     contributors.forEach((contributor, i) => {
       const row = rows.at(i)
-      assert.equal(row.find(".name").text(), "<missing>")
-      assert.equal(row.find(".email").text(), "<missing>")
+      assert.equal(row.find(".name").text(), MISSING_TEXT)
+      assert.equal(row.find(".email").text(), MISSING_TEXT)
     })
   })
 })

--- a/static/js/components/admin/EditChannelContributorsForm_test.js
+++ b/static/js/components/admin/EditChannelContributorsForm_test.js
@@ -1,0 +1,49 @@
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import EditChannelContributorsForm from "./EditChannelContributorsForm"
+import { newContributorsForm } from "../../lib/channels"
+import { profileURL } from "../../lib/url"
+import { makeChannel, makeContributors } from "../../factories/channels"
+
+import type { ChannelForm } from "../../flow/discussionTypes"
+
+describe("EditChannelContributorsForm", () => {
+  const renderForm = (form: ChannelForm) =>
+    shallow(<EditChannelContributorsForm form={form} />)
+  let form
+
+  beforeEach(() => {
+    form = newContributorsForm(makeChannel(), makeContributors())
+  })
+
+  it("should render names and emails", () => {
+    const wrapper = renderForm(form)
+    const rows = wrapper.find(".contributors .row")
+    form.contributors.forEach((contributor, i) => {
+      const row = rows.at(i)
+      const link = row.find(".name")
+      assert.equal(link.children().text(), contributor.full_name)
+      assert.equal(link.props().to, profileURL(contributor.contributor_name))
+      assert.equal(row.find(".email").text(), contributor.email)
+    })
+  })
+
+  it("should fill in missing names and emails", () => {
+    const contributors = makeContributors().map(contributor => ({
+      ...contributor,
+      full_name: null,
+      email:     null
+    }))
+    form = newContributorsForm(makeChannel(), contributors)
+
+    const wrapper = renderForm(form)
+    const rows = wrapper.find(".contributors .row")
+    form.contributors.forEach((contributor, i) => {
+      const row = rows.at(i)
+      assert.equal(row.find(".name").text(), "<missing>")
+      assert.equal(row.find(".email").text(), "<missing>")
+    })
+  })
+})

--- a/static/js/components/admin/EditChannelModeratorsForm.js
+++ b/static/js/components/admin/EditChannelModeratorsForm.js
@@ -1,0 +1,47 @@
+// @flow
+import React from "react"
+import { Link } from "react-router-dom"
+
+import Card from "../Card"
+import MembersNavbar from "./MembersNavbar"
+
+import { profileURL } from "../../lib/url"
+
+import type { ChannelModeratorsForm } from "../../flow/discussionTypes"
+
+export default class EditChannelModeratorsForm extends React.Component<
+  *,
+  void
+> {
+  props: {
+    form: ChannelModeratorsForm
+  }
+
+  render() {
+    const { form } = this.props
+    return (
+      <form className="form moderators-form">
+        <Card>
+          <MembersNavbar channelName={form.channel.name} />
+          <div className="moderators">
+            {form.moderators.map((moderator, index) => (
+              <div key={index} className="row">
+                {moderator.full_name ? (
+                  <Link
+                    className="name"
+                    to={profileURL(moderator.moderator_name)}
+                  >
+                    {moderator.full_name}
+                  </Link>
+                ) : (
+                  <span className="name">{"<missing>"}</span>
+                )}
+                <span className="email">{moderator.email || "<missing>"}</span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </form>
+    )
+  }
+}

--- a/static/js/components/admin/EditChannelModeratorsForm.js
+++ b/static/js/components/admin/EditChannelModeratorsForm.js
@@ -7,41 +7,40 @@ import MembersNavbar from "./MembersNavbar"
 
 import { profileURL } from "../../lib/url"
 
-import type { ChannelModeratorsForm } from "../../flow/discussionTypes"
+import type { ChannelModerators } from "../../flow/discussionTypes"
 
 export default class EditChannelModeratorsForm extends React.Component<
   *,
   void
 > {
   props: {
-    form: ChannelModeratorsForm
+    channelName: string,
+    moderators: ChannelModerators
   }
 
   render() {
-    const { form } = this.props
+    const { channelName, moderators } = this.props
     return (
-      <form className="form moderators-form">
-        <Card>
-          <MembersNavbar channelName={form.channel.name} />
-          <div className="moderators">
-            {form.moderators.map((moderator, index) => (
-              <div key={index} className="row">
-                {moderator.full_name ? (
-                  <Link
-                    className="name"
-                    to={profileURL(moderator.moderator_name)}
-                  >
-                    {moderator.full_name}
-                  </Link>
-                ) : (
-                  <span className="name">{"<missing>"}</span>
-                )}
-                <span className="email">{moderator.email || "<missing>"}</span>
-              </div>
-            ))}
-          </div>
-        </Card>
-      </form>
+      <Card>
+        <MembersNavbar channelName={channelName} />
+        <div className="moderators">
+          {moderators.map((moderator, index) => (
+            <div key={index} className="row">
+              {moderator.full_name ? (
+                <Link
+                  className="name"
+                  to={profileURL(moderator.moderator_name)}
+                >
+                  {moderator.full_name}
+                </Link>
+              ) : (
+                <span className="name">{"<missing>"}</span>
+              )}
+              <span className="email">{moderator.email || "<missing>"}</span>
+            </div>
+          ))}
+        </div>
+      </Card>
     )
   }
 }

--- a/static/js/components/admin/EditChannelModeratorsForm.js
+++ b/static/js/components/admin/EditChannelModeratorsForm.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 import Card from "../Card"
 import MembersNavbar from "./MembersNavbar"
 
+import { MISSING_TEXT } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 
 import type { ChannelModerators } from "../../flow/discussionTypes"
@@ -34,9 +35,9 @@ export default class EditChannelModeratorsForm extends React.Component<
                   {moderator.full_name}
                 </Link>
               ) : (
-                <span className="name">{"<missing>"}</span>
+                <span className="name">{MISSING_TEXT}</span>
               )}
-              <span className="email">{moderator.email || "<missing>"}</span>
+              <span className="email">{moderator.email || MISSING_TEXT}</span>
             </div>
           ))}
         </div>

--- a/static/js/components/admin/EditChannelModeratorsForm_test.js
+++ b/static/js/components/admin/EditChannelModeratorsForm_test.js
@@ -3,25 +3,28 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 
 import EditChannelModeratorsForm from "./EditChannelModeratorsForm"
-import { newModeratorsForm } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 import { makeChannel, makeModerators } from "../../factories/channels"
 
-import type { ChannelForm } from "../../flow/discussionTypes"
-
 describe("EditChannelModeratorsForm", () => {
-  const renderForm = (form: ChannelForm) =>
-    shallow(<EditChannelModeratorsForm form={form} />)
-  let form
+  const renderForm = (channel, moderators) =>
+    shallow(
+      <EditChannelModeratorsForm
+        channelName={channel.name}
+        moderators={moderators}
+      />
+    )
+  let channel, moderators
 
   beforeEach(() => {
-    form = newModeratorsForm(makeChannel(), makeModerators(null, true))
+    channel = makeChannel()
+    moderators = makeModerators(null, true)
   })
 
   it("should render names and emails", () => {
-    const wrapper = renderForm(form)
+    const wrapper = renderForm(channel, moderators)
     const rows = wrapper.find(".moderators .row")
-    form.moderators.forEach((moderator, i) => {
+    moderators.forEach((moderator, i) => {
       const row = rows.at(i)
       const link = row.find(".name")
       assert.equal(link.children().text(), moderator.full_name)
@@ -32,11 +35,10 @@ describe("EditChannelModeratorsForm", () => {
 
   it("should fill in missing names and emails", () => {
     const moderators = makeModerators(null, false)
-    form = newModeratorsForm(makeChannel(), moderators)
 
-    const wrapper = renderForm(form)
+    const wrapper = renderForm(channel, moderators)
     const rows = wrapper.find(".moderators .row")
-    form.moderators.forEach((moderator, i) => {
+    moderators.forEach((moderator, i) => {
       const row = rows.at(i)
       assert.equal(row.find(".name").text(), "<missing>")
       assert.equal(row.find(".email").text(), "<missing>")

--- a/static/js/components/admin/EditChannelModeratorsForm_test.js
+++ b/static/js/components/admin/EditChannelModeratorsForm_test.js
@@ -3,6 +3,8 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 
 import EditChannelModeratorsForm from "./EditChannelModeratorsForm"
+
+import { MISSING_TEXT } from "../../lib/channels"
 import { profileURL } from "../../lib/url"
 import { makeChannel, makeModerators } from "../../factories/channels"
 
@@ -40,8 +42,8 @@ describe("EditChannelModeratorsForm", () => {
     const rows = wrapper.find(".moderators .row")
     moderators.forEach((moderator, i) => {
       const row = rows.at(i)
-      assert.equal(row.find(".name").text(), "<missing>")
-      assert.equal(row.find(".email").text(), "<missing>")
+      assert.equal(row.find(".name").text(), MISSING_TEXT)
+      assert.equal(row.find(".email").text(), MISSING_TEXT)
     })
   })
 })

--- a/static/js/components/admin/EditChannelModeratorsForm_test.js
+++ b/static/js/components/admin/EditChannelModeratorsForm_test.js
@@ -1,0 +1,45 @@
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import EditChannelModeratorsForm from "./EditChannelModeratorsForm"
+import { newModeratorsForm } from "../../lib/channels"
+import { profileURL } from "../../lib/url"
+import { makeChannel, makeModerators } from "../../factories/channels"
+
+import type { ChannelForm } from "../../flow/discussionTypes"
+
+describe("EditChannelModeratorsForm", () => {
+  const renderForm = (form: ChannelForm) =>
+    shallow(<EditChannelModeratorsForm form={form} />)
+  let form
+
+  beforeEach(() => {
+    form = newModeratorsForm(makeChannel(), makeModerators(null, true))
+  })
+
+  it("should render names and emails", () => {
+    const wrapper = renderForm(form)
+    const rows = wrapper.find(".moderators .row")
+    form.moderators.forEach((moderator, i) => {
+      const row = rows.at(i)
+      const link = row.find(".name")
+      assert.equal(link.children().text(), moderator.full_name)
+      assert.equal(link.props().to, profileURL(moderator.moderator_name))
+      assert.equal(row.find(".email").text(), moderator.email)
+    })
+  })
+
+  it("should fill in missing names and emails", () => {
+    const moderators = makeModerators(null, false)
+    form = newModeratorsForm(makeChannel(), moderators)
+
+    const wrapper = renderForm(form)
+    const rows = wrapper.find(".moderators .row")
+    form.moderators.forEach((moderator, i) => {
+      const row = rows.at(i)
+      assert.equal(row.find(".name").text(), "<missing>")
+      assert.equal(row.find(".email").text(), "<missing>")
+    })
+  })
+})

--- a/static/js/components/admin/EditChannelNavbar.js
+++ b/static/js/components/admin/EditChannelNavbar.js
@@ -1,13 +1,21 @@
 // @flow
 import React from "react"
 import NavLink from "react-router-dom/NavLink"
+import R from "ramda"
 
-import { editChannelBasicURL, editChannelAppearanceURL } from "../../lib/url"
+import {
+  editChannelBasicURL,
+  editChannelAppearanceURL,
+  editChannelModeratorsURL
+} from "../../lib/url"
 
 type Props = {
   channelName: string
 }
 
+const membersIsActive = R.curry((channelName, match, location) =>
+  location.pathname.startsWith(`/manage/c/edit/${channelName}/members/`)
+)
 export default class EditChannelNavbar extends React.Component<Props> {
   render() {
     const { channelName } = this.props
@@ -16,6 +24,12 @@ export default class EditChannelNavbar extends React.Component<Props> {
       <div className="edit-channel-navbar">
         <NavLink to={editChannelBasicURL(channelName)}>Basic</NavLink>{" "}
         <NavLink to={editChannelAppearanceURL(channelName)}>Appearance</NavLink>
+        <NavLink
+          to={editChannelModeratorsURL(channelName)}
+          isActive={membersIsActive(channelName)}
+        >
+          Members
+        </NavLink>
       </div>
     )
   }

--- a/static/js/components/admin/EditChannelNavbar_test.js
+++ b/static/js/components/admin/EditChannelNavbar_test.js
@@ -2,29 +2,63 @@ import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 
+import IntegrationTestHelper from "../../util/integration_test_helper"
 import EditChannelNavbar from "./EditChannelNavbar"
-import { editChannelBasicURL, editChannelAppearanceURL } from "../../lib/url"
+import {
+  editChannelBasicURL,
+  editChannelAppearanceURL,
+  editChannelModeratorsURL,
+  editChannelContributorsURL
+} from "../../lib/url"
 
 describe("EditChannelNavbar", () => {
+  const channelName = "name"
+
+  let helper
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
   it("shows the navbar", () => {
-    const channelName = "name"
     const wrapper = shallow(<EditChannelNavbar channelName={channelName} />)
     const links = wrapper.find("NavLink")
-    assert.equal(links.at(0).props().to, editChannelBasicURL(channelName))
-    assert.equal(
-      links
-        .at(0)
-        .children()
-        .text(),
-      "Basic"
-    )
-    assert.equal(links.at(1).props().to, editChannelAppearanceURL(channelName))
-    assert.equal(
-      links
-        .at(1)
-        .children()
-        .text(),
-      "Appearance"
-    )
+
+    const linkPairs = [
+      ["Basic", editChannelBasicURL(channelName)],
+      ["Appearance", editChannelAppearanceURL(channelName)],
+      ["Members", editChannelModeratorsURL(channelName)]
+    ]
+
+    assert.equal(links.length, linkPairs.length)
+    linkPairs.forEach(([text, url], i) => {
+      const link = links.at(i)
+      assert.equal(link.props().to, url)
+      assert.equal(link.children().text(), text)
+    })
+  })
+  ;[
+    ["moderators", editChannelModeratorsURL(channelName), true],
+    ["contributors", editChannelContributorsURL(channelName), true],
+    ["basic", editChannelBasicURL(channelName), false],
+    ["appearance", editChannelAppearanceURL(channelName), false]
+  ].forEach(([description, url, isHighlighted]) => {
+    it(`${
+      isHighlighted ? "highlights" : "doesn't highlight"
+    } the members link for the ${description} url`, () => {
+      const wrapper = shallow(<EditChannelNavbar channelName={channelName} />)
+      const link = wrapper.find("NavLink").at(2)
+      assert.equal(link.children().text(), "Members")
+      assert.equal(
+        link.props().isActive(null, {
+          pathname: url
+        }),
+        isHighlighted
+      )
+    })
   })
 })

--- a/static/js/components/admin/MembersNavbar.js
+++ b/static/js/components/admin/MembersNavbar.js
@@ -1,0 +1,29 @@
+// @flow
+import React from "react"
+import NavLink from "react-router-dom/NavLink"
+
+import {
+  editChannelModeratorsURL,
+  editChannelContributorsURL
+} from "../../lib/url"
+
+type MembersNavbarProps = {
+  channelName: string
+}
+
+export default class MembersNavbar extends React.Component<*, void> {
+  props: MembersNavbarProps
+
+  render() {
+    const { channelName } = this.props
+
+    return (
+      <div className="members-navbar">
+        <NavLink to={editChannelModeratorsURL(channelName)}>Moderators</NavLink>{" "}
+        <NavLink to={editChannelContributorsURL(channelName)}>
+          Contributors
+        </NavLink>
+      </div>
+    )
+  }
+}

--- a/static/js/components/admin/MembersNavbar_test.js
+++ b/static/js/components/admin/MembersNavbar_test.js
@@ -1,0 +1,29 @@
+import React from "react"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import MembersNavbar from "./MembersNavbar"
+import {
+  editChannelContributorsURL,
+  editChannelModeratorsURL
+} from "../../lib/url"
+
+describe("MembersNavbar", () => {
+  it("shows the navbar", () => {
+    const channelName = "name"
+    const wrapper = shallow(<MembersNavbar channelName={channelName} />)
+    const links = wrapper.find("NavLink")
+
+    const linkPairs = [
+      ["Moderators", editChannelModeratorsURL(channelName)],
+      ["Contributors", editChannelContributorsURL(channelName)]
+    ]
+
+    assert.equal(links.length, linkPairs.length)
+    linkPairs.forEach(([text, url], i) => {
+      const link = links.at(i)
+      assert.equal(link.props().to, url)
+      assert.equal(link.children().text(), text)
+    })
+  })
+})

--- a/static/js/containers/admin/AdminPage.js
+++ b/static/js/containers/admin/AdminPage.js
@@ -5,6 +5,8 @@ import { Route } from "react-router-dom"
 import CreateChannelPage from "./CreateChannelPage"
 import EditChannelAppearancePage from "./EditChannelAppearancePage"
 import EditChannelBasicPage from "./EditChannelBasicPage"
+import EditChannelModeratorsPage from "./EditChannelModeratorsPage"
+import EditChannelContributorsPage from "./EditChannelContributorsPage"
 
 import type { Match } from "react-router"
 
@@ -25,6 +27,14 @@ export default class AdminPage extends React.Component<Props> {
         <Route
           path={`${match.url}/c/edit/:channelName/appearance`}
           component={EditChannelAppearancePage}
+        />
+        <Route
+          path={`${match.url}/c/edit/:channelName/members/moderators`}
+          component={EditChannelModeratorsPage}
+        />
+        <Route
+          path={`${match.url}/c/edit/:channelName/members/contributors`}
+          component={EditChannelContributorsPage}
         />
       </React.Fragment>
     )

--- a/static/js/containers/admin/EditChannelBasicPage.js
+++ b/static/js/containers/admin/EditChannelBasicPage.js
@@ -50,15 +50,13 @@ class EditChannelBasicPage extends React.Component<Props> {
     dispatch(actions.forms.formEndEdit(EDIT_CHANNEL_PAYLOAD))
   }
 
-  loadData = () => {
+  loadData = async () => {
     const { dispatch, channel, channelName } = this.props
     if (!channel) {
-      dispatch(actions.channels.get(channelName)).then(() => {
-        this.beginFormEdit()
-      })
-    } else {
-      this.beginFormEdit()
+      await dispatch(actions.channels.get(channelName))
     }
+
+    this.beginFormEdit()
   }
 
   beginFormEdit = () => {

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -9,15 +9,11 @@ import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
 import withSingleColumn from "../../hoc/withSingleColumn"
 
 import { actions } from "../../actions"
-import { newContributorsForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
 
 import type { Dispatch } from "redux"
 import type { Channel, ChannelContributors } from "../../flow/discussionTypes"
-
-const EDIT_CHANNEL_KEY = "channel:edit:contributors"
-const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
@@ -40,11 +36,6 @@ class EditChannelContributorsPage extends React.Component<*, void> {
     }
   }
 
-  componentWillUnmount() {
-    const { dispatch } = this.props
-    dispatch(actions.forms.formEndEdit(EDIT_CHANNEL_PAYLOAD))
-  }
-
   loadData = async () => {
     const { dispatch, channel, channelName, contributors } = this.props
     if (!channel) {
@@ -54,19 +45,6 @@ class EditChannelContributorsPage extends React.Component<*, void> {
     if (!contributors) {
       await dispatch(actions.channelContributors.get(channelName))
     }
-
-    this.beginFormEdit()
-  }
-
-  beginFormEdit = () => {
-    const { dispatch, channel, contributors } = this.props
-    dispatch(
-      actions.forms.formBeginEdit(
-        R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: newContributorsForm(channel, contributors)
-        })
-      )
-    )
   }
 
   render() {

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -14,16 +14,10 @@ import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
 
 import type { Dispatch } from "redux"
-import type { FormValue } from "../../flow/formTypes"
-import type {
-  Channel,
-  ChannelContributors,
-  ChannelContributorsForm
-} from "../../flow/discussionTypes"
+import type { Channel, ChannelContributors } from "../../flow/discussionTypes"
 
 const EDIT_CHANNEL_KEY = "channel:edit:contributors"
 const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
-const getForm = R.prop(EDIT_CHANNEL_KEY)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
@@ -32,10 +26,8 @@ class EditChannelContributorsPage extends React.Component<*, void> {
     dispatch: Dispatch<*>,
     history: Object,
     channel: Channel,
-    channelForm: FormValue<ChannelContributorsForm>,
     channelName: string,
-    contributors: ChannelContributors,
-    processing: boolean
+    contributors: ChannelContributors
   }
 
   componentDidMount() {
@@ -78,9 +70,9 @@ class EditChannelContributorsPage extends React.Component<*, void> {
   }
 
   render() {
-    const { channel, channelForm, processing } = this.props
+    const { channel, contributors } = this.props
 
-    if (!channelForm) {
+    if (!channel || !contributors) {
       return null
     }
 
@@ -91,9 +83,8 @@ class EditChannelContributorsPage extends React.Component<*, void> {
         </MetaTags>
         <EditChannelNavbar channelName={channel.name} />
         <EditChannelContributorsForm
-          form={channelForm.value}
-          validation={channelForm.errors}
-          processing={processing}
+          channelName={channel.name}
+          contributors={contributors}
         />
       </React.Fragment>
     )
@@ -110,8 +101,7 @@ const mapStateToProps = (state, ownProps) => {
     channel,
     contributors,
     channelName,
-    processing,
-    channelForm: getForm(state.forms)
+    processing
   }
 }
 

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -4,37 +4,40 @@ import R from "ramda"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
-import EditChannelAppearanceForm from "../../components/admin/EditChannelAppearanceForm"
+import EditChannelContributorsForm from "../../components/admin/EditChannelContributorsForm"
 import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
 import withSingleColumn from "../../hoc/withSingleColumn"
 
 import { actions } from "../../actions"
-import { editChannelForm } from "../../lib/channels"
-import { channelURL } from "../../lib/url"
+import { newContributorsForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
-import { validateChannelAppearanceEditForm } from "../../lib/validation"
 
 import type { Dispatch } from "redux"
 import type { FormValue } from "../../flow/formTypes"
-import type { Channel, ChannelForm } from "../../flow/discussionTypes"
+import type {
+  Channel,
+  ChannelContributors,
+  ChannelContributorsForm
+} from "../../flow/discussionTypes"
 
-const EDIT_CHANNEL_KEY = "channel:edit:appearance"
+const EDIT_CHANNEL_KEY = "channel:edit:contributors"
 const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
 const getForm = R.prop(EDIT_CHANNEL_KEY)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
-type Props = {
-  dispatch: Dispatch<*>,
-  history: Object,
-  channel: Channel,
-  channelForm: FormValue<ChannelForm>,
-  channelName: string,
-  processing: boolean
-}
+class EditChannelContributorsPage extends React.Component<*, void> {
+  props: {
+    dispatch: Dispatch<*>,
+    history: Object,
+    channel: Channel,
+    channelForm: FormValue<ChannelContributorsForm>,
+    channelName: string,
+    contributors: ChannelContributors,
+    processing: boolean
+  }
 
-class EditChannelAppearancePage extends React.Component<Props> {
   componentDidMount() {
     this.loadData()
   }
@@ -51,61 +54,31 @@ class EditChannelAppearancePage extends React.Component<Props> {
   }
 
   loadData = async () => {
-    const { dispatch, channel, channelName } = this.props
+    const { dispatch, channel, channelName, contributors } = this.props
     if (!channel) {
       await dispatch(actions.channels.get(channelName))
+    }
+
+    if (!contributors) {
+      await dispatch(actions.channelContributors.get(channelName))
     }
 
     this.beginFormEdit()
   }
 
   beginFormEdit = () => {
-    const { dispatch, channel } = this.props
+    const { dispatch, channel, contributors } = this.props
     dispatch(
       actions.forms.formBeginEdit(
         R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: editChannelForm(channel)
+          value: newContributorsForm(channel, contributors)
         })
       )
     )
-  }
-
-  onUpdate = (e: Object) => {
-    const { dispatch } = this.props
-    dispatch(
-      actions.forms.formUpdate(
-        R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: {
-            [e.target.name]: e.target.value
-          }
-        })
-      )
-    )
-  }
-
-  onSubmit = (e: Object) => {
-    const { dispatch, history, channelForm } = this.props
-
-    e.preventDefault()
-
-    const validation = validateChannelAppearanceEditForm(channelForm)
-
-    if (!channelForm || !R.isEmpty(validation)) {
-      dispatch(
-        actions.forms.formValidate({
-          ...EDIT_CHANNEL_PAYLOAD,
-          errors: validation.value
-        })
-      )
-    } else {
-      dispatch(actions.channels.patch(channelForm.value)).then(channel => {
-        history.push(channelURL(channel.name))
-      })
-    }
   }
 
   render() {
-    const { channel, channelForm, processing, history } = this.props
+    const { channel, channelForm, processing } = this.props
 
     if (!channelForm) {
       return null
@@ -117,11 +90,8 @@ class EditChannelAppearancePage extends React.Component<Props> {
           <title>{formatTitle("Edit Channel")}</title>
         </MetaTags>
         <EditChannelNavbar channelName={channel.name} />
-        <EditChannelAppearanceForm
-          onSubmit={this.onSubmit}
-          onUpdate={this.onUpdate}
+        <EditChannelContributorsForm
           form={channelForm.value}
-          history={history}
           validation={channelForm.errors}
           processing={processing}
         />
@@ -133,9 +103,12 @@ class EditChannelAppearancePage extends React.Component<Props> {
 const mapStateToProps = (state, ownProps) => {
   const channelName = getChannelName(ownProps)
   const channel = state.channels.data.get(channelName)
-  const processing = state.channels.processing
+  const processing =
+    state.channels.processing || state.channelContributors.processing
+  const contributors = state.channelContributors.data.get(channelName)
   return {
     channel,
+    contributors,
     channelName,
     processing,
     channelForm: getForm(state.forms)
@@ -145,4 +118,4 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withSingleColumn("edit-channel")
-)(EditChannelAppearancePage)
+)(EditChannelContributorsPage)

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -62,4 +62,11 @@ describe("EditChannelContributorsPage", () => {
     await renderPage()
     assert.equal(document.title, formatTitle("Edit Channel"))
   })
+
+  it("renders the form", async () => {
+    const wrapper = await renderPage()
+    const props = wrapper.find("EditChannelContributorsForm").props()
+    assert.deepEqual(props.contributors, contributors)
+    assert.equal(props.channelName, channel.name)
+  })
 })

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -4,13 +4,12 @@ import { assert } from "chai"
 import { makeChannel, makeContributors } from "../../factories/channels"
 import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
-import { FORM_BEGIN_EDIT, FORM_END_EDIT } from "../../actions/forms"
 import { formatTitle } from "../../lib/title"
 import { editChannelContributorsURL } from "../../lib/url"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 
 describe("EditChannelContributorsPage", () => {
-  let helper, renderComponent, channel, contributors, listenForActions
+  let helper, renderComponent, channel, contributors
 
   beforeEach(() => {
     channel = makeChannel()
@@ -34,7 +33,6 @@ describe("EditChannelContributorsPage", () => {
     helper.updateChannelStub.returns(Promise.resolve(channel))
     helper.getProfileStub.returns(Promise.resolve(""))
     renderComponent = helper.renderComponent.bind(helper)
-    listenForActions = helper.listenForActions.bind(helper)
     window.scrollTo = helper.sandbox.stub()
   })
 
@@ -54,8 +52,7 @@ describe("EditChannelContributorsPage", () => {
         actions.channelContributors.get.successType,
         actions.profiles.get.requestType,
         actions.profiles.get.successType,
-        SET_CHANNEL_DATA,
-        FORM_BEGIN_EDIT
+        SET_CHANNEL_DATA
       ]
     )
     return wrapper.update()
@@ -64,15 +61,5 @@ describe("EditChannelContributorsPage", () => {
   it("should set the document title", async () => {
     await renderPage()
     assert.equal(document.title, formatTitle("Edit Channel"))
-  })
-
-  it("ends the form after hitting the back button", async () => {
-    await renderPage()
-    await listenForActions(
-      [FORM_END_EDIT, actions.frontpage.get.requestType],
-      () => {
-        helper.browserHistory.goBack()
-      }
-    )
   })
 })

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -1,0 +1,78 @@
+// @flow
+import { assert } from "chai"
+
+import { makeChannel, makeContributors } from "../../factories/channels"
+import { actions } from "../../actions"
+import { SET_CHANNEL_DATA } from "../../actions/channel"
+import { FORM_BEGIN_EDIT, FORM_END_EDIT } from "../../actions/forms"
+import { formatTitle } from "../../lib/title"
+import { editChannelContributorsURL } from "../../lib/url"
+import IntegrationTestHelper from "../../util/integration_test_helper"
+
+describe("EditChannelContributorsPage", () => {
+  let helper, renderComponent, channel, contributors, listenForActions
+
+  beforeEach(() => {
+    channel = makeChannel()
+    contributors = makeContributors()
+    helper = new IntegrationTestHelper()
+    helper.getChannelStub.returns(Promise.resolve(channel))
+    helper.getChannelsStub.returns(Promise.resolve([channel]))
+    helper.getChannelContributorsStub.returns(Promise.resolve(contributors))
+    helper.getPostsForChannelStub.returns(
+      Promise.resolve({
+        pagination: {},
+        posts:      []
+      })
+    )
+    helper.getFrontpageStub.returns(
+      Promise.resolve({
+        pagination: {},
+        posts:      []
+      })
+    )
+    helper.updateChannelStub.returns(Promise.resolve(channel))
+    helper.getProfileStub.returns(Promise.resolve(""))
+    renderComponent = helper.renderComponent.bind(helper)
+    listenForActions = helper.listenForActions.bind(helper)
+    window.scrollTo = helper.sandbox.stub()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  const renderPage = async () => {
+    const [wrapper] = await renderComponent(
+      editChannelContributorsURL(channel.name),
+      [
+        actions.subscribedChannels.get.requestType,
+        actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
+        actions.channelContributors.get.requestType,
+        actions.channelContributors.get.successType,
+        actions.profiles.get.requestType,
+        actions.profiles.get.successType,
+        SET_CHANNEL_DATA,
+        FORM_BEGIN_EDIT
+      ]
+    )
+    return wrapper.update()
+  }
+
+  it("should set the document title", async () => {
+    await renderPage()
+    assert.equal(document.title, formatTitle("Edit Channel"))
+  })
+
+  it("ends the form after hitting the back button", async () => {
+    await renderPage()
+    await listenForActions(
+      [FORM_END_EDIT, actions.frontpage.get.requestType],
+      () => {
+        helper.browserHistory.goBack()
+      }
+    )
+  })
+})

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -14,16 +14,10 @@ import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
 
 import type { Dispatch } from "redux"
-import type { FormValue } from "../../flow/formTypes"
-import type {
-  Channel,
-  ChannelModerators,
-  ChannelModeratorsForm
-} from "../../flow/discussionTypes"
+import type { Channel, ChannelModerators } from "../../flow/discussionTypes"
 
 const EDIT_CHANNEL_KEY = "channel:edit:moderators"
 const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
-const getForm = R.prop(EDIT_CHANNEL_KEY)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
@@ -32,10 +26,8 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
     dispatch: Dispatch<*>,
     history: Object,
     channel: Channel,
-    channelForm: FormValue<ChannelModeratorsForm>,
     channelName: string,
-    moderators: ChannelModerators,
-    processing: boolean
+    moderators: ChannelModerators
   }
 
   componentDidMount() {
@@ -78,9 +70,9 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
   }
 
   render() {
-    const { channel, channelForm, processing } = this.props
+    const { channel, moderators } = this.props
 
-    if (!channelForm) {
+    if (!channel || !moderators) {
       return null
     }
 
@@ -91,9 +83,8 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
         </MetaTags>
         <EditChannelNavbar channelName={channel.name} />
         <EditChannelModeratorsForm
-          form={channelForm.value}
-          validation={channelForm.errors}
-          processing={processing}
+          moderators={moderators}
+          channelName={channel.name}
         />
       </React.Fragment>
     )
@@ -110,8 +101,7 @@ const mapStateToProps = (state, ownProps) => {
     channel,
     moderators,
     channelName,
-    processing,
-    channelForm: getForm(state.forms)
+    processing
   }
 }
 

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -4,37 +4,40 @@ import R from "ramda"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
-import EditChannelAppearanceForm from "../../components/admin/EditChannelAppearanceForm"
+import EditChannelModeratorsForm from "../../components/admin/EditChannelModeratorsForm"
 import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
 import withSingleColumn from "../../hoc/withSingleColumn"
 
 import { actions } from "../../actions"
-import { editChannelForm } from "../../lib/channels"
-import { channelURL } from "../../lib/url"
+import { newModeratorsForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
-import { validateChannelAppearanceEditForm } from "../../lib/validation"
 
 import type { Dispatch } from "redux"
 import type { FormValue } from "../../flow/formTypes"
-import type { Channel, ChannelForm } from "../../flow/discussionTypes"
+import type {
+  Channel,
+  ChannelModerators,
+  ChannelModeratorsForm
+} from "../../flow/discussionTypes"
 
-const EDIT_CHANNEL_KEY = "channel:edit:appearance"
+const EDIT_CHANNEL_KEY = "channel:edit:moderators"
 const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
 const getForm = R.prop(EDIT_CHANNEL_KEY)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
-type Props = {
-  dispatch: Dispatch<*>,
-  history: Object,
-  channel: Channel,
-  channelForm: FormValue<ChannelForm>,
-  channelName: string,
-  processing: boolean
-}
+class EditChannelModeratorsPage extends React.Component<*, void> {
+  props: {
+    dispatch: Dispatch<*>,
+    history: Object,
+    channel: Channel,
+    channelForm: FormValue<ChannelModeratorsForm>,
+    channelName: string,
+    moderators: ChannelModerators,
+    processing: boolean
+  }
 
-class EditChannelAppearancePage extends React.Component<Props> {
   componentDidMount() {
     this.loadData()
   }
@@ -51,57 +54,27 @@ class EditChannelAppearancePage extends React.Component<Props> {
   }
 
   loadData = async () => {
-    const { dispatch, channel, channelName } = this.props
+    const { dispatch, channel, channelName, moderators } = this.props
     if (!channel) {
       await dispatch(actions.channels.get(channelName))
+    }
+
+    if (!moderators) {
+      await dispatch(actions.channelModerators.get(channelName))
     }
 
     this.beginFormEdit()
   }
 
   beginFormEdit = () => {
-    const { dispatch, channel } = this.props
+    const { dispatch, channel, moderators } = this.props
     dispatch(
       actions.forms.formBeginEdit(
         R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: editChannelForm(channel)
+          value: newModeratorsForm(channel, moderators)
         })
       )
     )
-  }
-
-  onUpdate = (e: Object) => {
-    const { dispatch } = this.props
-    dispatch(
-      actions.forms.formUpdate(
-        R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: {
-            [e.target.name]: e.target.value
-          }
-        })
-      )
-    )
-  }
-
-  onSubmit = (e: Object) => {
-    const { dispatch, history, channelForm } = this.props
-
-    e.preventDefault()
-
-    const validation = validateChannelAppearanceEditForm(channelForm)
-
-    if (!channelForm || !R.isEmpty(validation)) {
-      dispatch(
-        actions.forms.formValidate({
-          ...EDIT_CHANNEL_PAYLOAD,
-          errors: validation.value
-        })
-      )
-    } else {
-      dispatch(actions.channels.patch(channelForm.value)).then(channel => {
-        history.push(channelURL(channel.name))
-      })
-    }
   }
 
   render() {
@@ -117,11 +90,8 @@ class EditChannelAppearancePage extends React.Component<Props> {
           <title>{formatTitle("Edit Channel")}</title>
         </MetaTags>
         <EditChannelNavbar channelName={channel.name} />
-        <EditChannelAppearanceForm
-          onSubmit={this.onSubmit}
-          onUpdate={this.onUpdate}
+        <EditChannelModeratorsForm
           form={channelForm.value}
-          history={history}
           validation={channelForm.errors}
           processing={processing}
         />
@@ -133,9 +103,12 @@ class EditChannelAppearancePage extends React.Component<Props> {
 const mapStateToProps = (state, ownProps) => {
   const channelName = getChannelName(ownProps)
   const channel = state.channels.data.get(channelName)
-  const processing = state.channels.processing
+  const processing =
+    state.channels.processing || state.channelModerators.processing
+  const moderators = state.channelModerators.data.get(channelName)
   return {
     channel,
+    moderators,
     channelName,
     processing,
     channelForm: getForm(state.forms)
@@ -145,4 +118,4 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withSingleColumn("edit-channel")
-)(EditChannelAppearancePage)
+)(EditChannelModeratorsPage)

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -9,15 +9,11 @@ import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
 import withSingleColumn from "../../hoc/withSingleColumn"
 
 import { actions } from "../../actions"
-import { newModeratorsForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
 
 import type { Dispatch } from "redux"
 import type { Channel, ChannelModerators } from "../../flow/discussionTypes"
-
-const EDIT_CHANNEL_KEY = "channel:edit:moderators"
-const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
@@ -40,11 +36,6 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
     }
   }
 
-  componentWillUnmount() {
-    const { dispatch } = this.props
-    dispatch(actions.forms.formEndEdit(EDIT_CHANNEL_PAYLOAD))
-  }
-
   loadData = async () => {
     const { dispatch, channel, channelName, moderators } = this.props
     if (!channel) {
@@ -54,19 +45,6 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
     if (!moderators) {
       await dispatch(actions.channelModerators.get(channelName))
     }
-
-    this.beginFormEdit()
-  }
-
-  beginFormEdit = () => {
-    const { dispatch, channel, moderators } = this.props
-    dispatch(
-      actions.forms.formBeginEdit(
-        R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: newModeratorsForm(channel, moderators)
-        })
-      )
-    )
   }
 
   render() {

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -78,7 +78,7 @@ class EditChannelModeratorsPage extends React.Component<*, void> {
   }
 
   render() {
-    const { channel, channelForm, processing, history } = this.props
+    const { channel, channelForm, processing } = this.props
 
     if (!channelForm) {
       return null

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -1,0 +1,78 @@
+// @flow
+import { assert } from "chai"
+
+import { makeChannel, makeModerators } from "../../factories/channels"
+import { actions } from "../../actions"
+import { SET_CHANNEL_DATA } from "../../actions/channel"
+import { FORM_BEGIN_EDIT, FORM_END_EDIT } from "../../actions/forms"
+import { formatTitle } from "../../lib/title"
+import { editChannelModeratorsURL } from "../../lib/url"
+import IntegrationTestHelper from "../../util/integration_test_helper"
+
+describe("EditChannelModeratorsPage", () => {
+  let helper, renderComponent, channel, moderators, listenForActions
+
+  beforeEach(() => {
+    channel = makeChannel()
+    moderators = makeModerators()
+    helper = new IntegrationTestHelper()
+    helper.getChannelStub.returns(Promise.resolve(channel))
+    helper.getChannelsStub.returns(Promise.resolve([channel]))
+    helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
+    helper.getPostsForChannelStub.returns(
+      Promise.resolve({
+        pagination: {},
+        posts:      []
+      })
+    )
+    helper.getFrontpageStub.returns(
+      Promise.resolve({
+        pagination: {},
+        posts:      []
+      })
+    )
+    helper.updateChannelStub.returns(Promise.resolve(channel))
+    helper.getProfileStub.returns(Promise.resolve(""))
+    renderComponent = helper.renderComponent.bind(helper)
+    listenForActions = helper.listenForActions.bind(helper)
+    window.scrollTo = helper.sandbox.stub()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  const renderPage = async () => {
+    const [wrapper] = await renderComponent(
+      editChannelModeratorsURL(channel.name),
+      [
+        actions.subscribedChannels.get.requestType,
+        actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
+        actions.channelModerators.get.requestType,
+        actions.channelModerators.get.successType,
+        actions.profiles.get.requestType,
+        actions.profiles.get.successType,
+        SET_CHANNEL_DATA,
+        FORM_BEGIN_EDIT
+      ]
+    )
+    return wrapper.update()
+  }
+
+  it("should set the document title", async () => {
+    await renderPage()
+    assert.equal(document.title, formatTitle("Edit Channel"))
+  })
+
+  it("ends the form after hitting the back button", async () => {
+    await renderPage()
+    await listenForActions(
+      [FORM_END_EDIT, actions.frontpage.get.requestType],
+      () => {
+        helper.browserHistory.goBack()
+      }
+    )
+  })
+})

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -62,4 +62,11 @@ describe("EditChannelModeratorsPage", () => {
     await renderPage()
     assert.equal(document.title, formatTitle("Edit Channel"))
   })
+
+  it("renders the form", async () => {
+    const wrapper = await renderPage()
+    const props = wrapper.find("EditChannelModeratorsForm").props()
+    assert.deepEqual(props.moderators, moderators)
+    assert.equal(props.channelName, channel.name)
+  })
 })

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -4,13 +4,12 @@ import { assert } from "chai"
 import { makeChannel, makeModerators } from "../../factories/channels"
 import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
-import { FORM_BEGIN_EDIT, FORM_END_EDIT } from "../../actions/forms"
 import { formatTitle } from "../../lib/title"
 import { editChannelModeratorsURL } from "../../lib/url"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 
 describe("EditChannelModeratorsPage", () => {
-  let helper, renderComponent, channel, moderators, listenForActions
+  let helper, renderComponent, channel, moderators
 
   beforeEach(() => {
     channel = makeChannel()
@@ -34,7 +33,6 @@ describe("EditChannelModeratorsPage", () => {
     helper.updateChannelStub.returns(Promise.resolve(channel))
     helper.getProfileStub.returns(Promise.resolve(""))
     renderComponent = helper.renderComponent.bind(helper)
-    listenForActions = helper.listenForActions.bind(helper)
     window.scrollTo = helper.sandbox.stub()
   })
 
@@ -54,8 +52,7 @@ describe("EditChannelModeratorsPage", () => {
         actions.channelModerators.get.successType,
         actions.profiles.get.requestType,
         actions.profiles.get.successType,
-        SET_CHANNEL_DATA,
-        FORM_BEGIN_EDIT
+        SET_CHANNEL_DATA
       ]
     )
     return wrapper.update()
@@ -64,15 +61,5 @@ describe("EditChannelModeratorsPage", () => {
   it("should set the document title", async () => {
     await renderPage()
     assert.equal(document.title, formatTitle("Edit Channel"))
-  })
-
-  it("ends the form after hitting the back button", async () => {
-    await renderPage()
-    await listenForActions(
-      [FORM_END_EDIT, actions.frontpage.get.requestType],
-      () => {
-        helper.browserHistory.goBack()
-      }
-    )
   })
 })

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -17,15 +17,16 @@ const incr = incrementer()
 
 export const makeChannel = (privateChannel: boolean = false): Channel => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
-  name:                `channel_${incr.next().value}`,
-  title:               casual.title,
-  channel_type:        privateChannel ? "private" : "public",
-  link_type:           LINK_TYPE_ANY,
-  description:         casual.description,
-  public_description:  casual.description,
-  num_users:           casual.integer(0, 500),
-  user_is_contributor: casual.coin_flip,
-  user_is_moderator:   casual.coin_flip
+  name:                  `channel_${incr.next().value}`,
+  title:                 casual.title,
+  channel_type:          privateChannel ? "private" : "public",
+  link_type:             LINK_TYPE_ANY,
+  description:           casual.description,
+  public_description:    casual.description,
+  num_users:             casual.integer(0, 500),
+  user_is_contributor:   casual.coin_flip,
+  user_is_moderator:     casual.coin_flip,
+  membership_is_managed: casual.coin_flip
 })
 
 export const makeChannelList = (numChannels: number = 20) => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -28,16 +28,6 @@ export type ChannelForm = {
   link_type:          LinkType
 }
 
-export type ChannelModeratorsForm = {
-  moderators: ChannelModerators,
-  channel: Channel,
-}
-
-export type ChannelContributorsForm = {
-  contributors: ChannelContributors,
-  channel: Channel,
-}
-
 export type ChannelAppearanceEditValidation = {
   title:              string,
   description:        string,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -15,7 +15,8 @@ export type Channel = {
   num_users:           number,
   user_is_contributor: boolean,
   user_is_moderator:   boolean,
-  link_type:           LinkType
+  link_type:          LinkType,
+  membership_is_managed: boolean,
 }
 
 export type ChannelForm = {
@@ -25,6 +26,16 @@ export type ChannelForm = {
   public_description: string,
   channel_type:       ChannelType,
   link_type:          LinkType
+}
+
+export type ChannelModeratorsForm = {
+  moderators: ChannelModerators,
+  channel: Channel,
+}
+
+export type ChannelContributorsForm = {
+  contributors: ChannelContributors,
+  channel: Channel,
 }
 
 export type ChannelAppearanceEditValidation = {

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -22,7 +22,7 @@ export type LinkType =
   | typeof LINK_TYPE_LINK
   | typeof LINK_TYPE_ANY
 
-export const MISSING_TEXT = '<missing>'
+export const MISSING_TEXT = "<missing>"
 
 export const newChannelForm = (): ChannelForm => ({
   name:               "",

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -22,6 +22,8 @@ export type LinkType =
   | typeof LINK_TYPE_LINK
   | typeof LINK_TYPE_ANY
 
+export const MISSING_TEXT = '<missing>'
+
 export const newChannelForm = (): ChannelForm => ({
   name:               "",
   title:              "",

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -1,7 +1,14 @@
 //@flow
 import R from "ramda"
 
-import type { Channel, ChannelForm } from "../flow/discussionTypes"
+import type {
+  Channel,
+  ChannelForm,
+  ChannelContributors,
+  ChannelContributorsForm,
+  ChannelModerators,
+  ChannelModeratorsForm
+} from "../flow/discussionTypes"
 
 export const CHANNEL_TYPE_PUBLIC: "public" = "public"
 export const CHANNEL_TYPE_RESTRICTED: "restricted" = "restricted"
@@ -43,6 +50,22 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
     ],
     channel
   )
+
+export const newModeratorsForm = (
+  channel: Channel,
+  moderators: ChannelModerators
+): ChannelModeratorsForm => ({
+  channel:    channel,
+  moderators: moderators
+})
+
+export const newContributorsForm = (
+  channel: Channel,
+  contributors: ChannelContributors
+): ChannelContributorsForm => ({
+  channel:      channel,
+  contributors: contributors
+})
 
 export const userCanPost = (channel: Channel) =>
   channel.channel_type === CHANNEL_TYPE_PUBLIC ||

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -1,14 +1,7 @@
 //@flow
 import R from "ramda"
 
-import type {
-  Channel,
-  ChannelForm,
-  ChannelContributors,
-  ChannelContributorsForm,
-  ChannelModerators,
-  ChannelModeratorsForm
-} from "../flow/discussionTypes"
+import type { Channel, ChannelForm } from "../flow/discussionTypes"
 
 export const CHANNEL_TYPE_PUBLIC: "public" = "public"
 export const CHANNEL_TYPE_RESTRICTED: "restricted" = "restricted"
@@ -50,22 +43,6 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
     ],
     channel
   )
-
-export const newModeratorsForm = (
-  channel: Channel,
-  moderators: ChannelModerators
-): ChannelModeratorsForm => ({
-  channel:    channel,
-  moderators: moderators
-})
-
-export const newContributorsForm = (
-  channel: Channel,
-  contributors: ChannelContributors
-): ChannelContributorsForm => ({
-  channel:      channel,
-  contributors: contributors
-})
 
 export const userCanPost = (channel: Channel) =>
   channel.channel_type === CHANNEL_TYPE_PUBLIC ||

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -6,6 +6,8 @@ import {
   CHANNEL_TYPE_RESTRICTED,
   CHANNEL_TYPE_PRIVATE,
   newChannelForm,
+  newContributorsForm,
+  newModeratorsForm,
   editChannelForm,
   userCanPost,
   LINK_TYPE_ANY,
@@ -16,7 +18,11 @@ import {
   isLinkTypeChecked,
   isTextTabSelected
 } from "./channels"
-import { makeChannel } from "../factories/channels"
+import {
+  makeChannel,
+  makeContributors,
+  makeModerators
+} from "../factories/channels"
 
 describe("Channel utils", () => {
   it("newChannelForm should return a new channel form with empty values and public type", () => {
@@ -40,6 +46,28 @@ describe("Channel utils", () => {
       public_description: channel.public_description,
       channel_type:       channel.channel_type,
       link_type:          channel.link_type
+    })
+  })
+
+  describe("newModeratorsForm", () => {
+    it("should make a new form for moderators and a channel", () => {
+      const channel = makeChannel()
+      const moderators = makeModerators()
+      assert.deepEqual(newModeratorsForm(channel, moderators), {
+        channel:    channel,
+        moderators: moderators
+      })
+    })
+  })
+
+  describe("newContributorsForm", () => {
+    it("should make a new form for contributors and a channel", () => {
+      const channel = makeChannel()
+      const contributors = makeContributors()
+      assert.deepEqual(newContributorsForm(channel, contributors), {
+        channel:      channel,
+        contributors: contributors
+      })
     })
   })
 

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -6,8 +6,6 @@ import {
   CHANNEL_TYPE_RESTRICTED,
   CHANNEL_TYPE_PRIVATE,
   newChannelForm,
-  newContributorsForm,
-  newModeratorsForm,
   editChannelForm,
   userCanPost,
   LINK_TYPE_ANY,
@@ -18,11 +16,7 @@ import {
   isLinkTypeChecked,
   isTextTabSelected
 } from "./channels"
-import {
-  makeChannel,
-  makeContributors,
-  makeModerators
-} from "../factories/channels"
+import { makeChannel } from "../factories/channels"
 
 describe("Channel utils", () => {
   it("newChannelForm should return a new channel form with empty values and public type", () => {
@@ -46,28 +40,6 @@ describe("Channel utils", () => {
       public_description: channel.public_description,
       channel_type:       channel.channel_type,
       link_type:          channel.link_type
-    })
-  })
-
-  describe("newModeratorsForm", () => {
-    it("should make a new form for moderators and a channel", () => {
-      const channel = makeChannel()
-      const moderators = makeModerators()
-      assert.deepEqual(newModeratorsForm(channel, moderators), {
-        channel:    channel,
-        moderators: moderators
-      })
-    })
-  })
-
-  describe("newContributorsForm", () => {
-    it("should make a new form for contributors and a channel", () => {
-      const channel = makeChannel()
-      const contributors = makeContributors()
-      assert.deepEqual(newContributorsForm(channel, contributors), {
-        channel:      channel,
-        contributors: contributors
-      })
     })
   })
 

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -15,6 +15,12 @@ export const editChannelBasicURL = (channelName: string) =>
 export const editChannelAppearanceURL = (channelName: string) =>
   `/manage/c/edit/${channelName}/appearance/`
 
+export const editChannelModeratorsURL = (channelName: string) =>
+  `/manage/c/edit/${channelName}/members/moderators/`
+
+export const editChannelContributorsURL = (channelName: string) =>
+  `/manage/c/edit/${channelName}/members/contributors/`
+
 export const postDetailURL = (
   channelName: string,
   postID: string,

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -4,9 +4,15 @@ import { assert } from "chai"
 import {
   AUTH_REQUIRED_URL,
   channelURL,
+  editChannelAppearanceURL,
+  editChannelBasicURL,
+  editChannelContributorsURL,
+  editChannelModeratorsURL,
   FRONTPAGE_URL,
   newPostURL,
   postDetailURL,
+  editProfileURL,
+  profileURL,
   getChannelNameFromPathname,
   commentPermalink,
   toQueryString,
@@ -54,6 +60,54 @@ describe("url helper functions", () => {
 
     it("should return a non-specific URL if not passed a channel name", () => {
       assert.equal(newPostURL(undefined), "/create_post/")
+    })
+  })
+
+  describe("editChannelAppearanceURL", () => {
+    it("should return a url to edit channel appearance", () => {
+      assert.equal(
+        editChannelAppearanceURL("channel_name"),
+        "/manage/c/edit/channel_name/appearance/"
+      )
+    })
+  })
+
+  describe("editChannelBasicURL", () => {
+    it("should return a url to edit basic channel settings", () => {
+      assert.equal(
+        editChannelBasicURL("channel_name"),
+        "/manage/c/edit/channel_name/basic/"
+      )
+    })
+  })
+
+  describe("editChannelContributorsURL", () => {
+    it("should return a url to edit channel appearance", () => {
+      assert.equal(
+        editChannelContributorsURL("channel_name"),
+        "/manage/c/edit/channel_name/members/contributors/"
+      )
+    })
+  })
+
+  describe("editChannelModeratorsURL", () => {
+    it("should return a url to edit channel appearance", () => {
+      assert.equal(
+        editChannelModeratorsURL("channel_name"),
+        "/manage/c/edit/channel_name/members/moderators/"
+      )
+    })
+  })
+
+  describe("editProfileURL", () => {
+    it("should return a url to edit a profile", () => {
+      assert.equal(editProfileURL("username"), "/profile/username/edit")
+    })
+  })
+
+  describe("profileURL", () => {
+    it("should return a url to view a profile", () => {
+      assert.equal(profileURL("username"), "/profile/username/")
     })
   })
 

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -9,7 +9,10 @@
     }
   }
 
-  .edit-channel-navbar {
+  .edit-channel-navbar,
+  .members-navbar {
+    margin-bottom: 20px;
+
     a {
       margin-right: 25px;
 
@@ -36,6 +39,14 @@
       label {
         margin: 0;
       }
+    }
+  }
+
+  .contributors,
+  .moderators {
+    .row {
+      display: flex;
+      justify-content: space-between;
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #864 

#### What's this PR do?
Adds a members tab with moderator and contributor tabs inside it. These list the current moderators and contributors respectively. There is no UI to edit or delete moderators and contributors yet, that will be next PR.

#### How should this be manually tested?
As a moderator, click the edit channel link. Click on the members tab then each of the two tabs inside it. You should see a list of moderators and contributors.

Note that you will see a blank row for the system user which created the channel. At some point we should remove it but it's out of scope of this issue: #891 
