### PR TITLE
Check on server that channels are not managed before letting users moderate them

### DIFF
--- a/channels/views/contributors.py
+++ b/channels/views/contributors.py
@@ -8,14 +8,14 @@ from rest_framework.views import APIView
 
 from channels.api import Api
 from channels.serializers import ContributorSerializer
-from open_discussions.permissions import JwtIsStaffOrModeratorPermission
+from open_discussions.permissions import ContributorPermissions
 
 
 class ContributorListView(ListCreateAPIView):
     """
     View to list and add contributors in channels
     """
-    permission_classes = (IsAuthenticated, JwtIsStaffOrModeratorPermission, )
+    permission_classes = (IsAuthenticated, ContributorPermissions)
     serializer_class = ContributorSerializer
 
     def get_serializer_context(self):
@@ -35,7 +35,7 @@ class ContributorDetailView(APIView):
     """
     View to retrieve and remove contributors in channels
     """
-    permission_classes = (IsAuthenticated, JwtIsStaffOrModeratorPermission, )
+    permission_classes = (IsAuthenticated, ContributorPermissions)
 
     def get_serializer_context(self):
         """Context for the request and view"""

--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -152,7 +152,7 @@ class AnonymousAccessReadonlyPermission(permissions.BasePermission):
         if not request.user.is_anonymous:
             return True
 
-        if request.method not in permissions.SAFE_METHODS:
+        if not is_readonly(request):
             return False
 
         return features.is_enabled(features.ANONYMOUS_ACCESS)

--- a/open_discussions/permissions_test.py
+++ b/open_discussions/permissions_test.py
@@ -6,69 +6,133 @@ from prawcore.exceptions import (
     Redirect as PrawRedirect,
 )
 
+from channels.models import Channel
 from open_discussions import features
 from open_discussions.permissions import (
     AnonymousAccessReadonlyPermission,
+    ContributorPermissions,
     JwtIsStaffPermission,
     JwtIsStaffOrModeratorPermission,
     JwtIsStaffOrReadonlyPermission,
+    JwtIsStaffModeratorOrReadonlyPermission,
+    ModeratorPermissions,
+    channel_is_mod_editable,
+    is_readonly,
+    is_moderator,
+    is_staff_jwt,
 )
 
 
