### PR TITLE
Use urls with post slugs in emails

### DIFF
--- a/mail/templates/comments/body.html
+++ b/mail/templates/comments/body.html
@@ -19,9 +19,9 @@
           <p class="comment-content">
             {{ comment.text|truncatewords:100 }}
             {% if is_comment_reply %}
-              <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id comment_id=comment.id %}">(read more)</a>
+              <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}">(read more)</a>
             {% else %}
-              <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">(read more)</a>
+              <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}">(read more)</a>
             {% endif %}
           </p>
         </div>
@@ -31,9 +31,9 @@
 </table>
 <div class="read-more alignleft" style="margin-left: 13px; margin-top: 13px;">
   {% if is_comment_reply %}
-  <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id comment_id=comment.id %}" class="btn-primary">View on Open Discussions</a>
+  <a href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}" class="btn-primary">View on Open Discussions</a>
   {% else %}
-  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}" class="btn-primary">View on Open Discussions</a>
+  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" class="btn-primary">View on Open Discussions</a>
   {% endif %}
 </div>
 {% endblock %}
@@ -43,6 +43,6 @@
   You are receiving this email because you are following a post on Open Discussions.
   <br/>
   If you don't want to receive these emails in the future, you can
-  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">unfollow this post</a>.
+  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}">unfollow this post</a>.
 </p>
 {% endblock %}

--- a/mail/templates/frontpage/body.html
+++ b/mail/templates/frontpage/body.html
@@ -50,7 +50,7 @@ p.comments {
       <td width="72" style="width: 72px"><img src="{{ post.profile_image }}" class="user-photo" width="72" height="72"/></td>
       <td><div>
         <h3 class="post-title">
-          <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id %}">{{ post.title }}</a>
+          <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}">{{ post.title }}</a>
         </h3>
         <p class="by-line">by {{ post.author_name }}, {{ post.created|parse_iso|naturaltime }} in <a href="{{ base_url }}{% url 'channel' channel_name=post.channel_name %}">{{ post.channel_title }}</a></p>
         <p class="comments">{{ post.num_comments }} comment{% if post.num_comments != 1 %}s{% endif %}</p>

--- a/notifications/notifiers/frontpage_test.py
+++ b/notifications/notifiers/frontpage_test.py
@@ -104,6 +104,7 @@ def test_send_notification(mocker):
     serializer_mock.return_value.data = {
         'id': 1,
         'title': 'post\'s title',
+        'slug': 'a_slug',
         'channel_name': 'micromasters',
         'channel_title': 'MicroMasters',
         'created': now_in_utc().isoformat(),

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -38,12 +38,12 @@ urlpatterns = [
     url(r'^content_policy/$', index),
     url(  # so that we can use reverse() to link to this
         r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/'
-        r'(?P<post_slug>[A-Za-z0-9_])?/?comment/(?P<comment_id>[A-Za-z0-9_]+)/$',
+        r'(?P<post_slug>[A-Za-z0-9_]+)/comment/(?P<comment_id>[A-Za-z0-9_]+)/$',
         index,
         name='channel-post-comment',
     ),
     url(  # so that we can use reverse() to link to this
-        r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>[A-Za-z0-9_])?/?$',
+        r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>[A-Za-z0-9_]+)/$',
         index,
         name='channel-post',
     ),

--- a/open_discussions/urls_test.py
+++ b/open_discussions/urls_test.py
@@ -10,3 +10,16 @@ class URLTests(TestCase):
     def test_urls(self):
         """Make sure URLs match with resolved names"""
         assert reverse('open_discussions-index') == '/'
+        assert reverse('channel-post',
+                       kwargs={
+                           'channel_name': 'channel1',
+                           'post_id': '1n',
+                           'post_slug': 'a_slug'
+                       }) == '/c/channel1/1n/a_slug/'
+        assert reverse('channel-post-comment',
+                       kwargs={
+                           'channel_name': 'channel1',
+                           'post_id': '1n',
+                           'post_slug': 'a_slug',
+                           'comment_id': 'b4'
+                       }) == '/c/channel1/1n/a_slug/comment/b4/'


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #994

#### What's this PR do?
Updates the links in the mail templates to include post slugs in the link URLs.  

#### How should this be manually tested?
- Create some new posts and comments.  
- In a shell:
  ```
  from notifications.api import *
  api.send_daily_frontpage_digests()
  api.send_unsent_email_notifications()
  ```
- You should get some new emails, check that the post and comment links contain the post slugs and that they load the correct pages.
- Old URL's without the post slug should still work, example:
  - `http://od.odl.local:8063/c/<channel_name>/<post_id>/` (post URL without post slug)
  - `http://od.odl.local:8063/c/<channel_name>/2t/comment/2e/` (post comment URL without slug)