### PR TITLE
Touched up account settings UI and added SAML auth type

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -112,17 +112,11 @@ def get_social_auth_types(request):
         UserSocialAuth
         .objects
         .filter(user=request.user)
-        .values('provider', 'user__email')
+        .values('provider')
+        .distinct()
     )
-    serialized_social_auths = [
-        {
-            'provider': social_auth['provider'],
-            'email': social_auth['user__email']
-        }
-        for social_auth in social_auths
-    ]
     return Response(
-        data=serialized_social_auths,
+        data=social_auths,
         status=status.HTTP_200_OK
     )
 

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -3,7 +3,8 @@ Factory for Users
 """
 import ulid
 from django.contrib.auth.models import User
-from factory import LazyFunction, RelatedFactory, Trait
+from social_django.models import UserSocialAuth
+from factory import LazyFunction, RelatedFactory, SubFactory, Trait
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
@@ -22,3 +23,12 @@ class UserFactory(DjangoModelFactory):
 
     class Params:
         no_profile = Trait(profile=None)
+
+
+class UserSocialAuthFactory(DjangoModelFactory):
+    """Factory for UserSocialAuth"""
+    provider = FuzzyText()
+    user = SubFactory(UserFactory)
+
+    class Meta:
+        model = UserSocialAuth

--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -11,7 +11,7 @@ const ExternalLogins = ({ className }: ExternalLoginProps) =>
   SETTINGS.allow_saml_auth ? (
     <div className={`actions row ${className || ""}`}>
       <div className="textline">Or</div>
-      <a className="link-button" href={TOUCHSTONE_URL}>
+      <a className="link-button touchstone-text-logo" href={TOUCHSTONE_URL}>
         Touchstone
         <span className="ampersand">@</span>
         MIT

--- a/static/js/containers/AccountSettingsPage.js
+++ b/static/js/containers/AccountSettingsPage.js
@@ -37,23 +37,23 @@ class AccountSettingsPage extends React.Component<Props> {
     switch (socialAuth.provider) {
     case "email":
       return (
-        <div key={index}>
-          <h4>MIT Open</h4>
-          <div className="account-settings-row">
-            <div className="email">{socialAuth.email}</div>
-            <div className="action">
-              <Link to="/settings/password">Change Password</Link>
-            </div>
-          </div>
+        <div key={index} className="account-settings-row">
+          <h5>MIT Open</h5>
+          <Link to="/settings/password">Change Password</Link>
         </div>
       )
     case "micromasters":
       return (
-        <div key={index}>
-          <h4>MicroMasters</h4>
-          <div className="account-settings-row">
-            <div className="email">{socialAuth.email}</div>
-          </div>
+        <div key={index} className="account-settings-row">
+          <h5>MicroMasters</h5>
+        </div>
+      )
+    case "saml":
+      return (
+        <div key={index} className="account-settings-row">
+          <h5 className="touchstone-text-logo">
+              Touchstone<span className="ampersand">@</span>MIT
+          </h5>
         </div>
       )
     default:
@@ -80,7 +80,7 @@ class AccountSettingsPage extends React.Component<Props> {
             {R.compose(
               R.addIndex(R.map)(this.renderSocialAuthLine),
               // Show email auth before any other social auths
-              R.sortBy(x => (x.provider === "email" ? 0 : 1))
+              R.sortBy(auth => (auth.provider === "email" ? 0 : 1))
             )(socialAuths)}
           </Card>
         </div>

--- a/static/js/containers/AccountSettingsPage_test.js
+++ b/static/js/containers/AccountSettingsPage_test.js
@@ -5,7 +5,7 @@ import { assert } from "chai"
 import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
-describe("PasswordChangePage", () => {
+describe("AccountSettingsPage", () => {
   let helper, renderComponent
 
   const renderPage = async () => {
@@ -29,61 +29,60 @@ describe("PasswordChangePage", () => {
     SETTINGS.user_full_name = "Test User"
     helper.getSocialAuthTypesStub.returns(
       Promise.resolve([
-        { provider: "email", email: "test1@example.com" },
-        { provider: "micromasters", email: "test2@example.com" },
-        { provider: "unknown_provider", email: "test3@example.com" }
+        { provider: "email" },
+        { provider: "micromasters" },
+        { provider: "saml" },
+        { provider: "unknown_provider" }
       ])
     )
     const wrapper = await renderPage()
 
-    const card = wrapper.find("Card").at(0)
-    assert.equal(card.find(".account-settings-row").length, 2)
+    const rows = wrapper.find(".account-settings-row")
+    assert.equal(rows.length, 3)
     assert.equal(
-      card
-        .find(".email")
+      rows
         .at(0)
+        .find("Link")
         .text(),
-      "test1@example.com"
+      "Change Password"
     )
     assert.equal(
-      card
-        .find(".email")
+      rows
+        .at(0)
+        .find("h5")
+        .text(),
+      "MIT Open"
+    )
+    assert.equal(
+      rows
         .at(1)
+        .find("h5")
         .text(),
-      "test2@example.com"
+      "MicroMasters"
     )
     assert.equal(
-      card
-        .find(".highlight")
-        .at(0)
-        .text()
-        .trim(),
-      "Test User"
+      rows
+        .at(2)
+        .find("h5")
+        .text(),
+      "Touchstone@MIT"
     )
   })
 
   it("renders the email auth type first", async () => {
     helper.getSocialAuthTypesStub.returns(
-      Promise.resolve([
-        { provider: "micromasters", email: "mm_auth@example.com" },
-        { provider: "email", email: "email_auth@example.com" }
-      ])
+      Promise.resolve([{ provider: "micromasters" }, { provider: "email" }])
     )
     const wrapper = await renderPage()
 
+    const rows = wrapper.find(".account-settings-row")
+    assert.equal(rows.length, 2)
     assert.equal(
-      wrapper
-        .find(".email")
+      rows
         .at(0)
+        .find("h5")
         .text(),
-      "email_auth@example.com"
-    )
-    assert.equal(
-      wrapper
-        .find(".email")
-        .at(1)
-        .text(),
-      "mm_auth@example.com"
+      "MIT Open"
     )
   })
 })

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -251,5 +251,4 @@ export type ProfilePayload = {
 
 export type SocialAuth = {
   provider: string,
-  email:    ?string
 }

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -433,10 +433,6 @@ export const postPasswordResetNewPassword = (
     })
   })
 
-export function getSocialAuthTypes(): Promise<Array<SocialAuth>> {
-  return fetchJSONWithAuthFailure("/api/v0/auths/")
-}
-
 export const postSetPassword = (
   currentPassword: string,
   newPassword: string
@@ -448,3 +444,7 @@ export const postSetPassword = (
       new_password:     newPassword
     })
   })
+
+export function getSocialAuthTypes(): Promise<Array<SocialAuth>> {
+  return fetchJSONWithAuthFailure("/api/v0/auths/")
+}

--- a/static/scss/basic.scss
+++ b/static/scss/basic.scss
@@ -17,12 +17,15 @@ a.button {
 .link-button {
   display: block;
   padding: 17px 40px;
-  color: $font-grey;
   border: 1px solid $bg-grey;
   text-align: center;
+  margin: 10px 0 20px;
+}
+
+.touchstone-text-logo {
+  color: $font-grey;
   font-size: 17px;
   font-weight: 400;
-  margin: 10px 0 20px;
 
   .ampersand {
     color: #68b90f;

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -148,17 +148,3 @@ textarea::placeholder {
 .actions {
   margin-top: 20px;
 }
-
-.account-settings-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  width: 100%;
-  color: #777;
-  border-bottom: 1px solid #777;
-  padding: 0 0 8px 0;
-
-  a:link {
-    font-weight: bold;
-  }
-}

--- a/static/scss/settings.scss
+++ b/static/scss/settings.scss
@@ -45,3 +45,27 @@
     display: inline-block;
   }
 }
+
+.account-settings-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 0 10px 0;
+  margin: 40px 0 0 0;
+  border-bottom: 1px solid #777;
+  color: #000;
+
+  h5,
+  h5.touchstone-text-logo {
+    margin: 0;
+    padding: 0;
+    font-size: inherit;
+    font-weight: 700;
+    color: inherit;
+  }
+
+  a:link {
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #922

#### What's this PR do?
Displays the 'saml' social auth provider type in the account settings page and makes some basic stylistic changes to that page based on various bits of feedback

#### How should this be manually tested?
Authenticate via Touchstone, or just hardcode a list of provider types that includes `'saml'` and return it in the `authentication.views.get_social_auth_types` view function

#### Any background context you want to provide?
From a UI perspective, we decided we no longer care about the email associated with each particular auth type

#### Screenshots (if appropriate)
![ss 2018-08-01 at 14 37 20](https://user-images.githubusercontent.com/14932219/43550100-8d49fddc-95b0-11e8-946e-19d4081fc7e2.png)


