### PR TITLE
layout tweaks

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -33,6 +33,9 @@ const Navigation = (props: NavigationProps) => {
       ? userCanPost(currentChannel)
       : R.any(userCanPost, [...channels.values()]))
 
+  const homeClassName =
+    pathname === "/" ? "location current-location" : "location"
+
   return (
     <div className="navigation">
       {showPostButton ? (
@@ -43,10 +46,14 @@ const Navigation = (props: NavigationProps) => {
           Submit a New Post
         </Link>
       ) : null}
-      <Link className="home-link" to={FRONTPAGE_URL}>
-        <i className="material-icons home">home</i>
-        Home
-      </Link>
+      <div className="location-list">
+        <div className={homeClassName}>
+          <Link className="home-link" to={FRONTPAGE_URL}>
+            <i className="material-icons home">home</i>
+            Home
+          </Link>
+        </div>
+      </div>
       <SubscriptionsList
         currentChannel={channelName}
         subscribedChannels={subscribedChannels}

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -52,6 +52,28 @@ describe("Navigation", () => {
       assert.equal(props.children, "Submit a New Post")
     })
 
+    it("should highlight the home link if, well, home", () => {
+      const wrapper = renderComponent()
+      assert.ok(
+        wrapper
+          .find(".location.current-location")
+          .find(".home-link")
+          .exists()
+      )
+    })
+
+    it("shouldn't highlight the homelink if not home!", () => {
+      defaultProps.pathname = "/hfodfo/asdfasdfasdf"
+      const wrapper = renderComponent()
+      defaultProps.pathname = "/hfodfo/asdfasdfasdf"
+      assert.isNotOk(
+        wrapper
+          .find(".location.current-location")
+          .find(".home-link")
+          .exists()
+      )
+    })
+
     it("create post link should have channel name if channelName is in URL", () => {
       const wrapper = renderComponent({
         ...defaultProps,

--- a/static/js/components/SortPicker.js
+++ b/static/js/components/SortPicker.js
@@ -15,7 +15,6 @@ type PostSortProps = {
 const SortPicker = R.curry(
   (labels, { updateSortParam, value }: PostSortProps) => (
     <div className="sorter">
-      <div className="sort-label">Sort:</div>
       <select onChange={updateSortParam} value={value}>
         {labels.map(([type, label]) => (
           <option label={label} value={type} key={type}>

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -11,16 +11,14 @@ type Props = {
 }
 
 const channelClassName = (channelName, currentChannel) =>
-  currentChannel === channelName
-    ? "channelname current-location"
-    : "channelname"
+  currentChannel === channelName ? "location current-location" : "location"
 
 export default class SubscriptionsList extends React.Component<Props> {
   render() {
     const { subscribedChannels, currentChannel } = this.props
 
     return (
-      <div className="subscriptions">
+      <div className="location-list subscribed-channels">
         {subscribedChannels.map(channel => (
           <div
             className={channelClassName(channel.name, currentChannel)}

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -32,10 +32,7 @@ describe("SubscriptionsList", function() {
     const wrapper = renderSubscriptionsList()
     const currentLocation = wrapper.find(".current-location")
     assert.lengthOf(currentLocation, 1)
-    assert.equal(
-      currentLocation.props().className,
-      "channelname current-location"
-    )
+    assert.equal(currentLocation.props().className, "location current-location")
     assert.equal(currentLocation.children().props().children, channels[0].title)
     assert.equal(
       currentLocation.children().props().to,

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -17,6 +17,14 @@ type Props = {
   showUserMenu: boolean
 }
 
+export const DropDownArrow = () => (
+  <i className="material-icons arrow_drop_down">arrow_drop_down</i>
+)
+
+export const DropUpArrow = () => (
+  <i className="material-icons arrow_drop_up">arrow_drop_up</i>
+)
+
 export default class UserMenu extends React.Component<Props> {
   render() {
     const { toggleShowUserMenu, showUserMenu, profile } = this.props
@@ -30,6 +38,7 @@ export default class UserMenu extends React.Component<Props> {
           onClick={toggleShowUserMenu}
           imageSize={PROFILE_IMAGE_SMALL}
         />
+        {showUserMenu ? <DropUpArrow /> : <DropDownArrow />}
         {SETTINGS.profile_ui_enabled && !isProfileComplete(profile) ? (
           <div className="profile-incomplete" />
         ) : null}

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -6,7 +6,7 @@ import { shallow } from "enzyme"
 import sinon from "sinon"
 import { Link } from "react-router-dom"
 
-import UserMenu from "./UserMenu"
+import UserMenu, { DropDownArrow, DropUpArrow } from "./UserMenu"
 import DropdownMenu from "./DropdownMenu"
 
 import { profileURL, SETTINGS_URL } from "../lib/url"
@@ -38,12 +38,13 @@ describe("UserMenu", () => {
     sandbox.restore()
   })
 
-  const renderUserMenu = () =>
+  const renderUserMenu = (props = {}) =>
     shallow(
       <UserMenu
         toggleShowUserMenu={toggleShowUserMenuStub}
         showUserMenu={showUserMenu}
         profile={profile}
+        {...props}
       />
     )
 
@@ -55,14 +56,17 @@ describe("UserMenu", () => {
   })
 
   it("should render the dropdown if showUserMenu", () => {
-    [true, false].forEach(showUserMenuValue => {
-      showUserMenu = showUserMenuValue
-      const wrapper = renderUserMenu()
-      if (showUserMenu) {
-        assert.isOk(wrapper.find(DropdownMenu).exists())
-      } else {
-        assert.isNotOk(wrapper.find(DropdownMenu).exists())
-      }
+    [true, false].forEach(showUserMenu => {
+      const wrapper = renderUserMenu({ showUserMenu })
+      assert.equal(showUserMenu, wrapper.find(DropdownMenu).exists())
+    })
+  })
+
+  it("should show a drop-down or -up menu, depending on showUserMenu", () => {
+    [true, false].forEach(showUserMenu => {
+      const wrapper = renderUserMenu({ showUserMenu })
+      assert.equal(showUserMenu, wrapper.find(DropUpArrow).exists())
+      assert.equal(!showUserMenu, wrapper.find(DropDownArrow).exists())
     })
   })
 

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -11,7 +11,6 @@ import withLoading from "../components/Loading"
 import PostListNavigation from "../components/PostListNavigation"
 import withChannelSidebar from "../hoc/withChannelSidebar"
 import { PostSortPicker } from "../components/SortPicker"
-import { ChannelBreadcrumbs } from "../components/ChannelBreadcrumbs"
 import {
   withPostModeration,
   postModerationSelector
@@ -140,7 +139,6 @@ class ChannelPage extends React.Component<ChannelPageProps> {
           <MetaTags>
             <title>{formatTitle(channel.title)}</title>
           </MetaTags>
-          <ChannelBreadcrumbs channel={channel} />
           <div className="post-list-title">
             <div>{channel.title}</div>
             <PostSortPicker

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -23,3 +23,4 @@ $navigation-text: rgba(0, 0, 0, 0.77);
 $subscribed-yellow: #fcffb0;
 $toolbar-height-desktop: 76px;
 $toolbar-height-mobile: 68px;
+$drawer-width: 300px;

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -3,6 +3,11 @@
   left: 0;
   height: calc(100vh - #{$toolbar-height-desktop});
   top: $toolbar-height-desktop;
+  width: $drawer-width;
+
+  .mdc-drawer__drawer {
+    width: $drawer-width;
+  }
 
   @include breakpoint(materialmobile) {
     height: calc(100vh - #{$toolbar-height-mobile});

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -56,7 +56,7 @@ body {
   min-height: 100vh;
 
   .persistent-drawer-open + .content {
-    padding-left: 240px;
+    padding-left: $drawer-width;
   }
 
   .content {

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -28,7 +28,8 @@ a.mitlogo {
 
   .user-menu-section {
     flex-grow: unset;
-    height: 49px;
+    padding-right: 0;
+    align-items: center;
   }
 }
 
@@ -43,8 +44,7 @@ a.mitlogo {
     margin-left: 36px;
   }
 
-  .mdc-button,
-  .home-link {
+  .mdc-button {
     width: 87%;
     height: 43px;
     line-height: 43px;
@@ -54,17 +54,6 @@ a.mitlogo {
     padding: 0 5px;
     box-shadow: none;
     margin-left: 14px;
-  }
-
-  .home-link {
-    display: flex;
-    align-items: center;
-    margin-top: 10px;
-    color: $navigation-text;
-
-    i {
-      margin-right: 10px;
-    }
   }
 
   .mdc-button:hover {
@@ -100,16 +89,35 @@ a.mitlogo {
   }
 }
 
-.subscriptions {
-  margin: 15px 0 20px;
-  width: 100%;
-  padding: 16px 0 18px 0;
-  box-sizing: border-box;
-  border: 1px solid $border-grey-alt;
-  border-width: 1px 0;
+.current-location {
+  background-color: $bg-grey;
+}
 
-  .channelname {
+.location-list {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 10px 0 5px;
+
+  &.subscribed-channels {
+    border: 1px solid $border-grey-alt;
+    border-width: 1px 0;
+    padding: 16px 0 18px 0;
+    margin: 15px 0 20px;
+  }
+
+  .location {
     margin: 0 0 0 0;
+
+    .home-link {
+      display: flex;
+      align-items: center;
+      margin-top: 10px;
+      color: $navigation-text;
+
+      i {
+        margin-right: 10px;
+      }
+    }
 
     a {
       color: $navigation-text;

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-bottom: 15px;
 }
 
 .post-list {

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -38,8 +38,6 @@
 
 .profile-image-container {
   display: flex;
-  float: left;
-  padding: 0px 15px 15px 0px;
 
   .avatar {
     position: relative;

--- a/static/scss/sort-picker.scss
+++ b/static/scss/sort-picker.scss
@@ -3,12 +3,6 @@
   align-items: center;
   height: 30px;
 
-  .sort-label {
-    color: $font-grey;
-    margin-right: 5px;
-    font-size: 16px;
-  }
-
   select {
     width: 90px;
     height: 20px;

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -1,12 +1,12 @@
 .user-menu {
   position: relative;
   cursor: pointer;
+  margin-right: 30px;
 
-  @include breakpoint(mobile) {
-    margin-right: 15px;
-  }
-
-  @include breakpoint(desktop) {
-    margin-right: 150px;
+  i {
+    color: black;
+    position: absolute;
+    top: 28px;
+    right: -6px;
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this makes a variety of little tweaks:

- profile image layout (in the toolbar up top) changed so that it is always a fixed 30px from the right edge of the screen, and also centered vertically (there was some `float: left` on there for some reason).
- add a little up or down arrow to the profile image menu
- make the drawer 300px wide, instead of 240px
- highlight 'home' in the left-side navigation sidebar the same way we do the current channel
- add 15px padding below the post list title and sort selector
- remove the channel breadcrumbs from the channel page
- remove the `"Sort:"` copy from the sort selector

...I think that should be it. Mostly cosmetic changes, not a whole lot that is functionally different.

#### How should this be manually tested?

Make sure all the things listed above work well, and nothing is broken. Check mobile display of everything to make sure it looks ok.
