### PR TITLE
Make touchstone button & MIT email invalidation contingent on FEATURE_SAML_AUTH flag 

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -79,6 +79,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "profile_ui_enabled": features.is_enabled(features.PROFILE_UI),
         "allow_anonymous": features.is_enabled(features.ANONYMOUS_ACCESS),
         "allow_email_auth": features.is_enabled(features.EMAIL_AUTH),
+        "allow_saml_auth": features.is_enabled(features.SAML_AUTH)
     }
 
     return render(request, "index.html", context={

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -22,6 +22,7 @@ def test_webpack_url(settings, client, user, mocker, authenticated_site):
     get_bundle_mock = mocker.patch('open_discussions.templatetags.render_bundle._get_bundle')
     settings.FEATURES[features.ANONYMOUS_ACCESS] = 'access'
     settings.FEATURES[features.EMAIL_AUTH] = False
+    settings.FEATURES[features.SAML_AUTH] = False
 
     client.force_login(user)
     response = client.get(reverse('open_discussions-index'))
@@ -51,6 +52,7 @@ def test_webpack_url(settings, client, user, mocker, authenticated_site):
         },
         'is_authenticated': True,
         'allow_anonymous': 'access',
+        'allow_saml_auth': False,
         'allow_email_auth': False,
         'support_email': settings.EMAIL_SUPPORT,
     }
@@ -63,6 +65,7 @@ def test_webpack_url_jwt(
     settings.GA_TRACKING_ID = 'fake'
     get_bundle_mock = mocker.patch('open_discussions.templatetags.render_bundle._get_bundle')
     settings.FEATURES[features.ANONYMOUS_ACCESS] = 'access'
+    settings.FEATURES[features.SAML_AUTH] = False
     client.cookies[api_settings.JWT_AUTH_COOKIE] = jwt_token
 
     response = client.get(reverse('open_discussions-index'))
@@ -92,6 +95,7 @@ def test_webpack_url_jwt(
         },
         'is_authenticated': False,
         'allow_anonymous': 'access',
+        'allow_saml_auth': False,
         'allow_email_auth': False,
         'support_email': settings.EMAIL_SUPPORT,
     }
@@ -103,6 +107,7 @@ def test_webpack_url_anonymous(settings, client, mocker, authenticated_site):
     get_bundle_mock = mocker.patch('open_discussions.templatetags.render_bundle._get_bundle')
     settings.FEATURES[features.ANONYMOUS_ACCESS] = 'access'
     settings.FEATURES[features.EMAIL_AUTH] = False
+    settings.FEATURES[features.SAML_AUTH] = False
 
     response = client.get(reverse('open_discussions-index'))
 
@@ -131,6 +136,7 @@ def test_webpack_url_anonymous(settings, client, mocker, authenticated_site):
         },
         'is_authenticated': False,
         'allow_anonymous': 'access',
+        'allow_saml_auth': False,
         'allow_email_auth': False,
         'support_email': settings.EMAIL_SUPPORT,
     }

--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { TOUCHSTONE_URL } from "../lib/url"
 
@@ -6,14 +7,16 @@ type ExternalLoginProps = {
   className?: string
 }
 
-const ExternalLogins = ({ className }: ExternalLoginProps) => (
-  <div className={`actions row ${className || ""}`}>
-    <a className="link-button" href={TOUCHSTONE_URL}>
-      Touchstone
-      <span className="ampersand">@</span>
-      MIT
-    </a>
-  </div>
-)
+const ExternalLogins = ({ className }: ExternalLoginProps) =>
+  SETTINGS.allow_saml_auth ? (
+    <div className={`actions row ${className || ""}`}>
+      <div className="textline">Or use</div>
+      <a className="link-button" href={TOUCHSTONE_URL}>
+        Touchstone
+        <span className="ampersand">@</span>
+        MIT
+      </a>
+    </div>
+  ) : null
 
 export default ExternalLogins

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -16,6 +16,7 @@ describe("ExternalLogins component", () => {
     const wrapper = mountExternalLogins({ className: "custom-class" })
     assert.equal(wrapper.props().className, "actions row custom-class")
   })
