### PR TITLE
Notify user via snackbar when URL is copied

### DIFF
--- a/static/js/components/SharePopup.js
+++ b/static/js/components/SharePopup.js
@@ -1,5 +1,7 @@
 // @flow
+import { connect } from "react-redux"
 import React from "react"
+import R from "ramda"
 import onClickOutside from "react-onclickoutside"
 import {
   FacebookShareButton,
@@ -8,10 +10,13 @@ import {
 } from "react-share"
 import { FacebookIcon, TwitterIcon, LinkedinIcon } from "react-share"
 
+import { setSnackbarMessage } from "../actions/ui"
+
 type SharePopupProps = {
   url: string,
   closePopup: Function,
-  hideSocialButtons?: boolean
+  hideSocialButtons?: boolean,
+  setSnackbarMessage: Function
 }
 
 export class SharePopupHelper extends React.Component<SharePopupProps> {
@@ -27,11 +32,13 @@ export class SharePopupHelper extends React.Component<SharePopupProps> {
     closePopup()
   }
 
-  selectInputText = (e: Event) => {
+  selectAndCopyLinkText = (e: Event) => {
+    const { setSnackbarMessage } = this.props
     e.preventDefault()
     if (this.input.current) {
       this.input.current.select()
       document.execCommand("copy")
+      setSnackbarMessage({ message: "Copied to clipboard" })
     }
   }
 
@@ -57,7 +64,7 @@ export class SharePopupHelper extends React.Component<SharePopupProps> {
               </TwitterShareButton>
             </div>
           )}
-          <a href="#" className="copy-url" onClick={this.selectInputText}>
+          <a href="#" className="copy-url" onClick={this.selectAndCopyLinkText}>
             Copy URL to clipboard
           </a>
         </div>
@@ -66,5 +73,10 @@ export class SharePopupHelper extends React.Component<SharePopupProps> {
   }
 }
 
-const SharePopup = onClickOutside(SharePopupHelper)
-export default SharePopup
+export default R.compose(
+  connect(
+    R.always({}), // mapStateToProps is not needed - just return an object
+    { setSnackbarMessage }
+  ),
+  onClickOutside
+)(SharePopupHelper)

--- a/static/js/components/SharePopup_test.js
+++ b/static/js/components/SharePopup_test.js
@@ -13,16 +13,24 @@ import { FacebookIcon, TwitterIcon, LinkedinIcon } from "react-share"
 import { SharePopupHelper } from "./SharePopup"
 
 describe("SharePopup", () => {
-  let closePopupStub, execCommandStub, url, sandbox
+  let closePopupStub, execCommandStub, setSnackbarMessageStub, url, sandbox
 
   // unfortunately have to use mount to get the ref to work
   const renderSharePopupHelper = (props = {}) =>
-    mount(<SharePopupHelper closePopup={closePopupStub} url={url} {...props} />)
+    mount(
+      <SharePopupHelper
+        closePopup={closePopupStub}
+        url={url}
+        setSnackbarMessage={setSnackbarMessageStub}
+        {...props}
+      />
+    )
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     closePopupStub = sandbox.stub()
     execCommandStub = sandbox.stub()
+    setSnackbarMessageStub = sandbox.stub()
     // $FlowFixMe: flow thinks this isn't writable (normally that's true!)
     document.execCommand = execCommandStub
     url = "http://en.wikipedia.org"
@@ -57,10 +65,13 @@ describe("SharePopup", () => {
     const wrapperInstance = renderSharePopupHelper().instance()
     const selectStub = sandbox.stub(wrapperInstance.input.current, "select")
     const fakeEvent = { preventDefault: sandbox.stub() }
-    wrapperInstance.selectInputText(fakeEvent)
+    wrapperInstance.selectAndCopyLinkText(fakeEvent)
     assert.ok(selectStub.called)
     assert.ok(fakeEvent.preventDefault.called)
     assert.ok(execCommandStub.calledWith("copy"))
+    assert.ok(
+      setSnackbarMessageStub.calledWith({ message: "Copied to clipboard" })
+    )
   })
 
   it("should include the share buttons we expect", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1000 

#### What's this PR do?
Notifies a user via snackbar when URL is copied from the Share popup

#### How should this be manually tested?
Copy a URL in the Share popup, which can be seen on the post detail page

#### Screenshots (if appropriate)
![ss 2018-08-02 at 14 45 17](https://user-images.githubusercontent.com/14932219/43605234-c088b520-9665-11e8-9c76-cb19ebb4cdcc.png)
