### PR TITLE
Hide comment section header when post has no comments

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -318,6 +318,38 @@ class PostPage extends React.Component<PostPageProps> {
     dispatch(hideDropdownDebounced(POST_SHARE_MENU_KEY))
   }
 
+  renderCommentSectionHeader = () => {
+    const {
+      post,
+      commentID,
+      channel,
+      location: { search }
+    } = this.props
+
+    if (commentID) {
+      return (
+        <Card className="comment-detail-card">
+          <div>You are viewing a single comment's thread.</div>
+          <Link to={postDetailURL(channel.name, post.id, post.slug)}>
+            View the rest of the comments
+          </Link>
+        </Card>
+      )
+    }
+    if (post.num_comments > 0) {
+      return (
+        <div className="count-and-sort">
+          <div className="comments-count">{formatCommentsCount(post)}</div>
+          <CommentSortPicker
+            updateSortParam={updateCommentSortParam(this.props)}
+            value={qs.parse(search).sort || COMMENT_SORT_BEST}
+          />
+        </div>
+      )
+    }
+    return null
+  }
+
   render() {
     const {
       dispatch,
@@ -335,7 +367,6 @@ class PostPage extends React.Component<PostPageProps> {
       approvePost,
       removeComment,
       approveComment,
-      location: { search },
       embedly,
       reportPost,
       postDropdownMenuOpen,
@@ -430,38 +461,29 @@ class PostPage extends React.Component<PostPageProps> {
             )}
           </div>
         </Card>
-        {commentID ? (
-          <Card className="comment-detail-card">
-            <div>You are viewing a single comment's thread.</div>
-            <Link to={postDetailURL(channel.name, post.id, post.slug)}>
-              View the rest of the comments
-            </Link>
-          </Card>
-        ) : (
-          <div className="count-and-sort">
-            <div className="comments-count">{formatCommentsCount(post)}</div>
-            <CommentSortPicker
-              updateSortParam={updateCommentSortParam(this.props)}
-              value={qs.parse(search).sort || COMMENT_SORT_BEST}
-            />
-          </div>
-        )}
-        <CommentTree
-          comments={commentsTree}
-          forms={forms}
-          upvote={this.upvote}
-          downvote={this.downvote}
-          approve={approveComment}
-          remove={removeComment}
-          deleteComment={this.showCommentDialog(DELETE_COMMENT_DIALOG)}
-          reportComment={this.showReportCommentDialog}
-          isModerator={isModerator}
-          loadMoreComments={this.loadMoreComments}
-          beginEditing={beginEditing(dispatch)}
-          processing={commentInFlight}
-          commentPermalink={commentPermalink(channel.name, post.id, post.slug)}
-          toggleFollowComment={toggleFollowComment(dispatch)}
-        />
+        {this.renderCommentSectionHeader()}
+        {commentsTree.length > 0 ? (
+          <CommentTree
+            comments={commentsTree}
+            forms={forms}
+            upvote={this.upvote}
+            downvote={this.downvote}
+            approve={approveComment}
+            remove={removeComment}
+            deleteComment={this.showCommentDialog(DELETE_COMMENT_DIALOG)}
+            reportComment={this.showReportCommentDialog}
+            isModerator={isModerator}
+            loadMoreComments={this.loadMoreComments}
+            beginEditing={beginEditing(dispatch)}
+            processing={commentInFlight}
+            commentPermalink={commentPermalink(
+              channel.name,
+              post.id,
+              post.slug
+            )}
+            toggleFollowComment={toggleFollowComment(dispatch)}
+          />
+        ) : null}
       </div>
     )
   }

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -230,6 +230,14 @@ describe("PostPage", function() {
     assert.isTrue(wrapper.find(ExpandedPostDisplay).props().showPermalinkUI)
   })
 
+  it("should hide the comments header section when there are no comments", async () => {
+    post.num_comments = 0
+    helper.getPostStub.returns(Promise.resolve(post))
+    helper.getCommentsStub.returns(Promise.resolve([]))
+    const wrapper = await renderPage()
+    assert.isFalse(wrapper.find(".count-and-sort").exists())
+  })
+
   //
   ;[true, false].forEach(userIsAnon => {
     it(`should not show a ReplyToPostForm when userIsAnonymous() === ${userIsAnon}`, async () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1001 

#### What's this PR do?
Hides the comment section header (count + sort control) when there no comments on a post

#### How should this be manually tested?
Open the post detail page for a post with no comments

#### Screenshots (if appropriate)
![ss 2018-08-02 at 16 42 38](https://user-images.githubusercontent.com/14932219/43609917-19a62a18-9673-11e8-934c-44f12145a70f.png)
