### PR TITLE
Filter out indexing user from moderator and contributor lists

### DIFF
--- a/cassettes/channels.views.contributors_test.test_list_contributors.json
+++ b/cassettes/channels.views.contributors_test.test_list_contributors.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-11T13:23:51",
+      "recorded_at": "2018-07-20T21:24:14",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ4R66W1KKBSNKAB59SHK89K"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWS89145ZWRDE98PYNQA65F"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNvQ6CMBhFX4V0NDapEolxRBPZTCAOsDRQPrEFbWn5q8Z3l8rkeE/uufeNcsbAGNrJGp7o4KHNjuCtKazeJz6uGktTuDThGJ6x6IUY0dpDMCmuwVDuBD8gZGY/n3ZWgRspINegXdcwuaCVSxpus3j/fzup6dHLKMjqIclinL7aVkE8yOh4dU4JA2dAeemGl4A+X0zKtWm4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0t9T19ylJCo4PrDJ0zkgzcDJwL3EySEkyKSz0CrdQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVORUHBkbl+biHh7pnFeWaFjumG/q6haZbFHqC9KSklmUmp8ZnpoAMhnCUagFQEFWMuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:51 GMT"
+            "Fri, 20 Jul 2018 21:24:14 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 10-Jul-2020 13:23:51 GMT",
-            "loidcreated=2018-07-11T13%3A23%3A51.337Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 10-Jul-2020 13:23:51 GMT"
+            "loid=Z2vmlGQmelRUSa5AUj; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:24:14 GMT",
+            "loidcreated=2018-07-20T21%3A24%3A13.941Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:24:14 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ4R66W1KKBSNKAB59SHK89K"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWS89145ZWRDE98PYNQA65F"
       }
     },
     {
-      "recorded_at": "2018-07-11T13:23:51",
+      "recorded_at": "2018-07-20T21:24:14",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Explicabo+tempora+voluptatibus+magnam+reiciendis.+Architecto+rem+ipsum+mollitia+dolorem.+Atque+officia+vitae+id+voluptatum.+Cum+nemo+minus+soluta+tempore.%0AExercitationem+minima+et+eum+possimus+facilis+sit+quas+cumque.+Earum+saepe+ratione+neque+nisi+voluptates+alias+tempore.%0AUt+minus+unde+autem+autem+esse.+Nesciunt+iure+nisi+dolore+tempora+ex.&link_type=any&name=1531315431_ut&public_description=Nulla+nam+libero+accusantium+libero.+Ipsum+dolore+cum+ad+dolorem+corporis+magnam+quos+accusamus.&title=Inventore+cupiditate+id+animi+soluta+quos+ipsam.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Laborum+doloribus+numquam+dolor+corporis.+Hic+facere+asperiores+dolor+reiciendis+corrupti+fuga+illo.+Consequuntur+aut+delectus+ratione+aut+cumque+ex+asperiores.%0ASunt+quibusdam+odit+magni+non.+Dolorem+aut+veritatis+assumenda+repellat.+Accusamus+accusantium+aliquid+molestiae+voluptas.&link_type=any&name=1532121854_ipsam&public_description=Dolor+laboriosam+pariatur+quae+ab+modi+vero.+A+quas+nam+minima+earum+cum.&title=Nihil+illo+animi+fugit+corporis+vero.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 150-2sbyr8S3-gly_YeOlBwBG-jujjw"
+            "bearer 179-OLtbS_Qz1Chf0B0GtB0db4qqJW8"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "609"
+            "515"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; loidcreated=2018-07-11T13%3A23%3A51.337Z"
+            "loid=Z2vmlGQmelRUSa5AUj; loidcreated=2018-07-20T21%3A24%3A13.941Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:51 GMT"
+            "Fri, 20 Jul 2018 21:24:14 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "369"
+            "346"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-11T13:23:58",
+      "recorded_at": "2018-07-20T21:24:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; loidcreated=2018-07-11T13%3A23%3A51.337Z"
+            "loid=Z2vmlGQmelRUSa5AUj; loidcreated=2018-07-20T21%3A24%3A13.941Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ4R6D88Z5GSW57XEVCT7Z8E"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWS8FB3VZTF9NSXD1QCH49N"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNQQuCMACF/4rsGAmbkY1uQRBKkF2Eugydz5xBjk3FjP57Tk8d38f73vuQTEpYK9rmiRfZe4RtmT8kAbuMJ5+fEVUYy874t0OSZ/09ImuPYNDKwArlhE1I6cRmX7RvDTeSIzMwrmtls6CVSwblJFb/b3WkOhaHg+b141gbmV53MeVpgHh+K9ArCaEKN7wE8v0BRNlr0LgAAAA=",
+          "base64_string": "H4sIAAAAAAAAA1WNXQvCIBiF/8rwMhoYAyddGrEaBGNl0JU4925JMUWlT/rvzXbV5Xk4zzlvJJUC70UwFxjQMkELilNbpXSVZVKx9HAcOlIS369dmZvTDs0TBA+rHXiho5ARjEf280V4WogjDUgHLna9MhOaxeSgG8Xz/1soGn7lG9XX1V7AnW65fjFWc5ab6LRw0wqEbuPwFNDnC0AMJ164AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:58 GMT"
+            "Fri, 20 Jul 2018 21:24:20 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ4R6D88Z5GSW57XEVCT7Z8E"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWS8FB3VZTF9NSXD1QCH49N"
       }
     },
     {
-      "recorded_at": "2018-07-11T13:23:58",
+      "recorded_at": "2018-07-20T21:24:20",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ4R6D88Z5GSW57XEVCT7Z8E&type=contributor"
+          "string": "api_type=json&name=01CJWS8FB3VZTF9NSXD1QCH49N&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 150-2sbyr8S3-gly_YeOlBwBG-jujjw"
+            "bearer 179-OLtbS_Qz1Chf0B0GtB0db4qqJW8"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; loidcreated=2018-07-11T13%3A23%3A51.337Z"
+            "loid=Z2vmlGQmelRUSa5AUj; loidcreated=2018-07-20T21%3A24%3A13.941Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531315431_ut/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1532121854_ipsam/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:58 GMT"
+            "Fri, 20 Jul 2018 21:24:20 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "362"
+            "340"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,15 +318,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531315431_ut/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1532121854_ipsam/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-11T13:23:58",
+      "recorded_at": "2018-07-20T21:24:20",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1531315431_ut"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1532121854_ipsam"
         },
         "headers": {
           "Accept": [
@@ -336,22 +336,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 151-xP21OzG-8LeIhezfur-YAPbavZI"
+            "bearer 180-pP-8C33acB-TVnf6J6sgErJ7oYM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "72"
+            "75"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; loidcreated=2018-07-11T13%3A23%3A51.337Z"
+            "loid=Z2vmlGQmelRUSa5AUj; loidcreated=2018-07-20T21%3A24%3A13.941Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:58 GMT"
+            "Fri, 20 Jul 2018 21:24:20 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "362"
+            "340"
           ],
           "x-ratelimit-used": [
             "1"
@@ -414,7 +414,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-11T13:23:58",
+      "recorded_at": "2018-07-20T21:24:23",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -428,25 +428,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 150-2sbyr8S3-gly_YeOlBwBG-jujjw"
+            "bearer 179-OLtbS_Qz1Chf0B0GtB0db4qqJW8"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=RSp2u5DoH3F2hFFWz1; loidcreated=2018-07-11T13%3A23%3A51.337Z"
+            "loid=Z2vmlGQmelRUSa5AUj; loidcreated=2018-07-20T21%3A24%3A13.941Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531315431_ut/about/contributors/?limit=100&raw_json=1"
+        "uri": "https://reddit.local/r/1532121854_ipsam/about/contributors/?limit=100&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"date\": 1531315438.0, \"name\": \"01CJ4R6D88Z5GSW57XEVCT7Z8E\", \"id\": \"t2_47\"}, {\"date\": 1531315431.0, \"name\": \"01CJ4R66W1KKBSNKAB59SHK89K\", \"id\": \"t2_46\"}], \"after\": null, \"before\": null}}"
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"date\": 1532121860.0, \"name\": \"01CJWS8FB3VZTF9NSXD1QCH49N\", \"id\": \"t2_50\"}, {\"date\": 1532121854.0, \"name\": \"01CJWS89145ZWRDE98PYNQA65F\", \"id\": \"t2_4z\"}], \"after\": null, \"before\": null}}"
         },
         "headers": {
           "Connection": [
@@ -459,7 +459,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 11 Jul 2018 13:23:58 GMT"
+            "Fri, 20 Jul 2018 21:24:23 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -480,13 +480,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "362"
+            "337"
           ],
           "x-ratelimit-used": [
             "3"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=CIYNL9nJ4kPOUN1DtVp%2BRH0FDp2viQAlC4fuPELD8Bzqyzw2Ig1LckVwYNmmrywiCfVjTB%2ByfjGBfqhiuUhB2zL9ap29%2BW6n"
+            "https://reddit.local/pixel/of_destiny.png?v=aVM25qnMrIGMvjdHi1XCS8ErG7d3wvwhDyiBQfDHj33PSeLN76TBhGhJPViutsLnBsjCIyb8ikXzpGAx1OSMqEMWumRy8Efj"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -499,7 +499,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531315431_ut/about/contributors/?limit=100&raw_json=1"
+        "url": "https://reddit.local/r/1532121854_ipsam/about/contributors/?limit=100&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-10T19:19:01",
+      "recorded_at": "2018-07-20T21:29:09",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2T3TBAK1HCV7H48XDX1YHN"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSH9CS1WAZHDM0Y001QREK"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WN0QqCMBiFX0V2GQnWQKHblNCMIIS6G27+0ow2t19kFr17Lq+6PB/nO+dNaiEAkQ36AYrsArKhSUgLczzkpdJuqGyZmb2JxcW4JEtzsg4IuF5aQCa9QOMomtnPZ8PUgx/hUFuwvotCL2jlk4V2Fu//b1sL5+7KJ2dGmr4Ur05dgU8Mbwq908AoBTDZ+OElkM8XzjSNl7gAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNZNyQxwS4lwzixyN9QN9XDJdjXKj3LydPNyCg9V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZZVkaGmaQG5JqaFyRZmFfEB5m55Ft4eCc751qA9KSklmUmp8ZnpoAMhnCUagGruCDCuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:01 GMT"
+            "Fri, 20 Jul 2018 21:29:09 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:19:01 GMT",
-            "loidcreated=2018-07-10T19%3A19%3A01.210Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:19:01 GMT"
+            "loid=Q7yDIMh20BawXfwcIP; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:29:09 GMT",
+            "loidcreated=2018-07-20T21%3A29%3A09.261Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:29:09 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2T3TBAK1HCV7H48XDX1YHN"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSH9CS1WAZHDM0Y001QREK"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:01",
+      "recorded_at": "2018-07-20T21:29:09",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Officiis+provident+aliquam+molestias+animi+soluta+sed+repudiandae.+Consequuntur+perspiciatis+officia+iste.+A+accusamus+necessitatibus+sapiente+aut.+Facere+aliquid+explicabo+quo+distinctio+aliquam+est.%0AQuasi+minima+mollitia+occaecati+hic+culpa.+Facilis+culpa+quae+veniam+voluptates+blanditiis+tempore+aliquid.+Delectus+quos+doloribus+eligendi+vel+et+unde.&link_type=any&name=1531250341_at&public_description=Quisquam+esse+nemo+aliquam+eum.+At+aliquam+ipsam+praesentium.&title=Saepe+fuga+perferendis+totam+magni+aperiam.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Modi+aliquid+atque+amet+quo+libero+deserunt+incidunt+error.+Expedita+nam+qui+consectetur+accusantium.+Unde+aperiam+iure+in+dolorum+unde+velit+maiores+alias.+Asperiores+recusandae+quae+architecto+expedita+rerum+repellat.%0APossimus+nisi+neque+deleniti+ipsum+quos+quo+error.+Ea+voluptas+molestias+officia+quae+odio.+Commodi+animi+a+animi+quidem.%0ACupiditate+maiores+blanditiis+veniam+veritatis+nam+ipsum+ipsa.+Optio+aspernatur+possimus+quod+labore+fugit+perspiciatis+corrupti.&link_type=any&name=1532122149_pariatur&public_description=Itaque+optio+omnis+aliquam+aliquam+modi.+Enim+possimus+eius+sint+distinctio+nostrum.&title=Tenetur+praesentium+sapiente+sed.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 137-3JqKGILnoxtTrLEqCq6cRqx7EDI"
+            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "577"
+            "715"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:01 GMT"
+            "Fri, 20 Jul 2018 21:29:09 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "59"
+            "51"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:08",
+      "recorded_at": "2018-07-20T21:29:16",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2T40RGCA1V2NS1KAAAS927"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHFT3PKK1TKB63NZZHM2M"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0ttANdsmKKjQrCAhKd0svDPNyCgs39ElxdKxKSUpX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVu1lG5IVYlBu5G4dFBSV5mTllZFiUOSW5ZQSC9KSklmUmp8ZnpoAMhnCUagHHOlOiuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNFNKglIDDMJzsost3SL8PDRdfR3z/QxSwkvcw1V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVeJSHFaXl+5qWu5u655cFl2QHZubmG0Y5+1uA9KSklmUmp8ZnpoAMhnCUagGxWrTVuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:08 GMT"
+            "Fri, 20 Jul 2018 21:29:16 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2T40RGCA1V2NS1KAAAS927"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHFT3PKK1TKB63NZZHM2M"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:08",
+      "recorded_at": "2018-07-20T21:29:16",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2T40RGCA1V2NS1KAAAS927&type=contributor"
+          "string": "api_type=json&name=01CJWSHFT3PKK1TKB63NZZHM2M&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 137-3JqKGILnoxtTrLEqCq6cRqx7EDI"
+            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531250341_at/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:08 GMT"
+            "Fri, 20 Jul 2018 21:29:16 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "52"
+            "44"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,15 +318,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531250341_at/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:08",
+      "recorded_at": "2018-07-20T21:29:16",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1531250341_at"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1532122149_pariatur"
         },
         "headers": {
           "Accept": [
@@ -336,22 +336,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 138-SDjZq6pPRgFgqVJBVW1LdAAzdbg"
+            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "72"
+            "78"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:08 GMT"
+            "Fri, 20 Jul 2018 21:29:16 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "52"
+            "44"
           ],
           "x-ratelimit-used": [
             "1"
@@ -414,7 +414,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:08",
+      "recorded_at": "2018-07-20T21:29:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -427,69 +427,48 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 138-SDjZq6pPRgFgqVJBVW1LdAAzdbg"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531250341_at/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHK87F2Y908071YZYW2W2"
       },
       "response": {
         "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1531250341.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJ2T3TBAK1HCV7H48XDX1YHN\", \"id\": \"t2_3t\"}]}}"
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNX1LfPyK6mKt7QoTDeOrIgKcyvI8DNP9fUMzw1V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFmWR6VhVF+eSnBOT4WOh6R2Vnm/t7VvlVmoNtS0kty0xOjc9MARkM4SjVAgC6ot9VuAAAAA==",
+          "encoding": "UTF-8"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "149"
+          "Content-Encoding": [
+            "gzip"
           ],
           "Content-Type": [
-            "application/json; charset=UTF-8"
+            "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:08 GMT"
+            "Fri, 20 Jul 2018 21:29:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
           ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
+          "Transfer-Encoding": [
+            "chunked"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
           "x-frame-options": [
             "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298.0"
-          ],
-          "x-ratelimit-reset": [
-            "52"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=v3Jz8RF1MR2t9JDfN7Pg4LV0LqhmROatanFh52Y0SHu585mRoUx94AYemqSuxPaF%2BO8kO%2F%2BX%2BRvGxZmGiiqI6AFaCx%2F82C0N"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -499,15 +478,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531250341_at/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHK87F2Y908071YZYW2W2"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:19:08",
+      "recorded_at": "2018-07-20T21:29:19",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01CJWSHK87F2Y908071YZYW2W2&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -517,38 +496,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 138-SDjZq6pPRgFgqVJBVW1LdAAzdbg"
+            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
           ],
           "Connection": [
             "keep-alive"
           ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
           "Cookie": [
-            "loid=wUi6CZfk5gncgJgRt3; loidcreated=2018-07-10T19%3A19%3A01.210Z"
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1531250341_at/about/moderators/?user=01CJ2T40RGCA1V2NS1KAAAS927&raw_json=1"
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "46"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:19:08 GMT"
+            "Fri, 20 Jul 2018 21:29:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -569,13 +554,10 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "52"
+            "41"
           ],
           "x-ratelimit-used": [
             "3"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=02LF5d5%2FKlNIYIWa6VUXr24xX7vOBBQqEnmHICGIfSjOAwOl0B%2F3SRSzeqDZsz2hgkw9J4g0zXukptuntYVePtIuSr3aE4z5"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -588,7 +570,277 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531250341_at/about/moderators/?user=01CJ2T40RGCA1V2NS1KAAAS927&raw_json=1"
+        "url": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T21:29:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 185-MvJNtz_98qg3YxZVFphN7eMIWmU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1532122149_pariatur/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 21:29:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "41"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532122149_pariatur/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T21:29:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1532122149_pariatur/about/moderators/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1532122149.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJWSH9CS1WAZHDM0Y001QREK\", \"id\": \"t2_53\"}, {\"date\": 1532122159.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJWSHK87F2Y908071YZYW2W2\", \"id\": \"t2_55\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "254"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 21:29:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "40"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=lasVyF327O7XiVe1lYBPzYbeffhzH1tUYlQT1LXKINVaJU8I1E2TcwpYI9qHn%2F%2BuzKr9qphLqQnhPQhFdAx0F7HuJt9MqjhL"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532122149_pariatur/about/moderators/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-07-20T21:29:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1532122149_pariatur/about/moderators/?user=01CJWSHFT3PKK1TKB63NZZHM2M&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "46"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 21:29:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "40"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=ryGzf8JjtIEAjagcc2gCKor%2F2EAoVodyEl3mg9yMl5DAzHJef2PIt979jtejqZx1LfDWzL0miGRqPEJX0uOCiGBfR7Bya0eI"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1532122149_pariatur/about/moderators/?user=01CJWSHFT3PKK1TKB63NZZHM2M&raw_json=1"
       }
     }
   ],

--- a/channels/views/contributors.py
+++ b/channels/views/contributors.py
@@ -1,5 +1,6 @@
 """Views for REST APIs for contributors"""
 
+from django.conf import settings
 from rest_framework import status
 from rest_framework.generics import ListCreateAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -28,7 +29,11 @@ class ContributorListView(ListCreateAPIView):
     def get_queryset(self):
         """Get generator for contributors in channel"""
         api = Api(user=self.request.user)
-        return api.list_contributors(self.kwargs['channel_name'])
+        return (
+            contributor for contributor in
+            api.list_contributors(self.kwargs['channel_name'])
+            if contributor.name != settings.INDEXING_API_USERNAME
+        )
 
 
 class ContributorDetailView(APIView):

--- a/channels/views/contributors_test.py
+++ b/channels/views/contributors_test.py
@@ -10,22 +10,20 @@ from open_discussions.features import ANONYMOUS_ACCESS
 pytestmark = pytest.mark.betamax
 
 
-def test_list_contributors(client, private_channel_and_contributor, staff_user, staff_jwt_header):
+def test_list_contributors(client, private_channel_and_contributor, staff_user, staff_jwt_header, settings):
     """
     List contributors in a channel
     """
+    settings.INDEXING_API_USERNAME = staff_user.username
     channel, user = private_channel_and_contributor
     url = reverse('contributor-list', kwargs={'channel_name': channel.name})
     resp = client.get(url, **staff_jwt_header)
     assert resp.status_code == status.HTTP_200_OK
+    # staff user is filtered out
     assert resp.json() == [{
         'contributor_name': user.username,
         'full_name': user.profile.name,
         'email': user.email,
-    }, {
-        'contributor_name': staff_user.username,
-        'full_name': staff_user.profile.name,
-        'email': staff_user.email,
     }]
 
 

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -1,5 +1,5 @@
 """Views for REST APIs for moderators"""
-
+from django.conf import settings
 from rest_framework import status
 from rest_framework.generics import ListCreateAPIView
 from rest_framework.response import Response
@@ -46,7 +46,11 @@ class ModeratorListView(ListCreateAPIView):
         """Get a list of moderators for channel"""
         api = Api(user=self.request.user)
         channel_name = self.kwargs['channel_name']
-        return api.list_moderators(channel_name)
+        return (
+            moderator for moderator in
+            api.list_moderators(channel_name)
+            if moderator.name != settings.INDEXING_API_USERNAME
+        )
 
 
 class ModeratorDetailView(APIView):

--- a/factory_data/channels.views.contributors_test.test_list_contributors.json
+++ b/factory_data/channels.views.contributors_test.test_list_contributors.json
@@ -2,18 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Explicabo tempora voluptatibus magnam reiciendis. Architecto rem ipsum mollitia dolorem. Atque officia vitae id voluptatum. Cum nemo minus soluta tempore.\nExercitationem minima et eum possimus facilis sit quas cumque. Earum saepe ratione neque nisi voluptates alias tempore.\nUt minus unde autem autem esse. Nesciunt iure nisi dolore tempora ex.",
-      "name": "1531315431_ut",
-      "public_description": "Nulla nam libero accusantium libero. Ipsum dolore cum ad dolorem corporis magnam quos accusamus.",
-      "title": "Inventore cupiditate id animi soluta quos ipsam."
+      "description": "Laborum doloribus numquam dolor corporis. Hic facere asperiores dolor reiciendis corrupti fuga illo. Consequuntur aut delectus ratione aut cumque ex asperiores.\nSunt quibusdam odit magni non. Dolorem aut veritatis assumenda repellat. Accusamus accusantium aliquid molestiae voluptas.",
+      "name": "1532121854_ipsam",
+      "public_description": "Dolor laboriosam pariatur quae ab modi vero. A quas nam minima earum cum.",
+      "title": "Nihil illo animi fugit corporis vero."
     }
   },
   "users": {
     "contributor": {
-      "username": "01CJ4R6D88Z5GSW57XEVCT7Z8E"
+      "username": "01CJWS8FB3VZTF9NSXD1QCH49N"
     },
     "staff_user": {
-      "username": "01CJ4R66W1KKBSNKAB59SHK89K"
+      "username": "01CJWS89145ZWRDE98PYNQA65F"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators.json
@@ -2,18 +2,21 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Officiis provident aliquam molestias animi soluta sed repudiandae. Consequuntur perspiciatis officia iste. A accusamus necessitatibus sapiente aut. Facere aliquid explicabo quo distinctio aliquam est.\nQuasi minima mollitia occaecati hic culpa. Facilis culpa quae veniam voluptates blanditiis tempore aliquid. Delectus quos doloribus eligendi vel et unde.",
-      "name": "1531250341_at",
-      "public_description": "Quisquam esse nemo aliquam eum. At aliquam ipsam praesentium.",
-      "title": "Saepe fuga perferendis totam magni aperiam."
+      "description": "Modi aliquid atque amet quo libero deserunt incidunt error. Expedita nam qui consectetur accusantium. Unde aperiam iure in dolorum unde velit maiores alias. Asperiores recusandae quae architecto expedita rerum repellat.\nPossimus nisi neque deleniti ipsum quos quo error. Ea voluptas molestias officia quae odio. Commodi animi a animi quidem.\nCupiditate maiores blanditiis veniam veritatis nam ipsum ipsa. Optio aspernatur possimus quod labore fugit perspiciatis corrupti.",
+      "name": "1532122149_pariatur",
+      "public_description": "Itaque optio omnis aliquam aliquam modi. Enim possimus eius sint distinctio nostrum.",
+      "title": "Tenetur praesentium sapiente sed."
     }
   },
   "users": {
     "contributor": {
-      "username": "01CJ2T40RGCA1V2NS1KAAAS927"
+      "username": "01CJWSHFT3PKK1TKB63NZZHM2M"
+    },
+    "new_mod": {
+      "username": "01CJWSHK87F2Y908071YZYW2W2"
     },
     "staff_user": {
-      "username": "01CJ2T3TBAK1HCV7H48XDX1YHN"
+      "username": "01CJWSH9CS1WAZHDM0Y001QREK"
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #891 

#### What's this PR do?
Remove channel creator from contributor and moderator list in UI. No changes are made to the REST API, though it won't matter since no user will have permission to remove that user as moderator, and their contributor status doesn't matter if they are a moderator.

#### How should this be manually tested?
View the contributor and moderator list. You should not see any user with `<missing>`.