-@pytest.mark.parametrize('perm', [
-    JwtIsStaffPermission(),
-    JwtIsStaffOrReadonlyPermission(),
+@pytest.mark.parametrize('method,result', [
+    ('GET', True),
+    ('HEAD', True),
+    ('OPTIONS', True),
+    ('POST', False),
+    ('PUT', False),
 ])
-def test_staff_anonymous_users_blocked(mocker, perm):
-    """
-    Test that anonymous users are not allowed
-    """
-    assert perm.has_permission(mocker.Mock(), mocker.Mock()) is False
+def test_is_readonly(mocker, method, result):
+    """is_readonly should return true for readonly HTTP verbs"""
+    request = mocker.Mock(method=method)
+    assert is_readonly(request) is result
 
 
-def test_staff_deny_non_staff_user(mocker, jwt_token):
-    """
-    Test that nonstaff users are not allowed
-    """
-    perm = JwtIsStaffPermission()
-    request = mocker.Mock(auth=jwt_token)
-    assert perm.has_permission(request, mocker.Mock()) is False
-
-
-@pytest.mark.parametrize('perm', [
-    JwtIsStaffPermission(),
-    JwtIsStaffOrReadonlyPermission(),
-])
-def test_staff_allow_staff_user(mocker, staff_jwt_token, perm):
-    """
-    Test that staff users are allowed
-    """
-    request = mocker.Mock(auth=staff_jwt_token)
-    assert perm.has_permission(request, mocker.Mock()) is True
-
-
-@pytest.mark.parametrize('is_moderator', [
-    True,
-    False,
-])
-def test_staff_or_moderator(mocker, user, jwt_token, is_moderator):
-    """
-    Test that moderators are allowed or not
-    """
-    perm = JwtIsStaffOrModeratorPermission()
-    request = mocker.Mock(auth=jwt_token, user=user)
+@pytest.mark.parametrize('result', [True, False])
+def test_is_moderator(user, mocker, result):
+    """is_moderator should return True if the user is a moderator for the channel"""
+    request = mocker.Mock(user=user)
     request.channel_api = mocker.patch('channels.api.Api').return_value
-    request.channel_api.is_moderator.return_value = is_moderator
-    view = mocker.Mock(kwargs=dict(channel_name='abc'))
-    assert perm.has_permission(request, view) is is_moderator
-    request.channel_api.is_moderator.assert_called_once_with('abc', user.username)
+    request.channel_api.is_moderator.return_value = result
+    channel_name = 'abc'
+    view = mocker.Mock(kwargs={'channel_name': channel_name})
+    assert is_moderator(request, view) is result
+    request.channel_api.is_moderator.assert_called_once_with(channel_name, user.username)
+
+
+@pytest.mark.parametrize('result', [True, False])
+def test_is_staff_jwt(mocker, staff_jwt_token, result):
+    """is_staff_jwt should return True if a valid JWT is provided"""
+    auth_kwargs = {'auth': staff_jwt_token} if result else {}
+    request = mocker.Mock(**auth_kwargs)
+    assert is_staff_jwt(request) is result
+
+
+@pytest.mark.parametrize('membership_is_managed,expected', [
+    [True, False],
+    [False, True],
+    [None, False]
+])
+def test_channel_is_mod_editable(mocker, membership_is_managed, expected, db):  # pylint: disable=unused-argument
+    """
+    channel_is_mod_editable should be true if the channel exists and the membership is not managed by micromasters
+    or another external server
+    """
+    channel_name = 'abc'
+    view = mocker.Mock(kwargs={'channel_name': channel_name})
+
+    if membership_is_managed is not None:
+        Channel.objects.create(name=channel_name, membership_is_managed=membership_is_managed)
+
+    assert channel_is_mod_editable(view) is expected
+
+
+@pytest.mark.parametrize('is_staff', [True, False])
+def test_is_staff_permission(mocker, is_staff):
+    """
+    Test that JwtIsStaffPermission checks that the user is a staff user
+    """
+    request, view = mocker.Mock(), mocker.Mock()
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    assert JwtIsStaffPermission().has_permission(request, view) is is_staff
+    is_staff_jwt_mock.assert_called_once_with(request)
+
+
+@pytest.mark.parametrize('is_staff,readonly,expected', [
+    [True, True, True],
+    [True, False, True],
+    [False, True, True],
+    [False, False, False],
+])
+def test_is_staff_or_readonly_permission(mocker, is_staff, readonly, expected):
+    """
+    Test that staff users or readonly verbs are allowed
+    """
+    request, view = mocker.Mock(), mocker.Mock()
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    is_readonly_mock = mocker.patch(
+        'open_discussions.permissions.is_readonly', autospec=True, return_value=readonly
+    )
+    assert JwtIsStaffOrReadonlyPermission().has_permission(request, view) is expected
+    if is_staff_jwt_mock.called:
+        is_staff_jwt_mock.assert_called_once_with(request)
+    is_readonly_mock.assert_called_once_with(request)
+
+
+@pytest.mark.parametrize('is_staff,moderator,expected', [
+    [True, True, True],
+    [True, False, True],
+    [False, True, True],
+    [False, False, False],
+])
+def test_is_staff_or_moderator_permission(mocker, is_staff, moderator, expected):
+    """
+    Test that staff users or moderators are allowed
+    """
+    request, view = mocker.Mock(), mocker.Mock()
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    is_moderator_mock = mocker.patch(
+        'open_discussions.permissions.is_moderator', autospec=True, return_value=moderator
+    )
+    assert JwtIsStaffOrModeratorPermission().has_permission(request, view) is expected
+    if is_moderator_mock.called:
+        is_moderator_mock.assert_called_once_with(request, view)
+    is_staff_jwt_mock.assert_called_once_with(request)
 
 
 @pytest.mark.parametrize('exception_cls', [
     PrawRedirect,
     PrawForbidden,
 ])
-def test_staff_or_moderator_exceptions(mocker, jwt_token, exception_cls):
+def test_is_staff_or_moderator_exceptions(mocker, jwt_token, exception_cls):
     """
     Test that user is deemed not a moderator if praw raises a forbidden or redirect error
     """
@@ -82,20 +146,123 @@ def test_staff_or_moderator_exceptions(mocker, jwt_token, exception_cls):
     assert perm.has_permission(request, view) is False
 
 
-@pytest.mark.parametrize('method,result', [
-    ('GET', True),
-    ('HEAD', True),
-    ('OPTIONS', True),
-    ('POST', False),
-    ('PUT', False),
+@pytest.mark.parametrize('is_staff,moderator,readonly,expected', [
+    [True, True, True, True],
+    [True, False, True, True],
+    [False, True, True, True],
+    [False, False, True, True],
+    [True, True, False, True],
+    [True, False, False, True],
+    [False, True, False, True],
+    [False, False, False, False],
 ])
-def test_readonly(mocker, jwt_token, method, result):
+def test_is_staff_moderator_or_readonly_permission(mocker, is_staff, moderator, readonly, expected):
     """
-    Test that mutation HTTP verbs return appropriately if nonstaff
+    Test that staff users or moderators are allowed
     """
-    perm = JwtIsStaffOrReadonlyPermission()
-    request = mocker.Mock(auth=jwt_token, method=method)
-    assert perm.has_permission(request, mocker.Mock()) is result
+    request, view = mocker.Mock(), mocker.Mock()
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    is_moderator_mock = mocker.patch(
+        'open_discussions.permissions.is_moderator', autospec=True, return_value=moderator
+    )
+    is_readonly_mock = mocker.patch(
+        'open_discussions.permissions.is_readonly', autospec=True, return_value=readonly
+    )
+    assert JwtIsStaffModeratorOrReadonlyPermission().has_permission(request, view) is expected
+    is_readonly_mock.assert_called_once_with(request)
+    if is_staff_jwt_mock.called:
+        is_staff_jwt_mock.assert_called_once_with(request)
+    if is_moderator_mock.called:
+        is_moderator_mock.assert_called_once_with(request, view)
+
+
+@pytest.mark.parametrize('exception_cls', [
+    PrawRedirect,
+    PrawForbidden,
+])
+def test_is_staff_moderator_or_readonly_exceptions(mocker, jwt_token, exception_cls):
+    """
+    Test that user is deemed not a moderator if praw raises a forbidden or redirect error
+    """
+    perm = JwtIsStaffModeratorOrReadonlyPermission()
+    request = mocker.Mock(auth=jwt_token)
+    request.channel_api = mocker.patch('channels.api.Api').return_value
+    request.channel_api.is_moderator.side_effect = exception_cls(mocker.MagicMock(headers={
+        'location': '/'
+    }))
+    view = mocker.Mock(kwargs=dict(channel_name='abc'))
+    assert perm.has_permission(request, view) is False
+
+
+@pytest.mark.parametrize('is_staff, mod_editable, moderator, expected', [
+    [True, True, True, True],
+    [True, True, False, True],
+    [True, False, True, True],
+    [True, False, False, True],
+    [False, True, True, True],
+    [False, True, False, False],
+    [False, False, True, False],
+    [False, False, False, False],
+])
+def test_contributor_permission(mocker, is_staff, mod_editable, moderator, expected):
+    """
+    Test who can view and edit via the contributor REST API
+    """
+    request, view = mocker.Mock(), mocker.Mock()
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    is_moderator_mock = mocker.patch(
+        'open_discussions.permissions.is_moderator', autospec=True, return_value=moderator
+    )
+    channel_is_mod_editable_mock = mocker.patch(
+        'open_discussions.permissions.channel_is_mod_editable', autospec=True, return_value=mod_editable
+    )
+    assert ContributorPermissions().has_permission(request, view) is expected
+    is_staff_jwt_mock.assert_called_once_with(request)
+    if is_moderator_mock.called:
+        is_moderator_mock.assert_called_once_with(request, view)
+    if channel_is_mod_editable_mock.called:
+        channel_is_mod_editable_mock.assert_called_once_with(view)
+
+
+@pytest.mark.parametrize('readonly, is_staff, mod_editable, moderator, expected', [
+    [True, True, True, True, True],
+    [True, True, True, False, True],
+    [True, True, False, True, True],
+    [True, True, False, False, True],
+    [True, False, True, True, True],
+    [True, False, True, False, True],
+    [True, False, False, True, True],
+    [True, False, False, False, True],
+    [False, True, True, True, True],
+    [False, True, True, False, True],
+    [False, True, False, True, True],
+    [False, True, False, False, True],
+    [False, False, True, True, True],
+    [False, False, True, False, False],
+    [False, False, False, True, False],
+    [False, False, False, False, False],
+])  # pylint: disable=too-many-arguments
+def test_moderator_permission(mocker, readonly, is_staff, mod_editable, moderator, expected):
+    """
+    Test who can view and edit via the moderator REST API
+    """
+    request, view = mocker.Mock(), mocker.Mock()
+    is_readonly_mock = mocker.patch('open_discussions.permissions.is_readonly', autospec=True, return_value=readonly)
+    is_staff_jwt_mock = mocker.patch('open_discussions.permissions.is_staff_jwt', autospec=True, return_value=is_staff)
+    is_moderator_mock = mocker.patch(
+        'open_discussions.permissions.is_moderator', autospec=True, return_value=moderator
+    )
+    channel_is_mod_editable_mock = mocker.patch(
+        'open_discussions.permissions.channel_is_mod_editable', autospec=True, return_value=mod_editable
+    )
+    assert ModeratorPermissions().has_permission(request, view) is expected
+    is_readonly_mock.assert_called_once_with(request)
+    if is_staff_jwt_mock.called:
+        is_staff_jwt_mock.assert_called_once_with(request)
+    if is_moderator_mock.called:
+        is_moderator_mock.assert_called_once_with(request, view)
+    if channel_is_mod_editable_mock.called:
+        channel_is_mod_editable_mock.assert_called_once_with(view)
 
 
 @pytest.mark.parametrize('method', ['GET', 'HEAD', 'OPTIONS', "POST", 'PUT'])


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #864 

#### What's this PR do?
Adds a check that users who are moderators can't moderate a channel which is managed by micromasters. Also some permissions refactoring

#### How should this be manually tested?
N/A
