### PR TITLE
Fix adding contributors and moderators by email

### DIFF
--- a/cassettes/channels.views.contributors_test.test_add_contributor_email.json
+++ b/cassettes/channels.views.contributors_test.test_add_contributor_email.json
@@ -1,0 +1,578 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-07-20T15:57:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6J1QDZSDJBJ9YEEJ2ZZ1Z"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0N9Q1cosycvI3z84qLahMDTQ2LgkKD3GKtDRxN0xW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZpGVlFMYHhlRURZlUFfjkuxlZ5gQaeqUbJbuC9KSklmUmp8ZnpoAMhnCUagHDuo0/uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 15:57:31 GMT",
+            "loidcreated=2018-07-20T15%3A57%3A31.243Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 15:57:31 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6J1QDZSDJBJ9YEEJ2ZZ1Z"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Quae+adipisci+pariatur+vitae+odio+recusandae+laborum.+Dignissimos+ea+iste+eum.+Vero+in+odio+nobis+iure+neque.%0ASint+quas+deserunt+animi+qui+dolorum+beatae+inventore.+Quod+officiis+quos+iusto+placeat.+Nemo+omnis+a+maxime+ratione+ex+quos+esse+minus.+Expedita+quaerat+porro+quam+perspiciatis+mollitia+quo+unde.%0AAt+totam+assumenda+consequatur+vitae+provident+dicta+exercitationem.+Odit+sint+harum+quae+qui+ipsa+neque+corporis+et.+Assumenda+nisi+harum+nobis+doloremque+incidunt.&link_type=any&name=1532102251_laboriosam&public_description=Nisi+ipsam+aliquam+quaerat+a+animi+quisquam+est.+Sed+facere+adipisci+a+natus+quia+repellendus.&title=Aliquid+suscipit+aliquam+libero+voluptas.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 171-2FZ2BO7kjupyeQ33tRWTBY94G1c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "735"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "149"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6J8362ZFE2N6YWNQQXGFW"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0N9L1DzFxMfL2qCg18gwzj0hLKs2PCsr0S3LLcvVV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5upV4W1hWehhllXuGeZcUhhs5m7n4R5oZBhSD9KSklmUmp8ZnpoAMhnCUagEWNuGDuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6J8362ZFE2N6YWNQQXGFW"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6JBBGXRH9EQ4CJYSYRJJT"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA02N0QqCMBiFX0X+y0jQKYndJRQRKBUV1M2Y2x9OYY5tRBm9ey5vujyH833nDYxztJa6vkMFywDiLAnr7LhJs4a6yzCQgyotUzpt2raqrjAPAJ9aGrRUeiBZRNHY/XjqXhq9pEZm0Pit5f1UzXwyeB/BUfz/tj2RWxOec0bKfCc75fSaFWIVD3vrGYEPyZFK4cVTgM8XRHOwq7gAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:41 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW6JBBGXRH9EQ4CJYSYRJJT"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CJW6J8362ZFE2N6YWNQQXGFW&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 171-2FZ2BO7kjupyeQ33tRWTBY94G1c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532102251_laboriosam/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:41 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "139"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532102251_laboriosam/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 172-OT4D2KHxu2IV7XfbuoZRiNbFjEM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532102251_laboriosam/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:41 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "139"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532102251_laboriosam/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T15:57:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CJW6JBBGXRH9EQ4CJYSYRJJT&type=contributor"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 171-2FZ2BO7kjupyeQ33tRWTBY94G1c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "62"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=yoWoqaRIlNhLCixs9R; loidcreated=2018-07-20T15%3A57%3A31.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532102251_laboriosam/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 15:57:41 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "139"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532102251_laboriosam/api/friend/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.moderators_test.test_add_moderator_email.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator_email.json
@@ -1,0 +1,759 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-07-20T14:51:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SDRABTTY8Q8CQSCS9E28"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0s9B1NTUzDIuMT6vySLLMy40IcywPr8qvcnTMcvNV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZ+BUZZTilBnll6+Z7G8dHpcQXhnuaGeUYmKeD9KSklmUmp8ZnpoAMhnCUagHVuoDfuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:38 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 19-Jul-2020 14:51:38 GMT",
+            "loidcreated=2018-07-20T14%3A51%3A38.651Z; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 19-Jul-2020 14:51:38 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SDRABTTY8Q8CQSCS9E28"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Quidem+illum+accusantium+necessitatibus+consequatur.+Voluptatum+assumenda+adipisci+consectetur.+Ab+voluptates+ipsum+commodi+repudiandae+assumenda+officiis.+Dolores+ducimus+ipsa+voluptates.%0AOptio+non+non+at+voluptates+similique+quibusdam+optio.+Libero+iure+nemo+quae+sit.+Voluptate+magnam+deserunt+doloribus+voluptatum+ex+iste.+Eaque+assumenda+nam+quam.&link_type=any&name=1532098298_ullam&public_description=Excepturi+distinctio+aut+fuga+tenetur.+Dolore+quis+magni+quam.+Magnam+dolor+illum+dolore+eaque.&title=Ipsam+eum+harum+error+quod+ut+ipsa.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "603"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "502"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SM8A2XJVPE3BC8NH5WV2"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGAmTyqyboIJ0UTqEXYbbPtkYNPk2pYj+ey5PHd+H93nfN+mFAOeYtwYe5ByRJD3FnKsbFcmE6uoPmaxM4i+Ols2sDdlGBJ6jRnBMB2GXUrqwn8/8a4QwwqFHwNB1wq5oExLCsIjq/y0rMab3eiqqoTi2ts5pi2IPDXRdcCTMWgDTMgyvgXy+E3UjEbgAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SM8A2XJVPE3BC8NH5WV2"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SQH42V47Y4MKH5R0V1TD"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNXQvCIBiF/8rwMho4Riu6bRDRJzQIupGlb+UMHWqmi/57s111eR7Oc84b1ZSCMcQqARLNE5RNcRr0Gecpk67z8kGDmu2cL22TLZVC4wSBb7kGQ3gU8gLjnv18YkMLceQCtQYdu4aqAY1i0nDtxfv/G+2OxekWnnshmlBuK3dYrRebCk/gFR0GjlMgnMXhIaDPF3E35ty4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:48 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SQH42V47Y4MKH5R0V1TD"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CJW2SM8A2XJVPE3BC8NH5WV2&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "492"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 169-bbhW0c1urhSt58dFk1tKs0EPvik"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "491"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CJW2SQH42V47Y4MKH5R0V1TD&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "491"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 170-yrZ03-dnvzxnlcyo8NvxDtj1Goo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "491"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T14:51:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CJW2SQH42V47Y4MKH5R0V1TD/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CJW2SQH42V47Y4MKH5R0V1TD\", \"is_friend\": false, \"created\": 1532098308.0, \"hide_from_robots\": false, \"created_utc\": 1532098308.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"4q\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 14:51:49 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "491"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=pRKdsS%2F%2BwVdMr5AhhP0IiqWhD8tfImYRZMf3ihckIuiOJG3nGqmjvvYfaNxlMfsL4TxN5aSJMX8%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CJW2SQH42V47Y4MKH5R0V1TD/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -605,6 +605,14 @@ class ContributorSerializer(serializers.Serializer):
             raise ValidationError("contributor name is not a valid user")
         return {'contributor_name': value}
 
