### PR TITLE
Update the urlHostname function to remove www. from beginning of domains

### DIFF
--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -91,4 +91,5 @@ export const TOUCHSTONE_URL = "/login/saml/?idp=default"
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`
 
-export const urlHostname = (url: ?string) => (url ? new URL(url).hostname : "")
+export const urlHostname = (url: ?string) =>
+  url ? new URL(url).hostname.replace(/^www\.(.*\.\w)/i, "$1") : ""

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -193,8 +193,10 @@ describe("url helper functions", () => {
         ["https://mail.google.com/", "mail.google.com"],
         [
           "https://www.nytimes.com/2017/10/16/us/politics/trump-mcconnell-bannon.html",
-          "www.nytimes.com"
-        ]
+          "nytimes.com"
+        ],
+        ["http://www.org/Security", "www.org"],
+        ["http://www.www.org/Security", "www.org"]
       ].forEach(([url, expectation]) => {
         assert.equal(urlHostname(url), expectation)
       })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #995 (Note: the issue title no longer reflects the actual issue being solved, read the comments).

#### What's this PR do?
Removes `www.` from the domain in a URL, unless the domain is something like `www.org`

#### How should this be manually tested?
Create some link posts, with urls like `http://www.nytimes.com`, `http://store.nytimes.com`, and `http://www.org`.  The domain listed next to each post title should be `nytimes.com`, `store.nytimes.com`, and `www.org` respectively.
