### PR TITLE
Added login & signup links to the signup & login pages

### DIFF
--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -10,7 +10,7 @@ type ExternalLoginProps = {
 const ExternalLogins = ({ className }: ExternalLoginProps) =>
   SETTINGS.allow_saml_auth ? (
     <div className={`actions row ${className || ""}`}>
-      <div className="textline">Or use</div>
+      <div className="textline">Or</div>
       <a className="link-button" href={TOUCHSTONE_URL}>
         Touchstone
         <span className="ampersand">@</span>

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -4,6 +4,7 @@ import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
 import { MetaTags } from "react-meta-tags"
+import { Link } from "react-router-dom"
 
 import Card from "../../components/Card"
 import AuthEmailForm from "../../components/auth/AuthEmailForm"
@@ -13,6 +14,7 @@ import { actions } from "../../actions"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
+import { REGISTER_URL } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
@@ -40,6 +42,9 @@ export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
         </MetaTags>
         {renderForm({ formError })}
         <ExternalLogins />
+        <div className="alternate-auth-link">
+          Not a member? <Link to={REGISTER_URL}>Sign up &gt;</Link>
+        </div>
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -7,6 +7,7 @@ import { actions } from "../../actions"
 import { FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedLoginPage, { LoginPage, FORM_KEY } from "./LoginPage"
+import { REGISTER_URL } from "../../lib/url"
 
 const DEFAULT_STATE = {
   auth: {
@@ -69,6 +70,14 @@ describe("LoginPage", () => {
     })
 
     const link = inner.find("ExternalLogins")
+    assert.ok(link.exists())
+  })
+
+  it("should contain a link to the signup page", async () => {
+    const { inner } = await renderPage()
+    const link = inner
+      .find("Link")
+      .findWhere(c => c.prop("to") === REGISTER_URL)
     assert.ok(link.exists())
   })
 

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -4,6 +4,7 @@ import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
 import { MetaTags } from "react-meta-tags"
+import { Link } from "react-router-dom"
 
 import Card from "../../components/Card"
 import AuthEmailForm from "../../components/auth/AuthEmailForm"
@@ -15,6 +16,7 @@ import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
 import { preventDefaultAndInvoke } from "../../lib/util"
+import { LOGIN_URL } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
@@ -53,7 +55,7 @@ export const RegisterPage = ({
         <h3>
           {partialToken && email
             ? `We could not find an account with the email: ${email}`
-            : "Sign up for free to unlock more features."}
+            : "Join MIT OPEN for free"}
         </h3>
         <MetaTags>
           <title>{formatTitle("Register")}</title>
@@ -75,6 +77,9 @@ export const RegisterPage = ({
           renderForm({ formError })
         )}
         <ExternalLogins />
+        <div className="alternate-auth-link">
+          Already have an account? <Link to={LOGIN_URL}>Log in &gt;</Link>
+        </div>
       </Card>
     </div>
   </div>

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -7,6 +7,7 @@ import { actions } from "../../actions"
 import { FLOW_REGISTER, STATE_REGISTER_CONFIRM_SENT } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedRegisterPage, { RegisterPage, FORM_KEY } from "./RegisterPage"
+import { LOGIN_URL } from "../../lib/url"
 
 const email = "test@example.com"
 
@@ -71,6 +72,12 @@ describe("RegisterPage", () => {
     })
 
     const link = inner.find("ExternalLogins")
+    assert.ok(link.exists())
+  })
+
+  it("should contain a link to the login page", async () => {
+    const { inner } = await renderPage()
+    const link = inner.find("Link").findWhere(c => c.prop("to") === LOGIN_URL)
     assert.ok(link.exists())
   })
 

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -7,3 +7,14 @@
     }
   }
 }
+
+.alternate-auth-link {
+  text-align: center;
+  color: $font-grey;
+
+  a:link,
+  a:visited {
+    text-decoration: underline;
+    color: $font-grey;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #917 
Closes #930

#### What's this PR do?
- Adds a login link to the signup pages
- Adds a signup link to the login pages

#### How should this be manually tested?
Visit `/login` and `/signup`

#### Any background context you want to provide?
Seemed pretty easy & sensible to combine these 2 issues into 1 PR

#### Screenshots (if appropriate)

![ss 2018-07-24 at 16 51 49](https://user-images.githubusercontent.com/14932219/43165473-ffbd8bf4-8f61-11e8-9e85-08ca3fdc16fd.png)
![ss 2018-07-24 at 16 51 17](https://user-images.githubusercontent.com/14932219/43165502-0a70415e-8f62-11e8-9812-fe94ca7533d0.png)