+    def validate_email(self, value):
+        """Validates the contributor email"""
+        if not isinstance(value, str):
+            raise ValidationError("email must be a string")
+        if not User.objects.filter(email__iexact=value).exists():
+            raise ValidationError("email does not exist")
+        return {'email': value}
+
     def create(self, validated_data):
         api = self.context['channel_api']
         channel_name = self.context['view'].kwargs['channel_name']
@@ -658,6 +666,14 @@ class ModeratorPrivateSerializer(serializers.Serializer):
         if not User.objects.filter(username=value).exists():
             raise ValidationError("moderator name is not a valid user")
         return {'moderator_name': value}
+
+    def validate_email(self, value):
+        """Validates the moderator email"""
+        if not isinstance(value, str):
+            raise ValidationError("email must be a string")
+        if not User.objects.filter(email__iexact=value).exists():
+            raise ValidationError("email does not exist")
+        return {'email': value}
 
     def create(self, validated_data):
         api = self.context['channel_api']

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -579,6 +579,28 @@ class GenericCommentSerializer(serializers.Serializer):
         raise ValueError('Unknown type {} in the comments list'.format(type(instance)))
 
 
+def _validate_username(key, value):
+    """
+    Helper function to validate the username
+    """
+    if not isinstance(value, str):
+        raise ValidationError("username must be a string")
+    if not User.objects.filter(username=value).exists():
+        raise ValidationError("username is not a valid user")
+    return {key: value}
+
+
+def _validate_email(value):
+    """
+    Helper function to validate email
+    """
+    if not isinstance(value, str):
+        raise ValidationError("email must be a string")
+    if not User.objects.filter(email__iexact=value).exists():
+        raise ValidationError("email does not exist")
+    return {'email': value}
+
+
 class ContributorSerializer(serializers.Serializer):
     """Serializer for contributors. Should be accessible by moderators only"""
     contributor_name = WriteableSerializerMethodField()
