### PR TITLE
fix location of profile dot

### DIFF
--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -31,17 +31,18 @@ export default class UserMenu extends React.Component<Props> {
 
     return (
       <div className="user-menu">
-        <ProfileImage
-          editable={false}
-          userName={SETTINGS.username}
-          profile={profile}
-          onClick={toggleShowUserMenu}
-          imageSize={PROFILE_IMAGE_SMALL}
-        />
-        {showUserMenu ? <DropUpArrow /> : <DropDownArrow />}
-        {SETTINGS.profile_ui_enabled && !isProfileComplete(profile) ? (
-          <div className="profile-incomplete" />
-        ) : null}
+        <div className="user-menu-clickarea" onClick={toggleShowUserMenu}>
+          <ProfileImage
+            editable={false}
+            userName={SETTINGS.username}
+            profile={profile}
+            imageSize={PROFILE_IMAGE_SMALL}
+          />
+          {showUserMenu ? <DropUpArrow /> : <DropDownArrow />}
+          {SETTINGS.profile_ui_enabled && !isProfileComplete(profile) ? (
+            <div className="profile-incomplete" />
+          ) : null}
+        </div>
         {showUserMenu ? (
           <DropdownMenu closeMenu={toggleShowUserMenu}>
             <li>

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -11,7 +11,6 @@ import DropdownMenu from "./DropdownMenu"
 
 import { profileURL, SETTINGS_URL } from "../lib/url"
 import * as utilFuncs from "../lib/util"
-import ProfileImage from "../containers/ProfileImage"
 import { defaultProfileImageUrl } from "../lib/util"
 
 describe("UserMenu", () => {
@@ -53,7 +52,7 @@ describe("UserMenu", () => {
 
   it("should include the profile image with onclick handler", () => {
     const wrapper = renderUserMenu()
-    const { onClick } = wrapper.find(ProfileImage).props()
+    const { onClick } = wrapper.find(".user-menu-clickarea").props()
     onClick()
     assert.isOk(toggleShowUserMenuStub.called)
   })

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -14,6 +14,7 @@ import { configureForm } from "../lib/forms"
 import { newProfileImageForm } from "../lib/profile"
 import { mergeAndInjectProps } from "../lib/redux_props"
 import { validateImageForm } from "../lib/validation"
+
 import type { Profile, ProfileImageForm } from "../flow/discussionTypes"
 import type { WithFormProps } from "../flow/formTypes"
 import type { Dispatch } from "redux"

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -32,8 +32,8 @@
   background-color: red;
   border-radius: 50%;
   position: relative;
-  left: 34px;
-  top: 3px;
+  left: 3px;
+  top: -10px;
 }
 
 .profile-image-container {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #988 
closes #1003 

#### What's this PR do?

moves the profile dot to where it should be and also increases the size of the click area (just to encompass the little dropdown basically).

#### How should this be manually tested?

check that it appears in the bottom left of the user menu, and check that clicking on the little arrow opens the user menu too.