### PR TITLE
Added API change to support prompting the user to login via MM

### DIFF
--- a/authentication/exceptions.py
+++ b/authentication/exceptions.py
@@ -2,6 +2,13 @@
 from social_core.exceptions import AuthException
 
 
+class RequireProviderException(AuthException):
+    """The user is required to authenticate via a specific provider/backend"""
+    def __init__(self, backend, provider):
+        self.provider = provider
+        super().__init__(backend)
+
+
 class PartialException(AuthException):
     """Partial pipeline exception"""
     def __init__(self, backend, partial):

--- a/authentication/serializers_test.py
+++ b/authentication/serializers_test.py
@@ -1,6 +1,7 @@
 """Serializers tests"""
 import pytest
 from rest_framework.serializers import ValidationError
+from social_core.backends.email import EmailAuth
 from social_core.exceptions import InvalidEmail, AuthException
 
 from authentication.serializers import RegisterEmailSerializer
@@ -24,6 +25,7 @@ def test_social_auth_serializer_error(mocker, side_effect, result):
     mocked_authenticate.side_effect = side_effect
 
     result.flow = SocialAuthState.FLOW_REGISTER
+    result.provider = EmailAuth.name
 
     serializer = RegisterEmailSerializer(data={
         'flow': result.flow,

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -17,7 +17,7 @@ class SocialAuthState:
     # login states
     STATE_LOGIN_EMAIL = "login/email"
     STATE_LOGIN_PASSWORD = "login/password"
-    STATE_LOGIN_EDX = "login/edx"
+    STATE_LOGIN_PROVIDER = "login/provider"
 
     # registration states
     STATE_REGISTER_EMAIL = "register/email"
@@ -31,10 +31,13 @@ class SocialAuthState:
     STATE_INACTIVE = "inactive"
     STATE_INVALID_EMAIL = "invalid-email"
 
-    def __init__(self, state, partial=None, flow=None, errors=None):
+    def __init__(
+            self, state, *, provider=None, partial=None, flow=None, errors=None
+    ):  # pylint: disable=too-many-arguments
         self.state = state
         self.partial = partial
         self.flow = flow
+        self.provider = provider
         self.errors = errors or []
 
 

--- a/cassettes/authentication.views_test.test_login_register_flows[login_email_mm_only].json
+++ b/cassettes/authentication.views_test.test_login_register_flows[login_email_mm_only].json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-07-20T20:57:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWQQVBY5RN9K6F04C2F63G0"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyt9Q1ya7MMXRy9gj1zzfMN0/JLncK9S8pLKvIK/RU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5B5tGeQVXuTqFG0e5J+t6G3iVl/joJrlb+mWD9KSklmUmp8ZnpoAMhnCUagFkolO2uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 20 Jul 2018 20:57:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=3fvvOkRNFRcAnc9oR8; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 20:57:47 GMT",
+            "loidcreated=2018-07-20T20%3A57%3A47.123Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 20:57:47 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWQQVBY5RN9K6F04C2F63G0"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/factory_data/authentication.views_test.test_login_register_flows[login_email_mm_only].json
+++ b/factory_data/authentication.views_test.test_login_register_flows[login_email_mm_only].json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "contributor": {
+      "username": "01CJWQQVBY5RN9K6F04C2F63G0"
+    }
+  }
+}

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -252,6 +252,9 @@ SOCIAL_AUTH_PIPELINE = (
     # validate an incoming email auth request
     'authentication.pipeline.user.validate_email_auth_request',
 
+    # if the user only has micromasters auth but is trying to login via email
+    'authentication.pipeline.user.require_micromasters_provider',
+
     # require a password and profile if they're not set
     'authentication.pipeline.user.validate_password',
 


### PR DESCRIPTION
#### What are the relevant tickets?
#673 

#### What's this PR do?
Backend changes to require users with MM-only social auth to login via that method.

#### How should this be manually tested?

You could try to login with a micromasters-only user and verify you see the expected response from the backend. Dealing with the UI piece in a separate PR.