@@ -599,19 +621,11 @@ class ContributorSerializer(serializers.Serializer):
 
     def validate_contributor_name(self, value):
         """Validates the contributor name"""
-        if not isinstance(value, str):
-            raise ValidationError("contributor name must be a string")
-        if not User.objects.filter(username=value).exists():
-            raise ValidationError("contributor name is not a valid user")
-        return {'contributor_name': value}
+        return _validate_username('contributor_name', value)
 
     def validate_email(self, value):
         """Validates the contributor email"""
-        if not isinstance(value, str):
-            raise ValidationError("email must be a string")
-        if not User.objects.filter(email__iexact=value).exists():
-            raise ValidationError("email does not exist")
-        return {'email': value}
+        return _validate_email(value)
 
     def create(self, validated_data):
         api = self.context['channel_api']
@@ -661,19 +675,11 @@ class ModeratorPrivateSerializer(serializers.Serializer):
 
     def validate_moderator_name(self, value):
         """Validates the moderator name"""
-        if not isinstance(value, str):
-            raise ValidationError("moderator name must be a string")
-        if not User.objects.filter(username=value).exists():
-            raise ValidationError("moderator name is not a valid user")
-        return {'moderator_name': value}
+        return _validate_username('moderator_name', value)
 
     def validate_email(self, value):
         """Validates the moderator email"""
-        if not isinstance(value, str):
-            raise ValidationError("email must be a string")
-        if not User.objects.filter(email__iexact=value).exists():
-            raise ValidationError("email does not exist")
-        return {'email': value}
+        return _validate_email(value)
 
     def create(self, validated_data):
         api = self.context['channel_api']

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -251,6 +251,26 @@ def test_contributor_validate_name():
     assert ContributorSerializer().validate_contributor_name(user.username) == {'contributor_name': user.username}
 
 
+def test_contributor_validate_email_no_string():
+    """validate the input in case the value is not a string"""
+    with pytest.raises(ValidationError) as ex:
+        ContributorSerializer().validate_email(None)
+    assert ex.value.args[0] == 'email must be a string'
+
+
+def test_contributor_validate_email_no_valid_user():
+    """validate the input in case the user does not exists in the DB"""
+    with pytest.raises(ValidationError) as ex:
+        ContributorSerializer().validate_email('foo_user')
+    assert ex.value.args[0] == 'email does not exist'
+
+
+def test_contributor_validate_email():
+    """validate the input"""
+    user = UserFactory.create()
+    assert ContributorSerializer().validate_email(user.email) == {'email': user.email}
+
+
 def test_contributor_create_username():
     """Adds a contributor by username"""
     user = UserFactory.create()
