### PR TITLE
fix 'rich' embed display

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -4,6 +4,7 @@ import React from "react"
 import ContentLoader from "react-content-loader"
 
 import { urlHostname } from "../lib/url"
+import { hasIframe } from "../lib/embed"
 
 export const EmbedlyLoader = (props: Object = {}) => (
   <div className="content-loader">
@@ -36,7 +37,7 @@ export default class Embedly extends React.Component<Props> {
     if (embedly.type === "video") {
       return (
         <div
-          className="video-container"
+          className="video iframe-container"
           dangerouslySetInnerHTML={{ __html: embedly.html }}
         />
       )
@@ -45,7 +46,9 @@ export default class Embedly extends React.Component<Props> {
     if (embedly.type === "rich" || embedly.html) {
       return (
         <div
-          className="rich"
+          className={`rich ${
+            hasIframe(embedly.html) ? "iframe-container" : ""
+          }`}
           dangerouslySetInnerHTML={{ __html: embedly.html }}
         />
       )

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -1,4 +1,6 @@
 // @flow
+import R from "ramda"
+
 import type { EmbedlyResponse } from "../reducers/embedly"
 
 export const ensureTwitterEmbedJS = () => {
@@ -27,3 +29,9 @@ export const handleTwitterWidgets = (embedlyResponse: EmbedlyResponse) => {
     window.twttr.widgets.load()
   }
 }
+
+export const hasIframe = R.memoizeWith(R.identity, (html: string) => {
+  const div = document.createElement("div")
+  div.innerHTML = html
+  return !!div.querySelector("iframe")
+})

--- a/static/js/lib/embed_test.js
+++ b/static/js/lib/embed_test.js
@@ -1,7 +1,7 @@
 import { assert } from "chai"
 import sinon from "sinon"
 
-import { handleTwitterWidgets } from "./embed"
+import { handleTwitterWidgets, hasIframe } from "./embed"
 
 describe("embed utils", () => {
   let twitterLoadStub
@@ -23,6 +23,15 @@ describe("embed utils", () => {
     }call the load func when appropriate`, () => {
       handleTwitterWidgets(response)
       assert.equal(shouldCall, twitterLoadStub.called)
+    })
+  })
+
+  it("hasIframe should check for an iframe!", () => {
+    [
+      ['<iframe className="iframe-wow"></iframe>', true],
+      ['<div className="iframe">iframe here? never!</div', false]
+    ].forEach(([htmlString, exp]) => {
+      assert.equal(hasIframe(htmlString), exp)
     })
   })
 })

--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -4,7 +4,7 @@
 }
 
 .embedly {
-  .video-container {
+  .iframe-container {
     padding: 15px 0;
     position: relative;
     width: 100%;


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this fixes the 'rich' type embed display a little bit. basically, this just changes things so that, if the 'rich' type is an iframe, we do the same responsive iframe thingy we do for videos currently. sometimes, notably with wikipedia articles, 'rich' type embeds are *not* iframes, so we don't always want to do this.

#### How should this be manually tested?

Check that `<iframe>`-using 'rich' embeds render in a nice, full-width responsive container that looks like this:

![nice_google_iframe](https://user-images.githubusercontent.com/6207644/43407253-3318c71e-93ec-11e8-98e6-e486cdb3067e.png)

(google docs are a good thing to test with)

Also test that the `.iframe-container` class (and associated styling) is *not* applied for rich embeds which are not iframes. Wikipedia articles are the main example of this that I know of, but there may be others. A wikipedia article should still look something like this:

![wiki_elephant](https://user-images.githubusercontent.com/6207644/43407277-47407ade-93ec-11e8-94ec-5c6fec1d0e3d.png)
