### PR TITLE
make post body optional (frontend)

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -7,7 +7,8 @@ import {
   isLinkTypeAllowed,
   userCanPost,
   LINK_TYPE_LINK,
-  LINK_TYPE_TEXT
+  LINK_TYPE_TEXT,
+  LINK_TYPE_ANY
 } from "../lib/channels"
 import { goBackAndHandleEvent } from "../lib/util"
 import { validationMessage } from "../lib/validation"
@@ -79,12 +80,21 @@ export default class CreatePostForm extends React.Component<Props> {
     )
   }
 
+  clearInputButton = () => {
+    const { updatePostType, channel } = this.props
+
+    return channel.link_type === LINK_TYPE_ANY ? (
+      <div className="close-button" onClick={() => updatePostType(null)}>
+        <i className="material-icons clear">clear</i>
+      </div>
+    ) : null
+  }
+
   postContentInputs = () => {
     const {
       postForm,
       onUpdate,
       validation,
-      updatePostType,
       embedlyInFlight,
       embedly
     } = this.props
@@ -97,9 +107,7 @@ export default class CreatePostForm extends React.Component<Props> {
     return postType === LINK_TYPE_TEXT ? (
       <div className="text row post-content">
         <textarea placeholder="" name="text" value={text} onChange={onUpdate} />
-        <div className="close-button" onClick={() => updatePostType(null)}>
-          <i className="material-icons clear">clear</i>
-        </div>
+        {this.clearInputButton()}
         {validationMessage(validation.text)}
       </div>
     ) : (
@@ -118,9 +126,7 @@ export default class CreatePostForm extends React.Component<Props> {
         {embedlyInFlight && !embedly ? (
           <EmbedlyLoader primaryColor="#c9bfbf" secondaryColor="#c9c8c8" />
         ) : null}
-        <div className="close-button" onClick={() => updatePostType(null)}>
-          <i className="material-icons clear">clear</i>
-        </div>
+        {this.clearInputButton()}
         {validationMessage(validation.url)}
       </div>
     )

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -7,7 +7,7 @@ import sinon from "sinon"
 import CreatePostForm from "./CreatePostForm"
 import Embedly, { EmbedlyLoader } from "./Embedly"
 
-import { LINK_TYPE_LINK, LINK_TYPE_TEXT } from "../lib/channels"
+import { LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_ANY } from "../lib/channels"
 import * as channels from "../lib/channels"
 import { makeChannel } from "../factories/channels"
 import { makeArticle } from "../factories/embedly"
@@ -71,6 +71,24 @@ describe("CreatePostForm", () => {
       postForm
     })
     assert.equal(wrapper.find(".text .validation-message").text(), "HEY")
+  })
+
+  //
+  ;[
+    [LINK_TYPE_ANY, LINK_TYPE_LINK, true],
+    [LINK_TYPE_ANY, LINK_TYPE_TEXT, true],
+    [LINK_TYPE_TEXT, LINK_TYPE_TEXT, false],
+    [LINK_TYPE_LINK, LINK_TYPE_LINK, false]
+  ].forEach(([channelType, selectedType, showClosebutton]) => {
+    it(`${
+      showClosebutton ? "should" : "should not"
+    } show clear button when channel ${channelType} and form has ${selectedType}`, () => {
+      const postForm = { ...newPostForm(), postType: selectedType }
+      const channel = makeChannel()
+      channel.link_type = channelType
+      const wrapper = renderPostForm({ postForm, channel })
+      assert.equal(wrapper.find(".close-button").exists(), showClosebutton)
+    })
   })
 
   it("should show url validation message", () => {

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -54,14 +54,7 @@ export const PostTitleAndHostname = ({ post }: { post: Post }) => (
 export const getPostDropdownMenuKey = (post: Post) => `POST_DROPDOWN_${post.id}`
 
 export const formatPostTitle = (post: Post) =>
-  post.text ? (
-    <Link
-      className="post-title"
-      to={postDetailURL(post.channel_name, post.id, post.slug)}
-    >
-      {post.title}
-    </Link>
-  ) : (
+  post.url ? (
     <div>
       <a
         className="post-title"
@@ -73,6 +66,13 @@ export const formatPostTitle = (post: Post) =>
       </a>
       <span className="url-hostname">{`(${urlHostname(post.url)})`}</span>
     </div>
+  ) : (
+    <Link
+      className="post-title"
+      to={postDetailURL(post.channel_name, post.id, post.slug)}
+    >
+      {post.title}
+    </Link>
   )
 
 type PostVotingProps = {

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -4,8 +4,8 @@ import React from "react"
 import R from "ramda"
 
 import { S } from "./sanctuary"
+import { LINK_TYPE_LINK } from "../lib/channels"
 
-import { isTextTabSelected } from "../lib/channels"
 import type { PostForm } from "../flow/discussionTypes"
 
 export const PASSWORD_LENGTH_MINIMUM = 8
@@ -60,23 +60,7 @@ export const postUrlOrTextPresent = (postForm: { value: PostForm }) => {
   }
 
   const post = postForm.value
-  if (!postForm.value.postType) {
-    return S.Just(
-      R.set(
-        R.lensPath(["value", "post_type"]),
-        "You must either add text or a link to your post"
-      )
-    )
-  }
-  const isText = isTextTabSelected(postForm.value.postType, null)
-
-  if (isText && emptyOrNil(post.text)) {
-    return S.Just(
-      R.set(R.lensPath(["value", "text"]), "Post text cannot be empty")
-    )
-  }
-
-  if (!isText && emptyOrNil(post.url)) {
+  if (post.postType === LINK_TYPE_LINK && emptyOrNil(post.url)) {
     return S.Just(
       R.set(R.lensPath(["value", "url"]), "Post url cannot be empty")
     )

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -114,13 +114,9 @@ describe("validation library", () => {
       })
     })
 
-    it("should complain about no text on a text post", () => {
+    it("should not complain about no text on a text post", () => {
       const post = { value: { postType: LINK_TYPE_TEXT, title: "potato" } }
-      assert.deepEqual(validatePostCreateForm(post), {
-        value: {
-          text: "Post text cannot be empty"
-        }
-      })
+      assert.deepEqual(validatePostCreateForm(post), {})
     })
 
     it("should complain about no url on a url post", () => {
@@ -128,15 +124,6 @@ describe("validation library", () => {
       assert.deepEqual(validatePostCreateForm(post), {
         value: {
           url: "Post url cannot be empty"
-        }
-      })
-    })
-
-    it("should complain about missing post type", () => {
-      const post = { value: { postType: null, title: "potato" } }
-      assert.deepEqual(validatePostCreateForm(post), {
-        value: {
-          post_type: "You must either add text or a link to your post"
         }
       })
     })


### PR DESCRIPTION
#### What are the relevant tickets?

closes #923 
closes #909 

#### What's this PR do?

This makes the changes necessary on the frontend to allow for empty text posts to go through, and also makes the change to only show the inputs for the allowed post type on channels which are not `LINK_TYPE_ANY`.

#### How should this be manually tested?

On channels which allow all types (or text posts) you should be able to submit an empty post (i.e. just a title) and you should be able to submit a link or text post as normal.

On channels which only allow one or the other type of post you should see just the input for the corresponding post type when you go to submit a post. You should not be allowed to submit an 'empty' post (without url) on a link-only subreddit.

also, if on a link or text only subreddit, you shouldn't see the little 'x' button that normally appears on the upper right of the post content input.

It should handle switching between different subreddits in the create post page relatively well.