@@ -353,6 +373,26 @@ def test_moderator_validate_name():
     """validate the input"""
     user = UserFactory.create()
     assert ModeratorPrivateSerializer().validate_moderator_name(user.username) == {'moderator_name': user.username}
+
+
+def test_moderator_validate_email_no_string():
+    """validate the input in case the value is not a string"""
+    with pytest.raises(ValidationError) as ex:
+        ModeratorPrivateSerializer().validate_email(None)
+    assert ex.value.args[0] == 'email must be a string'
+
+
+def test_moderator_validate_email_no_valid_user():
+    """validate the input in case the user does not exists in the DB"""
+    with pytest.raises(ValidationError) as ex:
+        ModeratorPrivateSerializer().validate_email('foo_user')
+    assert ex.value.args[0] == 'email does not exist'
+
+
+def test_moderator_validate_email():
+    """validate the input"""
+    user = UserFactory.create()
+    assert ModeratorPrivateSerializer().validate_email(user.email) == {'email': user.email}
 
 
 def test_moderator_create_username():

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -235,14 +235,14 @@ def test_contributor_validate_name_no_string():
     """validate the input in case the value is not a string"""
     with pytest.raises(ValidationError) as ex:
         ContributorSerializer().validate_contributor_name(None)
-    assert ex.value.args[0] == 'contributor name must be a string'
+    assert ex.value.args[0] == 'username must be a string'
 
 
 def test_contributor_validate_name_no_valid_user():
     """validate the input in case the user does not exists in the DB"""
     with pytest.raises(ValidationError) as ex:
         ContributorSerializer().validate_contributor_name('foo_user')
-    assert ex.value.args[0] == 'contributor name is not a valid user'
+    assert ex.value.args[0] == 'username is not a valid user'
 
 
 def test_contributor_validate_name():
@@ -359,14 +359,14 @@ def test_moderator_validate_name_no_string():
     """validate the input in case the value is not a string"""
     with pytest.raises(ValidationError) as ex:
         ModeratorPrivateSerializer().validate_moderator_name(None)
-    assert ex.value.args[0] == 'moderator name must be a string'
+    assert ex.value.args[0] == 'username must be a string'
 
 
 def test_moderator_validate_name_no_valid_user():
     """validate the input in case the user does not exists in the DB"""
     with pytest.raises(ValidationError) as ex:
         ModeratorPrivateSerializer().validate_moderator_name('foo_user')
-    assert ex.value.args[0] == 'moderator name is not a valid user'
+    assert ex.value.args[0] == 'username is not a valid user'
 
 
 def test_moderator_validate_name():

--- a/channels/views/contributors_test.py
+++ b/channels/views/contributors_test.py
@@ -54,6 +54,26 @@ def test_add_contributor(client, staff_jwt_header):
     }
 
 
