### PR TITLE
Don't silence 403 status for reddit moderator API

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -971,13 +971,7 @@ class Api:
         except User.DoesNotExist:
             raise NotFound("User {} does not exist".format(moderator_name))
 
-        try:
-            self.get_channel(channel_name).moderator.remove(user)
-        except PrawForbidden:
-            # User is already not a moderator,
-            # or maybe there's another unrelated 403 error from reddit, but we can't tell the difference,
-            # and the double removal case is probably more common.
-            pass
+        self.get_channel(channel_name).moderator.remove(user)
 
     def _list_moderators(self, *, channel_name, moderator_name):
         """

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -10,6 +10,7 @@ from channels.serializers import (
     ModeratorPrivateSerializer,
     ModeratorPublicSerializer,
 )
+from channels.utils import translate_praw_exceptions
 from open_discussions.permissions import (
     AnonymousAccessReadonlyPermission,
     is_moderator,
@@ -60,5 +61,6 @@ class ModeratorDetailView(APIView):
         channel_name = self.kwargs['channel_name']
         moderator_name = self.kwargs['moderator_name']
 
-        api.remove_moderator(moderator_name, channel_name)
+        with translate_praw_exceptions(request.user):
+            api.remove_moderator(moderator_name, channel_name)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/channels/views/moderators_test.py
+++ b/channels/views/moderators_test.py
@@ -131,13 +131,14 @@ def test_remove_moderator(client, staff_jwt_header):
 
 def test_remove_moderator_again(client, staff_jwt_header):
     """
-    If a user is already not a moderator for a channel we should still return a 204
+    If a user is already not a moderator for a channel we should return a 403, signaling that the user does not have
+    permission to remove that user as a moderator.
     """
     moderator = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse(
         'moderator-detail', kwargs={'channel_name': 'admin_channel', 'moderator_name': moderator.username})
     resp = client.delete(url, **staff_jwt_header)
-    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.parametrize("allow_anonymous", [True, False])


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #864 

#### What's this PR do?
I originally assumed that a 403 wouldn't happen except in rare cases and that forwarding it from reddit breaks idempotent behavior if the user removes the moderator twice. However we need this status to have the frontend know if certain moderator operations failed.

#### How should this be manually tested?
N/A, no UI yet
