### PR TITLE
Add membership notice and alert tab visibility based on channel type

### DIFF
--- a/static/js/components/admin/MembersNavbar.js
+++ b/static/js/components/admin/MembersNavbar.js
@@ -2,27 +2,34 @@
 import React from "react"
 import NavLink from "react-router-dom/NavLink"
 
+import { CHANNEL_TYPE_PUBLIC } from "../../lib/channels"
 import {
   editChannelModeratorsURL,
   editChannelContributorsURL
 } from "../../lib/url"
 
+import type { Channel } from "../../flow/discussionTypes"
+
 type MembersNavbarProps = {
-  channelName: string
+  channel: Channel
 }
 
 export default class MembersNavbar extends React.Component<*, void> {
   props: MembersNavbarProps
 
   render() {
-    const { channelName } = this.props
+    const { channel } = this.props
 
     return (
       <div className="members-navbar">
-        <NavLink to={editChannelModeratorsURL(channelName)}>Moderators</NavLink>{" "}
-        <NavLink to={editChannelContributorsURL(channelName)}>
-          Contributors
-        </NavLink>
+        <NavLink to={editChannelModeratorsURL(channel.name)}>
+          Moderators
+        </NavLink>{" "}
+        {channel.channel_type !== CHANNEL_TYPE_PUBLIC ? (
+          <NavLink to={editChannelContributorsURL(channel.name)}>
+            Contributors
+          </NavLink>
+        ) : null}
       </div>
     )
   }

--- a/static/js/components/admin/MembersNavbar_test.js
+++ b/static/js/components/admin/MembersNavbar_test.js
@@ -3,27 +3,46 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 
 import MembersNavbar from "./MembersNavbar"
+
+import { makeChannel } from "../../factories/channels"
 import {
   editChannelContributorsURL,
   editChannelModeratorsURL
 } from "../../lib/url"
+import {
+  CHANNEL_TYPE_PUBLIC,
+  CHANNEL_TYPE_RESTRICTED,
+  CHANNEL_TYPE_PRIVATE
+} from "../../lib/channels"
 
 describe("MembersNavbar", () => {
-  it("shows the navbar", () => {
-    const channelName = "name"
-    const wrapper = shallow(<MembersNavbar channelName={channelName} />)
-    const links = wrapper.find("NavLink")
+  let channel
+  beforeEach(() => {
+    channel = makeChannel()
+  })
+  ;[
+    [CHANNEL_TYPE_PUBLIC, false],
+    [CHANNEL_TYPE_PRIVATE, true],
+    [CHANNEL_TYPE_RESTRICTED, true]
+  ].forEach(([channelType, showContributor]) => {
+    it(`shows the navbar for channel type ${channelType}`, () => {
+      channel.channel_type = channelType
+      const wrapper = shallow(<MembersNavbar channel={channel} />)
+      const links = wrapper.find("NavLink")
 
-    const linkPairs = [
-      ["Moderators", editChannelModeratorsURL(channelName)],
-      ["Contributors", editChannelContributorsURL(channelName)]
-    ]
+      const linkPairs = [
+        ["Moderators", editChannelModeratorsURL(channel.name)],
+        ...(showContributor
+          ? [["Contributors", editChannelContributorsURL(channel.name)]]
+          : [])
+      ]
 
-    assert.equal(links.length, linkPairs.length)
-    linkPairs.forEach(([text, url], i) => {
-      const link = links.at(i)
-      assert.equal(link.props().to, url)
-      assert.equal(link.children().text(), text)
+      assert.equal(links.length, linkPairs.length)
+      linkPairs.forEach(([text, url], i) => {
+        const link = links.at(i)
+        assert.equal(link.props().to, url)
+        assert.equal(link.children().text(), text)
+      })
     })
   })
 })

--- a/static/js/hoc/withMemberForm.js
+++ b/static/js/hoc/withMemberForm.js
@@ -53,7 +53,7 @@ const withMemberForm = (WrappedComponent: *) => {
         <React.Fragment>
           <EditChannelNavbar channelName={channel.name} />
           <Card>
-            <MembersNavbar channelName={channel.name} />
+            <MembersNavbar channel={channel} />
             <EditChannelMembersForm
               members={members}
               usernameGetter={usernameGetter}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #864 

#### What's this PR do?
Hides the contributors tab if the channel is public

#### How should this be manually tested?
For a public channel go to the members tab in the edit channel page. You should only see a tab for moderators.
