### PR TITLE
Allow readonly contributor view for moderators for managed channels

### DIFF
--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -130,7 +130,9 @@ class ContributorPermissions(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         return is_staff_jwt(request) or (
-            channel_is_mod_editable(view) and is_moderator(request, view)
+            (
+                channel_is_mod_editable(view) or is_readonly(request)
+            ) and is_moderator(request, view)
         )
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixed by #961 

#### What's this PR do?
Allows readonly view for the contributors API for moderators for channels managed by micromasters. Currently it forbids moderators from viewing the list of contributors but we only want to forbid the editing of the list.

#### How should this be manually tested?
Find a channel you are a moderator of. Mark a channel as managed by micromasters in the database. View the contributor list and verify that you don't get an error message (which you should see on master).