+  //
   ;[true, false].forEach(allowSaml => {
     it(`should ${allowSaml ? "" : "not "}have a link to Touchstone`, () => {
       SETTINGS.allow_saml_auth = allowSaml

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { shallow } from "enzyme"
 import { assert } from "chai"
@@ -10,15 +11,24 @@ describe("ExternalLogins component", () => {
   const mountExternalLogins = (props = {}) =>
     shallow(<ExternalLogins {...props} />)
 
-  it("should have a link to Touchstone", () => {
-    const wrapper = mountExternalLogins()
-    const link = wrapper.find(".link-button")
-    assert.ok(link.exists())
-    assert.equal(link.props().href, TOUCHSTONE_URL)
-  })
-
   it("should put className, if passed one", () => {
+    SETTINGS.allow_saml_auth = true
     const wrapper = mountExternalLogins({ className: "custom-class" })
     assert.equal(wrapper.props().className, "actions row custom-class")
+  })
+  ;[true, false].forEach(allowSaml => {
+    it(`should ${allowSaml ? "" : "not "}have a link to Touchstone`, () => {
+      SETTINGS.allow_saml_auth = allowSaml
+      const wrapper = mountExternalLogins()
+      const link = wrapper.find(".link-button")
+      assert.equal(link.exists(), allowSaml)
+    })
+  })
+
+  it("should have the correct URL for Touchstone", () => {
+    SETTINGS.allow_saml_auth = true
+    const wrapper = mountExternalLogins()
+    const link = wrapper.find(".link-button")
+    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 })

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -39,12 +39,7 @@ export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
           <title>{formatTitle("Log In")}</title>
         </MetaTags>
         {renderForm({ formError })}
-        {SETTINGS.allow_saml_auth ? (
-          <div>
-            <div className="textline">Or use</div>
-            <ExternalLogins />
-          </div>
-        ) : null}
+        <ExternalLogins />
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
@@ -38,8 +39,12 @@ export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
           <title>{formatTitle("Log In")}</title>
         </MetaTags>
         {renderForm({ formError })}
-        <div className="textline">Or use</div>
-        <ExternalLogins />
+        {SETTINGS.allow_saml_auth ? (
+          <div>
+            <div className="textline">Or use</div>
+            <ExternalLogins />
+          </div>
+        ) : null}
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { assert } from "chai"
 import sinon from "sinon"
 
@@ -57,18 +58,22 @@ describe("LoginPage", () => {
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
   })
-
-  it("should render an ExternalLogins component", async () => {
-    const { inner } = await renderPage({
-      auth: {
-        data: {
-          errors: ["error"]
+  ;[true, false].forEach(allowSAML => {
+    it(`should ${
+      allowSAML ? "" : "not"
+    } render an ExternalLogins component`, async () => {
+      SETTINGS.allow_saml_auth = allowSAML
+      const { inner } = await renderPage({
+        auth: {
+          data: {
+            errors: ["error"]
+          }
         }
-      }
-    })
+      })
 
-    const link = inner.find("ExternalLogins")
-    assert.ok(link.exists())
+      const link = inner.find("ExternalLogins")
+      assert.equal(link.exists(), allowSAML)
+    })
   })
 
   it("form onSubmit prop calls api correctly", async () => {

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -58,22 +58,18 @@ describe("LoginPage", () => {
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
   })
-  ;[true, false].forEach(allowSAML => {
-    it(`should ${
-      allowSAML ? "" : "not"
-    } render an ExternalLogins component`, async () => {
-      SETTINGS.allow_saml_auth = allowSAML
-      const { inner } = await renderPage({
-        auth: {
-          data: {
-            errors: ["error"]
-          }
-        }
-      })
 
-      const link = inner.find("ExternalLogins")
-      assert.equal(link.exists(), allowSAML)
+  it("should render an ExternalLogins component", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
     })
+
+    const link = inner.find("ExternalLogins")
+    assert.ok(link.exists())
   })
 
   it("form onSubmit prop calls api correctly", async () => {

--- a/static/js/containers/auth/PasswordResetPage.js
+++ b/static/js/containers/auth/PasswordResetPage.js
@@ -46,7 +46,6 @@ export const PasswordResetPage = ({
           </MetaTags>
           <h3>Forgot your password?</h3>
           {renderForm({ emailApiError })}
-          <div className="textline">Or use</div>
           <ExternalLogins />
         </Card>
       )}

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
@@ -73,8 +74,12 @@ export const RegisterPage = ({
         ) : (
           renderForm({ formError })
         )}
-        <div className="textline">Or use</div>
-        <ExternalLogins />
+        {SETTINGS.allow_saml_auth ? (
+          <div>
+            <div className="textline">Or use</div>
+            <ExternalLogins />
+          </div>
+        ) : null}
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -74,12 +74,7 @@ export const RegisterPage = ({
         ) : (
           renderForm({ formError })
         )}
-        {SETTINGS.allow_saml_auth ? (
-          <div>
-            <div className="textline">Or use</div>
-            <ExternalLogins />
-          </div>
-        ) : null}
+        <ExternalLogins />
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { assert } from "chai"
 import sinon from "sinon"
 
@@ -59,18 +60,22 @@ describe("RegisterPage", () => {
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
   })
-
-  it("should render an ExternalLogins component", async () => {
-    const { inner } = await renderPage({
-      auth: {
-        data: {
-          errors: ["error"]
+  ;[true, false].forEach(allowSAML => {
+    it(`should ${
+      allowSAML ? "" : "not"
+    } render an ExternalLogins component`, async () => {
+      SETTINGS.allow_saml_auth = allowSAML
+      const { inner } = await renderPage({
+        auth: {
+          data: {
+            errors: ["error"]
+          }
         }
-      }
-    })
+      })
 
-    const link = inner.find("ExternalLogins")
-    assert.ok(link.exists())
+      const link = inner.find("ExternalLogins")
+      assert.equal(link.exists(), allowSAML)
+    })
   })
 
   it("should show a different header if tried to login", async () => {

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -60,22 +60,18 @@ describe("RegisterPage", () => {
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
   })
-  ;[true, false].forEach(allowSAML => {
-    it(`should ${
-      allowSAML ? "" : "not"
-    } render an ExternalLogins component`, async () => {
-      SETTINGS.allow_saml_auth = allowSAML
-      const { inner } = await renderPage({
-        auth: {
-          data: {
-            errors: ["error"]
-          }
-        }
-      })
 
-      const link = inner.find("ExternalLogins")
-      assert.equal(link.exists(), allowSAML)
+  it("should render an ExternalLogins component", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
     })
+
+    const link = inner.find("ExternalLogins")
+    assert.ok(link.exists())
   })
 
   it("should show a different header if tried to login", async () => {

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -20,6 +20,7 @@ declare var SETTINGS: {
   },
   is_authenticated: boolean,
   allow_anonymous: boolean,
+  allow_saml_auth: boolean,
   allow_email_auth: boolean,
   support_email: string
 }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -18,6 +18,8 @@ const _createSettings = () => ({
     tos_url:     "http://fake.tos.url/"
   },
   allow_anonymous:    false,
+  allow_saml_auth:    false,
+  allow_email_auth:   false,
   is_authenticated:   true,
   username:           "greatusername",
   user_full_name:     "Great User",

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import R from "ramda"
 
@@ -146,7 +147,7 @@ export const validationMessage = (message: ?string) =>
 
 export const validateEmailForm = validate([
   validation(
-    R.complement(validNotMIT),
+    R.complement(SETTINGS.allow_saml_auth ? validNotMIT : R.always(true)),
     R.lensPath(["value", "email"]),
     "MIT users please login with Touchstone below"
   ),

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { assert } from "chai"
 import R from "ramda"
 
@@ -15,7 +16,8 @@ import {
   validatePasswordForm,
   validatePasswordResetForm,
   validatePasswordChangeForm,
-  PASSWORD_LENGTH_MINIMUM
+  PASSWORD_LENGTH_MINIMUM,
+  validNotMIT
 } from "./validation"
 
 describe("validation library", () => {
@@ -216,6 +218,27 @@ describe("validation library", () => {
     })
   })
 
+  describe("validNotMIT", () => {
+    [
+      ["user@mit.edu", true],
+      ["user@MIT.EDU", true],
+      ["user@test.mit.edu", true],
+      ["user@TEST.MIT.edu", true],
+      ["user@ALUM.MIT.edu", false],
+      ["user@alum.mit.edu", false],
+      ["user@other.alum.mit.edu", false],
+      ["user@other.school.mit.edu", true],
+      ["user@aluminum.mit.edu", true],
+      ["user@amit.edu", false],
+      ["user@mit.eduu", false],
+      ["user@mit.com", false]
+    ].forEach(([email, invalid]) => {
+      it(`should ${invalid ? "" : "not"} invalidate ${email}`, () => {
+        assert.equal(validNotMIT(email), !invalid)
+      })
+    })
+  })
+
   describe("validateEmailForm", () => {
     it("should complain about no email", () => {
       const form = { value: { email: "" } }
@@ -232,33 +255,6 @@ describe("validation library", () => {
         value: {
           email: "Email is not formatted correctly"
         }
-      })
-    })
-
-    it("should complain about an MIT email except alum.mit.edu", () => {
-      [
-        ["user@mit.edu", true],
-        ["user@MIT.EDU", true],
-        ["user@test.mit.edu", true],
-        ["user@TEST.MIT.edu", true],
-        ["user@ALUM.MIT.edu", false],
-        ["user@alum.mit.edu", false],
-        ["user@other.alum.mit.edu", false],
-        ["user@other.school.mit.edu", true],
-        ["user@aluminum.mit.edu", true],
-        ["user@amit.edu", false],
-        ["user@mit.eduu", false],
-        ["user@mit.com", false]
-      ].forEach(([email, invalid]) => {
-        const form = { value: { email } }
-        assert.deepEqual(
-          validateEmailForm(form),
-          invalid
-            ? {
-              value: { email: "MIT users please login with Touchstone below" }
-            }
-            : {}
-        )
       })
     })
   })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #919 

#### What's this PR do?
Invalidates MIT emails and displays the Touchstone login button only if `FEATURE_SAML_AUTH=True`

#### How should this be manually tested?
- Set `FEATURE_SAML_AUTH=True` in your `.env` file
- The Touchstone login button should appear on login and register pages, and emails ending with `mit.edu` should be invalidated on those pages.
- Set `FEATURE_SAML_AUTH=False` in your `.env` file
- The Touchstone login button should not appear on login and register pages, and emails ending with `mit.edu` should be considered valid for registering.