+def test_add_contributor_email(client, public_channel, staff_jwt_header, staff_api, reddit_factories):
+    """
+    Adds a contributor to a channel by email
+    """
+    moderator = reddit_factories.user("mod_user1")
+    new_contributor = reddit_factories.user("new_mod_user")
+    staff_api.add_moderator(moderator.username, public_channel.name)
+    client.force_login(moderator)
+
+    url = reverse('contributor-list', kwargs={'channel_name': public_channel.name})
+    resp = client.post(url, data={'email': new_contributor.email}, format='json', **staff_jwt_header)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.json() == {
+        'contributor_name': new_contributor.username,
+        'email': new_contributor.email,
+        'full_name': new_contributor.profile.name,
+    }
+
+
 def test_add_contributor_again(client, staff_jwt_header):
     """
     If the user is already a contributor a 201 status should be returned

--- a/channels/views/moderators_test.py
+++ b/channels/views/moderators_test.py
@@ -94,6 +94,26 @@ def test_add_moderator(client, staff_jwt_header):
     }
 
 
+def test_add_moderator_email(client, public_channel, staff_jwt_header, staff_api, reddit_factories):
+    """
+    Adds a moderator to a channel by email
+    """
+    existing_mod_user = reddit_factories.user("mod_user1")
+    new_mod_user = reddit_factories.user("new_mod_user")
+    staff_api.add_moderator(existing_mod_user.username, public_channel.name)
+    client.force_login(existing_mod_user)
+
+    url = reverse('moderator-list', kwargs={'channel_name': public_channel.name})
+    resp = client.post(url, data={'email': new_mod_user.email}, format='json', **staff_jwt_header)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.json() == {
+        'moderator_name': new_mod_user.username,
+        'email': new_mod_user.email,
+        'full_name': new_mod_user.profile.name,
+    }
+
+
 def test_add_moderator_again(client, staff_jwt_header):
     """
     If a user is already a moderator we should return 201 without making any changes

--- a/factory_data/channels.views.contributors_test.test_add_contributor_email.json
+++ b/factory_data/channels.views.contributors_test.test_add_contributor_email.json
@@ -1,0 +1,22 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Quae adipisci pariatur vitae odio recusandae laborum. Dignissimos ea iste eum. Vero in odio nobis iure neque.\nSint quas deserunt animi qui dolorum beatae inventore. Quod officiis quos iusto placeat. Nemo omnis a maxime ratione ex quos esse minus. Expedita quaerat porro quam perspiciatis mollitia quo unde.\nAt totam assumenda consequatur vitae provident dicta exercitationem. Odit sint harum quae qui ipsa neque corporis et. Assumenda nisi harum nobis doloremque incidunt.",
+      "name": "1532102251_laboriosam",
+      "public_description": "Nisi ipsam aliquam quaerat a animi quisquam est. Sed facere adipisci a natus quia repellendus.",
+      "title": "Aliquid suscipit aliquam libero voluptas."
+    }
+  },
+  "users": {
+    "mod_user1": {
+      "username": "01CJW6J8362ZFE2N6YWNQQXGFW"
+    },
+    "new_mod_user": {
+      "username": "01CJW6JBBGXRH9EQ4CJYSYRJJT"
+    },
+    "staff_user": {
+      "username": "01CJW6J1QDZSDJBJ9YEEJ2ZZ1Z"
+    }
+  }
+}

--- a/factory_data/channels.views.moderators_test.test_add_moderator_email.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator_email.json
@@ -1,0 +1,22 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Quidem illum accusantium necessitatibus consequatur. Voluptatum assumenda adipisci consectetur. Ab voluptates ipsum commodi repudiandae assumenda officiis. Dolores ducimus ipsa voluptates.\nOptio non non at voluptates similique quibusdam optio. Libero iure nemo quae sit. Voluptate magnam deserunt doloribus voluptatum ex iste. Eaque assumenda nam quam.",
+      "name": "1532098298_ullam",
+      "public_description": "Excepturi distinctio aut fuga tenetur. Dolore quis magni quam. Magnam dolor illum dolore eaque.",
+      "title": "Ipsam eum harum error quod ut ipsa."
+    }
+  },
+  "users": {
+    "mod_user1": {
+      "username": "01CJW2SM8A2XJVPE3BC8NH5WV2"
+    },
+    "new_mod_user": {
+      "username": "01CJW2SQH42V47Y4MKH5R0V1TD"
+    },
+    "staff_user": {
+      "username": "01CJW2SDRABTTY8Q8CQSCS9E28"
+    }
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #864 

#### What's this PR do?
The REST API to add contributors and moderators by email wasn't working. This adds a fix for those cases and some tests which exercise the REST API view rather than just the serializer.

#### How should this be manually tested?
N/A, no UI yet
