### PR TITLE
Add can_remove field to serializers

### DIFF
--- a/cassettes/channels.views.moderators_test.test_add_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-09-25T16:20:36",
+      "recorded_at": "2018-08-02T15:01:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJG9F9PKYEZTNH1J16DSPG"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDKyMNT1c0ssDnQJDbZ0TY73KEkOyXLMirKwyC52jwpV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5G3k6lTg6l2TkZ1dUmrlFVAQHFZVF+emGWjiC9KSklmUmp8ZnpoAMhnCUagEmgeHLuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdU1CTP3C0qrCMpK83dMcsutCjbyyszPSMkoCcxX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5hHqkJRlnBocEOBfqBjinOoV4m1uGJlsE6zqC9KSklmUmp8ZnpoAMhnCUagG3Dqe+uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:20:36 GMT"
+            "Thu, 02 Aug 2018 15:01:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:20:36 GMT",
-            "loidcreated=2017-09-25T16%3A20%3A36.307Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Wed, 25-Sep-2019 16:20:36 GMT"
+            "loid=dJMGWK20A3oRMtJ8NE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 15:01:13 GMT",
+            "loidcreated=2018-08-02T15%3A01%3A12.787Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 15:01:13 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJG9F9PKYEZTNH1J16DSPG"
       }
     },
     {
-      "recorded_at": "2017-09-25T16:20:36",
+      "recorded_at": "2018-08-02T15:01:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=281-C2IBtACthokxy6FXxSRrvZN-U8A"
+          "string": "api_type=json&description=Cumque+unde+ipsam+dicta+blanditiis+omnis+ea+aliquid+soluta.+Laborum+voluptas+blanditiis+saepe+magnam+optio+atque+illo.+Quisquam+repudiandae+molestiae+fugit.+Facilis+minima+asperiores+iure+atque+soluta+ullam.%0AMagni+quaerat+neque+nisi+quas+ducimus.+Dolorum+qui+ab+quisquam+accusantium.+Quos+at+excepturi+ducimus.+Harum+non+quibusdam+at+debitis+quibusdam.%0ADolorem+corrupti+delectus+modi+inventore.+Occaecati+mollitia+sed+debitis.+Consequuntur+possimus+non+quam+repellat.&link_type=any&name=1533222073_tenetur&public_description=Nesciunt+voluptatibus+voluptates+pariatur+eaque.+Sunt+facilis+totam+ullam+facilis+labore+tenetur.&title=Veritatis+dolorem+reprehenderit+laudantium+id.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,121 +84,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
+            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "70"
+            "735"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"281-IO1Fou9ea-TePPZ-NrLVsBaQtbM\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "109"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:20:36 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299"
-          ],
-          "x-ratelimit-reset": [
-            "564"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-25T16:20:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 281-IO1Fou9ea-TePPZ-NrLVsBaQtbM"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1506356020.0, \"mod_permissions\": [\"all\"], \"name\": \"admin\", \"id\": \"t2_7t\"}, {\"date\": 1506356121.0, \"mod_permissions\": [\"all\"], \"name\": \"01BTN7HXFM5MA85XBD1ZCD6XC6\", \"id\": \"t2_7q\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "233"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Mon, 25 Sep 2017 16:20:36 GMT"
+            "Thu, 02 Aug 2018 15:01:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -219,13 +142,10 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "564"
+            "527"
           ],
           "x-ratelimit-used": [
             "1"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=iBWUzw6VWlQSu0tupr5u%2Fco6mqtKxc7yRO6vz9GWvhuHlq%2BQxxAfffpo1zLBRtm4MsIgHp3DRBpolLMe7cXoAqSlRfSoUI%2Bo"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -238,15 +158,83 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2017-09-25T16:20:38",
+      "recorded_at": "2018-08-02T15:01:19",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01BTN6G82RKTS3WF61Q33AA0ND&permissions=%2Ball&type=moderator"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJGFSKN49XFKM3W9ZFHMYW"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdMtdjfKtSgP8Q+uCC3NCwp0jKjKyna2SPSpKMlW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVGUR6Reb6l8Y7BluWlhslBzinhUQE5xqbJIeC9KSklmUmp8ZnpoAMhnCUagHnHQatuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 15:01:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJGFSKN49XFKM3W9ZFHMYW"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T15:01:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKXJGFSKN49XFKM3W9ZFHMYW&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -256,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 281-IO1Fou9ea-TePPZ-NrLVsBaQtbM"
+            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
           ],
           "Connection": [
             "keep-alive"
@@ -268,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533222073_tenetur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -293,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:20:38 GMT"
+            "Thu, 02 Aug 2018 15:01:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -314,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "562"
+            "521"
           ],
           "x-ratelimit-used": [
             "2"
@@ -330,162 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533222073_tenetur/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2017-09-25T16:20:38",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJoQUEkdhcmERZGgS1PbR6xVW1+JoRr/XSqT4z2559434UKAc6wzGu5kFZEkW8xSj3W7vzWcysqWO24qxEcNRaINmUYEeqsQHFNBSJdxPLCfzzpvIYycgCNg6DphRjQJCaEdxPP/m301m+tBZ9ue1r5Yl5m/uCNtmMvnwZHwVAKYkmF4DOTzBTUGmcS4AAAA",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Mon, 25 Sep 2017 16:20:38 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01BTN6G82RKTS3WF61Q33AA0ND"
-      }
-    },
-    {
-      "recorded_at": "2017-09-25T16:20:38",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=275-pzXJlYk7Rx9VyDBM7yjsZ9X_sC4"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "Basic MW1pM3JwTTZ4SjN0RlE6LTNmQkxfZDk2R2o5d20tQU01TTRSOHpFajA0"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "70"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/api/v1/access_token"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"access_token\": \"275-iH149DRZnFwTAUMmRk7eTlin-KY\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "109"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Mon, 25 Sep 2017 16:20:38 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298"
-          ],
-          "x-ratelimit-reset": [
-            "562"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/access_token"
-      }
-    },
-    {
-      "recorded_at": "2017-09-25T16:20:38",
+      "recorded_at": "2018-08-02T15:01:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -499,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 275-iH149DRZnFwTAUMmRk7eTlin-KY"
+            "bearer 246-sG2m8wTOSxUunRQAXzjkC8aLxtk"
           ],
           "Connection": [
             "keep-alive"
@@ -511,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=KgYw1VVKIi2s5vJAF3; loidcreated=2017-09-25T16%3A20%3A36.307Z"
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.0.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/admin_channel/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533222073_tenetur/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -536,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Mon, 25 Sep 2017 16:20:38 GMT"
+            "Thu, 02 Aug 2018 15:01:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -557,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "562"
+            "521"
           ],
           "x-ratelimit-used": [
             "1"
@@ -573,7 +410,179 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/admin_channel/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533222073_tenetur/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T15:01:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKXJGFSKN49XFKM3W9ZFHMYW/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXJGFSKN49XFKM3W9ZFHMYW\", \"is_friend\": false, \"created\": 1533222079.0, \"hide_from_robots\": false, \"created_utc\": 1533222079.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6u\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 15:01:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "521"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=FLH7LKRM394ffIl41Rj2hHNYQSLe13UGj7KvlFJHcX9oeEyZdEbVo1CM7%2FG88OXsLw1GH1CvRn8%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKXJGFSKN49XFKM3W9ZFHMYW/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T15:01:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXJG9F9PKYEZTNH1J16DSPG\", \"created\": 1533222073.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533222073.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6t\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "484"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 15:01:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "521"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_add_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-02T15:01:13",
+      "recorded_at": "2018-08-03T21:28:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJG9F9PKYEZTNH1J16DSPG"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0V1PP2T147K4ZA2A7VBQS7"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdU1CTP3C0qrCMpK83dMcsutCjbyyszPSMkoCcxX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5hHqkJRlnBocEOBfqBjinOoV4m1uGJlsE6zqC9KSklmUmp8ZnpoAMhnCUagG3Dqe+uAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNwQrCMBBEf6XsURSCKUW8ebUFi4fWegkxWUkU07IJtVb8dxt78jiPeTNvkEqh9yK0d3SwTYCnfMUfZu2N09XuyM6jHOo+y4vDpstVA8sEcOgsoRc2CjxjbGI/X4RXh3HkgpKQYterdkaLmAivk2j+36pWhJMKI/Wlw5Lck6q0EXW9v7HoaOytQmF1HJ4DfL5i0odQuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:13 GMT"
+            "Fri, 03 Aug 2018 21:28:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 15:01:13 GMT",
-            "loidcreated=2018-08-02T15%3A01%3A12.787Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 15:01:13 GMT"
+            "loid=PNF3WIpIj2s9Ksi2cK; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:28:15 GMT",
+            "loidcreated=2018-08-03T21%3A28%3A15.280Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:28:15 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJG9F9PKYEZTNH1J16DSPG"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0V1PP2T147K4ZA2A7VBQS7"
       }
     },
     {
-      "recorded_at": "2018-08-02T15:01:13",
+      "recorded_at": "2018-08-03T21:28:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Cumque+unde+ipsam+dicta+blanditiis+omnis+ea+aliquid+soluta.+Laborum+voluptas+blanditiis+saepe+magnam+optio+atque+illo.+Quisquam+repudiandae+molestiae+fugit.+Facilis+minima+asperiores+iure+atque+soluta+ullam.%0AMagni+quaerat+neque+nisi+quas+ducimus.+Dolorum+qui+ab+quisquam+accusantium.+Quos+at+excepturi+ducimus.+Harum+non+quibusdam+at+debitis+quibusdam.%0ADolorem+corrupti+delectus+modi+inventore.+Occaecati+mollitia+sed+debitis.+Consequuntur+possimus+non+quam+repellat.&link_type=any&name=1533222073_tenetur&public_description=Nesciunt+voluptatibus+voluptates+pariatur+eaque.+Sunt+facilis+totam+ullam+facilis+labore+tenetur.&title=Veritatis+dolorem+reprehenderit+laudantium+id.&type=public&wikimode=disabled"
+          "string": "api_type=json&description=Voluptatibus+nemo+libero+ratione+accusantium+incidunt.+Saepe+ratione+nam+reiciendis+consectetur+quo+esse+nam.+Voluptatum+harum+voluptas+quaerat+quo+ab+quos+iste.%0AOptio+tempore+corporis+qui.+Sint+voluptatibus+consequuntur+maiores+commodi.+Nesciunt+sit+excepturi+enim+eos.+Consequuntur+iste+eos+consequatur+maiores+dicta+dolorem.%0APlaceat+reiciendis+esse+quae+esse+ad.+Incidunt+voluptatibus+voluptate+reiciendis+alias+reiciendis+doloremque+eveniet.+Assumenda+rem+doloribus+magnam+hic.&link_type=any&name=1533331695_totam&public_description=Iste+facilis+sunt+illum+quod.+Exercitationem+alias+asperiores+voluptates+praesentium+quibusdam.&title=Voluptas+a+debitis+culpa+ipsam+iusto+suscipit.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
+            "bearer 343-3mh2shndVAR0ZzaxWv6KLO8pKcY"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "735"
+            "745"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:13 GMT"
+            "Fri, 03 Aug 2018 21:28:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "527"
+            "105"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-02T15:01:19",
+      "recorded_at": "2018-08-03T21:28:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJGFSKN49XFKM3W9ZFHMYW"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0V1X23AN6F10R78DSMNV42"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdMtdjfKtSgP8Q+uCC3NCwp0jKjKyna2SPSpKMlW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVGUR6Reb6l8Y7BluWlhslBzinhUQE5xqbJIeC9KSklmUmp8ZnpoAMhnCUagHnHQatuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2MdF1DY9MzfXLyg7J94sozy4wzUx3NTRK90uLd01W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblmEcGZ+WbWJqlhpW5ZzuGFRU6+pcGZIaGGvmC9KSklmUmp8ZnpoAMhnCUagFk98IOuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:19 GMT"
+            "Fri, 03 Aug 2018 21:28:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJGFSKN49XFKM3W9ZFHMYW"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0V1X23AN6F10R78DSMNV42"
       }
     },
     {
-      "recorded_at": "2018-08-02T15:01:19",
+      "recorded_at": "2018-08-03T21:28:22",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKXJGFSKN49XFKM3W9ZFHMYW&permissions=%2Ball&type=moderator"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -244,44 +244,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
+            "bearer 343-3mh2shndVAR0ZzaxWv6KLO8pKcY"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533222073_tenetur/api/friend/?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533331695_totam/about/moderators/?user=01CM0V1PP2T147K4ZA2A7VBQS7&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533331695.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0V1PP2T147K4ZA2A7VBQS7\", \"id\": \"t2_9j\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "24"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:19 GMT"
+            "Fri, 03 Aug 2018 21:28:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,10 +296,13 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "521"
+            "98"
           ],
           "x-ratelimit-used": [
             "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=lI5F8mElwr7dnAeMoBhea2Pb%2ByaaXl8L%2Bs%2B8YhGDSe1NO8YiSXKyQDNP1qg0Ex%2F7%2FXHEEqmcUGEfHM%2BNqwwjLj77hzjM21ge"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -318,15 +315,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533222073_tenetur/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533331695_totam/about/moderators/?user=01CM0V1PP2T147K4ZA2A7VBQS7&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T15:01:19",
+      "recorded_at": "2018-08-03T21:28:22",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json"
+          "string": "api_type=json&name=01CM0V1X23AN6F10R78DSMNV42&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -336,26 +333,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 246-sG2m8wTOSxUunRQAXzjkC8aLxtk"
+            "bearer 343-3mh2shndVAR0ZzaxWv6KLO8pKcY"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "13"
+            "79"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533222073_tenetur/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533331695_totam/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -373,93 +370,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:19 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "521"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533222073_tenetur/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-02T15:01:19",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/user/01CKXJGFSKN49XFKM3W9ZFHMYW/about/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXJGFSKN49XFKM3W9ZFHMYW\", \"is_friend\": false, \"created\": 1533222079.0, \"hide_from_robots\": false, \"created_utc\": 1533222079.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6u\"}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "275"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Thu, 02 Aug 2018 15:01:19 GMT"
+            "Fri, 03 Aug 2018 21:28:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -480,13 +391,10 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "521"
+            "98"
           ],
           "x-ratelimit-used": [
             "3"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=FLH7LKRM394ffIl41Rj2hHNYQSLe13UGj7KvlFJHcX9oeEyZdEbVo1CM7%2FG88OXsLw1GH1CvRn8%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -499,11 +407,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKXJGFSKN49XFKM3W9ZFHMYW/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533331695_totam/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T15:01:19",
+      "recorded_at": "2018-08-03T21:28:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 344-EWYemNjkToNXwkp5igE12gNf_Ec"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533331695_totam/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:28:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533331695_totam/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:28:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -517,38 +517,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 245-4V7NRfxRjfOAbFmzS2JiohdhtQo"
+            "bearer 343-3mh2shndVAR0ZzaxWv6KLO8pKcY"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=dJMGWK20A3oRMtJ8NE; loidcreated=2018-08-02T15%3A01%3A12.787Z"
+            "loid=PNF3WIpIj2s9Ksi2cK; loidcreated=2018-08-03T21%3A28%3A15.280Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+        "uri": "https://reddit.local/r/1533331695_totam/about/moderators/?user=01CM0V1X23AN6F10R78DSMNV42&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXJG9F9PKYEZTNH1J16DSPG\", \"created\": 1533222073.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533222073.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6t\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533331702.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0V1X23AN6F10R78DSMNV42\", \"id\": \"t2_9k\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "484"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 15:01:19 GMT"
+            "Fri, 03 Aug 2018 21:28:22 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -569,10 +569,16 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "521"
+            "98"
           ],
           "x-ratelimit-used": [
             "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=E8VGpGMtyqT6FbFAHFzXhdQn085NRFBMsgyhP0SLhd4caNFneHGMl232jrhongNmkaSF0q9eRAtgxOZY%2FuFMue0h%2BZHvDaa9"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -582,7 +588,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
+        "url": "https://reddit.local/r/1533331695_totam/about/moderators/?user=01CM0V1X23AN6F10R78DSMNV42&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_add_moderator_again.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-10-31T16:20:21",
+      "recorded_at": "2018-08-02T14:51:10",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHXWSKNQYR0JEHY1QH2RMM"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNeNCjDxSU3NLnYxNMv2Ty4Oc3FOCfc0cXMvzspX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5BaZERUVYZppEuSabm/imewT4GSZGGmc7xkeC9KSklmUmp8ZnpoAMhnCUagHOrH10uAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJo0IoS4OWCjCSRubk0pj9IUAV8riMZ/l8rkeE/uufdNhJRgLXedgZbsA7Ld0U14QyNVC+fCJKzJTzEe7kzksWMjWQcEnr1GsFx7IYwpndnP527qwY8UIBDQd63sFrTyCaGaxfr/LZpUmqrrBV1GI5Ox18M2ohqHY6K8U8KgJXBd+uElkM8XcaAMIbgAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Oct 2017 16:20:21 GMT"
+            "Thu, 02 Aug 2018 14:51:10 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=oT1X231llRskGWYeX1; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 31-Oct-2019 16:20:21 GMT",
-            "loidcreated=2017-10-31T16%3A20%3A21.713Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 31-Oct-2019 16:20:21 GMT"
+            "loid=3HayLIFs7oZn5UJxxE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:51:10 GMT",
+            "loidcreated=2018-08-02T14%3A51%3A09.997Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:51:10 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=admin"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHXWSKNQYR0JEHY1QH2RMM"
       }
     },
     {
-      "recorded_at": "2017-10-31T16:20:23",
+      "recorded_at": "2018-08-02T14:51:10",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=already_mod&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&description=Perferendis+provident+beatae+id+dolorem+quia+ducimus+sit.+Quaerat+fugit+quam+quo+molestias+voluptate+sapiente+vitae.+Explicabo+itaque+recusandae+voluptates.+Dolore+facere+recusandae+numquam+at+rerum.%0AImpedit+similique+cupiditate+assumenda+possimus+nemo+quis.+Eveniet+suscipit+deserunt+laudantium+quia+ducimus+earum+fuga.+Iusto+dolorem+repudiandae+nobis+odio+architecto+distinctio+at.&link_type=any&name=1533221470_dolor&public_description=Dicta+ullam+magnam+assumenda+illum.+Cumque+eligendi+quas+quam+ex.+Facilis+quos+at+nihil.&title=Neque+eligendi+et+accusamus+dolores.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,44 +84,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 187-ZP4LeeksD16kOcsVDCdWI4FGsjo"
+            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "64"
+            "628"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=oT1X231llRskGWYeX1; loidcreated=2017-10-31T16%3A20%3A21.713Z"
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.3.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/a_channel/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": [[\"ALREADY_MODERATOR\", \"that user is already a moderator\", \"name\"]]}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "89"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Oct 2017 16:20:23 GMT"
+            "Thu, 02 Aug 2018 14:51:10 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "577"
+            "530"
           ],
           "x-ratelimit-used": [
             "1"
@@ -158,7 +158,523 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/a_channel/api/friend/?raw_json=1"
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHY37XP7484ZDAVQBS4B71"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdRNiggMzfbytDDz8nErLzFxcTVIdvMpCE0sLHJV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZl+HrEe/oEVZj7hQWlBsZXeZoXFIcZufiU+TuC9KSklmUmp8ZnpoAMhnCUagHxLRkYuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHY37XP7484ZDAVQBS4B71"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKXHY37XP7484ZDAVQBS4B71&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "524"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 241-bXQUkJI86JLFwt4DE0cFLpUaqrE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533221470_dolor/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "523"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533221470_dolor/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKXHY37XP7484ZDAVQBS4B71&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"ALREADY_MODERATOR\", \"that user is already a moderator\", \"name\"]]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "89"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "523"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKXHY37XP7484ZDAVQBS4B71/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXHY37XP7484ZDAVQBS4B71\", \"is_friend\": false, \"created\": 1533221476.0, \"hide_from_robots\": false, \"created_utc\": 1533221476.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6p\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "523"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=eaQL%2B0KpBZu4IkOGaA36n%2Bd0uJtDCiN2l8Fy8OpXnUamwwIfw0OQ0oBOVNEC%2BZiwfrSgxFGApWA%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKXHY37XP7484ZDAVQBS4B71/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:51:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXHXWSKNQYR0JEHY1QH2RMM\", \"created\": 1533221470.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533221470.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6o\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "484"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:51:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "523"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_add_moderator_again.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator_again.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-02T14:51:10",
+      "recorded_at": "2018-08-03T21:10:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHXWSKNQYR0JEHY1QH2RMM"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T1CB3AP4NFXWPWYSHRQXQ"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJo0IoS4OWCjCSRubk0pj9IUAV8riMZ/l8rkeE/uufdNhJRgLXedgZbsA7Ld0U14QyNVC+fCJKzJTzEe7kzksWMjWQcEnr1GsFx7IYwpndnP527qwY8UIBDQd63sFrTyCaGaxfr/LZpUmqrrBV1GI5Ox18M2ohqHY6K8U8KgJXBd+uElkM8XcaAMIbgAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2MdQtS0rzzo3KdPIurQg3TkrLc6xMMTDUdayMSAxV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLa5B6R5RDo6O+aWZcW7Gxu4eLr5mJYUpSQnReaD9KSklmUmp8ZnpoAMhnCUagFuDp0wuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:10 GMT"
+            "Fri, 03 Aug 2018 21:10:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:51:10 GMT",
-            "loidcreated=2018-08-02T14%3A51%3A09.997Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:51:10 GMT"
+            "loid=Owr8ATD7vPrS56q0Qh; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:10:36 GMT",
+            "loidcreated=2018-08-03T21%3A10%3A36.107Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:10:36 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHXWSKNQYR0JEHY1QH2RMM"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T1CB3AP4NFXWPWYSHRQXQ"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:10",
+      "recorded_at": "2018-08-03T21:10:36",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Perferendis+provident+beatae+id+dolorem+quia+ducimus+sit.+Quaerat+fugit+quam+quo+molestias+voluptate+sapiente+vitae.+Explicabo+itaque+recusandae+voluptates.+Dolore+facere+recusandae+numquam+at+rerum.%0AImpedit+similique+cupiditate+assumenda+possimus+nemo+quis.+Eveniet+suscipit+deserunt+laudantium+quia+ducimus+earum+fuga.+Iusto+dolorem+repudiandae+nobis+odio+architecto+distinctio+at.&link_type=any&name=1533221470_dolor&public_description=Dicta+ullam+magnam+assumenda+illum.+Cumque+eligendi+quas+quam+ex.+Facilis+quos+at+nihil.&title=Neque+eligendi+et+accusamus+dolores.&type=public&wikimode=disabled"
+          "string": "api_type=json&description=Iure+at+blanditiis+repellendus+sunt+dicta.+Consequuntur+ad+ex+minus+fugit+saepe+odit+est+voluptas.%0AEligendi+nemo+dignissimos+dolorum+distinctio.+Accusantium+mollitia+veritatis+quisquam+quod+temporibus+blanditiis+nesciunt.+Optio+placeat+adipisci+excepturi+necessitatibus+eum+doloribus.%0AEsse+excepturi+velit+numquam+sunt+corporis+suscipit.+Dolore+dolorem+at+nam+quas.+Delectus+eum+ullam+facere+ducimus+ad.+Odio+excepturi+eius+ad+quas+aspernatur+excepturi+laboriosam.&link_type=any&name=1533330636_ratione&public_description=Fugit+quasi+quisquam+officia.+Cumque+repellat+dolor+delectus+voluptate+magnam+aut+sed+earum.&title=Dolorum+architecto+quos+officia+magni+est.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "628"
+            "723"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:10 GMT"
+            "Fri, 03 Aug 2018 21:10:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "530"
+            "564"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:16",
+      "recorded_at": "2018-08-03T21:10:42",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHY37XP7484ZDAVQBS4B71"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T1JP7Z4BZ0H0CASQJJD33"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdRNiggMzfbytDDz8nErLzFxcTVIdvMpCE0sLHJV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZl+HrEe/oEVZj7hQWlBsZXeZoXFIcZufiU+TuC9KSklmUmp8ZnpoAMhnCUagHxLRkYuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNPQ+CQBBE/wq50khyAlGxI5dYURC1MDYX2FtlPSN4S/Ar/nc5qSznZd7MW5QAyKy7xuJVrAIRJ1FIRV65SKtFdjepDGWfH2rGdHm7sJgGAh8tOWRNXojnUg7s5+vu2aIfqbB06HyXoRnRxCeHx0Gs/98SOtsTzzJbqAgANmZPO/Uqt2YtvWOwJ0BNxg+PQXy+FhxKebgAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:16 GMT"
+            "Fri, 03 Aug 2018 21:10:42 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXHY37XP7484ZDAVQBS4B71"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T1JP7Z4BZ0H0CASQJJD33"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:17",
+      "recorded_at": "2018-08-03T21:10:43",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKXHY37XP7484ZDAVQBS4B71&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0T1JP7Z4BZ0H0CASQJJD33&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330636_ratione/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:17 GMT"
+            "Fri, 03 Aug 2018 21:10:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "524"
+            "558"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,11 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330636_ratione/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:17",
+      "recorded_at": "2018-08-03T21:10:43",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -336,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 241-bXQUkJI86JLFwt4DE0cFLpUaqrE"
+            "bearer 342-iPLbr2_C7Awd90-0vLZhse98qls"
           ],
           "Connection": [
             "keep-alive"
@@ -348,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533221470_dolor/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533330636_ratione/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:17 GMT"
+            "Fri, 03 Aug 2018 21:10:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "523"
+            "557"
           ],
           "x-ratelimit-used": [
             "1"
@@ -410,15 +410,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221470_dolor/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533330636_ratione/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:17",
+      "recorded_at": "2018-08-03T21:10:43",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKXHY37XP7484ZDAVQBS4B71&permissions=%2Ball&type=moderator"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -428,44 +428,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1JP7Z4BZ0H0CASQJJD33&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": [[\"ALREADY_MODERATOR\", \"that user is already a moderator\", \"name\"]]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330643.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T1JP7Z4BZ0H0CASQJJD33\", \"id\": \"t2_9i\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "89"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:17 GMT"
+            "Fri, 03 Aug 2018 21:10:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -486,10 +480,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "523"
+            "557"
           ],
           "x-ratelimit-used": [
             "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=teqq3HuEw8Ga%2Bgz7YgDjpbCVxFFgzdJaoHJd8zDK0kt9%2F8VDcf606QpWznt61V9jlj9ZbB3y6edbd5LxhckGYFFEMf3Z%2BcEC"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -502,11 +499,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221470_dolor/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1JP7Z4BZ0H0CASQJJD33&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:17",
+      "recorded_at": "2018-08-03T21:10:43",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -520,38 +517,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKXHY37XP7484ZDAVQBS4B71/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1CB3AP4NFXWPWYSHRQXQ&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXHY37XP7484ZDAVQBS4B71\", \"is_friend\": false, \"created\": 1533221476.0, \"hide_from_robots\": false, \"created_utc\": 1533221476.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6p\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330636.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T1CB3AP4NFXWPWYSHRQXQ\", \"id\": \"t2_9h\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:17 GMT"
+            "Fri, 03 Aug 2018 21:10:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -572,13 +569,13 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "523"
+            "557"
           ],
           "x-ratelimit-used": [
             "4"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=eaQL%2B0KpBZu4IkOGaA36n%2Bd0uJtDCiN2l8Fy8OpXnUamwwIfw0OQ0oBOVNEC%2BZiwfrSgxFGApWA%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=cw6mrwyW71JtTB7a2PaRF%2Bt2gcg0HICznxobxZXAHYao9Nu6uTuCnx9gJ%2FhyJG0yqjiD55NZfKG01M%2Fv93B5pE%2BS2bxLEHAL"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -591,15 +588,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKXHY37XP7484ZDAVQBS4B71/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1CB3AP4NFXWPWYSHRQXQ&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:51:17",
+      "recorded_at": "2018-08-03T21:10:43",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01CM0T1JP7Z4BZ0H0CASQJJD33&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -609,38 +606,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 240-3mrkcgneJbk8GlNI6rAqGaN6tGw"
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
           ],
           "Connection": [
             "keep-alive"
           ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
           "Cookie": [
-            "loid=3HayLIFs7oZn5UJxxE; loidcreated=2018-08-02T14%3A51%3A09.997Z"
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330636_ratione/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXHXWSKNQYR0JEHY1QH2RMM\", \"created\": 1533221470.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533221470.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6o\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+          "string": "{\"json\": {\"errors\": [[\"ALREADY_MODERATOR\", \"that user is already a moderator\", \"name\"]]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "484"
+            "89"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:51:17 GMT"
+            "Fri, 03 Aug 2018 21:10:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -661,10 +664,13 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "523"
+            "557"
           ],
           "x-ratelimit-used": [
             "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -674,7 +680,96 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
+        "url": "https://reddit.local/r/1533330636_ratione/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 341-vbfKmZiBKuxW3bfnAyd01-AyXaU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=Owr8ATD7vPrS56q0Qh; loidcreated=2018-08-03T21%3A10%3A36.107Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1JP7Z4BZ0H0CASQJJD33&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330643.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T1JP7Z4BZ0H0CASQJJD33\", \"id\": \"t2_9i\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:43 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "557"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=sBkGqVskr6jHUCpc8CjEyGB7XTqeOFicYLWhN%2FD%2BndA4tvzhOf6yHvsmjYgTGK8eZni%2FacMS0ZvFvkB74psJ48wOKboXHKQr"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330636_ratione/about/moderators/?user=01CM0T1JP7Z4BZ0H0CASQJJD33&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_add_moderator_email.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator_email.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-20T14:51:38",
+      "recorded_at": "2018-08-02T14:56:48",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SDRABTTY8Q8CQSCS9E28"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8706YQ0ZQ30ZM4D536CV"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0s9B1NTUzDIuMT6vySLLMy40IcywPr8qvcnTMcvNV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZ+BUZZTilBnll6+Z7G8dHpcQXhnuaGeUYmKeD9KSklmUmp8ZnpoAMhnCUagHVuoDfuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdJNdA9ODfULKc1yDs4ML/dM8vGMMvNzMw7w8jdR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbF+6cYBxcbOZVZWOj6h0Slx2eGl4Z4lvtbFkaC9KSklmUmp8ZnpoAMhnCUagGuUQO+uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:38 GMT"
+            "Thu, 02 Aug 2018 14:56:48 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 19-Jul-2020 14:51:38 GMT",
-            "loidcreated=2018-07-20T14%3A51%3A38.651Z; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 19-Jul-2020 14:51:38 GMT"
+            "loid=3jY3pqKeXQxPG6nqDi; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:56:48 GMT",
+            "loidcreated=2018-08-02T14%3A56%3A48.113Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:56:48 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SDRABTTY8Q8CQSCS9E28"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8706YQ0ZQ30ZM4D536CV"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:39",
+      "recorded_at": "2018-08-02T14:56:48",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Quidem+illum+accusantium+necessitatibus+consequatur.+Voluptatum+assumenda+adipisci+consectetur.+Ab+voluptates+ipsum+commodi+repudiandae+assumenda+officiis.+Dolores+ducimus+ipsa+voluptates.%0AOptio+non+non+at+voluptates+similique+quibusdam+optio.+Libero+iure+nemo+quae+sit.+Voluptate+magnam+deserunt+doloribus+voluptatum+ex+iste.+Eaque+assumenda+nam+quam.&link_type=any&name=1532098298_ullam&public_description=Excepturi+distinctio+aut+fuga+tenetur.+Dolore+quis+magni+quam.+Magnam+dolor+illum+dolore+eaque.&title=Ipsam+eum+harum+error+quod+ut+ipsa.&type=public&wikimode=disabled"
+          "string": "api_type=json&description=Nam+quos+itaque+enim+amet+culpa+pariatur+quos.+In+nobis+dolor+nostrum+eos+mollitia.+Incidunt+autem+quis+doloribus+voluptatum.+Ad+nisi+aliquam+porro+magni.%0ASunt+facere+doloribus+ducimus+vel+ab.+Ducimus+maxime+voluptate+velit+possimus+eius+nulla+repudiandae+quos.+Fuga+optio+tempore+hic+quae+laboriosam+perspiciatis+soluta.%0AEx+quia+perspiciatis+autem.+Dolor+nesciunt+aliquid+quos+consequatur+ipsa+explicabo.+Hic+eius+quod+assumenda+nam+adipisci+quidem+quis.&link_type=any&name=1533221808_adipisci&public_description=Ducimus+iure+error+fuga.+Debitis+culpa+nisi+in+molestias+doloremque.&title=Animi+consectetur+deleniti+totam+deleniti+quas.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "603"
+            "696"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:39 GMT"
+            "Thu, 02 Aug 2018 14:56:48 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "502"
+            "192"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:45",
+      "recorded_at": "2018-08-02T14:56:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SM8A2XJVPE3BC8NH5WV2"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8DDRDVRBBWMSCAT8T8ZK"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGAmTyqyboIJ0UTqEXYbbPtkYNPk2pYj+ey5PHd+H93nfN+mFAOeYtwYe5ByRJD3FnKsbFcmE6uoPmaxM4i+Ols2sDdlGBJ6jRnBMB2GXUrqwn8/8a4QwwqFHwNB1wq5oExLCsIjq/y0rMab3eiqqoTi2ts5pi2IPDXRdcCTMWgDTMgyvgXy+E3UjEbgAAAA=",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGA1ER4duUcMO6ugQkZfhPj9pSCrbTCX677k8dXwf3ud936QEQGul6xpsyT4gEYtp0djBcSWFEImeI5pJfqqOhzFtr2QbEJx6bdBK7YV4F4YL+/nSzT36EYWlQeO7FroVbXwyWC/i4/+Nc/ass2GcGD1DXjiT3+GmWCou4J0KXxpQ6soPr4F8vqYtx/i4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:45 GMT"
+            "Thu, 02 Aug 2018 14:56:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,11 +226,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SM8A2XJVPE3BC8NH5WV2"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8DDRDVRBBWMSCAT8T8ZK"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:48",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -247,18 +247,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SQH42V47Y4MKH5R0V1TD"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8GNSKJJHEVBGB1R8GF2H"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNXQvCIBiF/8rwMho4Riu6bRDRJzQIupGlb+UMHWqmi/57s111eR7Oc84b1ZSCMcQqARLNE5RNcRr0Gecpk67z8kGDmu2cL22TLZVC4wSBb7kGQ3gU8gLjnv18YkMLceQCtQYdu4aqAY1i0nDtxfv/G+2OxekWnnshmlBuK3dYrRebCk/gFR0GjlMgnMXhIaDPF3E35ty4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdH1N7FIrvDxKk70iDT31C2McDFNCynNrzKOyA9U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZleDp5hPomh5sFhmbEW6Y5B6Q6xweb50TmO5eD9KSklmUmp8ZnpoAMhnCUagFNliV5uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -272,7 +272,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:48 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -294,15 +294,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJW2SQH42V47Y4MKH5R0V1TD"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8GNSKJJHEVBGB1R8GF2H"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:49",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJW2SM8A2XJVPE3BC8NH5WV2&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CKXJ8DDRDVRBBWMSCAT8T8ZK&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -312,7 +312,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
           ],
           "Connection": [
             "keep-alive"
@@ -324,14 +324,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -349,7 +349,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:49 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -370,7 +370,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "492"
+            "182"
           ],
           "x-ratelimit-used": [
             "2"
@@ -386,11 +386,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:49",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -404,7 +404,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 169-bbhW0c1urhSt58dFk1tKs0EPvik"
+            "bearer 243-ZksutEb_OOOGiy2-M_EDdCAwLnU"
           ],
           "Connection": [
             "keep-alive"
@@ -416,14 +416,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -441,7 +441,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:49 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -462,7 +462,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "491"
+            "182"
           ],
           "x-ratelimit-used": [
             "1"
@@ -478,15 +478,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:49",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJW2SQH42V47Y4MKH5R0V1TD&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CKXJ8GNSKJJHEVBGB1R8GF2H&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -496,7 +496,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
           ],
           "Connection": [
             "keep-alive"
@@ -508,14 +508,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -533,7 +533,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:49 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -554,7 +554,7 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "491"
+            "182"
           ],
           "x-ratelimit-used": [
             "3"
@@ -570,11 +570,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532098298_ullam/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:49",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -588,7 +588,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 170-yrZ03-dnvzxnlcyo8NvxDtj1Goo"
+            "bearer 244-O48cxLJsaHY7I-qXD5fTuoz3XoQ"
           ],
           "Connection": [
             "keep-alive"
@@ -600,14 +600,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -625,7 +625,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:49 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -646,7 +646,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "491"
+            "182"
           ],
           "x-ratelimit-used": [
             "1"
@@ -662,11 +662,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532098298_ullam/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T14:51:49",
+      "recorded_at": "2018-08-02T14:56:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -680,25 +680,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 168-E561VY_fzHb9nmXVAwWzozAAjFM"
+            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=ikCN18N3cJ9hGvsdBe; loidcreated=2018-07-20T14%3A51%3A38.651Z"
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.1 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CJW2SQH42V47Y4MKH5R0V1TD/about/?raw_json=1"
+        "uri": "https://reddit.local/user/01CKXJ8GNSKJJHEVBGB1R8GF2H/about/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CJW2SQH42V47Y4MKH5R0V1TD\", \"is_friend\": false, \"created\": 1532098308.0, \"hide_from_robots\": false, \"created_utc\": 1532098308.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"4q\"}}"
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXJ8GNSKJJHEVBGB1R8GF2H\", \"is_friend\": false, \"created\": 1533221818.0, \"hide_from_robots\": false, \"created_utc\": 1533221818.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6s\"}}"
         },
         "headers": {
           "Connection": [
@@ -711,7 +711,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 14:51:49 GMT"
+            "Thu, 02 Aug 2018 14:56:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -732,13 +732,13 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "491"
+            "182"
           ],
           "x-ratelimit-used": [
             "4"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=pRKdsS%2F%2BwVdMr5AhhP0IiqWhD8tfImYRZMf3ihckIuiOJG3nGqmjvvYfaNxlMfsL4TxN5aSJMX8%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=wDCik8Pks80k4fdY74cfAswvrERR%2Fc%2Bqqz32DjyVTquZ85DjfC%2FiLuNLjebl18feJ88lWDDqozA%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -751,7 +751,90 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CJW2SQH42V47Y4MKH5R0V1TD/about/?raw_json=1"
+        "url": "https://reddit.local/user/01CKXJ8GNSKJJHEVBGB1R8GF2H/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-02T14:56:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXJ8706YQ0ZQ30ZM4D536CV\", \"created\": 1533221808.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533221808.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6q\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "484"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 02 Aug 2018 14:56:58 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "182"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_add_moderator_email.json
+++ b/cassettes/channels.views.moderators_test.test_add_moderator_email.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-02T14:56:48",
+      "recorded_at": "2018-08-03T21:36:44",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8706YQ0ZQ30ZM4D536CV"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VH7QW9E2PP6WMRMGARFNE"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdJNdA9ODfULKc1yDs4ML/dM8vGMMvNzMw7w8jdR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbF+6cYBxcbOZVZWOj6h0Slx2eGl4Z4lvtbFkaC9KSklmUmp8ZnpoAMhnCUagGuUQO+uAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2sdCtctGtNI0od3VKyTVLSwsvDnXJMfEqybTM90pW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZlmlgm+YaEGbuGhOe6e6VURrp5ZadWuOQ4RxmA9KSklmUmp8ZnpoAMhnCUagF1dkoxuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:48 GMT"
+            "Fri, 03 Aug 2018 21:36:44 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:56:48 GMT",
-            "loidcreated=2018-08-02T14%3A56%3A48.113Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 01-Aug-2020 14:56:48 GMT"
+            "loid=rBeZ9k7ryigrKznKCI; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:36:44 GMT",
+            "loidcreated=2018-08-03T21%3A36%3A44.257Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:36:44 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8706YQ0ZQ30ZM4D536CV"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VH7QW9E2PP6WMRMGARFNE"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:48",
+      "recorded_at": "2018-08-03T21:36:44",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Nam+quos+itaque+enim+amet+culpa+pariatur+quos.+In+nobis+dolor+nostrum+eos+mollitia.+Incidunt+autem+quis+doloribus+voluptatum.+Ad+nisi+aliquam+porro+magni.%0ASunt+facere+doloribus+ducimus+vel+ab.+Ducimus+maxime+voluptate+velit+possimus+eius+nulla+repudiandae+quos.+Fuga+optio+tempore+hic+quae+laboriosam+perspiciatis+soluta.%0AEx+quia+perspiciatis+autem.+Dolor+nesciunt+aliquid+quos+consequatur+ipsa+explicabo.+Hic+eius+quod+assumenda+nam+adipisci+quidem+quis.&link_type=any&name=1533221808_adipisci&public_description=Ducimus+iure+error+fuga.+Debitis+culpa+nisi+in+molestias+doloremque.&title=Animi+consectetur+deleniti+totam+deleniti+quas.&type=public&wikimode=disabled"
+          "string": "api_type=json&description=Qui+earum+animi+laborum+ex+nulla+illum+illo.+Quia+accusantium+eius+corrupti.+Explicabo+magni+laudantium+qui+deleniti.+Ut+quos+facere+quae+libero.%0AIn+ipsam+iusto+mollitia+necessitatibus.+Veritatis+ab+rerum+quisquam+officiis+incidunt.%0AVitae+accusamus+quaerat+nulla+possimus.+Quae+eligendi+dicta+molestias+eius.+Provident+quod+eaque+natus+magnam+distinctio.&link_type=any&name=1533332204_tenetur&public_description=Quae+repellat+accusamus+nisi+molestias+eos.+Hic+nulla+mollitia+expedita+aliquam+nam.&title=Architecto+eius+ratione+animi+possimus.&type=public&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
+            "bearer 348-zD-y5XwEBdm6ffWsUDl4Jti9oJc"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "696"
+            "602"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:48 GMT"
+            "Fri, 03 Aug 2018 21:36:44 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "192"
+            "196"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:54",
+      "recorded_at": "2018-08-03T21:36:51",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8DDRDVRBBWMSCAT8T8ZK"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VHE23C13DWZ4TFYGE6N0Q"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGA1ER4duUcMO6ugQkZfhPj9pSCrbTCX677k8dXwf3ud936QEQGul6xpsyT4gEYtp0djBcSWFEImeI5pJfqqOhzFtr2QbEJx6bdBK7YV4F4YL+/nSzT36EYWlQeO7FroVbXwyWC/i4/+Nc/ass2GcGD1DXjiT3+GmWCou4J0KXxpQ6soPr4F8vqYtx/i4AAAA",
+          "base64_string": "H4sIAAAAAAAAA1WNsQ6CMBRFf4V0NJJUMRjdYMAok2J0bLC8lsYKpQ9UNP67VCbHe3LPvW+Scw6IrK2vUJG1R4LFyi/FOdvFls6jV6VRpdiH21kudWOQTD0CT6MsIFNOCEJKB/bzWdsbcCMXyC1Y10Vej2jikgUxiOX/m+34cn9LYZPog8m6o3+KZRMJkOrhnALuigNThRseA/l8AXPWYmq4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:54 GMT"
+            "Fri, 03 Aug 2018 21:36:51 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,11 +226,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8DDRDVRBBWMSCAT8T8ZK"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VHE23C13DWZ4TFYGE6N0Q"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -247,18 +247,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8GNSKJJHEVBGB1R8GF2H"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VHHANKWQYA6750NKTXW9J"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMdH1N7FIrvDxKk70iDT31C2McDFNCynNrzKOyA9U0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZleDp5hPomh5sFhmbEW6Y5B6Q6xweb50TmO5eD9KSklmUmp8ZnpoAMhnCUagFNliV5uAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNPQ+CMBRF/wrpaDRpbOjgpk4SN+Ln0tT2QR9EKW1BjPG/S2VyvCf33PsmUinwXoSmhgdZJYSldHHnHavQnMPeUnrka7lJdQnLPjdPMk8IDBYdeIFRYJzSkf18EV4W4sgNpAMXu141E5rF5KAYRfP/Vm+VsoG3eXswBcJph1VVZkOXXy/R0dCjAoE6Dk+BfL5AyXYpuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -272,7 +272,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -294,15 +294,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKXJ8GNSKJJHEVBGB1R8GF2H"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0VHHANKWQYA6750NKTXW9J"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKXJ8DDRDVRBBWMSCAT8T8ZK&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0VHE23C13DWZ4TFYGE6N0Q&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -312,7 +312,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
+            "bearer 348-zD-y5XwEBdm6ffWsUDl4Jti9oJc"
           ],
           "Connection": [
             "keep-alive"
@@ -324,14 +324,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533332204_tenetur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -349,7 +349,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -370,7 +370,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "182"
+            "186"
           ],
           "x-ratelimit-used": [
             "2"
@@ -386,11 +386,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533332204_tenetur/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -404,7 +404,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 243-ZksutEb_OOOGiy2-M_EDdCAwLnU"
+            "bearer 349-hfWSJBr02AznlsiKsy6I1aglqps"
           ],
           "Connection": [
             "keep-alive"
@@ -416,14 +416,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533332204_tenetur/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -441,7 +441,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -462,7 +462,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "182"
+            "186"
           ],
           "x-ratelimit-used": [
             "1"
@@ -478,15 +478,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533332204_tenetur/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKXJ8GNSKJJHEVBGB1R8GF2H&permissions=%2Ball&type=moderator"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -496,44 +496,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
+            "bearer 348-zD-y5XwEBdm6ffWsUDl4Jti9oJc"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533332204_tenetur/about/moderators/?user=01CM0VH7QW9E2PP6WMRMGARFNE&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533332204.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0VH7QW9E2PP6WMRMGARFNE\", \"id\": \"t2_9o\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "24"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -554,10 +548,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "182"
+            "186"
           ],
           "x-ratelimit-used": [
             "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2B4OC1ndXxH0B7rbDPSiDkWAIN8s3g8UzZABRWJ%2FEbAt%2F2li8uS1lznw56XuLjtsDKoKNIRg6%2FlENhOdM7A5ilqheuWrnRxbn"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -570,15 +567,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533221808_adipisci/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533332204_tenetur/about/moderators/?user=01CM0VH7QW9E2PP6WMRMGARFNE&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:55",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json"
+          "string": "api_type=json&name=01CM0VHHANKWQYA6750NKTXW9J&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -588,26 +585,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 244-O48cxLJsaHY7I-qXD5fTuoz3XoQ"
+            "bearer 348-zD-y5XwEBdm6ffWsUDl4Jti9oJc"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "13"
+            "79"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533332204_tenetur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -625,93 +622,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "182"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533221808_adipisci/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-02T14:56:58",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/user/01CKXJ8GNSKJJHEVBGB1R8GF2H/about/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKXJ8GNSKJJHEVBGB1R8GF2H\", \"is_friend\": false, \"created\": 1533221818.0, \"hide_from_robots\": false, \"created_utc\": 1533221818.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6s\"}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "275"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -732,13 +643,10 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "182"
+            "186"
           ],
           "x-ratelimit-used": [
             "4"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=wDCik8Pks80k4fdY74cfAswvrERR%2Fc%2Bqqz32DjyVTquZ85DjfC%2FiLuNLjebl18feJ88lWDDqozA%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -751,11 +659,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKXJ8GNSKJJHEVBGB1R8GF2H/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533332204_tenetur/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-02T14:56:58",
+      "recorded_at": "2018-08-03T21:36:55",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 350-m6u3jihXtLp00V6AaB5dge2vShw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533332204_tenetur/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:36:55 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "185"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533332204_tenetur/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:36:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -769,38 +769,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 242-aGSeUNTujCSiWwIbLIZ6NF3PJO4"
+            "bearer 348-zD-y5XwEBdm6ffWsUDl4Jti9oJc"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=3jY3pqKeXQxPG6nqDi; loidcreated=2018-08-02T14%3A56%3A48.113Z"
+            "loid=rBeZ9k7ryigrKznKCI; loidcreated=2018-08-03T21%3A36%3A44.257Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+        "uri": "https://reddit.local/r/1533332204_tenetur/about/moderators/?user=01CM0VHHANKWQYA6750NKTXW9J&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKXJ8706YQ0ZQ30ZM4D536CV\", \"created\": 1533221808.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533221808.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6q\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533332215.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0VHHANKWQYA6750NKTXW9J\", \"id\": \"t2_9q\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "484"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Thu, 02 Aug 2018 14:56:58 GMT"
+            "Fri, 03 Aug 2018 21:36:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -821,10 +821,16 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "182"
+            "185"
           ],
           "x-ratelimit-used": [
             "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=5Hy2Y1QVQViwxBkXquVzRZ6Q4135gZFfaiE9DnPc4fHozoEEFrK6CgKmlYLGfWFp4CCk8UtBKYZ7U7LvhptKYnDivrjyrwTe"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -834,7 +840,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
+        "url": "https://reddit.local/r/1533332204_tenetur/about/moderators/?user=01CM0VHHANKWQYA6750NKTXW9J&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-20T21:29:09",
+      "recorded_at": "2018-08-03T21:08:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSH9CS1WAZHDM0Y001QREK"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SY8VMVD3NM4AWK7KNA0BK"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNZNyQxwS4lwzixyN9QN9XDJdjXKj3LydPNyCg9V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZZVkaGmaQG5JqaFyRZmFfEB5m55Ft4eCc751qA9KSklmUmp8ZnpoAMhnCUagGruCDCuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGA0Ul4yu0qGiEJd0HLb9o2HNtak0o++ey1PH9+P93nujWghwjndtAxqtI5QmFDOqxnJ338Jj9Hk/CNk8vTliu+EHtIwQvIyy4LgKQprF8cR+Pu+8gTBygdqCDV0n2hktQrJwncTb/xvNSM2FLvbnVUUZwSRnSa+LU0mq4EgYlACuZBieA/p8AeL0IPm4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:09 GMT"
+            "Fri, 03 Aug 2018 21:08:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:29:09 GMT",
-            "loidcreated=2018-07-20T21%3A29%3A09.261Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 19-Jul-2020 21:29:09 GMT"
+            "loid=UTgGs9sck1oKKqqXU0; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:08:54 GMT",
+            "loidcreated=2018-08-03T21%3A08%3A54.225Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:08:54 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSH9CS1WAZHDM0Y001QREK"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SY8VMVD3NM4AWK7KNA0BK"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:09",
+      "recorded_at": "2018-08-03T21:08:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Modi+aliquid+atque+amet+quo+libero+deserunt+incidunt+error.+Expedita+nam+qui+consectetur+accusantium.+Unde+aperiam+iure+in+dolorum+unde+velit+maiores+alias.+Asperiores+recusandae+quae+architecto+expedita+rerum+repellat.%0APossimus+nisi+neque+deleniti+ipsum+quos+quo+error.+Ea+voluptas+molestias+officia+quae+odio.+Commodi+animi+a+animi+quidem.%0ACupiditate+maiores+blanditiis+veniam+veritatis+nam+ipsum+ipsa.+Optio+aspernatur+possimus+quod+labore+fugit+perspiciatis+corrupti.&link_type=any&name=1532122149_pariatur&public_description=Itaque+optio+omnis+aliquam+aliquam+modi.+Enim+possimus+eius+sint+distinctio+nostrum.&title=Tenetur+praesentium+sapiente+sed.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Odio+maiores+accusamus+ullam+minima.+Debitis+porro+enim+autem+autem+sequi.+Nam+esse+dignissimos+aperiam+eum.+Id+eveniet+quo+omnis+consequuntur+possimus.%0AEius+optio+tempora+harum.+Qui+id+odio+aliquam+mollitia+iusto+cupiditate+placeat+iste.+Ipsa+asperiores+maiores+at+provident+debitis+harum+blanditiis+velit.%0AProvident+consequuntur+nobis+velit.+Ea+nulla+consectetur+omnis.+Dicta+ipsam+ullam+quae+vero+sequi+voluptate+nobis.+Quis+voluptas+repellendus+quibusdam+dicta+dolore+tempora+consectetur.&link_type=any&name=1533330534_debitis&public_description=Odit+dolor+praesentium+commodi.+At+repellat+iure+dicta+quo+voluptatibus+ratione+nihil.&title=Nam+dolorem+laborum+aut+eum+eaque.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
+            "bearer 318-S8izRJlIemzyCuvcdkqypN-rE_M"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "715"
+            "738"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:09 GMT"
+            "Fri, 03 Aug 2018 21:08:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "51"
+            "66"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:16",
+      "recorded_at": "2018-08-03T21:09:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHFT3PKK1TKB63NZZHM2M"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYF5HS0DM70VPS6F6F0A6"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNFNKglIDDMJzsost3SL8PDRdfR3z/QxSwkvcw1V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVeJSHFaXl+5qWu5u655cFl2QHZubmG0Y5+1uA9KSklmUmp8ZnpoAMhnCUagGxWrTVuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2tNQNN0qviPLMC3F1Ky0N8vEqd033K3XOMnYt9nZU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFBOWUZ1XoGni5+ESEVQWEOvuGOJcVeLmkhpeD9KSklmUmp8ZnpoAMhnCUagGwjM6guAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:16 GMT"
+            "Fri, 03 Aug 2018 21:09:01 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHFT3PKK1TKB63NZZHM2M"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYF5HS0DM70VPS6F6F0A6"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:16",
+      "recorded_at": "2018-08-03T21:09:01",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJWSHFT3PKK1TKB63NZZHM2M&type=contributor"
+          "string": "api_type=json&name=01CM0SYF5HS0DM70VPS6F6F0A6&type=contributor"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
+            "bearer 318-S8izRJlIemzyCuvcdkqypN-rE_M"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330534_debitis/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:16 GMT"
+            "Fri, 03 Aug 2018 21:09:01 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "44"
+            "59"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,15 +318,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330534_debitis/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:16",
+      "recorded_at": "2018-08-03T21:09:01",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1532122149_pariatur"
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1533330534_debitis"
         },
         "headers": {
           "Accept": [
@@ -336,22 +336,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
+            "bearer 319-W2gxZInTEFuuRLJwEgNuCj3EsKA"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "78"
+            "77"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:16 GMT"
+            "Fri, 03 Aug 2018 21:09:01 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "44"
+            "59"
           ],
           "x-ratelimit-used": [
             "1"
@@ -414,7 +414,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:19",
+      "recorded_at": "2018-08-03T21:09:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -431,18 +431,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHK87F2Y908071YZYW2W2"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYJK7B1DGB3HT0XKY3537"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNX1LfPyK6mKt7QoTDeOrIgKcyvI8DNP9fUMzw1V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFmWR6VhVF+eSnBOT4WOh6R2Vnm/t7VvlVmoNtS0kty0xOjc9MARkM4SjVAgC6ot9VuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2MtAtzozyDywvLzf3LbDwCNZ1zs0ocQzPrLLM0PVV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYlGSQZJaWUJUcUGQVn+LtE5GR7FgW7mwTnFTuC9KSklmUmp8ZnpoAMhnCUagHZtu5EuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -456,7 +456,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:19 GMT"
+            "Fri, 03 Aug 2018 21:09:04 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -478,15 +478,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJWSHK87F2Y908071YZYW2W2"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYJK7B1DGB3HT0XKY3537"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:19",
+      "recorded_at": "2018-08-03T21:09:04",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJWSHK87F2Y908071YZYW2W2&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0SYJK7B1DGB3HT0XKY3537&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -496,7 +496,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 183-diPFdXCirG1-UHDkE2oZBIFJBWU"
+            "bearer 318-S8izRJlIemzyCuvcdkqypN-rE_M"
           ],
           "Connection": [
             "keep-alive"
@@ -508,14 +508,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330534_debitis/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -533,7 +533,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:19 GMT"
+            "Fri, 03 Aug 2018 21:09:04 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -554,7 +554,7 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "41"
+            "56"
           ],
           "x-ratelimit-used": [
             "3"
@@ -570,11 +570,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532122149_pariatur/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330534_debitis/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:19",
+      "recorded_at": "2018-08-03T21:09:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -588,7 +588,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 185-MvJNtz_98qg3YxZVFphN7eMIWmU"
+            "bearer 320-siZOQwww7Mp8HS-CmhtAWiz9h-M"
           ],
           "Connection": [
             "keep-alive"
@@ -600,14 +600,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1532122149_pariatur/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533330534_debitis/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -625,7 +625,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:19 GMT"
+            "Fri, 03 Aug 2018 21:09:04 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -646,7 +646,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "41"
+            "56"
           ],
           "x-ratelimit-used": [
             "1"
@@ -662,11 +662,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532122149_pariatur/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533330534_debitis/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:20",
+      "recorded_at": "2018-08-03T21:09:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -680,25 +680,114 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
+            "bearer 318-S8izRJlIemzyCuvcdkqypN-rE_M"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1532122149_pariatur/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYJK7B1DGB3HT0XKY3537&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1532122149.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJWSH9CS1WAZHDM0Y001QREK\", \"id\": \"t2_53\"}, {\"date\": 1532122159.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJWSHK87F2Y908071YZYW2W2\", \"id\": \"t2_55\"}]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330544.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SYJK7B1DGB3HT0XKY3537\", \"id\": \"t2_8w\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "56"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=nraXyB1v%2BgNRSG43J7Tvm73i3%2FnVpidRdFcWpL4UkW4AezuSYICy32kfYiDt4YOx2VFSRtIv6nBRbjFLypYXxrEvIDPIhKKD"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYJK7B1DGB3HT0XKY3537&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 319-W2gxZInTEFuuRLJwEgNuCj3EsKA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330534_debitis/about/moderators/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330534.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SY8VMVD3NM4AWK7KNA0BK\", \"id\": \"t2_8u\"}, {\"date\": 1533330544.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SYJK7B1DGB3HT0XKY3537\", \"id\": \"t2_8w\"}]}}"
         },
         "headers": {
           "Connection": [
@@ -711,7 +800,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:20 GMT"
+            "Fri, 03 Aug 2018 21:09:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -732,13 +821,13 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "40"
+            "55"
           ],
           "x-ratelimit-used": [
             "2"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=lasVyF327O7XiVe1lYBPzYbeffhzH1tUYlQT1LXKINVaJU8I1E2TcwpYI9qHn%2F%2BuzKr9qphLqQnhPQhFdAx0F7HuJt9MqjhL"
+            "https://reddit.local/pixel/of_destiny.png?v=zt4CRkxHVXLKw4m73HK%2BT%2Fb1Px%2F9wd5a3lKRaLwP4KJsWiGcAfgD45Mo4LFOTsKxfbvJrf36BIF2po2nYfpB1s1QYp23H7In"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -751,11 +840,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532122149_pariatur/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/r/1533330534_debitis/about/moderators/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-20T21:29:20",
+      "recorded_at": "2018-08-03T21:09:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -769,20 +858,20 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 184-btPaV4Sjiw9FXHL-AOGiL6dWvEU"
+            "bearer 319-W2gxZInTEFuuRLJwEgNuCj3EsKA"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=Q7yDIMh20BawXfwcIP; loidcreated=2018-07-20T21%3A29%3A09.261Z"
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.37.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1532122149_pariatur/about/moderators/?user=01CJWSHFT3PKK1TKB63NZZHM2M&raw_json=1"
+        "uri": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYF5HS0DM70VPS6F6F0A6&raw_json=1"
       },
       "response": {
         "body": {
@@ -800,7 +889,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 20 Jul 2018 21:29:20 GMT"
+            "Fri, 03 Aug 2018 21:09:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -821,13 +910,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "40"
+            "55"
           ],
           "x-ratelimit-used": [
             "3"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=ryGzf8JjtIEAjagcc2gCKor%2F2EAoVodyEl3mg9yMl5DAzHJef2PIt979jtejqZx1LfDWzL0miGRqPEJX0uOCiGBfR7Bya0eI"
+            "https://reddit.local/pixel/of_destiny.png?v=HQU3cfp4%2FJ1jcbhpU%2ByIKGtw%2F81ERzzOvSUjAGUvQT8khORXAsYL9FPZiJ3wqrUADJ0w9Ux0nFCFLK3atITqRj2CyR%2Bp%2FdHm"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -840,7 +929,96 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1532122149_pariatur/about/moderators/?user=01CJWSHFT3PKK1TKB63NZZHM2M&raw_json=1"
+        "url": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYF5HS0DM70VPS6F6F0A6&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 319-W2gxZInTEFuuRLJwEgNuCj3EsKA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=UTgGs9sck1oKKqqXU0; loidcreated=2018-08-03T21%3A08%3A54.225Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYF5HS0DM70VPS6F6F0A6&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "46"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "55"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=tYBRmiyfxil06WKVY%2FHQD3t5HneUeXnRwRHOIJM87E6%2FqIelB0as%2F9KMfrq7HaDozIvBY%2FA2vC2n5YbUkKu7zjdy1dhhXYkR"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330534_debitis/about/moderators/?user=01CM0SYF5HS0DM70VPS6F6F0A6&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators_many_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_many_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-01T21:29:08",
+      "recorded_at": "2018-08-03T21:09:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9WQCKBM0NVNGKRWZ6WVM"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZAYNWVX9CJDCASX97R06"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNXQuCMBiF/4rsMgrWJgZdFxQJSvRhV2POdzaWOjaxRvTfc3nV5Xk4zzlvxIUA51jfaWjROkKEkMWD1+nxljwv7OqKgXppTitfxwVuNZpHCF5GWXBMBYEmGI/s57PeGwgjJXALNnSd6CY0C8mCHMX7/5sk3KdNuaPnA88anG1wvF2CLvN8H5wKBiWAqSoMTwF9vsoi4w64AAAA",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAnmmoeugR4icmDQbbjtL86yjW2oGX33XJ46vh/v994b1UKAc8zrOzzRIUI4JXHmx76Yh8rmkJbAc9Lzm7gY1ckz2kYIJqMsOKaCgLMkWdjPZ/5lIIxwqC3Y0HVCr2gTkoVmEdv/t8epks14tPE8Uc0p9TvSlnhPx+4aHAmDEsCUDMNrQJ8vgfheS7gAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:08 GMT"
+            "Fri, 03 Aug 2018 21:09:29 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:29:08 GMT",
-            "loidcreated=2018-08-01T21%3A29%3A08.545Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:29:08 GMT"
+            "loid=88uPnctMZoT8HoggM5; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:09:29 GMT",
+            "loidcreated=2018-08-03T21%3A09%3A29.124Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:09:29 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9WQCKBM0NVNGKRWZ6WVM"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZAYNWVX9CJDCASX97R06"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:08",
+      "recorded_at": "2018-08-03T21:09:29",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Perspiciatis+in+officia+nulla+quae+dolores+cumque.+Pariatur+animi+accusantium+dolorem+magnam.+Itaque+distinctio+quaerat+fugiat+autem+nesciunt+tempora.+Qui+quo+accusamus+nobis+culpa+ipsum+autem+odio.%0AAliquid+repellat+pariatur+minima+sunt+repudiandae.+Omnis+voluptate+sunt+sequi+error+facere+unde+explicabo.+Eligendi+pariatur+cum+reiciendis+officia+rerum.&link_type=any&name=1533158948_distinctio&public_description=Explicabo+qui+blanditiis+eaque+odit+amet.+Dicta+dicta+ipsam+soluta+doloremque.&title=Architecto+nobis+quasi+aliquam+iusto.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Inventore+ullam+perspiciatis+mollitia+harum.+Molestias+eaque+quas+aspernatur+aperiam.+Explicabo+esse+illo+maiores+dignissimos.+Dolorum+non+rem+nemo.%0AVoluptatibus+rerum+quae+tempora.+Quae+laborum+sapiente+maiores+eum+alias+velit+consequuntur.+Omnis+minus+repellendus+fuga+provident.%0APerspiciatis+earum+ad+praesentium+tempora+enim+laudantium.+Omnis+asperiores+accusantium+debitis+magnam+dolores+laudantium+dicta+sint.+Corrupti+aspernatur+perspiciatis+dolorum.&link_type=any&name=1533330569_deserunt&public_description=Rem+quam+unde+quae+saepe+a+deserunt.+Eveniet+aliquam+nemo+aut+beatae.&title=Quisquam+debitis+eum+ea+eos+eos+perferendis.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "595"
+            "697"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:08 GMT"
+            "Fri, 03 Aug 2018 21:09:29 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "52"
+            "31"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:15",
+      "recorded_at": "2018-08-03T21:09:35",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA313F8E136M5A6RRPGJ3"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZH7K02WE30CE4Y7FP5F0"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtZNMvQ0NsmOKPAOzbaIctY19nBNdnbzz/LPT05W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFVkY6Gwb55ZZXGZWmRJqFVYVkpWSVhSYlJjuC9KSklmUmp8ZnpoAMhnCUagH/6hL7uAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNXQuCMBiF/4rsMgpGA/u4K4U0IrHweszXVx1jOTaLLPrvubzq8jyc55w3EQDoHO87hTeyDQhbhotExDqK8vw87Awv8bqCkGVZem8pkHlA8GmkRcelF1hI6ch+Pu8Hg36kRGHR+q6DbkIznyzWo9j+vxWb4zpOCjg09lRLpftCpZeXVvVeeafChwTksvLDUyCfL/rjKi64AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:15 GMT"
+            "Fri, 03 Aug 2018 21:09:35 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA313F8E136M5A6RRPGJ3"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZH7K02WE30CE4Y7FP5F0"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:15",
+      "recorded_at": "2018-08-03T21:09:35",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPA313F8E136M5A6RRPGJ3&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0SZH7K02WE30CE4Y7FP5F0&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:15 GMT"
+            "Fri, 03 Aug 2018 21:09:35 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "45"
+            "25"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,11 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:15",
+      "recorded_at": "2018-08-03T21:09:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -336,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 223-b1I34kXpKUk8ZC-3HEcCFOjOocc"
+            "bearer 326-HaDmCCQQNyAp_beS7c63OOIuh0c"
           ],
           "Connection": [
             "keep-alive"
@@ -348,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -373,1519 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:15 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "45"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:18",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA6HCTE1R0RFX6E0QR4WB"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtENN/YtDnTLTsw1N7cINXJJdo30tjR0D/YI9rdQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5VwW7mRQGhJomRxgFWBZkGAS4emfHZ5hU5JiA9KSklmUmp8ZnpoAMhnCUagH1vJ2YuAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:18 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA6HCTE1R0RFX6E0QR4WB"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:19",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPA6HCTE1R0RFX6E0QR4WB&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:19 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "297.0"
-          ],
-          "x-ratelimit-reset": [
-            "42"
-          ],
-          "x-ratelimit-used": [
-            "3"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:19",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 224-W3MsQFkam778U2DcEYK91GSHSO8"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:19 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "41"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:22",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAA2441BGJZ1NQB6SRYZS"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtX1Cczw9TQpSklOcgs1L/D1CM31L410cQm2qCpW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5hwUlJxq7GjqXeHmkZVUUGrmn5/qZl2ZHFVqA9KSklmUmp8ZnpoAMhnCUagHKvU4juAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:22 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAA2441BGJZ1NQB6SRYZS"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:22",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAA2441BGJZ1NQB6SRYZS&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:22 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "296.0"
-          ],
-          "x-ratelimit-reset": [
-            "38"
-          ],
-          "x-ratelimit-used": [
-            "4"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:22",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 225-LQhMI4rdcbFU7pMHUmOuYDDS8zs"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:22 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "38"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:26",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPADM6Q93ZX1VFSWK1QRPD"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGAliMqRb6SFIpWaHbmNtXzoknd8kFtF/z+Wp4/vwPu/7JkJKsJZPQwc92QYkjmnYp7rMU5PtXaOYuDT9FWsmHywJS7IOCDijESzXXtjQKJrZz+fTy4AfuYFAQN+1cljQyieE+yy2/29RUqWiOLiKFqPGGo/ixNqdG7Pu7B0FTy2Ba+WHl0A+XxapGlW4AAAA",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:26 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPADM6Q93ZX1VFSWK1QRPD"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:26",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPADM6Q93ZX1VFSWK1QRPD&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:26 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "295.0"
-          ],
-          "x-ratelimit-reset": [
-            "34"
-          ],
-          "x-ratelimit-used": [
-            "5"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:26",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 226-n8iMD8pCBxgdRaTgnXrSRcmR4-M"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:26 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "34"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAH2MZPM05NJQ5RMRJBST"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtcND0guTPJLM4soCPQu9A+OCg30rPKNKjMNtPBU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVFvvq5niGF2UVujqH+ZsFVASFOwbGB6WnJ0WC9KSklmUmp8ZnpoAMhnCUagGqzUL/uAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:29 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAH2MZPM05NJQ5RMRJBST"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAH2MZPM05NJQ5RMRJBST&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:29 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "294.0"
-          ],
-          "x-ratelimit-reset": [
-            "31"
-          ],
-          "x-ratelimit-used": [
-            "6"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 227-WPcqbNf6XpQKqOSZUQIzMZv5Q8I"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:29 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "31"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:33",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAMHXN8EHVVMDBWQET8VB"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIystAt8ijzzDZxzi01LUzzCi0LDDePqLB08/X3DLFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZFIb5WOpGBOclZ2XkWYYYBoebe3inehabFySD9KSklmUmp8ZnpoAMhnCUagHccTw5uAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:33 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAMHXN8EHVVMDBWQET8VB"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:33",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAMHXN8EHVVMDBWQET8VB&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:33 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "293.0"
-          ],
-          "x-ratelimit-reset": [
-            "27"
-          ],
-          "x-ratelimit-used": [
-            "7"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:33",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:33 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "27"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAR09Y0MVT5PT9BD6YTHT"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIystQ1djEJzU2KLyyxKA4u9fDMiPAIMDXIziop9HZU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZG3q4VBhlBHuGlpumOmdbGnpWGYWFJFWFmJeD9KSklmUmp8ZnpoAMhnCUagEdBTHguAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:36 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAR09Y0MVT5PT9BD6YTHT"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAR09Y0MVT5PT9BD6YTHT&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:36 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "292.0"
-          ],
-          "x-ratelimit-reset": [
-            "24"
-          ],
-          "x-ratelimit-used": [
-            "8"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:36",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 229-3D4Umb_qt8sSuHIhXHP50kjtqKA"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:36 GMT"
+            "Fri, 03 Aug 2018 21:09:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -1922,767 +410,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAVF2NHV89J2C7YB78S13"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtDNTAwKCQsuqQzN0PX18Ul0DIpISo0PKqzy9HZV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5BZt7exY6uZh7R2Rk+DslpmW4BAcER3mEFoeC9KSklmUmp8ZnpoAMhnCUagH+FVahuAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAVF2NHV89J2C7YB78S13"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAVF2NHV89J2C7YB78S13&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "291.0"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "9"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:40",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 230-iaRTVStyUh-MLLaARXbe_RqzIKE"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:40 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "20"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:43",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAYXCN60GNN63KTS11S1Q"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtR1iQ8uCPL0D3IsL7D0qcgrKPCPck8rLXF0ifJV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY55pkVh6eXlVXmWJb7GATEG6cEmEUV+jsXOuWD9KSklmUmp8ZnpoAMhnCUagH27PIPuAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:43 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAYXCN60GNN63KTS11S1Q"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:43",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPAYXCN60GNN63KTS11S1Q&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:44 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "290.0"
-          ],
-          "x-ratelimit-reset": [
-            "17"
-          ],
-          "x-ratelimit-used": [
-            "10"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:44",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 231-D_SpRIORAwp9LxnppOZGfutADZM"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:44 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "16"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:47",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPB2CMY0VXHNA183P2NKP6"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtJN8ct09svPMcj1zC/KdE9LcjVKzPDwcc/xN3dU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZZmKdmBfvkGIdGBlYlWuS5pFXmZ5f7poYGFiWD9KSklmUmp8ZnpoAMhnCUagHvl032uAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPB2CMY0VXHNA183P2NKP6"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:47",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVPB2CMY0VXHNA183P2NKP6&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "289.0"
-          ],
-          "x-ratelimit-reset": [
-            "13"
-          ],
-          "x-ratelimit-used": [
-            "11"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:47",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 232-dNiCNol0mIoriGfbE2ahHLGlO7A"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "13"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2696,114 +428,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1533158948_distinctio/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZH7K02WE30CE4Y7FP5F0&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158948.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9WQCKBM0NVNGKRWZ6WVM\", \"id\": \"t2_66\"}, {\"date\": 1533158955.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPA313F8E136M5A6RRPGJ3\", \"id\": \"t2_67\"}, {\"date\": 1533158959.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPA6HCTE1R0RFX6E0QR4WB\", \"id\": \"t2_68\"}, {\"date\": 1533158962.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAA2441BGJZ1NQB6SRYZS\", \"id\": \"t2_69\"}, {\"date\": 1533158966.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPADM6Q93ZX1VFSWK1QRPD\", \"id\": \"t2_6a\"}, {\"date\": 1533158969.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAH2MZPM05NJQ5RMRJBST\", \"id\": \"t2_6b\"}, {\"date\": 1533158973.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"id\": \"t2_6c\"}, {\"date\": 1533158976.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAR09Y0MVT5PT9BD6YTHT\", \"id\": \"t2_6d\"}, {\"date\": 1533158980.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAVF2NHV89J2C7YB78S13\", \"id\": \"t2_6e\"}, {\"date\": 1533158984.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAYXCN60GNN63KTS11S1Q\", \"id\": \"t2_6f\"}, {\"date\": 1533158987.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPB2CMY0VXHNA183P2NKP6\", \"id\": \"t2_6g\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "1199"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298.0"
-          ],
-          "x-ratelimit-reset": [
-            "13"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=GE3YSSc6Dm3CJs2Crn9E157WqTjji7iNkenkObASRXbJ7kt%2BJiZEa9ZER9spL09IEXGgtXfKG5tjcF4wvrYIkkWbYf9suKg7"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158948_distinctio/about/moderators/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:47",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1533158948_distinctio/about/moderators/?user=01CKVPAMHXN8EHVVMDBWQET8VB&raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158973.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"id\": \"t2_6c\"}]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330576.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZH7K02WE30CE4Y7FP5F0\", \"id\": \"t2_92\"}]}}"
         },
         "headers": {
           "Connection": [
@@ -2816,7 +459,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:36 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -2837,13 +480,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "24"
           ],
           "x-ratelimit-used": [
             "3"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=DKIYLMOnxkK5hIqVrOM61jBe9CKSCoqk1OyBzoajPcAXIqW1%2F0aVTnb0hvOpgQC5ttiH8rirdvl3a4O98YOJ4LfrSelotLfA"
+            "https://reddit.local/pixel/of_destiny.png?v=IRf4BJzvlSsw%2FxsZIVZgVgGuZNwYzLCGkL8MbUKh1WnU5%2ByKdTPsqrW2s3domOWfeirGe6uOvHnJxAo2%2BULV%2FeGvifLKg%2F%2Bt"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -2856,11 +499,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158948_distinctio/about/moderators/?user=01CKVPAMHXN8EHVVMDBWQET8VB&raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZH7K02WE30CE4Y7FP5F0&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2873,39 +516,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVP9WQCKBM0NVNGKRWZ6WVM/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZMQ4ES7QPHGGZV4BTJB7"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2Mtctyo8yTvWs9M4KTEtzNM8MMvA1TM+ocjM0CcpW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZl5Oua5UYY+3p6OZoWpPi55eYYOfkVhOQVG4JtS0kty0xOjc9MARkM4SjVAgAfku2MuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZMQ4ES7QPHGGZV4BTJB7"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0SZMQ4ES7QPHGGZV4BTJB7&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9WQCKBM0NVNGKRWZ6WVM\", \"is_friend\": false, \"created\": 1533158948.0, \"hide_from_robots\": false, \"created_utc\": 1533158948.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"66\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -2926,13 +643,10 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "21"
           ],
           "x-ratelimit-used": [
             "4"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=SiRe5LQC%2BTp5QptCzY4xKN4Erx0MOuZVT7olGvBOFyT5Pz%2BcI0qcl4ygqYNNKuENnWCFdctD51c%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -2945,11 +659,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVP9WQCKBM0NVNGKRWZ6WVM/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 327-roZ3eIyKjQffA7iR0M1ghzF14Rk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "21"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2963,38 +769,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZMQ4ES7QPHGGZV4BTJB7&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": true, \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"created\": 1533158973.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158973.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6c\", \"gold_expiration\": null, \"inbox_count\": 1, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330579.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZMQ4ES7QPHGGZV4BTJB7\", \"id\": \"t2_93\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "483"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:39 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3015,10 +821,16 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "21"
           ],
           "x-ratelimit-used": [
             "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=D8fKcgYAdeUbBTLZz5ZOlLDKzCoV1FPyhDty0qtrhS55oVDhCkTeFaKtqtkS1tbc38gzEckXtwvuZ7B%2BjfQgTeIXHUO10YVn"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -3028,11 +840,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZMQ4ES7QPHGGZV4BTJB7&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:42",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3045,39 +857,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPA313F8E136M5A6RRPGJ3/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZR6GKXE0YM63AEAW43FZ"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2stAtyTGqzCxIcjOoMC1IMvas8MjLKg6vCi0oyXZU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYl+eUWpIenhViWl1UERpXnJKab+3u7R2QHG1iA9KSklmUmp8ZnpoAMhnCUagHfJOsJuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZR6GKXE0YM63AEAW43FZ"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0SZR6GKXE0YM63AEAW43FZ&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPA313F8E136M5A6RRPGJ3\", \"is_friend\": false, \"created\": 1533158955.0, \"hide_from_robots\": false, \"created_utc\": 1533158955.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"67\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3098,13 +984,10 @@
             "294.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "18"
           ],
           "x-ratelimit-used": [
             "6"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=UM9KNnaq7wGYIV1tFAm8oiV6vxWEh9QkpKt2bEVqHFDEfy6haIAPE%2BewrDtcaqME677JwFKqBKI%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3117,11 +1000,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPA313F8E136M5A6RRPGJ3/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 328-tl2yipbF0x5pb3IxHnjsWzUptkA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:43 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "17"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:43",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3135,38 +1110,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPA6HCTE1R0RFX6E0QR4WB/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZR6GKXE0YM63AEAW43FZ&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPA6HCTE1R0RFX6E0QR4WB\", \"is_friend\": false, \"created\": 1533158958.0, \"hide_from_robots\": false, \"created_utc\": 1533158958.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"68\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330583.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZR6GKXE0YM63AEAW43FZ\", \"id\": \"t2_94\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:43 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3187,13 +1162,13 @@
             "293.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "17"
           ],
           "x-ratelimit-used": [
             "7"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=pQM7N%2FE96bmt1HlnV2ZOudUZvHhmJsaOOmDmoZmOpbDigD%2FStDP3Lc97e3pUWtu3EgxN0ugCm%2Fw%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=z9%2BcrLu0UxC2J4I8FhNFlKsAU29uBD2aFv9%2FqMQVn8V%2BifzibJCx4IKrirkgAcY7VbWI5tHQ6CdxuZKvyy38tmVMxCx2%2F1Ty"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3206,11 +1181,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPA6HCTE1R0RFX6E0QR4WB/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZR6GKXE0YM63AEAW43FZ&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:46",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3223,39 +1198,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAA2441BGJZ1NQB6SRYZS/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZVRMKGKQ2AS76FB3S4VP"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQrCMBREr1L+UhSiIYLuFBopuBKq4iY06S8NQlOT1DaKd7exK5fzmDfzhkIpdE54c8cGtgnQ1WbB+ZDT047Tcm9YyA94oam89VfTZzBPAIdWW3RCR4GuCRnZzxc+tBhHJBYWbew6ZSY0i8liNYr1/9vrqNmZiYZLXwXpUx6W2aPrAmEqOiU+tUKhyzg8Bfh8Abd2pue4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:46 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZVRMKGKQ2AS76FB3S4VP"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0SZVRMKGKQ2AS76FB3S4VP&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAA2441BGJZ1NQB6SRYZS\", \"is_friend\": false, \"created\": 1533158962.0, \"hide_from_robots\": false, \"created_utc\": 1533158962.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"69\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:46 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3276,13 +1325,10 @@
             "292.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "14"
           ],
           "x-ratelimit-used": [
             "8"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=StCqXZbrIN0zRxSwQExe6NvUVxToHtomlU%2BrnsdjEdtfiIS9urLy6rDCAlM4sjN3beq2c%2BVR9Z8%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3295,11 +1341,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAA2441BGJZ1NQB6SRYZS/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 329-FFxU3RAF3dBo5yUGeW3EbZwXowI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:46 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "14"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:46",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3313,38 +1451,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPADM6Q93ZX1VFSWK1QRPD/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZVRMKGKQ2AS76FB3S4VP&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPADM6Q93ZX1VFSWK1QRPD\", \"is_friend\": false, \"created\": 1533158966.0, \"hide_from_robots\": false, \"created_utc\": 1533158966.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6a\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330586.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZVRMKGKQ2AS76FB3S4VP\", \"id\": \"t2_95\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:46 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3365,13 +1503,13 @@
             "291.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "14"
           ],
           "x-ratelimit-used": [
             "9"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=1XT3lQNzQxKdMmYmsc5WB2SSeXQw1Nr%2BY9%2FTxAiw2Rc23q2wnUT5EZJw597R3T5FQZH6iJrWIng%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=oFuREy0Ir6ggMQvdwofTfv1Fltiwrb2R9SMGdmeSlHWD6W50hLEIoYRNpjYUFB2RItFCMPpTv%2FJrw7A95U3vMNjV5R3zIBLV"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3384,11 +1522,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPADM6Q93ZX1VFSWK1QRPD/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZVRMKGKQ2AS76FB3S4VP&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:50",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3401,39 +1539,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAH2MZPM05NJQ5RMRJBST/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZZABEQZA8G1VV899VW95"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2NtA1y8zzqPDLzilLzEh0dXHOK8qxiPI0zCjyMCxX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZeAW7BLkER4QZ+VX6hmakmYc6pnpamBi6x7uC9KSklmUmp8ZnpoAMhnCUagFEug4fuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZZABEQZA8G1VV899VW95"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0SZZABEQZA8G1VV899VW95&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAH2MZPM05NJQ5RMRJBST\", \"is_friend\": false, \"created\": 1533158969.0, \"hide_from_robots\": false, \"created_utc\": 1533158969.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6b\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:50 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3454,13 +1666,10 @@
             "290.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "10"
           ],
           "x-ratelimit-used": [
             "10"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=V69S%2Fa0ETjJKzxc98fCbLjRYgCqU9U8BEty7eVVZn%2BN1dKuKdocTI5x4bF8UwXRaYCqCIdoUazQ%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3473,11 +1682,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAH2MZPM05NJQ5RMRJBST/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 330-6inHxNklvahaEDCnrl8ZI1hrH1w"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "10"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:50",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3491,38 +1792,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAMHXN8EHVVMDBWQET8VB/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZZABEQZA8G1VV899VW95&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"pause_ads\": true}, \"is_friend\": false, \"is_suspended\": false, \"gold_expiration\": null, \"id\": \"6c\", \"suspension_expiration_utc\": null, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"has_mod_mail\": true, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 1, \"inbox_count\": 1, \"has_mail\": true, \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"created\": 1533158973.0, \"gold_creddits\": 0, \"created_utc\": 1533158973.0, \"in_beta\": false, \"comment_karma\": 0}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330590.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZZABEQZA8G1VV899VW95\", \"id\": \"t2_96\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "544"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:50 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3543,13 +1844,13 @@
             "289.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "10"
           ],
           "x-ratelimit-used": [
             "11"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=6Zm5MBEXBwXzgEsuRBduMrtiWAhY%2FCK825SKTUS22%2F5wlqJGaCUWvSUz5hd%2FXdUkWz3yZYj65mU%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=K1Cv9t6S5tXFDmmv1FQcaqMbH7L3LstwcSb0EGAwXRaLgwMvqsbRNy%2BGUCBDxttFidczWyulTPOQ24npVuFWBNMT1i6bTjV6"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3562,11 +1863,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAMHXN8EHVVMDBWQET8VB/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0SZZABEQZA8G1VV899VW95&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:53",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3579,39 +1880,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAR09Y0MVT5PT9BD6YTHT/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T02Y8AY8DS06PTQ8TQ5D4"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2NtR1jTI3Mzbz8HUp9I8sKTQqyPXxjYzyTMrIzAxV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5pkcZ5VSWhoVb6BZmZXmap5u4+0U6pgdahpiA9KSklmUmp8ZnpoAMhnCUagGVOX0JuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T02Y8AY8DS06PTQ8TQ5D4"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0T02Y8AY8DS06PTQ8TQ5D4&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAR09Y0MVT5PT9BD6YTHT\", \"is_friend\": false, \"created\": 1533158976.0, \"hide_from_robots\": false, \"created_utc\": 1533158976.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6d\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3632,13 +2007,10 @@
             "288.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "6"
           ],
           "x-ratelimit-used": [
             "12"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=%2BKOHrizKmIyXr94SYiR%2FJB8goVza839Ay8m3be5Pgop2Zkw3%2FwUNGumyzHwgTa1YomdUnPiSLIA%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3651,11 +2023,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAR09Y0MVT5PT9BD6YTHT/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 331-EZ7636HMDqOYtq2pmLMYZIbhiiU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "6"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3669,38 +2133,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAVF2NHV89J2C7YB78S13/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAVF2NHV89J2C7YB78S13\", \"is_friend\": false, \"created\": 1533158980.0, \"hide_from_robots\": false, \"created_utc\": 1533158980.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6e\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330594.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T02Y8AY8DS06PTQ8TQ5D4\", \"id\": \"t2_97\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3721,13 +2185,13 @@
             "287.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "6"
           ],
           "x-ratelimit-used": [
             "13"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=lwLISlSDoXWLh7hx4ydk5gge3TW88iwKGyYHtQwG17v6FknroKRJwzAkanfh5ddniELMBtgN3tE%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=fPuyOxOQBk%2FrL0YH7DqrS9YqCCYGHha4eoWluQsZkZdyRnLfJC%2BYcqPsgoLpMFMHMv8fj4Q52XeDm8vx02FdGSpdLAmLLIyU"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3740,11 +2204,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAVF2NHV89J2C7YB78S13/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3757,39 +2221,113 @@
           "Accept-Encoding": [
             "gzip, deflate"
           ],
-          "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
-          ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPAYXCN60GNN63KTS11S1Q/about/?raw_json=1"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T06FE7XDB9P6RZY4PTM4B"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2NtL1rgovqTLILc90NQ8qdo6KskwzLNYNdvYP9oxU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZmjkVlOuGZ+salgc4lhmamhYlegSWZJuGV+SD9KSklmUmp8ZnpoAMhnCUagEA/UnjuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T06FE7XDB9P6RZY4PTM4B"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0T06FE7XDB9P6RZY4PTM4B&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAYXCN60GNN63KTS11S1Q\", \"is_friend\": false, \"created\": 1533158983.0, \"hide_from_robots\": false, \"created_utc\": 1533158983.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6f\"}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:57 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3810,13 +2348,10 @@
             "286.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "3"
           ],
           "x-ratelimit-used": [
             "14"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=haZ0Op2iXQtEYmYrgxz5mqdGPwZFW%2FJev1CWIQ7PRCDWgZxuzwiwzvy0hTY%2BcJEfSDRwI%2BvTwUo%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3829,11 +2364,103 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPAYXCN60GNN63KTS11S1Q/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:47",
+      "recorded_at": "2018-08-03T21:09:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 332-KzWtz0mwiE7RsCZZ9f1s-SCOSIY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "3"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3847,38 +2474,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVPB2CMY0VXHNA183P2NKP6/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T06FE7XDB9P6RZY4PTM4B&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPB2CMY0VXHNA183P2NKP6\", \"is_friend\": false, \"created\": 1533158987.0, \"hide_from_robots\": false, \"created_utc\": 1533158987.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6g\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330597.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T06FE7XDB9P6RZY4PTM4B\", \"id\": \"t2_98\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:47 GMT"
+            "Fri, 03 Aug 2018 21:09:57 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -3899,13 +2526,13 @@
             "285.0"
           ],
           "x-ratelimit-reset": [
-            "13"
+            "3"
           ],
           "x-ratelimit-used": [
             "15"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=9mrv008kkZTHowlrAuJqL5iX%2Fen9ZE8xjWaYVyqphnOX93RnKf0xoPZcqGhMF%2Bjm4bmYpf0nP6Y%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=BeLuW0QoyuK9V8amc3LqO1EMqu4zkCvbe2ZPe9V2e%2BnDZxfNk%2BAsb6eNtv09Y03%2Fs2sko%2F97em1QVzX9NCvNHZ6TF1H87N7H"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -3918,7 +2545,1297 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVPB2CMY0VXHNA183P2NKP6/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T06FE7XDB9P6RZY4PTM4B&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0A0W8AWR91X67FWYM4WB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQvCIBzFv8rwGAmGtEO3kNXNiCDqJNP912SoQ6Xcou/ebKeO78f7vfdGtVIQgoiuB4t2BaKU4gpzmfrOyQ0Jh9P2MdqJYZUIu9zRukCQBu0hCJ0FWhIys58v4jhAHpFQe/C5G5Rb0ConD+0sdv9vvDUv60g0ZcVYOptjG2+ecXmd9tlp4KkVCN3k4SWgzxcVad2huAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0A0W8AWR91X67FWYM4WB"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0T0A0W8AWR91X67FWYM4WB&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "599"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 333-E-Nbxkhob10sFO5gynzC-cx0CSY"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "599"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0A0W8AWR91X67FWYM4WB&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330601.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0A0W8AWR91X67FWYM4WB\", \"id\": \"t2_99\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:01 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "599"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=9dLgCxG90Jzyk7G5CuPw7NDLX8TxX%2FEAdnHtSAQ%2FsL24mlo7wMPZr1%2Bo1yNCs4py92xoI4u5I0Ajv%2FaIAIqFKVnTxQn2603j"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0A0W8AWR91X67FWYM4WB&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0DG81C5FKQB75HJA7VVG"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2NtENSc4sDfAOMszOcfPL8kwqSwwy90kLiI80K0hW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbplpR4WxbmxDuWR5Wn55S7uYc4eaZG+btYOmeD9KSklmUmp8ZnpoAMhnCUagGrWglNuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0DG81C5FKQB75HJA7VVG"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0T0DG81C5FKQB75HJA7VVG&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "596"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 334-TciuPKR1klFNjIbvaR7LfP_Y6pc"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "595"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0DG81C5FKQB75HJA7VVG&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330605.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0DG81C5FKQB75HJA7VVG\", \"id\": \"t2_9a\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "595"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=rYQRTN8nl9I%2FKSYb6FPaqv120zDwXsG9P1sEidhqUxkp%2BiOVfYBGkcBabKaGI4Xs4PLYk%2FMX6RkdoHAjGhnYhvsJWyDsmoJU"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0DG81C5FKQB75HJA7VVG&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0H3ZBHK5W23F9HE3VR4H"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2NtVNMgjVNTFOcswLNw0xdfayyMgNSzF1rEoNjnJU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVRRT4eEYYhgTHe0QVRPjmpGV6+Re564YUJBeD9KSklmUmp8ZnpoAMhnCUagE/+3aIuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0T0H3ZBHK5W23F9HE3VR4H"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CM0T0H3ZBHK5W23F9HE3VR4H&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 335-b0U-43bAnW5T5CJ8hmVd5AzeSZA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 325-6twmGzvTrFe2PebF5mbXcOpijdM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0H3ZBHK5W23F9HE3VR4H&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330608.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0H3ZBHK5W23F9HE3VR4H\", \"id\": \"t2_9b\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=YMcSkm05eASRqb%2BQR4UdWlOqFGBD1r7NSGGuUMCcodG6aUEVDEFqpISY6NyX%2FafWTLHyPtjgNMMlSRYwxBB0SvP2Zi89Tbrt"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T0H3ZBHK5W23F9HE3VR4H&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 331-EZ7636HMDqOYtq2pmLMYZIbhiiU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330569.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZAYNWVX9CJDCASX97R06\", \"id\": \"t2_91\"}, {\"date\": 1533330576.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZH7K02WE30CE4Y7FP5F0\", \"id\": \"t2_92\"}, {\"date\": 1533330579.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZMQ4ES7QPHGGZV4BTJB7\", \"id\": \"t2_93\"}, {\"date\": 1533330583.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZR6GKXE0YM63AEAW43FZ\", \"id\": \"t2_94\"}, {\"date\": 1533330586.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZVRMKGKQ2AS76FB3S4VP\", \"id\": \"t2_95\"}, {\"date\": 1533330590.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZZABEQZA8G1VV899VW95\", \"id\": \"t2_96\"}, {\"date\": 1533330594.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T02Y8AY8DS06PTQ8TQ5D4\", \"id\": \"t2_97\"}, {\"date\": 1533330597.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T06FE7XDB9P6RZY4PTM4B\", \"id\": \"t2_98\"}, {\"date\": 1533330601.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0A0W8AWR91X67FWYM4WB\", \"id\": \"t2_99\"}, {\"date\": 1533330605.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0DG81C5FKQB75HJA7VVG\", \"id\": \"t2_9a\"}, {\"date\": 1533330608.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T0H3ZBHK5W23F9HE3VR4H\", \"id\": \"t2_9b\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1199"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=bZr%2F2cYqsuFAwNYaIAwjKKnnVEQSTmHPnG9MxSNI2kXnPFVqBAJJ%2B1b03np2o6Yc%2FU257ZPGv%2BCy6cCK1R0uYAMpSk4AMO7a"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 331-EZ7636HMDqOYtq2pmLMYZIbhiiU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330594.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T02Y8AY8DS06PTQ8TQ5D4\", \"id\": \"t2_97\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=kqn6Ly%2BfnraobHxgQRXmvmKvoGrw8APriQGDx4QLF%2BujydnnhnT%2B2Y4kPdX8X8%2Bgv35nL%2FScMr6aCj1RdUNNdbii0hVXs4GP"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:10:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 331-EZ7636HMDqOYtq2pmLMYZIbhiiU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=88uPnctMZoT8HoggM5; loidcreated=2018-08-03T21%3A09%3A29.124Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330594.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0T02Y8AY8DS06PTQ8TQ5D4\", \"id\": \"t2_97\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:10:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "592"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=4cIFRzVZVEgJBtleoY5KcVme5RJFhppifUbMMmonAbZ21MYiO38YENWvFveHQypauZ5IYnAo6nNIwnawnk4xTn6kG9Okwv1E"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330569_deserunt/about/moderators/?user=01CM0T02Y8AY8DS06PTQ8TQ5D4&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators_many_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_many_moderator.json
@@ -1,0 +1,3926 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-08-01T21:29:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9WQCKBM0NVNGKRWZ6WVM"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNXQuCMBiF/4rsMgrWJgZdFxQJSvRhV2POdzaWOjaxRvTfc3nV5Xk4zzlvxIUA51jfaWjROkKEkMWD1+nxljwv7OqKgXppTitfxwVuNZpHCF5GWXBMBYEmGI/s57PeGwgjJXALNnSd6CY0C8mCHMX7/5sk3KdNuaPnA88anG1wvF2CLvN8H5wKBiWAqSoMTwF9vsoi4w64AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:29:08 GMT",
+            "loidcreated=2018-08-01T21%3A29%3A08.545Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:29:08 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9WQCKBM0NVNGKRWZ6WVM"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&description=Perspiciatis+in+officia+nulla+quae+dolores+cumque.+Pariatur+animi+accusantium+dolorem+magnam.+Itaque+distinctio+quaerat+fugiat+autem+nesciunt+tempora.+Qui+quo+accusamus+nobis+culpa+ipsum+autem+odio.%0AAliquid+repellat+pariatur+minima+sunt+repudiandae.+Omnis+voluptate+sunt+sequi+error+facere+unde+explicabo.+Eligendi+pariatur+cum+reiciendis+officia+rerum.&link_type=any&name=1533158948_distinctio&public_description=Explicabo+qui+blanditiis+eaque+odit+amet.+Dicta+dicta+ipsam+soluta+doloremque.&title=Architecto+nobis+quasi+aliquam+iusto.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "595"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:08 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "52"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA313F8E136M5A6RRPGJ3"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtZNMvQ0NsmOKPAOzbaIctY19nBNdnbzz/LPT05W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFVkY6Gwb55ZZXGZWmRJqFVYVkpWSVhSYlJjuC9KSklmUmp8ZnpoAMhnCUagH/6hL7uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA313F8E136M5A6RRPGJ3"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPA313F8E136M5A6RRPGJ3&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "45"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 223-b1I34kXpKUk8ZC-3HEcCFOjOocc"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "45"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA6HCTE1R0RFX6E0QR4WB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtENN/YtDnTLTsw1N7cINXJJdo30tjR0D/YI9rdQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5VwW7mRQGhJomRxgFWBZkGAS4emfHZ5hU5JiA9KSklmUmp8ZnpoAMhnCUagH1vJ2YuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPA6HCTE1R0RFX6E0QR4WB"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPA6HCTE1R0RFX6E0QR4WB&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "42"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 224-W3MsQFkam778U2DcEYK91GSHSO8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "41"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAA2441BGJZ1NQB6SRYZS"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtX1Cczw9TQpSklOcgs1L/D1CM31L410cQm2qCpW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5hwUlJxq7GjqXeHmkZVUUGrmn5/qZl2ZHFVqA9KSklmUmp8ZnpoAMhnCUagHKvU4juAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAA2441BGJZ1NQB6SRYZS"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAA2441BGJZ1NQB6SRYZS&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "38"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 225-LQhMI4rdcbFU7pMHUmOuYDDS8zs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "38"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPADM6Q93ZX1VFSWK1QRPD"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBiG/4rsGAliMqRb6SFIpWaHbmNtXzoknd8kFtF/z+Wp4/vwPu/7JkJKsJZPQwc92QYkjmnYp7rMU5PtXaOYuDT9FWsmHywJS7IOCDijESzXXtjQKJrZz+fTy4AfuYFAQN+1cljQyieE+yy2/29RUqWiOLiKFqPGGo/ixNqdG7Pu7B0FTy2Ba+WHl0A+XxapGlW4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPADM6Q93ZX1VFSWK1QRPD"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPADM6Q93ZX1VFSWK1QRPD&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "34"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 226-n8iMD8pCBxgdRaTgnXrSRcmR4-M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "34"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAH2MZPM05NJQ5RMRJBST"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtcND0guTPJLM4soCPQu9A+OCg30rPKNKjMNtPBU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVFvvq5niGF2UVujqH+ZsFVASFOwbGB6WnJ0WC9KSklmUmp8ZnpoAMhnCUagGqzUL/uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAH2MZPM05NJQ5RMRJBST"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAH2MZPM05NJQ5RMRJBST&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "31"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 227-WPcqbNf6XpQKqOSZUQIzMZv5Q8I"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "31"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAMHXN8EHVVMDBWQET8VB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIystAt8ijzzDZxzi01LUzzCi0LDDePqLB08/X3DLFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZFIb5WOpGBOclZ2XkWYYYBoebe3inehabFySD9KSklmUmp8ZnpoAMhnCUagHccTw5uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAMHXN8EHVVMDBWQET8VB"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAMHXN8EHVVMDBWQET8VB&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "27"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "27"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAR09Y0MVT5PT9BD6YTHT"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIystQ1djEJzU2KLyyxKA4u9fDMiPAIMDXIziop9HZU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZG3q4VBhlBHuGlpumOmdbGnpWGYWFJFWFmJeD9KSklmUmp8ZnpoAMhnCUagEdBTHguAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAR09Y0MVT5PT9BD6YTHT"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAR09Y0MVT5PT9BD6YTHT&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "292.0"
+          ],
+          "x-ratelimit-reset": [
+            "24"
+          ],
+          "x-ratelimit-used": [
+            "8"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 229-3D4Umb_qt8sSuHIhXHP50kjtqKA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "24"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAVF2NHV89J2C7YB78S13"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtDNTAwKCQsuqQzN0PX18Ul0DIpISo0PKqzy9HZV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5BZt7exY6uZh7R2Rk+DslpmW4BAcER3mEFoeC9KSklmUmp8ZnpoAMhnCUagH+FVahuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAVF2NHV89J2C7YB78S13"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAVF2NHV89J2C7YB78S13&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "291.0"
+          ],
+          "x-ratelimit-reset": [
+            "20"
+          ],
+          "x-ratelimit-used": [
+            "9"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 230-iaRTVStyUh-MLLaARXbe_RqzIKE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "20"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAYXCN60GNN63KTS11S1Q"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtR1iQ8uCPL0D3IsL7D0qcgrKPCPck8rLXF0ifJV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY55pkVh6eXlVXmWJb7GATEG6cEmEUV+jsXOuWD9KSklmUmp8ZnpoAMhnCUagH27PIPuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:43 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPAYXCN60GNN63KTS11S1Q"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPAYXCN60GNN63KTS11S1Q&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "290.0"
+          ],
+          "x-ratelimit-reset": [
+            "17"
+          ],
+          "x-ratelimit-used": [
+            "10"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 231-D_SpRIORAwp9LxnppOZGfutADZM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "16"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPB2CMY0VXHNA183P2NKP6"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyNtJN8ct09svPMcj1zC/KdE9LcjVKzPDwcc/xN3dU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZZmKdmBfvkGIdGBlYlWuS5pFXmZ5f7poYGFiWD9KSklmUmp8ZnpoAMhnCUagHvl032uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVPB2CMY0VXHNA183P2NKP6"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CKVPB2CMY0VXHNA183P2NKP6&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 222-lagLRY6wV_WsXv3yfpT7yg4X0nk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "289.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "11"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 232-dNiCNol0mIoriGfbE2ahHLGlO7A"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533158948_distinctio/about/moderators/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158948.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9WQCKBM0NVNGKRWZ6WVM\", \"id\": \"t2_66\"}, {\"date\": 1533158955.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPA313F8E136M5A6RRPGJ3\", \"id\": \"t2_67\"}, {\"date\": 1533158959.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPA6HCTE1R0RFX6E0QR4WB\", \"id\": \"t2_68\"}, {\"date\": 1533158962.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAA2441BGJZ1NQB6SRYZS\", \"id\": \"t2_69\"}, {\"date\": 1533158966.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPADM6Q93ZX1VFSWK1QRPD\", \"id\": \"t2_6a\"}, {\"date\": 1533158969.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAH2MZPM05NJQ5RMRJBST\", \"id\": \"t2_6b\"}, {\"date\": 1533158973.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"id\": \"t2_6c\"}, {\"date\": 1533158976.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAR09Y0MVT5PT9BD6YTHT\", \"id\": \"t2_6d\"}, {\"date\": 1533158980.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAVF2NHV89J2C7YB78S13\", \"id\": \"t2_6e\"}, {\"date\": 1533158984.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAYXCN60GNN63KTS11S1Q\", \"id\": \"t2_6f\"}, {\"date\": 1533158987.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPB2CMY0VXHNA183P2NKP6\", \"id\": \"t2_6g\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1199"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=GE3YSSc6Dm3CJs2Crn9E157WqTjji7iNkenkObASRXbJ7kt%2BJiZEa9ZER9spL09IEXGgtXfKG5tjcF4wvrYIkkWbYf9suKg7"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/about/moderators/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533158948_distinctio/about/moderators/?user=01CKVPAMHXN8EHVVMDBWQET8VB&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158973.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"id\": \"t2_6c\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=DKIYLMOnxkK5hIqVrOM61jBe9CKSCoqk1OyBzoajPcAXIqW1%2F0aVTnb0hvOpgQC5ttiH8rirdvl3a4O98YOJ4LfrSelotLfA"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533158948_distinctio/about/moderators/?user=01CKVPAMHXN8EHVVMDBWQET8VB&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVP9WQCKBM0NVNGKRWZ6WVM/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9WQCKBM0NVNGKRWZ6WVM\", \"is_friend\": false, \"created\": 1533158948.0, \"hide_from_robots\": false, \"created_utc\": 1533158948.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"66\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=SiRe5LQC%2BTp5QptCzY4xKN4Erx0MOuZVT7olGvBOFyT5Pz%2BcI0qcl4ygqYNNKuENnWCFdctD51c%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVP9WQCKBM0NVNGKRWZ6WVM/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"has_mail\": true, \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"created\": 1533158973.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158973.0, \"has_mod_mail\": true, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"6c\", \"gold_expiration\": null, \"inbox_count\": 1, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "483"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPA313F8E136M5A6RRPGJ3/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPA313F8E136M5A6RRPGJ3\", \"is_friend\": false, \"created\": 1533158955.0, \"hide_from_robots\": false, \"created_utc\": 1533158955.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"67\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=UM9KNnaq7wGYIV1tFAm8oiV6vxWEh9QkpKt2bEVqHFDEfy6haIAPE%2BewrDtcaqME677JwFKqBKI%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPA313F8E136M5A6RRPGJ3/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPA6HCTE1R0RFX6E0QR4WB/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPA6HCTE1R0RFX6E0QR4WB\", \"is_friend\": false, \"created\": 1533158958.0, \"hide_from_robots\": false, \"created_utc\": 1533158958.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"68\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=pQM7N%2FE96bmt1HlnV2ZOudUZvHhmJsaOOmDmoZmOpbDigD%2FStDP3Lc97e3pUWtu3EgxN0ugCm%2Fw%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPA6HCTE1R0RFX6E0QR4WB/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAA2441BGJZ1NQB6SRYZS/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAA2441BGJZ1NQB6SRYZS\", \"is_friend\": false, \"created\": 1533158962.0, \"hide_from_robots\": false, \"created_utc\": 1533158962.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"69\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "292.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "8"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=StCqXZbrIN0zRxSwQExe6NvUVxToHtomlU%2BrnsdjEdtfiIS9urLy6rDCAlM4sjN3beq2c%2BVR9Z8%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAA2441BGJZ1NQB6SRYZS/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPADM6Q93ZX1VFSWK1QRPD/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPADM6Q93ZX1VFSWK1QRPD\", \"is_friend\": false, \"created\": 1533158966.0, \"hide_from_robots\": false, \"created_utc\": 1533158966.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6a\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "291.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "9"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=1XT3lQNzQxKdMmYmsc5WB2SSeXQw1Nr%2BY9%2FTxAiw2Rc23q2wnUT5EZJw597R3T5FQZH6iJrWIng%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPADM6Q93ZX1VFSWK1QRPD/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAH2MZPM05NJQ5RMRJBST/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAH2MZPM05NJQ5RMRJBST\", \"is_friend\": false, \"created\": 1533158969.0, \"hide_from_robots\": false, \"created_utc\": 1533158969.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6b\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "290.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "10"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=V69S%2Fa0ETjJKzxc98fCbLjRYgCqU9U8BEty7eVVZn%2BN1dKuKdocTI5x4bF8UwXRaYCqCIdoUazQ%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAH2MZPM05NJQ5RMRJBST/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAMHXN8EHVVMDBWQET8VB/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"pause_ads\": true}, \"is_friend\": false, \"is_suspended\": false, \"gold_expiration\": null, \"id\": \"6c\", \"suspension_expiration_utc\": null, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"has_mod_mail\": true, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 1, \"inbox_count\": 1, \"has_mail\": true, \"name\": \"01CKVPAMHXN8EHVVMDBWQET8VB\", \"created\": 1533158973.0, \"gold_creddits\": 0, \"created_utc\": 1533158973.0, \"in_beta\": false, \"comment_karma\": 0}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "544"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "289.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "11"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=6Zm5MBEXBwXzgEsuRBduMrtiWAhY%2FCK825SKTUS22%2F5wlqJGaCUWvSUz5hd%2FXdUkWz3yZYj65mU%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAMHXN8EHVVMDBWQET8VB/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAR09Y0MVT5PT9BD6YTHT/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAR09Y0MVT5PT9BD6YTHT\", \"is_friend\": false, \"created\": 1533158976.0, \"hide_from_robots\": false, \"created_utc\": 1533158976.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6d\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "288.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "12"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2BKOHrizKmIyXr94SYiR%2FJB8goVza839Ay8m3be5Pgop2Zkw3%2FwUNGumyzHwgTa1YomdUnPiSLIA%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAR09Y0MVT5PT9BD6YTHT/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAVF2NHV89J2C7YB78S13/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAVF2NHV89J2C7YB78S13\", \"is_friend\": false, \"created\": 1533158980.0, \"hide_from_robots\": false, \"created_utc\": 1533158980.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6e\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "287.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "13"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=lwLISlSDoXWLh7hx4ydk5gge3TW88iwKGyYHtQwG17v6FknroKRJwzAkanfh5ddniELMBtgN3tE%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAVF2NHV89J2C7YB78S13/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPAYXCN60GNN63KTS11S1Q/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPAYXCN60GNN63KTS11S1Q\", \"is_friend\": false, \"created\": 1533158983.0, \"hide_from_robots\": false, \"created_utc\": 1533158983.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6f\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "286.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "14"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=haZ0Op2iXQtEYmYrgxz5mqdGPwZFW%2FJev1CWIQ7PRCDWgZxuzwiwzvy0hTY%2BcJEfSDRwI%2BvTwUo%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPAYXCN60GNN63KTS11S1Q/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 228-rHvIk4Cmu5qfJUvQW7Xx9FMOIT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=n07y6gNkC1BNwQ1NJU; loidcreated=2018-08-01T21%3A29%3A08.545Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVPB2CMY0VXHNA183P2NKP6/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVPB2CMY0VXHNA183P2NKP6\", \"is_friend\": false, \"created\": 1533158987.0, \"hide_from_robots\": false, \"created_utc\": 1533158987.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"6g\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "285.0"
+          ],
+          "x-ratelimit-reset": [
+            "13"
+          ],
+          "x-ratelimit-used": [
+            "15"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=9mrv008kkZTHowlrAuJqL5iX%2Fen9ZE8xjWaYVyqphnOX93RnKf0xoPZcqGhMF%2Bjm4bmYpf0nP6Y%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVPB2CMY0VXHNA183P2NKP6/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.moderators_test.test_list_moderators_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-01T21:28:58",
+      "recorded_at": "2018-08-03T21:09:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9JNPTQS1ZQAVM86PH62W"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZ102MZZG3GEG8SXZEWH9"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtAtjQpOTzLL9PR1twxLMjW3NA5MizR1yiwK8DFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVeHoblmRWmDpaekYF6pbGuztleTuaORWa+wSC9KSklmUmp8ZnpoAMhnCUagH1fKMCuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2MtZ1yo/SzQs0CilwTi8NcfXLD7ewLHbKMUiKcLNQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFxbukhXmaZnmZ5Xq4eDgF+KSbm7s7FbpmZCeD9KSklmUmp8ZnpoAMhnCUagFVU2yzuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:58 GMT"
+            "Fri, 03 Aug 2018 21:09:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=DOas4ON7eTX3VZV0la; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:58 GMT",
-            "loidcreated=2018-08-01T21%3A28%3A58.276Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:58 GMT"
+            "loid=4fv91vpr5JhZEPnjyJ; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:09:19 GMT",
+            "loidcreated=2018-08-03T21%3A09%3A18.956Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 02-Aug-2020 21:09:19 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9JNPTQS1ZQAVM86PH62W"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZ102MZZG3GEG8SXZEWH9"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:58",
+      "recorded_at": "2018-08-03T21:09:19",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Totam+quas+quidem+eligendi+neque+voluptate.+Debitis+provident+itaque+illum+exercitationem+accusantium+explicabo+dolores.+Corporis+ipsa+tenetur+nemo+quam+dolorum+sit.+In+aliquam+suscipit+necessitatibus+at+esse+in+doloribus.+Autem+et+fuga+sunt+soluta+quo.%0ACorporis+dolor+quibusdam+nobis+qui+natus.+Ex+culpa+labore+suscipit+dolor.+Inventore+iste+sapiente+doloremque+expedita+labore.+Necessitatibus+nobis+voluptate+ut+ad.&link_type=any&name=1533158938_cumque&public_description=Laborum+excepturi+incidunt+modi+beatae+laborum.+Quam+eius+quis+ea+mollitia+asperiores.&title=Voluptatibus+porro+consequatur+ut+sint.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Eius+est+possimus+cumque+reiciendis.+Architecto+recusandae+repudiandae+corrupti+quia+architecto+nostrum.+Perferendis+incidunt+enim+deserunt+quaerat.%0ANemo+dolorem+incidunt+neque+rem+veniam+ea.+Nihil+commodi+voluptate+voluptatibus+corporis+pariatur.+Voluptatem+enim+consequatur+explicabo+culpa+error+nulla+ut+neque.+Voluptatum+quasi+quibusdam+molestias+asperiores+suscipit.+Minus+ab+placeat+rerum+veritatis+nesciunt+repellat.&link_type=any&name=1533330559_quis&public_description=Illum+facere+temporibus+consectetur+placeat.+Reiciendis+accusamus+ipsam+veritatis+quis+inventore.&title=Adipisci+aliquam+voluptates+laboriosam+vel.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 220-uZSgb6iIMG9Vb5793QfY5BirPL0"
+            "bearer 323-BoZ-nQ2TpCguTENoW89sBl0bXF8"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "665"
+            "684"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:58 GMT"
+            "Fri, 03 Aug 2018 21:09:19 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "62"
+            "41"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:05",
+      "recorded_at": "2018-08-03T21:09:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9S26K2295GSN856C32QX"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZ7B5BA8MGYZX2D7MY6ND"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtR1TXEv8PAuc/Moco6qyAkLdTV3NEwJKneM9DRQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5JxvlhBg66Vp4l+bnFEdUOLp5O/kGRumGebiC9KSklmUmp8ZnpoAMhnCUagF3ecceuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0VmGQVTWmg7XcymSAgycPPQmScOwozNiGTRv+fLVct7uOfeN6ukRO9hsB0adgxYuIs2Ijk3d6xs2Ht+KkyUp/XjVrw6O1q2Dhg+e+3QgyYhPHA+s58Pw9QjjdRYOXTU9dIuaEXJYTOL7f8bZJnSaZ7I0sDEzdaXl3hfXoWAmByFo5YIWtHwEtjnC2r7p/u4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
+            "Fri, 03 Aug 2018 21:09:25 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9S26K2295GSN856C32QX"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SZ7B5BA8MGYZX2D7MY6ND"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:05",
+      "recorded_at": "2018-08-03T21:09:25",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVP9S26K2295GSN856C32QX&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0SZ7B5BA8MGYZX2D7MY6ND&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 220-uZSgb6iIMG9Vb5793QfY5BirPL0"
+            "bearer 323-BoZ-nQ2TpCguTENoW89sBl0bXF8"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158938_cumque/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330559_quis/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
+            "Fri, 03 Aug 2018 21:09:25 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "55"
+            "35"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,11 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158938_cumque/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330559_quis/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:05",
+      "recorded_at": "2018-08-03T21:09:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -336,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+            "bearer 324-F9LfWeao3ps0KVn4OAbqUVzkovo"
           ],
           "Connection": [
             "keep-alive"
@@ -348,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158938_cumque/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533330559_quis/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
+            "Fri, 03 Aug 2018 21:09:25 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "55"
+            "35"
           ],
           "x-ratelimit-used": [
             "1"
@@ -410,11 +410,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158938_cumque/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533330559_quis/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:05",
+      "recorded_at": "2018-08-03T21:09:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -428,114 +428,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+            "bearer 323-BoZ-nQ2TpCguTENoW89sBl0bXF8"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1533158938_cumque/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158938.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9JNPTQS1ZQAVM86PH62W\", \"id\": \"t2_64\"}, {\"date\": 1533158945.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"id\": \"t2_65\"}]}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "254"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "298.0"
-          ],
-          "x-ratelimit-reset": [
-            "55"
-          ],
-          "x-ratelimit-used": [
-            "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=DpRb4SFKB6ICHY7XttBsaz62a%2FFtpROc9Nl4d9G6QhAE55Zd8IcHxYsioTw6h8EfaYfdsR%2F6%2BGSttQkD2jOt%2Fvj9n1MC5XmK"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1533158938_cumque/about/moderators/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:05",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1533158938_cumque/about/moderators/?user=01CKVP9S26K2295GSN856C32QX&raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158945.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"id\": \"t2_65\"}]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330565.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZ7B5BA8MGYZX2D7MY6ND\", \"id\": \"t2_90\"}]}}"
         },
         "headers": {
           "Connection": [
@@ -548,7 +459,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
+            "Fri, 03 Aug 2018 21:09:26 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -569,13 +480,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "55"
+            "35"
           ],
           "x-ratelimit-used": [
             "3"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=Dt7qkK1bs3jRQML%2BlvHNlH%2FBKv%2Fx2Qmg23Q%2BRQNkw%2BEidJE71mWdICKuAT20T6b4YzJ8hmVj1u6QBcy%2FHdVyCGb%2Fc6a7puHz"
+            "https://reddit.local/pixel/of_destiny.png?v=NZWegU0dhDMYhOOBt2JNGlF%2BZjcsw3vNAwmzZXTNHXPvP9NdYDyWNCoU%2BLpQZqUbVQ%2BVEcr6%2BfE1fOrAZ6GuZjbteoDlJMrZ"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -588,11 +499,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158938_cumque/about/moderators/?user=01CKVP9S26K2295GSN856C32QX&raw_json=1"
+        "url": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:29:05",
+      "recorded_at": "2018-08-03T21:09:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -606,38 +517,216 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+            "bearer 324-F9LfWeao3ps0KVn4OAbqUVzkovo"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVP9JNPTQS1ZQAVM86PH62W/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330559_quis/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9JNPTQS1ZQAVM86PH62W\", \"is_friend\": false, \"created\": 1533158938.0, \"hide_from_robots\": false, \"created_utc\": 1533158938.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"64\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330559.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZ102MZZG3GEG8SXZEWH9\", \"id\": \"t2_8z\"}, {\"date\": 1533330565.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZ7B5BA8MGYZX2D7MY6ND\", \"id\": \"t2_90\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "254"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
+            "Fri, 03 Aug 2018 21:09:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "34"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=h6K7c%2B1nLX1U31BOqBDvieeY4y8KbzEWAWpvAnbSsgt4tpM6FRnZvRfCgite2%2FujPeA%2BwObA6mpYwBw9Py7ealbMyEyeMcZ1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330559_quis/about/moderators/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 324-F9LfWeao3ps0KVn4OAbqUVzkovo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330565.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZ7B5BA8MGYZX2D7MY6ND\", \"id\": \"t2_90\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "34"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=edYNy1x02FZixpkd2IUScdb9fKCCgVE7Rq9tlc%2B7SaHrHeWruvM2GmH2eLv751zJyHA0sV93wOw1wZrNaVgv%2BXA%2Fu1YdcttJ"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-03T21:09:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 324-F9LfWeao3ps0KVn4OAbqUVzkovo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=4fv91vpr5JhZEPnjyJ; loidcreated=2018-08-03T21%3A09%3A18.956Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330565.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SZ7B5BA8MGYZX2D7MY6ND\", \"id\": \"t2_90\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 03 Aug 2018 21:09:26 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -658,13 +747,13 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "55"
+            "34"
           ],
           "x-ratelimit-used": [
             "4"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=rhF58j9Yr7oXu07KzruE20oIIhPFFNf61DwMYEl55T7E2AvEXsvEmQ6oTEvZksYAew3ypa0Hv98%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=royuGPJRMxwkKiXBEC2MqW7jAjlZmrnkDiukWir7VEnSDTD%2FrWj5%2BlyfnD7TW8JCW1URqKgTtpvRsPikOpzSFR6rPd6WkVhD"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -677,179 +766,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVP9JNPTQS1ZQAVM86PH62W/about/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:05",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": true, \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"created\": 1533158945.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158945.0, \"has_mod_mail\": false, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"65\", \"gold_expiration\": null, \"inbox_count\": 1, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "484"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "295.0"
-          ],
-          "x-ratelimit-reset": [
-            "55"
-          ],
-          "x-ratelimit-used": [
-            "5"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-08-01T21:29:05",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/user/01CKVP9S26K2295GSN856C32QX/about/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"pause_ads\": true}, \"is_friend\": false, \"is_suspended\": false, \"gold_expiration\": null, \"id\": \"65\", \"suspension_expiration_utc\": null, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 1, \"inbox_count\": 1, \"has_mail\": true, \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"created\": 1533158945.0, \"gold_creddits\": 0, \"created_utc\": 1533158945.0, \"in_beta\": false, \"comment_karma\": 0}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "545"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Wed, 01 Aug 2018 21:29:05 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "294.0"
-          ],
-          "x-ratelimit-reset": [
-            "55"
-          ],
-          "x-ratelimit-used": [
-            "6"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=yA8qfrnudY8qRmjF2ryqJfF8SWqyeSYzV4JEe7IkCAbjkwom34aZnN%2FnhpA6XIgUKILSi8VmtJ0%3D"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/user/01CKVP9S26K2295GSN856C32QX/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330559_quis/about/moderators/?user=01CM0SZ7B5BA8MGYZX2D7MY6ND&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators_moderator.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_moderator.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-10T19:46:31",
+      "recorded_at": "2018-08-01T21:28:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VP5QKA9K2JT6KFN2B071Z"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9JNPTQS1ZQAVM86PH62W"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdH1d48sDQ0y8/E1KPXL9w5x8XYv0/V2cfSLzChW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFZucFOeVkRMZXmBdbplaYBhq7hlZ6lJsUFGeD9KSklmUmp8ZnpoAMhnCUagF83LVNuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtAtjQpOTzLL9PR1twxLMjW3NA5MizR1yiwK8DFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYVeHoblmRWmDpaekYF6pbGuztleTuaORWa+wSC9KSklmUmp8ZnpoAMhnCUagH1fKMCuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:31 GMT"
+            "Wed, 01 Aug 2018 21:28:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:46:31 GMT",
-            "loidcreated=2018-07-10T19%3A46%3A31.261Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:46:31 GMT"
+            "loid=DOas4ON7eTX3VZV0la; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:58 GMT",
+            "loidcreated=2018-08-01T21%3A28%3A58.276Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:58 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VP5QKA9K2JT6KFN2B071Z"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9JNPTQS1ZQAVM86PH62W"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:31",
+      "recorded_at": "2018-08-01T21:28:58",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Placeat+ut+quaerat+nostrum+animi+eum.+Temporibus+molestiae+consequatur+impedit+occaecati+quos+repellendus.%0ALaudantium+magnam+earum+quasi+tempore+maxime+ipsum+magni.+Doloribus+esse+cupiditate+fugiat+ea+porro+dolorum+recusandae.+Nesciunt+veniam+deleniti+quae+accusamus+provident+ipsam+blanditiis.%0ADoloribus+quibusdam+quibusdam+esse+illum+quam+iste.+Possimus+ipsum+blanditiis+illo+at.+Hic+voluptatem+quo+vitae+amet+corrupti.+Aspernatur+dignissimos+sed+impedit+perferendis.&link_type=any&name=1531251991_aperiam&public_description=Velit+commodi+accusantium+sint+ipsa+reiciendis+quisquam+et.+Minus+quidem+eaque+eveniet+quod.&title=Optio+eius+laborum+fugit+inventore.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Totam+quas+quidem+eligendi+neque+voluptate.+Debitis+provident+itaque+illum+exercitationem+accusantium+explicabo+dolores.+Corporis+ipsa+tenetur+nemo+quam+dolorum+sit.+In+aliquam+suscipit+necessitatibus+at+esse+in+doloribus.+Autem+et+fuga+sunt+soluta+quo.%0ACorporis+dolor+quibusdam+nobis+qui+natus.+Ex+culpa+labore+suscipit+dolor.+Inventore+iste+sapiente+doloremque+expedita+labore.+Necessitatibus+nobis+voluptate+ut+ad.&link_type=any&name=1533158938_cumque&public_description=Laborum+excepturi+incidunt+modi+beatae+laborum.+Quam+eius+quis+ea+mollitia+asperiores.&title=Voluptatibus+porro+consequatur+ut+sint.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 144-OGYuUR6LM0uNoKTDKGv-KDANYhs"
+            "bearer 220-uZSgb6iIMG9Vb5793QfY5BirPL0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "722"
+            "665"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:31 GMT"
+            "Wed, 01 Aug 2018 21:28:58 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "209"
+            "62"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:38",
+      "recorded_at": "2018-08-01T21:29:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VPC1N10NXN7V4H718HKEX"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9S26K2295GSN856C32QX"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdW1NEjJTAvwLclODXfKtYwKLfSMdw7z8vN3NE9X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVm0ekFxmnhib5FPqkOHq7Ffonmhe5uxr4hoeC9KSklmUmp8ZnpoAMhnCUagGtwz1duAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyMtR1TXEv8PAuc/Moco6qyAkLdTV3NEwJKneM9DRQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLb5JxvlhBg66Vp4l+bnFEdUOLp5O/kGRumGebiC9KSklmUmp8ZnpoAMhnCUagF3ecceuAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:37 GMT"
+            "Wed, 01 Aug 2018 21:29:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VPC1N10NXN7V4H718HKEX"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9S26K2295GSN856C32QX"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:38",
+      "recorded_at": "2018-08-01T21:29:05",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2VPC1N10NXN7V4H718HKEX&type=contributor"
+          "string": "api_type=json&name=01CKVP9S26K2295GSN856C32QX&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,26 +244,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 144-OGYuUR6LM0uNoKTDKGv-KDANYhs"
+            "bearer 220-uZSgb6iIMG9Vb5793QfY5BirPL0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "62"
+            "79"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531251991_aperiam/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533158938_cumque/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:38 GMT"
+            "Wed, 01 Aug 2018 21:29:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "202"
+            "55"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,263 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251991_aperiam/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533158938_cumque/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:38",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1531251991_aperiam"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 145-90difPMtkeWBm9ZUqI_CVJNOA7g"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "77"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "2"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 10 Jul 2018 19:46:38 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "202"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/subscribe/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-07-10T19:46:41",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VPFQSESTNYEMAH1HGBNMW"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdP1L4lP1Q2JcA83TXPyzw32rkgydDO1yDXJjXJV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZ55n4JEUYl5UWlmREuGSF+pkbeeenOWWamoNtS0kty0xOjc9MARkM4SjVAgBJ3jeSuAAAAA==",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 10 Jul 2018 19:46:41 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2VPFQSESTNYEMAH1HGBNMW"
-      }
-    },
-    {
-      "recorded_at": "2018-07-10T19:46:41",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2VPFQSESTNYEMAH1HGBNMW&permissions=%2Ball&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 144-OGYuUR6LM0uNoKTDKGv-KDANYhs"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "79"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1531251991_aperiam/api/friend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 10 Jul 2018 19:46:41 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "297.0"
-          ],
-          "x-ratelimit-reset": [
-            "199"
-          ],
-          "x-ratelimit-used": [
-            "3"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1531251991_aperiam/api/friend/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-07-10T19:46:42",
+      "recorded_at": "2018-08-01T21:29:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -588,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 146-Ot_e-TXGW5fBOmSKxb1F58m4mZE"
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
           ],
           "Connection": [
             "keep-alive"
@@ -600,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531251991_aperiam/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533158938_cumque/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -625,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:42 GMT"
+            "Wed, 01 Aug 2018 21:29:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -646,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "199"
+            "55"
           ],
           "x-ratelimit-used": [
             "1"
@@ -662,11 +410,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251991_aperiam/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533158938_cumque/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:42",
+      "recorded_at": "2018-08-01T21:29:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -680,25 +428,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 146-Ot_e-TXGW5fBOmSKxb1F58m4mZE"
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531251991_aperiam/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/r/1533158938_cumque/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1531251991.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJ2VP5QKA9K2JT6KFN2B071Z\", \"id\": \"t2_40\"}, {\"date\": 1531252001.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJ2VPFQSESTNYEMAH1HGBNMW\", \"id\": \"t2_42\"}]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158938.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9JNPTQS1ZQAVM86PH62W\", \"id\": \"t2_64\"}, {\"date\": 1533158945.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"id\": \"t2_65\"}]}}"
         },
         "headers": {
           "Connection": [
@@ -711,7 +459,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:42 GMT"
+            "Wed, 01 Aug 2018 21:29:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -732,13 +480,13 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "198"
+            "55"
           ],
           "x-ratelimit-used": [
             "2"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=Gf5bXZvw6al4WxwoGDwHrZrc1fxL63wVjqJkqsGuIxE6y5gzRwz8a2NGXfvP1tsiJLg%2BtmCWiyx5etDQz3GRYtIrIFazin7B"
+            "https://reddit.local/pixel/of_destiny.png?v=DpRb4SFKB6ICHY7XttBsaz62a%2FFtpROc9Nl4d9G6QhAE55Zd8IcHxYsioTw6h8EfaYfdsR%2F6%2BGSttQkD2jOt%2Fvj9n1MC5XmK"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -751,11 +499,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251991_aperiam/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/r/1533158938_cumque/about/moderators/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:46:42",
+      "recorded_at": "2018-08-01T21:29:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -769,25 +517,25 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 146-Ot_e-TXGW5fBOmSKxb1F58m4mZE"
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=mvfpJGTAnylOe1pRw7; loidcreated=2018-07-10T19%3A46%3A31.261Z"
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531251991_aperiam/about/moderators/?user=01CJ2VPFQSESTNYEMAH1HGBNMW&raw_json=1"
+        "uri": "https://reddit.local/r/1533158938_cumque/about/moderators/?user=01CKVP9S26K2295GSN856C32QX&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1531252001.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJ2VPFQSESTNYEMAH1HGBNMW\", \"id\": \"t2_42\"}]}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158945.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"id\": \"t2_65\"}]}}"
         },
         "headers": {
           "Connection": [
@@ -800,7 +548,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:46:42 GMT"
+            "Wed, 01 Aug 2018 21:29:05 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -821,13 +569,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "198"
+            "55"
           ],
           "x-ratelimit-used": [
             "3"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=9%2FmLaAgu5HBjJTzEdkG73f%2FWmHUaOC5MjUCK0bVSebgEyEVwwI0Q6S%2FQdq2vM7yFolUrGITwjHhQiyCB%2BAhfu5UsUNuEk8TQ"
+            "https://reddit.local/pixel/of_destiny.png?v=Dt7qkK1bs3jRQML%2BlvHNlH%2FBKv%2Fx2Qmg23Q%2BRQNkw%2BEidJE71mWdICKuAT20T6b4YzJ8hmVj1u6QBcy%2FHdVyCGb%2Fc6a7puHz"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -840,7 +588,268 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251991_aperiam/about/moderators/?user=01CJ2VPFQSESTNYEMAH1HGBNMW&raw_json=1"
+        "url": "https://reddit.local/r/1533158938_cumque/about/moderators/?user=01CKVP9S26K2295GSN856C32QX&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVP9JNPTQS1ZQAVM86PH62W/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9JNPTQS1ZQAVM86PH62W\", \"is_friend\": false, \"created\": 1533158938.0, \"hide_from_robots\": false, \"created_utc\": 1533158938.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"64\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "275"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "55"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=rhF58j9Yr7oXu07KzruE20oIIhPFFNf61DwMYEl55T7E2AvEXsvEmQ6oTEvZksYAew3ypa0Hv98%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVP9JNPTQS1ZQAVM86PH62W/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"has_mail\": true, \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"created\": 1533158945.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158945.0, \"has_mod_mail\": false, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"id\": \"65\", \"gold_expiration\": null, \"inbox_count\": 1, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "484"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "55"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-08-01T21:29:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 221-EdGpHKvFHrCZxlVUE7A1dRwAYI0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=DOas4ON7eTX3VZV0la; loidcreated=2018-08-01T21%3A28%3A58.276Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/user/01CKVP9S26K2295GSN856C32QX/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"pause_ads\": true}, \"is_friend\": false, \"is_suspended\": false, \"gold_expiration\": null, \"id\": \"65\", \"suspension_expiration_utc\": null, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 1, \"inbox_count\": 1, \"has_mail\": true, \"name\": \"01CKVP9S26K2295GSN856C32QX\", \"created\": 1533158945.0, \"gold_creddits\": 0, \"created_utc\": 1533158945.0, \"in_beta\": false, \"comment_karma\": 0}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "545"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 01 Aug 2018 21:29:05 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "55"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=yA8qfrnudY8qRmjF2ryqJfF8SWqyeSYzV4JEe7IkCAbjkwom34aZnN%2FnhpA6XIgUKILSi8VmtJ0%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/user/01CKVP9S26K2295GSN856C32QX/about/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators_staff.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_staff.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-01T21:28:48",
+      "recorded_at": "2018-08-03T21:09:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP98HRGK3BRZX4RQJY2Y6S"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYPRZ8FS4P9SDEB6Q7VXN"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WN0QqCMBiFX0V2GQkzIa3bCiIZEUSEN2P9/nOrdLqJFdG75/Kqy/NxvnPeRACgc7wzN6zJMiCzKA1NvYZt3FZJaGRYsjRjFHPcl6vzgUwDgs9GW3RceyGeUzqwn8+7V4N+5ILCovVdB2ZEE58sykFU/29CqY3OoY8SCu1ucWTV6fpQdyEz8E6BvQbkuvDDYyCfL37Pl864AAAA",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAU6a0lXsYNYMAiDXcba/rElON1MjOi75/LU8f14v/feSEgJ3vPBNtCiQ4RSnGx4v2U7Uubjo9B4uBbePNmZ9bQ+UbSOEEydceC5CUJK4nhmP58Prw7CyA2EAxe6XtoFrUJycJ9F/f9GWeIEEdURt5m+qKnmlVa2NNm+CY6C0UjgRoXhJaDPFxvPR/64AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:48 GMT"
+            "Fri, 03 Aug 2018 21:09:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=f97okeVBXaHuOpDzCY; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:48 GMT",
-            "loidcreated=2018-08-01T21%3A28%3A47.893Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:48 GMT"
+            "loid=137hAVwbHWwPkFAkf8; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 02-Aug-2020 21:09:08 GMT",
+            "loidcreated=2018-08-03T21%3A09%3A08.485Z; Domain=reddit.local; Max-Age=63072000; Path=/; expires=Sun, 02-Aug-2020 21:09:08 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP98HRGK3BRZX4RQJY2Y6S"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYPRZ8FS4P9SDEB6Q7VXN"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:48",
+      "recorded_at": "2018-08-03T21:09:08",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Fugit+illum+excepturi+nam+placeat+eaque+maxime+maiores.+Nostrum+soluta+asperiores+ullam.+Excepturi+iste+corrupti+voluptates+quisquam.%0AVel+facilis+incidunt+dolor.+Recusandae+quidem+voluptate+sint+inventore+quo+quis+rem+illo.+Consectetur+quia+alias+totam+ex+repellendus+dolorum+laborum.+Perspiciatis+ea+dicta+dolore+deleniti+natus.%0ADicta+recusandae+placeat+ipsum+dolore+recusandae.+Perferendis+maiores+nemo+praesentium+perferendis.+Iusto+esse+quis+error+eum+eveniet.+Vitae+impedit+rem+libero.&link_type=any&name=1533158928_quisquam&public_description=In+ex+qui+doloremque.+Quas+porro+esse+harum+consequatur.+Ratione+vel+repudiandae+enim+sed+velit.&title=Natus+magni+hic+doloribus+aliquam.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Ab+ullam+pariatur+quia+atque+facere+ut.+Dolorem+iure+eligendi+distinctio+rerum+illo+quis.+Ipsam+harum+sunt+ipsam+ipsa+delectus.%0AConsectetur+corporis+fuga+quasi+id+aperiam+minima+maxime.+Molestiae+quidem+porro+nulla+reiciendis+autem.+Magni+sunt+repellendus+quos+minus+ratione+saepe+sit+dolorum.+Explicabo+accusamus+occaecati+vero+sequi+qui+beatae+eaque+voluptatibus.&link_type=any&name=1533330548_repudianda&public_description=Quis+quisquam+tempore+facere+ex.+Impedit+maxime+tempora+perspiciatis+enim+tempore+voluptatem.&title=Quidem+aut+ipsum+nihil+sequi.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,19 +84,19 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "747"
+            "614"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:48 GMT"
+            "Fri, 03 Aug 2018 21:09:08 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "72"
+            "52"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:54",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9EWX7CSDHASG4F3XNQHZ"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYX4EXGZJ3FJ0BG71Q7DT"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIytNQtjYxKyzQpCjaLqCh30Q2PyCgxCHdyKy6y8EtW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYF5rhnJ3qnR6YHeVokpUaWWhqahVYmR2WGJ1uA9KSklmUmp8ZnpoAMhnCUagFTF41guAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAlzA7FuZgihWYEXT2Ntf3NETrYhZfTdc3nq+H6833tvxIUAa5nTd+jRNkCUkJDTvILK1VEyWSFlNroOhzEtzr1G6wDBc1AGLFNeoDHGM/v5zL0G8CNX4AaM71qhF7TyyUA7i93/W8pPj1u6j6by0BC7awpct5eS5Ztj4h0JoxLAlPTDS0CfLxXKwDm4AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:54 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9EWX7CSDHASG4F3XNQHZ"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CM0SYX4EXGZJ3FJ0BG71Q7DT"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:54",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVP9EWX7CSDHASG4F3XNQHZ&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CM0SYX4EXGZJ3FJ0BG71Q7DT&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,7 +244,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
@@ -256,14 +256,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158928_quisquam/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330548_repudianda/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:54 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "66"
+            "45"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,11 +318,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158928_quisquam/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:54",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -336,7 +336,7 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 219-uYZfi4rS6XxwD-WXht0WBFsr8Nc"
+            "bearer 322-a3FNeNtT18zscddCvth0-63KPno"
           ],
           "Connection": [
             "keep-alive"
@@ -348,14 +348,14 @@
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1533158928_quisquam/api/accept_moderator_invite?raw_json=1"
+        "uri": "https://reddit.local/r/1533330548_repudianda/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
@@ -373,7 +373,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:54 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "66"
+            "45"
           ],
           "x-ratelimit-used": [
             "1"
@@ -410,15 +410,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158928_quisquam/api/accept_moderator_invite?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:54",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CKVP98HRGK3BRZX4RQJY2Y6S&type=moderator"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -428,44 +428,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "60"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1533158928_quisquam/api/unfriend/?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533330548_repudianda/about/moderators/?user=01CM0SYX4EXGZJ3FJ0BG71Q7DT&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330555.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SYX4EXGZJ3FJ0BG71Q7DT\", \"id\": \"t2_8y\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:55 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -486,10 +480,13 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "66"
+            "45"
           ],
           "x-ratelimit-used": [
             "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=T43wk2C4jGHVZHgbfHAzJCc5iQk%2FjcD2iisJ9WO%2FyO3J3T9ewGtPM%2F53xLs1fVpEDs%2BK9aZRjUxgys65qu17D57DFaNKqL50"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -502,15 +499,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158928_quisquam/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/about/moderators/?user=01CM0SYX4EXGZJ3FJ0BG71Q7DT&raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:55",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01CM0SYPRZ8FS4P9SDEB6Q7VXN&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -520,38 +517,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
           ],
+          "Content-Length": [
+            "60"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1533158928_quisquam/about/moderators/?raw_json=1"
+        "method": "POST",
+        "uri": "https://reddit.local/r/1533330548_repudianda/api/unfriend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158934.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9EWX7CSDHASG4F3XNQHZ\", \"id\": \"t2_63\"}]}}"
+          "string": "{}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "149"
+            "2"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:55 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -572,13 +575,10 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "65"
+            "45"
           ],
           "x-ratelimit-used": [
             "4"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=YwMCr8CScPn79HSPoXy2Ch%2FrYHfY3ujyNBGuXj4bsaYYBCmNTjMCM%2Fyk7HVfi%2Fw4CpDyyXhKGJYzgwaipVDSK3DQt4zrURco"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -591,11 +591,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1533158928_quisquam/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/api/unfriend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:55",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -609,38 +609,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/user/01CKVP9EWX7CSDHASG4F3XNQHZ/about/?raw_json=1"
+        "uri": "https://reddit.local/r/1533330548_repudianda/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9EWX7CSDHASG4F3XNQHZ\", \"is_friend\": false, \"created\": 1533158934.0, \"hide_from_robots\": false, \"created_utc\": 1533158934.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"63\"}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533330555.0, \"mod_permissions\": [\"all\"], \"name\": \"01CM0SYX4EXGZJ3FJ0BG71Q7DT\", \"id\": \"t2_8y\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "275"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:55 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -661,13 +661,13 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "65"
+            "45"
           ],
           "x-ratelimit-used": [
             "5"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=GTLgDCk6IYrguN7L41Y7HTEnsqBcED7P1aBtpy5NEpzO%2Bd5DDZW6OkcfUCE66O%2F777k9d89d13E%3D"
+            "https://reddit.local/pixel/of_destiny.png?v=IaMeAdeOADz07TVxtnxwu6OBgEIZOIc1fJXTsFbyYODQbrdfarKdSUkPTOnFTefFM%2BFSRxC3etywkXwGTvyHpnYvEs15XPyj"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -680,11 +680,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/user/01CKVP9EWX7CSDHASG4F3XNQHZ/about/?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/about/moderators/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-08-01T21:28:55",
+      "recorded_at": "2018-08-03T21:09:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -698,38 +698,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
+            "bearer 321-_q4Z56JCvjEh2tWEsiuZNZqQVMQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
+            "loid=137hAVwbHWwPkFAkf8; loidcreated=2018-08-03T21%3A09%3A08.485Z"
           ],
           "User-Agent": [
             "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/me?raw_json=1"
+        "uri": "https://reddit.local/r/1533330548_repudianda/about/moderators/?user=01CM0SYPRZ8FS4P9SDEB6Q7VXN&raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKVP98HRGK3BRZX4RQJY2Y6S\", \"created\": 1533158928.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158928.0, \"has_mod_mail\": false, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": false, \"id\": \"62\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "486"
+            "46"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Wed, 01 Aug 2018 21:28:55 GMT"
+            "Fri, 03 Aug 2018 21:09:15 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -750,10 +750,16 @@
             "294.0"
           ],
           "x-ratelimit-reset": [
-            "65"
+            "45"
           ],
           "x-ratelimit-used": [
             "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=FoJppgsE49QJ%2FekIc7LKLP%2BIITqSMUHB7nJHxCql0K7i8PjOtRVmxGXLvhcUgQIHY9zduCJW8AattM174966mWy9Q9qXlyrc"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -763,7 +769,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/me?raw_json=1"
+        "url": "https://reddit.local/r/1533330548_repudianda/about/moderators/?user=01CM0SYPRZ8FS4P9SDEB6Q7VXN&raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.moderators_test.test_list_moderators_staff.json
+++ b/cassettes/channels.views.moderators_test.test_list_moderators_staff.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-07-10T19:37:19",
+      "recorded_at": "2018-08-01T21:28:48",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5A5899V3B15YC1E9BPXD"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP98HRGK3BRZX4RQJY2Y6S"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdRNDnE2Lgso9TOPTPPJc7PwcymrKDatNHILCXNU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZFQS5hvmkJ5sk+/h4+ZvpepVE+pp7lBjoRrmC9KSklmUmp8ZnpoAMhnCUagGFbyjMuAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA1WN0QqCMBiFX0V2GQkzIa3bCiIZEUSEN2P9/nOrdLqJFdG75/Kqy/NxvnPeRACgc7wzN6zJMiCzKA1NvYZt3FZJaGRYsjRjFHPcl6vzgUwDgs9GW3RceyGeUzqwn8+7V4N+5ILCovVdB2ZEE58sykFU/29CqY3OoY8SCu1ucWTV6fpQdyEz8E6BvQbkuvDDYyCfL37Pl864AAAA",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:19 GMT"
+            "Wed, 01 Aug 2018 21:28:48 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=wscua8NdH59h5CGEsP; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:37:19 GMT",
-            "loidcreated=2018-07-10T19%3A37%3A18.744Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 09-Jul-2020 19:37:19 GMT"
+            "loid=f97okeVBXaHuOpDzCY; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:48 GMT",
+            "loidcreated=2018-08-01T21%3A28%3A47.893Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 31-Jul-2020 21:28:48 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5A5899V3B15YC1E9BPXD"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP98HRGK3BRZX4RQJY2Y6S"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:19",
+      "recorded_at": "2018-08-01T21:28:48",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&description=Officiis+recusandae+reiciendis+perspiciatis+tempora+ea.+Consequatur+quae+veniam+quis+nemo+nemo+minus+nostrum.+Libero+itaque+molestiae+amet+inventore+ad+delectus.+Soluta+pariatur+recusandae+quia+dolor+veritatis+incidunt+expedita.+Harum+odit+dolorem+dicta+quibusdam.%0AAutem+voluptate+sapiente+officiis+molestiae+laborum+corporis+eius.+Eius+laudantium+vel+aut.+Accusantium+saepe+tenetur+ullam+velit+blanditiis+explicabo+adipisci.&link_type=any&name=1531251439_animi&public_description=Esse+ipsa+officiis+ipsam+sed+totam+quibusdam.+Accusamus+cum+deleniti+veritatis.&title=Repudiandae+asperiores+vitae+amet+quaerat.&type=private&wikimode=disabled"
+          "string": "api_type=json&description=Fugit+illum+excepturi+nam+placeat+eaque+maxime+maiores.+Nostrum+soluta+asperiores+ullam.+Excepturi+iste+corrupti+voluptates+quisquam.%0AVel+facilis+incidunt+dolor.+Recusandae+quidem+voluptate+sint+inventore+quo+quis+rem+illo.+Consectetur+quia+alias+totam+ex+repellendus+dolorum+laborum.+Perspiciatis+ea+dicta+dolore+deleniti+natus.%0ADicta+recusandae+placeat+ipsum+dolore+recusandae.+Perferendis+maiores+nemo+praesentium+perferendis.+Iusto+esse+quis+error+eum+eveniet.+Vitae+impedit+rem+libero.&link_type=any&name=1533158928_quisquam&public_description=In+ex+qui+doloremque.+Quas+porro+esse+harum+consequatur.+Ratione+vel+repudiandae+enim+sed+velit.&title=Natus+magni+hic+doloribus+aliquam.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +84,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "668"
+            "747"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +121,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:19 GMT"
+            "Wed, 01 Aug 2018 21:28:48 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +142,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "161"
+            "72"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,7 +162,7 @@
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:25",
+      "recorded_at": "2018-08-01T21:28:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,18 +179,18 @@
             "keep-alive"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5GGVW5SC766HSB6VFHYW"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9EWX7CSDHASG4F3XNQHZ"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdJ1NS6KL68ycfZJCs4xS0zXNcvyD4gMCa70C3VU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYFp5kGZicnlTr6Z+gamiQHW6amehhFGRmkGIaC9KSklmUmp8ZnpoAMhnCUagE0xyIauAAAAA==",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIytNQtjYxKyzQpCjaLqCh30Q2PyCgxCHdyKy6y8EtW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYF5rhnJ3qnR6YHeVokpUaWWhqahVYmR2WGJ1uA9KSklmUmp8ZnpoAMhnCUagFTF41guAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -204,7 +204,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:25 GMT"
+            "Wed, 01 Aug 2018 21:28:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -226,15 +226,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5GGVW5SC766HSB6VFHYW"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CKVP9EWX7CSDHASG4F3XNQHZ"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:25",
+      "recorded_at": "2018-08-01T21:28:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2V5GGVW5SC766HSB6VFHYW&type=contributor"
+          "string": "api_type=json&name=01CKVP9EWX7CSDHASG4F3XNQHZ&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -244,26 +244,26 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "62"
+            "79"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531251439_animi/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533158928_quisquam/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
@@ -281,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:25 GMT"
+            "Wed, 01 Aug 2018 21:28:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -302,7 +302,7 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "155"
+            "66"
           ],
           "x-ratelimit-used": [
             "2"
@@ -318,15 +318,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251439_animi/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533158928_quisquam/api/friend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:25",
+      "recorded_at": "2018-08-01T21:28:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1531251439_animi"
+          "string": "api_type=json"
         },
         "headers": {
           "Accept": [
@@ -336,44 +336,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 142-E3r_wz4CLbSl6ag-6jOPYTSyNUA"
+            "bearer 219-uYZfi4rS6XxwD-WXht0WBFsr8Nc"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "75"
+            "13"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+        "uri": "https://reddit.local/r/1533158928_quisquam/api/accept_moderator_invite?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:25 GMT"
+            "Wed, 01 Aug 2018 21:28:54 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -394,7 +394,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "155"
+            "66"
           ],
           "x-ratelimit-used": [
             "1"
@@ -410,83 +410,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+        "url": "https://reddit.local/r/1533158928_quisquam/api/accept_moderator_invite?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:29",
+      "recorded_at": "2018-08-01T21:28:54",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5KXRHGK39KBH86PVYCYS"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNXQuCMBiF/4q8l5EwM+zjToMgMEIR8W6s7R2OLNcm4Yj+ey6vujwP5znnDYxztJYO/Q0fsA8gWschFZSFLmnIvatPz7ojkSZVkW+FPsMyABy1Mmip8kKcEDKxn08Hp9GPXJEZNL5reT+jhU8G5SS2/2+mKh0ra1SX46rNNululDzNJWsOhXcEvhRHqoQfngN8vk1jX6e4AAAA",
-          "encoding": "UTF-8"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Type": [
-            "text/html; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "Transfer-Encoding": [
-            "chunked"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CJ2V5KXRHGK39KBH86PVYCYS"
-      }
-    },
-    {
-      "recorded_at": "2018-07-10T19:37:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2V5KXRHGK39KBH86PVYCYS&permissions=%2Ball&type=moderator"
+          "string": "api_type=json&name=01CKVP98HRGK3BRZX4RQJY2Y6S&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -496,44 +428,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "79"
+            "60"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
-        "uri": "https://reddit.local/r/1531251439_animi/api/friend/?raw_json=1"
+        "uri": "https://reddit.local/r/1533158928_quisquam/api/unfriend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
+          "string": "{}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "24"
+            "2"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
+            "Wed, 01 Aug 2018 21:28:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -554,7 +486,7 @@
             "297.0"
           ],
           "x-ratelimit-reset": [
-            "151"
+            "66"
           ],
           "x-ratelimit-used": [
             "3"
@@ -570,15 +502,15 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251439_animi/api/friend/?raw_json=1"
+        "url": "https://reddit.local/r/1533158928_quisquam/api/unfriend/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:29",
+      "recorded_at": "2018-08-01T21:28:55",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json"
+          "string": ""
         },
         "headers": {
           "Accept": [
@@ -588,136 +520,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 143-_d_a-y6X0mlVIqVl01p0TQL8dpM"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "Content-Length": [
-            "13"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1531251439_animi/api/accept_moderator_invite?raw_json=1"
+        "method": "GET",
+        "uri": "https://reddit.local/r/1533158928_quisquam/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1533158934.0, \"mod_permissions\": [\"all\"], \"name\": \"01CKVP9EWX7CSDHASG4F3XNQHZ\", \"id\": \"t2_63\"}]}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "24"
+            "149"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
-          ],
-          "Server": [
-            "PasteWSGIServer/0.5 Python/2.7.6"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "299.0"
-          ],
-          "x-ratelimit-reset": [
-            "151"
-          ],
-          "x-ratelimit-used": [
-            "1"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://reddit.local/r/1531251439_animi/api/accept_moderator_invite?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2018-07-10T19:37:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "api_type=json&name=01CJ2V5A5899V3B15YC1E9BPXD&type=moderator"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "60"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
-          ],
-          "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://reddit.local/r/1531251439_animi/api/unfriend/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{}"
-        },
-        "headers": {
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "2"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
+            "Wed, 01 Aug 2018 21:28:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -738,10 +572,13 @@
             "296.0"
           ],
           "x-ratelimit-reset": [
-            "151"
+            "65"
           ],
           "x-ratelimit-used": [
             "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=YwMCr8CScPn79HSPoXy2Ch%2FrYHfY3ujyNBGuXj4bsaYYBCmNTjMCM%2Fyk7HVfi%2Fw4CpDyyXhKGJYzgwaipVDSK3DQt4zrURco"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -754,11 +591,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251439_animi/api/unfriend/?raw_json=1"
+        "url": "https://reddit.local/r/1533158928_quisquam/about/moderators/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:29",
+      "recorded_at": "2018-08-01T21:28:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -772,38 +609,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531251439_animi/about/moderators/?raw_json=1"
+        "uri": "https://reddit.local/user/01CKVP9EWX7CSDHASG4F3XNQHZ/about/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1531251449.0, \"mod_permissions\": [\"all\"], \"name\": \"01CJ2V5KXRHGK39KBH86PVYCYS\", \"id\": \"t2_3z\"}]}}"
+          "string": "{\"kind\": \"t2\", \"data\": {\"name\": \"01CKVP9EWX7CSDHASG4F3XNQHZ\", \"is_friend\": false, \"created\": 1533158934.0, \"hide_from_robots\": false, \"created_utc\": 1533158934.0, \"link_karma\": 1, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": false, \"id\": \"63\"}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "149"
+            "275"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
+            "Wed, 01 Aug 2018 21:28:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -824,13 +661,13 @@
             "295.0"
           ],
           "x-ratelimit-reset": [
-            "151"
+            "65"
           ],
           "x-ratelimit-used": [
             "5"
           ],
           "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=iEfiRbfHKLmViYVpXInwWje36oTIYMiurwBBudPsBoF6%2BsQHllEPds%2F9DU%2FIS7JPkspKO7D%2B2w4oLPmJSFwDjoD%2FLI8pwBwB"
+            "https://reddit.local/pixel/of_destiny.png?v=GTLgDCk6IYrguN7L41Y7HTEnsqBcED7P1aBtpy5NEpzO%2Bd5DDZW6OkcfUCE66O%2F777k9d89d13E%3D"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -843,11 +680,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251439_animi/about/moderators/?raw_json=1"
+        "url": "https://reddit.local/user/01CKVP9EWX7CSDHASG4F3XNQHZ/about/?raw_json=1"
       }
     },
     {
-      "recorded_at": "2018-07-10T19:37:29",
+      "recorded_at": "2018-08-01T21:28:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -861,38 +698,38 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 141-cTC3vPuN7YfLnF8NDvxs5y2FTVA"
+            "bearer 218-onDcH3qm7-of-gM8KM0eZeOgCXQ"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Cookie": [
-            "loid=wscua8NdH59h5CGEsP; loidcreated=2018-07-10T19%3A37%3A18.744Z"
+            "loid=f97okeVBXaHuOpDzCY; loidcreated=2018-08-01T21%3A28%3A47.893Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.36.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.39.0 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/r/1531251439_animi/about/moderators/?user=01CJ2V5A5899V3B15YC1E9BPXD&raw_json=1"
+        "uri": "https://reddit.local/api/v1/me?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+          "string": "{\"is_employee\": false, \"has_mail\": false, \"name\": \"01CKVP98HRGK3BRZX4RQJY2Y6S\", \"created\": 1533158928.0, \"hide_from_robots\": false, \"is_suspended\": false, \"created_utc\": 1533158928.0, \"has_mod_mail\": false, \"link_karma\": 1, \"in_beta\": false, \"comment_karma\": 0, \"features\": {\"pause_ads\": true}, \"over_18\": false, \"is_gold\": false, \"is_mod\": false, \"id\": \"62\", \"gold_expiration\": null, \"inbox_count\": 0, \"has_verified_email\": false, \"gold_creddits\": 0, \"suspension_expiration_utc\": null}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "46"
+            "486"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 10 Jul 2018 19:37:29 GMT"
+            "Wed, 01 Aug 2018 21:28:55 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -913,16 +750,10 @@
             "294.0"
           ],
           "x-ratelimit-reset": [
-            "151"
+            "65"
           ],
           "x-ratelimit-used": [
             "6"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=GMLL58%2FcRVZXqixKwH3UqbaX1z5ChZjA8iBK7fvqNsssoejknW2k5u2q%2BAoWRY85yHfLcrkI%2Fw3NqRnQPxoTqoJpkQhKpHrk"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
           ],
           "x-xss-protection": [
             "1; mode=block"
@@ -932,7 +763,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1531251439_animi/about/moderators/?user=01CJ2V5A5899V3B15YC1E9BPXD&raw_json=1"
+        "url": "https://reddit.local/api/v1/me?raw_json=1"
       }
     }
   ],

--- a/channels/api.py
+++ b/channels/api.py
@@ -937,9 +937,6 @@ class Api:
         Args:
             moderator_name(str): username of the user
             channel_name(str): name of the channel
-
-        Returns:
-            praw.models.Redditor: the reddit representation of the user
         """
         try:
             user = User.objects.get(username=moderator_name)
@@ -952,7 +949,6 @@ class Api:
         except APIException as ex:
             if ex.error_type != "ALREADY_MODERATOR":
                 raise
-        return Redditor(self.reddit, name=moderator_name)
 
     def accept_invite(self, channel_name):
         """

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -671,7 +671,8 @@ def test_add_moderator(mock_client):
     moderator = UserFactory.create()
     redditor = client.add_moderator(moderator.username, 'channel_test_name')
     mock_client.subreddit.return_value.moderator.add.assert_called_once_with(moderator)
-    assert redditor.name == moderator.username
+    # API function doesn't return the moderator. To do this the view calls _list_moderators
+    assert redditor is None
 
 
 def test_add_moderator_no_user(mock_client):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -734,6 +734,7 @@ class ModeratorPrivateSerializer(serializers.Serializer):
     moderator_name = WriteableSerializerMethodField()
     email = WriteableSerializerMethodField()
     full_name = serializers.SerializerMethodField()
+    can_remove = serializers.SerializerMethodField()
 
     def get_moderator_name(self, instance):
         """Returns the name for the moderator"""
@@ -746,6 +747,11 @@ class ModeratorPrivateSerializer(serializers.Serializer):
     def get_full_name(self, instance):
         """Get the full name of the associated user"""
         return Profile.objects.filter(user__username=instance.name).values_list('name', flat=True).first()
+
+    def get_can_remove(self, instance):
+        """Figure out whether the logged in user can remove this moderator"""
+        channel_api = self.context['channel_api']
+        return int(instance.created) >= int(channel_api.reddit.user.me().created)
 
     def validate_moderator_name(self, value):
         """Validates the moderator name"""

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -750,8 +750,9 @@ class ModeratorPrivateSerializer(serializers.Serializer):
 
     def get_can_remove(self, instance):
         """Figure out whether the logged in user can remove this moderator"""
-        channel_api = self.context['channel_api']
-        return int(instance.created) >= int(channel_api.reddit.user.me().created)
+        if self.context['mod_date'] is None:
+            return False
+        return int(instance.date) >= int(self.context['mod_date'])
 
     def validate_moderator_name(self, value):
         """Validates the moderator name"""
@@ -778,7 +779,11 @@ class ModeratorPrivateSerializer(serializers.Serializer):
         else:
             raise ValueError("Missing moderator_name or email")
 
-        return api.add_moderator(username, channel_name)
+        api.add_moderator(username, channel_name)
+        return api._list_moderators(
+            channel_name=channel_name,
+            moderator_name=username,
+        )[0]
 
 
 class SubscriberSerializer(serializers.Serializer):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -780,7 +780,7 @@ class ModeratorPrivateSerializer(serializers.Serializer):
             raise ValueError("Missing moderator_name or email")
 
         api.add_moderator(username, channel_name)
-        return api._list_moderators(
+        return api._list_moderators(  # pylint: disable=protected-access
             channel_name=channel_name,
             moderator_name=username,
         )[0]

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -404,15 +404,24 @@ def test_moderator_create_username():
     moderator_user = UserFactory.create()
     moderator_redditor = Mock(spec=Redditor)
     moderator_redditor.name = moderator_user.username
-
-    api_mock = Mock(add_moderator=Mock(return_value=moderator_redditor))
+    add_moderator_mock = Mock(return_value=None)
+    list_moderators_mock = Mock(return_value=[moderator_redditor])
+    api_mock = Mock(
+        add_moderator=add_moderator_mock,
+        _list_moderators=list_moderators_mock,
+    )
+    channel_name = 'foo_channel'
     moderator = ModeratorPrivateSerializer(context={
         "channel_api": api_mock,
         "request": Mock(user=user),
-        "view": Mock(kwargs={'channel_name': 'foo_channel'})
+        "view": Mock(kwargs={'channel_name': channel_name})
     }).create({'moderator_name': moderator_user.username})
     assert moderator is moderator_redditor
-    api_mock.add_moderator.assert_called_once_with(moderator_user.username, 'foo_channel')
+    api_mock.add_moderator.assert_called_once_with(moderator_user.username, channel_name)
+    list_moderators_mock.assert_called_once_with(
+        channel_name=channel_name,
+        moderator_name=moderator_user.username,
+    )
 
 
 def test_moderator_create_email():
@@ -421,16 +430,27 @@ def test_moderator_create_email():
     moderator_user = UserFactory.create()
     moderator_redditor = Mock(spec=Redditor)
     moderator_redditor.name = moderator_user.username
-    api_mock = Mock(add_moderator=Mock(return_value=moderator_redditor))
+    add_moderator_mock = Mock(return_value=None)
+    list_moderators_mock = Mock(return_value=[moderator_redditor])
+    api_mock = Mock(
+        add_moderator=add_moderator_mock,
+        _list_moderators=list_moderators_mock,
+    )
+    channel_name = 'foo_channel'
     # Make sure that we're testing case insensitivity of email
     assert moderator_user.email != moderator_user.email.upper()
     moderator = ModeratorPrivateSerializer(context={
         "channel_api": api_mock,
         "request": Mock(user=user),
-        "view": Mock(kwargs={'channel_name': 'foo_channel'})
+        "view": Mock(kwargs={'channel_name': channel_name})
     }).create({'email': moderator_user.email.upper()})
     assert moderator is moderator_redditor
-    api_mock.add_moderator.assert_called_once_with(moderator_user.username, 'foo_channel')
+
+    add_moderator_mock.assert_called_once_with(moderator_user.username, channel_name)
+    list_moderators_mock.assert_called_once_with(
+        channel_name=channel_name,
+        moderator_name=moderator_user.username,
+    )
 
 
 def test_moderator_create_both():

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -37,14 +37,26 @@ class ModeratorListView(ListCreateAPIView):
 
     def get_serializer_context(self):
         """Context for the request and view"""
+        channel_api = self.request.channel_api
+        channel_name = self.kwargs['channel_name']
+        mods = list(channel_api._list_moderators(
+            channel_name=channel_name,
+            moderator_name=channel_api.user.username,
+        ))
+        if mods:
+            user_mod_date = mods[0].date
+        else:
+            user_mod_date = None
+
         return {
-            'channel_api': self.request.channel_api,
+            'channel_api': channel_api,
             'view': self,
+            'mod_date': user_mod_date,
         }
 
     def get_queryset(self):
         """Get a list of moderators for channel"""
-        api = Api(user=self.request.user)
+        api = self.request.channel_api
         channel_name = self.kwargs['channel_name']
         return (
             moderator for moderator in

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -39,7 +39,7 @@ class ModeratorListView(ListCreateAPIView):
         """Context for the request and view"""
         channel_api = self.request.channel_api
         channel_name = self.kwargs['channel_name']
-        mods = list(channel_api._list_moderators(
+        mods = list(channel_api._list_moderators(  # pylint: disable=protected-access
             channel_name=channel_name,
             moderator_name=channel_api.user.username,
         ))

--- a/channels/views/moderators_test.py
+++ b/channels/views/moderators_test.py
@@ -45,7 +45,7 @@ def test_list_moderators_staff(  # pylint: disable=too-many-arguments
         'moderator_name': mod_user.username,
         'full_name': mod_user.profile.name,
         'email': mod_user.email,
-        'can_remove': True,
+        'can_remove': False,
     }]
 
 

--- a/factory_data/channels.views.moderators_test.test_add_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator.json
@@ -1,7 +1,19 @@
 {
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Cumque unde ipsam dicta blanditiis omnis ea aliquid soluta. Laborum voluptas blanditiis saepe magnam optio atque illo. Quisquam repudiandae molestiae fugit. Facilis minima asperiores iure atque soluta ullam.\nMagni quaerat neque nisi quas ducimus. Dolorum qui ab quisquam accusantium. Quos at excepturi ducimus. Harum non quibusdam at debitis quibusdam.\nDolorem corrupti delectus modi inventore. Occaecati mollitia sed debitis. Consequuntur possimus non quam repellat.",
+      "name": "1533222073_tenetur",
+      "public_description": "Nesciunt voluptatibus voluptates pariatur eaque. Sunt facilis totam ullam facilis labore tenetur.",
+      "title": "Veritatis dolorem reprehenderit laudantium id."
+    }
+  },
   "users": {
+    "new_mod_user": {
+      "username": "01CKXJGFSKN49XFKM3W9ZFHMYW"
+    },
     "staff_user": {
-      "username": "01BYXNKW00TWQ74CZE1J38HZB6"
+      "username": "01CKXJG9F9PKYEZTNH1J16DSPG"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_add_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator.json
@@ -2,18 +2,18 @@
   "channels": {
     "public_channel": {
       "channel_type": "public",
-      "description": "Cumque unde ipsam dicta blanditiis omnis ea aliquid soluta. Laborum voluptas blanditiis saepe magnam optio atque illo. Quisquam repudiandae molestiae fugit. Facilis minima asperiores iure atque soluta ullam.\nMagni quaerat neque nisi quas ducimus. Dolorum qui ab quisquam accusantium. Quos at excepturi ducimus. Harum non quibusdam at debitis quibusdam.\nDolorem corrupti delectus modi inventore. Occaecati mollitia sed debitis. Consequuntur possimus non quam repellat.",
-      "name": "1533222073_tenetur",
-      "public_description": "Nesciunt voluptatibus voluptates pariatur eaque. Sunt facilis totam ullam facilis labore tenetur.",
-      "title": "Veritatis dolorem reprehenderit laudantium id."
+      "description": "Voluptatibus nemo libero ratione accusantium incidunt. Saepe ratione nam reiciendis consectetur quo esse nam. Voluptatum harum voluptas quaerat quo ab quos iste.\nOptio tempore corporis qui. Sint voluptatibus consequuntur maiores commodi. Nesciunt sit excepturi enim eos. Consequuntur iste eos consequatur maiores dicta dolorem.\nPlaceat reiciendis esse quae esse ad. Incidunt voluptatibus voluptate reiciendis alias reiciendis doloremque eveniet. Assumenda rem doloribus magnam hic.",
+      "name": "1533331695_totam",
+      "public_description": "Iste facilis sunt illum quod. Exercitationem alias asperiores voluptates praesentium quibusdam.",
+      "title": "Voluptas a debitis culpa ipsam iusto suscipit."
     }
   },
   "users": {
     "new_mod_user": {
-      "username": "01CKXJGFSKN49XFKM3W9ZFHMYW"
+      "username": "01CM0V1X23AN6F10R78DSMNV42"
     },
     "staff_user": {
-      "username": "01CKXJG9F9PKYEZTNH1J16DSPG"
+      "username": "01CM0V1PP2T147K4ZA2A7VBQS7"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_add_moderator_again.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator_again.json
@@ -1,7 +1,19 @@
 {
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Perferendis provident beatae id dolorem quia ducimus sit. Quaerat fugit quam quo molestias voluptate sapiente vitae. Explicabo itaque recusandae voluptates. Dolore facere recusandae numquam at rerum.\nImpedit similique cupiditate assumenda possimus nemo quis. Eveniet suscipit deserunt laudantium quia ducimus earum fuga. Iusto dolorem repudiandae nobis odio architecto distinctio at.",
+      "name": "1533221470_dolor",
+      "public_description": "Dicta ullam magnam assumenda illum. Cumque eligendi quas quam ex. Facilis quos at nihil.",
+      "title": "Neque eligendi et accusamus dolores."
+    }
+  },
   "users": {
+    "already_mod": {
+      "username": "01CKXHY37XP7484ZDAVQBS4B71"
+    },
     "staff_user": {
-      "username": "01BYXNKW1KGTC7K86AAHB8QYPQ"
+      "username": "01CKXHXWSKNQYR0JEHY1QH2RMM"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_add_moderator_again.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator_again.json
@@ -2,18 +2,18 @@
   "channels": {
     "public_channel": {
       "channel_type": "public",
-      "description": "Perferendis provident beatae id dolorem quia ducimus sit. Quaerat fugit quam quo molestias voluptate sapiente vitae. Explicabo itaque recusandae voluptates. Dolore facere recusandae numquam at rerum.\nImpedit similique cupiditate assumenda possimus nemo quis. Eveniet suscipit deserunt laudantium quia ducimus earum fuga. Iusto dolorem repudiandae nobis odio architecto distinctio at.",
-      "name": "1533221470_dolor",
-      "public_description": "Dicta ullam magnam assumenda illum. Cumque eligendi quas quam ex. Facilis quos at nihil.",
-      "title": "Neque eligendi et accusamus dolores."
+      "description": "Iure at blanditiis repellendus sunt dicta. Consequuntur ad ex minus fugit saepe odit est voluptas.\nEligendi nemo dignissimos dolorum distinctio. Accusantium mollitia veritatis quisquam quod temporibus blanditiis nesciunt. Optio placeat adipisci excepturi necessitatibus eum doloribus.\nEsse excepturi velit numquam sunt corporis suscipit. Dolore dolorem at nam quas. Delectus eum ullam facere ducimus ad. Odio excepturi eius ad quas aspernatur excepturi laboriosam.",
+      "name": "1533330636_ratione",
+      "public_description": "Fugit quasi quisquam officia. Cumque repellat dolor delectus voluptate magnam aut sed earum.",
+      "title": "Dolorum architecto quos officia magni est."
     }
   },
   "users": {
     "already_mod": {
-      "username": "01CKXHY37XP7484ZDAVQBS4B71"
+      "username": "01CM0T1JP7Z4BZ0H0CASQJJD33"
     },
     "staff_user": {
-      "username": "01CKXHXWSKNQYR0JEHY1QH2RMM"
+      "username": "01CM0T1CB3AP4NFXWPWYSHRQXQ"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_add_moderator_email.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator_email.json
@@ -2,21 +2,21 @@
   "channels": {
     "public_channel": {
       "channel_type": "public",
-      "description": "Nam quos itaque enim amet culpa pariatur quos. In nobis dolor nostrum eos mollitia. Incidunt autem quis doloribus voluptatum. Ad nisi aliquam porro magni.\nSunt facere doloribus ducimus vel ab. Ducimus maxime voluptate velit possimus eius nulla repudiandae quos. Fuga optio tempore hic quae laboriosam perspiciatis soluta.\nEx quia perspiciatis autem. Dolor nesciunt aliquid quos consequatur ipsa explicabo. Hic eius quod assumenda nam adipisci quidem quis.",
-      "name": "1533221808_adipisci",
-      "public_description": "Ducimus iure error fuga. Debitis culpa nisi in molestias doloremque.",
-      "title": "Animi consectetur deleniti totam deleniti quas."
+      "description": "Qui earum animi laborum ex nulla illum illo. Quia accusantium eius corrupti. Explicabo magni laudantium qui deleniti. Ut quos facere quae libero.\nIn ipsam iusto mollitia necessitatibus. Veritatis ab rerum quisquam officiis incidunt.\nVitae accusamus quaerat nulla possimus. Quae eligendi dicta molestias eius. Provident quod eaque natus magnam distinctio.",
+      "name": "1533332204_tenetur",
+      "public_description": "Quae repellat accusamus nisi molestias eos. Hic nulla mollitia expedita aliquam nam.",
+      "title": "Architecto eius ratione animi possimus."
     }
   },
   "users": {
     "mod_user1": {
-      "username": "01CKXJ8DDRDVRBBWMSCAT8T8ZK"
+      "username": "01CM0VHE23C13DWZ4TFYGE6N0Q"
     },
     "new_mod_user": {
-      "username": "01CKXJ8GNSKJJHEVBGB1R8GF2H"
+      "username": "01CM0VHHANKWQYA6750NKTXW9J"
     },
     "staff_user": {
-      "username": "01CKXJ8706YQ0ZQ30ZM4D536CV"
+      "username": "01CM0VH7QW9E2PP6WMRMGARFNE"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_add_moderator_email.json
+++ b/factory_data/channels.views.moderators_test.test_add_moderator_email.json
@@ -2,21 +2,21 @@
   "channels": {
     "public_channel": {
       "channel_type": "public",
-      "description": "Quidem illum accusantium necessitatibus consequatur. Voluptatum assumenda adipisci consectetur. Ab voluptates ipsum commodi repudiandae assumenda officiis. Dolores ducimus ipsa voluptates.\nOptio non non at voluptates similique quibusdam optio. Libero iure nemo quae sit. Voluptate magnam deserunt doloribus voluptatum ex iste. Eaque assumenda nam quam.",
-      "name": "1532098298_ullam",
-      "public_description": "Excepturi distinctio aut fuga tenetur. Dolore quis magni quam. Magnam dolor illum dolore eaque.",
-      "title": "Ipsam eum harum error quod ut ipsa."
+      "description": "Nam quos itaque enim amet culpa pariatur quos. In nobis dolor nostrum eos mollitia. Incidunt autem quis doloribus voluptatum. Ad nisi aliquam porro magni.\nSunt facere doloribus ducimus vel ab. Ducimus maxime voluptate velit possimus eius nulla repudiandae quos. Fuga optio tempore hic quae laboriosam perspiciatis soluta.\nEx quia perspiciatis autem. Dolor nesciunt aliquid quos consequatur ipsa explicabo. Hic eius quod assumenda nam adipisci quidem quis.",
+      "name": "1533221808_adipisci",
+      "public_description": "Ducimus iure error fuga. Debitis culpa nisi in molestias doloremque.",
+      "title": "Animi consectetur deleniti totam deleniti quas."
     }
   },
   "users": {
     "mod_user1": {
-      "username": "01CJW2SM8A2XJVPE3BC8NH5WV2"
+      "username": "01CKXJ8DDRDVRBBWMSCAT8T8ZK"
     },
     "new_mod_user": {
-      "username": "01CJW2SQH42V47Y4MKH5R0V1TD"
+      "username": "01CKXJ8GNSKJJHEVBGB1R8GF2H"
     },
     "staff_user": {
-      "username": "01CJW2SDRABTTY8Q8CQSCS9E28"
+      "username": "01CKXJ8706YQ0ZQ30ZM4D536CV"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators.json
@@ -2,21 +2,21 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Modi aliquid atque amet quo libero deserunt incidunt error. Expedita nam qui consectetur accusantium. Unde aperiam iure in dolorum unde velit maiores alias. Asperiores recusandae quae architecto expedita rerum repellat.\nPossimus nisi neque deleniti ipsum quos quo error. Ea voluptas molestias officia quae odio. Commodi animi a animi quidem.\nCupiditate maiores blanditiis veniam veritatis nam ipsum ipsa. Optio aspernatur possimus quod labore fugit perspiciatis corrupti.",
-      "name": "1532122149_pariatur",
-      "public_description": "Itaque optio omnis aliquam aliquam modi. Enim possimus eius sint distinctio nostrum.",
-      "title": "Tenetur praesentium sapiente sed."
+      "description": "Odio maiores accusamus ullam minima. Debitis porro enim autem autem sequi. Nam esse dignissimos aperiam eum. Id eveniet quo omnis consequuntur possimus.\nEius optio tempora harum. Qui id odio aliquam mollitia iusto cupiditate placeat iste. Ipsa asperiores maiores at provident debitis harum blanditiis velit.\nProvident consequuntur nobis velit. Ea nulla consectetur omnis. Dicta ipsam ullam quae vero sequi voluptate nobis. Quis voluptas repellendus quibusdam dicta dolore tempora consectetur.",
+      "name": "1533330534_debitis",
+      "public_description": "Odit dolor praesentium commodi. At repellat iure dicta quo voluptatibus ratione nihil.",
+      "title": "Nam dolorem laborum aut eum eaque."
     }
   },
   "users": {
     "contributor": {
-      "username": "01CJWSHFT3PKK1TKB63NZZHM2M"
+      "username": "01CM0SYF5HS0DM70VPS6F6F0A6"
     },
     "new_mod": {
-      "username": "01CJWSHK87F2Y908071YZYW2W2"
+      "username": "01CM0SYJK7B1DGB3HT0XKY3537"
     },
     "staff_user": {
-      "username": "01CJWSH9CS1WAZHDM0Y001QREK"
+      "username": "01CM0SY8VMVD3NM4AWK7KNA0BK"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators_many_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_many_moderator.json
@@ -1,0 +1,46 @@
+{
+  "channels": {
+    "private_channel": {
+      "channel_type": "private",
+      "description": "Perspiciatis in officia nulla quae dolores cumque. Pariatur animi accusantium dolorem magnam. Itaque distinctio quaerat fugiat autem nesciunt tempora. Qui quo accusamus nobis culpa ipsum autem odio.\nAliquid repellat pariatur minima sunt repudiandae. Omnis voluptate sunt sequi error facere unde explicabo. Eligendi pariatur cum reiciendis officia rerum.",
+      "name": "1533158948_distinctio",
+      "public_description": "Explicabo qui blanditiis eaque odit amet. Dicta dicta ipsam soluta doloremque.",
+      "title": "Architecto nobis quasi aliquam iusto."
+    }
+  },
+  "users": {
+    "staff_user": {
+      "username": "01CKVP9WQCKBM0NVNGKRWZ6WVM"
+    },
+    "user0": {
+      "username": "01CKVPA313F8E136M5A6RRPGJ3"
+    },
+    "user1": {
+      "username": "01CKVPA6HCTE1R0RFX6E0QR4WB"
+    },
+    "user2": {
+      "username": "01CKVPAA2441BGJZ1NQB6SRYZS"
+    },
+    "user3": {
+      "username": "01CKVPADM6Q93ZX1VFSWK1QRPD"
+    },
+    "user4": {
+      "username": "01CKVPAH2MZPM05NJQ5RMRJBST"
+    },
+    "user5": {
+      "username": "01CKVPAMHXN8EHVVMDBWQET8VB"
+    },
+    "user6": {
+      "username": "01CKVPAR09Y0MVT5PT9BD6YTHT"
+    },
+    "user7": {
+      "username": "01CKVPAVF2NHV89J2C7YB78S13"
+    },
+    "user8": {
+      "username": "01CKVPAYXCN60GNN63KTS11S1Q"
+    },
+    "user9": {
+      "username": "01CKVPB2CMY0VXHNA183P2NKP6"
+    }
+  }
+}

--- a/factory_data/channels.views.moderators_test.test_list_moderators_many_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_many_moderator.json
@@ -2,45 +2,45 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Perspiciatis in officia nulla quae dolores cumque. Pariatur animi accusantium dolorem magnam. Itaque distinctio quaerat fugiat autem nesciunt tempora. Qui quo accusamus nobis culpa ipsum autem odio.\nAliquid repellat pariatur minima sunt repudiandae. Omnis voluptate sunt sequi error facere unde explicabo. Eligendi pariatur cum reiciendis officia rerum.",
-      "name": "1533158948_distinctio",
-      "public_description": "Explicabo qui blanditiis eaque odit amet. Dicta dicta ipsam soluta doloremque.",
-      "title": "Architecto nobis quasi aliquam iusto."
+      "description": "Inventore ullam perspiciatis mollitia harum. Molestias eaque quas aspernatur aperiam. Explicabo esse illo maiores dignissimos. Dolorum non rem nemo.\nVoluptatibus rerum quae tempora. Quae laborum sapiente maiores eum alias velit consequuntur. Omnis minus repellendus fuga provident.\nPerspiciatis earum ad praesentium tempora enim laudantium. Omnis asperiores accusantium debitis magnam dolores laudantium dicta sint. Corrupti aspernatur perspiciatis dolorum.",
+      "name": "1533330569_deserunt",
+      "public_description": "Rem quam unde quae saepe a deserunt. Eveniet aliquam nemo aut beatae.",
+      "title": "Quisquam debitis eum ea eos eos perferendis."
     }
   },
   "users": {
     "staff_user": {
-      "username": "01CKVP9WQCKBM0NVNGKRWZ6WVM"
+      "username": "01CM0SZAYNWVX9CJDCASX97R06"
     },
     "user0": {
-      "username": "01CKVPA313F8E136M5A6RRPGJ3"
+      "username": "01CM0SZH7K02WE30CE4Y7FP5F0"
     },
     "user1": {
-      "username": "01CKVPA6HCTE1R0RFX6E0QR4WB"
+      "username": "01CM0SZMQ4ES7QPHGGZV4BTJB7"
     },
     "user2": {
-      "username": "01CKVPAA2441BGJZ1NQB6SRYZS"
+      "username": "01CM0SZR6GKXE0YM63AEAW43FZ"
     },
     "user3": {
-      "username": "01CKVPADM6Q93ZX1VFSWK1QRPD"
+      "username": "01CM0SZVRMKGKQ2AS76FB3S4VP"
     },
     "user4": {
-      "username": "01CKVPAH2MZPM05NJQ5RMRJBST"
+      "username": "01CM0SZZABEQZA8G1VV899VW95"
     },
     "user5": {
-      "username": "01CKVPAMHXN8EHVVMDBWQET8VB"
+      "username": "01CM0T02Y8AY8DS06PTQ8TQ5D4"
     },
     "user6": {
-      "username": "01CKVPAR09Y0MVT5PT9BD6YTHT"
+      "username": "01CM0T06FE7XDB9P6RZY4PTM4B"
     },
     "user7": {
-      "username": "01CKVPAVF2NHV89J2C7YB78S13"
+      "username": "01CM0T0A0W8AWR91X67FWYM4WB"
     },
     "user8": {
-      "username": "01CKVPAYXCN60GNN63KTS11S1Q"
+      "username": "01CM0T0DG81C5FKQB75HJA7VVG"
     },
     "user9": {
-      "username": "01CKVPB2CMY0VXHNA183P2NKP6"
+      "username": "01CM0T0H3ZBHK5W23F9HE3VR4H"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_moderator.json
@@ -2,21 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Placeat ut quaerat nostrum animi eum. Temporibus molestiae consequatur impedit occaecati quos repellendus.\nLaudantium magnam earum quasi tempore maxime ipsum magni. Doloribus esse cupiditate fugiat ea porro dolorum recusandae. Nesciunt veniam deleniti quae accusamus provident ipsam blanditiis.\nDoloribus quibusdam quibusdam esse illum quam iste. Possimus ipsum blanditiis illo at. Hic voluptatem quo vitae amet corrupti. Aspernatur dignissimos sed impedit perferendis.",
-      "name": "1531251991_aperiam",
-      "public_description": "Velit commodi accusantium sint ipsa reiciendis quisquam et. Minus quidem eaque eveniet quod.",
-      "title": "Optio eius laborum fugit inventore."
+      "description": "Totam quas quidem eligendi neque voluptate. Debitis provident itaque illum exercitationem accusantium explicabo dolores. Corporis ipsa tenetur nemo quam dolorum sit. In aliquam suscipit necessitatibus at esse in doloribus. Autem et fuga sunt soluta quo.\nCorporis dolor quibusdam nobis qui natus. Ex culpa labore suscipit dolor. Inventore iste sapiente doloremque expedita labore. Necessitatibus nobis voluptate ut ad.",
+      "name": "1533158938_cumque",
+      "public_description": "Laborum excepturi incidunt modi beatae laborum. Quam eius quis ea mollitia asperiores.",
+      "title": "Voluptatibus porro consequatur ut sint."
     }
   },
   "users": {
-    "contributor": {
-      "username": "01CJ2VPC1N10NXN7V4H718HKEX"
-    },
     "staff_user": {
-      "username": "01CJ2VP5QKA9K2JT6KFN2B071Z"
+      "username": "01CKVP9JNPTQS1ZQAVM86PH62W"
     },
     "user2": {
-      "username": "01CJ2VPFQSESTNYEMAH1HGBNMW"
+      "username": "01CKVP9S26K2295GSN856C32QX"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators_moderator.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_moderator.json
@@ -2,18 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Totam quas quidem eligendi neque voluptate. Debitis provident itaque illum exercitationem accusantium explicabo dolores. Corporis ipsa tenetur nemo quam dolorum sit. In aliquam suscipit necessitatibus at esse in doloribus. Autem et fuga sunt soluta quo.\nCorporis dolor quibusdam nobis qui natus. Ex culpa labore suscipit dolor. Inventore iste sapiente doloremque expedita labore. Necessitatibus nobis voluptate ut ad.",
-      "name": "1533158938_cumque",
-      "public_description": "Laborum excepturi incidunt modi beatae laborum. Quam eius quis ea mollitia asperiores.",
-      "title": "Voluptatibus porro consequatur ut sint."
+      "description": "Eius est possimus cumque reiciendis. Architecto recusandae repudiandae corrupti quia architecto nostrum. Perferendis incidunt enim deserunt quaerat.\nNemo dolorem incidunt neque rem veniam ea. Nihil commodi voluptate voluptatibus corporis pariatur. Voluptatem enim consequatur explicabo culpa error nulla ut neque. Voluptatum quasi quibusdam molestias asperiores suscipit. Minus ab placeat rerum veritatis nesciunt repellat.",
+      "name": "1533330559_quis",
+      "public_description": "Illum facere temporibus consectetur placeat. Reiciendis accusamus ipsam veritatis quis inventore.",
+      "title": "Adipisci aliquam voluptates laboriosam vel."
     }
   },
   "users": {
     "staff_user": {
-      "username": "01CKVP9JNPTQS1ZQAVM86PH62W"
+      "username": "01CM0SZ102MZZG3GEG8SXZEWH9"
     },
     "user2": {
-      "username": "01CKVP9S26K2295GSN856C32QX"
+      "username": "01CM0SZ7B5BA8MGYZX2D7MY6ND"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators_staff.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_staff.json
@@ -2,21 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Officiis recusandae reiciendis perspiciatis tempora ea. Consequatur quae veniam quis nemo nemo minus nostrum. Libero itaque molestiae amet inventore ad delectus. Soluta pariatur recusandae quia dolor veritatis incidunt expedita. Harum odit dolorem dicta quibusdam.\nAutem voluptate sapiente officiis molestiae laborum corporis eius. Eius laudantium vel aut. Accusantium saepe tenetur ullam velit blanditiis explicabo adipisci.",
-      "name": "1531251439_animi",
-      "public_description": "Esse ipsa officiis ipsam sed totam quibusdam. Accusamus cum deleniti veritatis.",
-      "title": "Repudiandae asperiores vitae amet quaerat."
+      "description": "Fugit illum excepturi nam placeat eaque maxime maiores. Nostrum soluta asperiores ullam. Excepturi iste corrupti voluptates quisquam.\nVel facilis incidunt dolor. Recusandae quidem voluptate sint inventore quo quis rem illo. Consectetur quia alias totam ex repellendus dolorum laborum. Perspiciatis ea dicta dolore deleniti natus.\nDicta recusandae placeat ipsum dolore recusandae. Perferendis maiores nemo praesentium perferendis. Iusto esse quis error eum eveniet. Vitae impedit rem libero.",
+      "name": "1533158928_quisquam",
+      "public_description": "In ex qui doloremque. Quas porro esse harum consequatur. Ratione vel repudiandae enim sed velit.",
+      "title": "Natus magni hic doloribus aliquam."
     }
   },
   "users": {
-    "contributor": {
-      "username": "01CJ2V5GGVW5SC766HSB6VFHYW"
-    },
     "staff_user": {
-      "username": "01CJ2V5A5899V3B15YC1E9BPXD"
+      "username": "01CKVP98HRGK3BRZX4RQJY2Y6S"
     },
     "user2": {
-      "username": "01CJ2V5KXRHGK39KBH86PVYCYS"
+      "username": "01CKVP9EWX7CSDHASG4F3XNQHZ"
     }
   }
 }

--- a/factory_data/channels.views.moderators_test.test_list_moderators_staff.json
+++ b/factory_data/channels.views.moderators_test.test_list_moderators_staff.json
@@ -2,18 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Fugit illum excepturi nam placeat eaque maxime maiores. Nostrum soluta asperiores ullam. Excepturi iste corrupti voluptates quisquam.\nVel facilis incidunt dolor. Recusandae quidem voluptate sint inventore quo quis rem illo. Consectetur quia alias totam ex repellendus dolorum laborum. Perspiciatis ea dicta dolore deleniti natus.\nDicta recusandae placeat ipsum dolore recusandae. Perferendis maiores nemo praesentium perferendis. Iusto esse quis error eum eveniet. Vitae impedit rem libero.",
-      "name": "1533158928_quisquam",
-      "public_description": "In ex qui doloremque. Quas porro esse harum consequatur. Ratione vel repudiandae enim sed velit.",
-      "title": "Natus magni hic doloribus aliquam."
+      "description": "Ab ullam pariatur quia atque facere ut. Dolorem iure eligendi distinctio rerum illo quis. Ipsam harum sunt ipsam ipsa delectus.\nConsectetur corporis fuga quasi id aperiam minima maxime. Molestiae quidem porro nulla reiciendis autem. Magni sunt repellendus quos minus ratione saepe sit dolorum. Explicabo accusamus occaecati vero sequi qui beatae eaque voluptatibus.",
+      "name": "1533330548_repudianda",
+      "public_description": "Quis quisquam tempore facere ex. Impedit maxime tempora perspiciatis enim tempore voluptatem.",
+      "title": "Quidem aut ipsum nihil sequi."
     }
   },
   "users": {
     "staff_user": {
-      "username": "01CKVP98HRGK3BRZX4RQJY2Y6S"
+      "username": "01CM0SYPRZ8FS4P9SDEB6Q7VXN"
     },
     "user2": {
-      "username": "01CKVP9EWX7CSDHASG4F3XNQHZ"
+      "username": "01CM0SYX4EXGZJ3FJ0BG71Q7DT"
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #1004

#### What's this PR do?
Adds a field to the moderators REST API showing who can and can't be removed by the logged in user (who must also be a moderator)

#### How should this be manually tested?
View `/api/v0/channels/<channel_name>/moderators/` and verify that the `can_remove` field is True for you and other moderators, and False for older moderators
