### PR TITLE
Fixed password reset UI and refactored redirect/load logic

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -38,6 +38,7 @@ import {
 } from "../actions/ui"
 import { setChannelData } from "../actions/channel"
 import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
+import { isAnonAccessiblePath, needsAuthedSite } from "../lib/auth"
 import { isMobileWidth } from "../lib/util"
 
 import type { Location, Match } from "react-router"
@@ -82,14 +83,7 @@ class App extends React.Component<*, void> {
     const {
       location: { pathname }
     } = this.props
-    if (pathname === AUTH_REQUIRED_URL || pathname.startsWith(SETTINGS_URL)) {
-      // user is at auth required page or settings page
-      return
-    }
-
-    if (!SETTINGS.authenticated_site.session_url && !SETTINGS.allow_anonymous) {
-      // user will be redirected to login required page due to missing session_url
-      // if anonymous access is not allowed
+    if (needsAuthedSite() || isAnonAccessiblePath(pathname)) {
       return
     }
 
@@ -137,13 +131,7 @@ class App extends React.Component<*, void> {
       profile
     } = this.props
 
-    if (
-      !SETTINGS.authenticated_site.session_url &&
-      pathname !== AUTH_REQUIRED_URL &&
-      !pathname.startsWith(SETTINGS_URL) &&
-      !SETTINGS.allow_anonymous
-    ) {
-      // user does not have the jwt cookie, they must go through login workflow first
+    if (needsAuthedSite() && !isAnonAccessiblePath(pathname)) {
       return <Redirect to={AUTH_REQUIRED_URL} />
     }
 

--- a/static/js/containers/auth/PasswordResetPage.js
+++ b/static/js/containers/auth/PasswordResetPage.js
@@ -7,6 +7,7 @@ import R from "ramda"
 
 import Card from "../../components/Card"
 import PasswordResetForm from "../../components/auth/PasswordResetForm"
+import ExternalLogins from "../../components/ExternalLogins"
 import withForm from "../../hoc/withForm"
 
 import { actions } from "../../actions"
@@ -45,6 +46,8 @@ export const PasswordResetPage = ({
             <title>{formatTitle("Password Reset")}</title>
           </MetaTags>
           {renderForm({ emailApiError })}
+          <div className="textline">Or use</div>
+          <ExternalLogins />
         </Card>
       )}
     </div>

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 // @flow
 import {
   LOGIN_URL,
@@ -6,7 +7,9 @@ import {
   REGISTER_CONFIRM_URL,
   REGISTER_DETAILS_URL,
   INACTIVE_USER_URL,
-  FRONTPAGE_URL
+  FRONTPAGE_URL,
+  SETTINGS_URL,
+  AUTH_REQUIRED_URL
 } from "./url"
 
 import {
@@ -45,3 +48,9 @@ export const processAuthResponse = (
     history.push(INACTIVE_USER_URL)
   }
 }
+
+export const isAnonAccessiblePath = (pathname: string): boolean =>
+  pathname === AUTH_REQUIRED_URL || pathname.startsWith(SETTINGS_URL)
+
+export const needsAuthedSite = (): boolean =>
+  !SETTINGS.allow_anonymous && !SETTINGS.authenticated_site.session_url

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -20,3 +20,7 @@ export const assertIsJust = (m: Maybe, val: any) => {
 export const assertIsJustNoVal = (m: Maybe) => {
   assert(m.isJust, "should be a Just")
 }
+
+export const shouldIf = (tf: boolean) => (tf ? "should" : "should not")
+
+export const shouldIfGt0 = (num: number) => shouldIf(num > 0)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #912

#### What's this PR do?
Refactors front-end redirect/load logic (including tests) and adds the touchstone link to the password reset page to agree with the MIT address form validation error

#### How should this be manually tested?
- Use the password reset page
- Try to get to the settings page and any channel page with a non-logged-in user with the `ANONYMOUS_ACCESS` feature on and off. Make sure it redirects as expected

#### Screenshots (if appropriate)
![ss 2018-07-13 at 17 46 48](https://user-images.githubusercontent.com/14932219/42716419-6760c2ea-86c9-11e8-91ec-9151ce12147a.png)

