### PR TITLE
link names to profile in comment and post displays

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -20,6 +20,7 @@ import {
   getCommentReplyInitialValue
 } from "../components/CommentForms"
 import { makeProfile } from "../lib/profile"
+import { profileURL } from "../lib/url"
 
 import type {
   GenericComment,
@@ -112,17 +113,21 @@ export default class CommentTree extends React.Component<Props> {
         className={`comment ${comment.removed ? "removed" : ""}`}
         key={`comment-${comment.id}`}
       >
-        <ProfileImage
-          profile={makeProfile({
-            name:                comment.author_name,
-            username:            SETTINGS.username,
-            profile_image_small: comment.profile_image
-          })}
-          imageSize={PROFILE_IMAGE_SMALL}
-        />
+        <Link to={profileURL(comment.author_id)}>
+          <ProfileImage
+            profile={makeProfile({
+              name:                comment.author_name,
+              username:            SETTINGS.username,
+              profile_image_small: comment.profile_image
+            })}
+            imageSize={PROFILE_IMAGE_SMALL}
+          />
+        </Link>
         <div className="comment-contents">
           <div className="author-info">
-            <span className="author-name">{comment.author_name}</span>
+            <Link to={profileURL(comment.author_id)}>
+              <span className="author-name">{comment.author_name}</span>
+            </Link>
             <span className="authored-date">
               {moment(comment.created).fromNow()}
             </span>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -14,7 +14,7 @@ import {
   replyToCommentKey,
   editCommentKey
 } from "./CommentForms"
-import { commentPermalink } from "../lib/url"
+import { commentPermalink, profileURL } from "../lib/url"
 import Router from "../Router"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
@@ -266,6 +266,23 @@ describe("CommentTree", () => {
       .at(0)
       .text()
     assert.equal(authorName, comments[0].author_name)
+  })
+
+  it("should link to the author's profile", () => {
+    const wrapper = renderCommentTree()
+    const link = wrapper
+      .find(".author-info")
+      .at(0)
+      .find("Link")
+    assert.equal(link.text(), comments[0].author_name)
+    assert.equal(link.props().to, profileURL(comments[0].author_id))
+    const secondLink = wrapper
+      .find(".comment")
+      .at(0)
+      .find("Link")
+      .at(0)
+    assert.equal(secondLink.props().to, profileURL(comments[0].author_id))
+    assert(secondLink.find("ProfileImage").exists())
   })
 
   it("should limit replies to the max comment depth", () => {

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -8,7 +8,12 @@ import { Link } from "react-router-dom"
 import Card from "./Card"
 import DropdownMenu from "./DropdownMenu"
 
-import { channelURL, embedlyThumbnail, postDetailURL } from "../lib/url"
+import {
+  channelURL,
+  embedlyThumbnail,
+  postDetailURL,
+  profileURL
+} from "../lib/url"
 import {
   PostVotingButtons,
   PostTitleAndHostname,
@@ -79,7 +84,9 @@ export class CompactPostDisplay extends React.Component<Props> {
             </div>
             <div className="row">
               <div className="authored-by">
-                <div className="author-name">{post.author_name}</div>
+                <Link to={profileURL(post.author_id)}>
+                  <div className="author-name">{post.author_name}</div>
+                </Link>
                 <div className="date">
                   {formattedDate}
                   {this.showChannelLink()}

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -11,7 +11,7 @@ import DropdownMenu from "./DropdownMenu"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { wait } from "../lib/util"
-import { channelURL, postDetailURL, urlHostname } from "../lib/url"
+import { channelURL, postDetailURL, urlHostname, profileURL } from "../lib/url"
 import { PostTitleAndHostname, getPostDropdownMenuKey } from "../lib/posts"
 import { makePost } from "../factories/posts"
 import { showDropdown } from "../actions/ui"
@@ -71,12 +71,20 @@ describe("CompactPostDisplay", () => {
     assert.isNotEmpty(authoredBy.substring(post.author_name.length))
   })
 
+  it("should link to the author's profile", () => {
+    const link = renderPostDisplay({ post })
+      .find(".authored-by")
+      .find("Link")
+    assert.equal(link.text(), post.author_name)
+    assert.equal(link.props().to, profileURL(post.author_id))
+  })
+
   it("should link to the subreddit, if told to", () => {
     post.channel_name = "channel_name"
     const wrapper = renderPostDisplay({ post, showChannelLink: true })
     const linkProps = wrapper
+      .find(".date")
       .find(Link)
-      .at(1)
       .props()
     assert.equal(linkProps.to, channelURL("channel_name"))
     assert.equal(linkProps.children, post.channel_title)
@@ -87,7 +95,7 @@ describe("CompactPostDisplay", () => {
     const wrapper = renderPostDisplay({ post })
     const { href, target } = wrapper
       .find("a")
-      .at(1)
+      .at(2)
       .props()
     assert.equal(href, post.url)
     assert.equal(target, "_blank")
@@ -261,8 +269,8 @@ describe("CompactPostDisplay", () => {
         isModerator: true,
         removePost:  removePostStub
       })
-      const link = wrapper.find("a").at(2)
-      assert.equal(link.text(), "remove")
+      const link = wrapper.find({ children: "remove" })
+      assert(link.exists())
       link.simulate("click")
       assert.ok(removePostStub.calledWith(post))
     })
@@ -274,8 +282,8 @@ describe("CompactPostDisplay", () => {
         isModerator:       true,
         ignorePostReports: ignorePostStub
       })
-      const link = wrapper.find("a").at(2)
-      assert.equal(link.text(), "ignore all reports")
+      const link = wrapper.find({ children: "ignore all reports" })
+      assert(link.exists())
       link.simulate("click")
       assert.ok(ignorePostStub.calledWith(post))
     })

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -3,6 +3,7 @@
 import React from "react"
 import moment from "moment"
 import R from "ramda"
+import { Link } from "react-router-dom"
 
 import { EditPostForm } from "./CommentForms"
 import { renderTextContent } from "./Markdown"
@@ -15,7 +16,7 @@ import { formatPostTitle, PostVotingButtons } from "../lib/posts"
 import { preventDefaultAndInvoke, userIsAnonymous } from "../lib/util"
 import { editPostKey } from "../components/CommentForms"
 import { makeProfile } from "../lib/profile"
-import { postPermalink } from "../lib/url"
+import { postPermalink, profileURL } from "../lib/url"
 
 import type { Post, Channel } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
@@ -201,7 +202,7 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
         <div className="summary">
           <div className="post-title">{formatPostTitle(post)}</div>
           <div className="authored-by">
-            <div className="left">
+            <Link className="left" to={profileURL(post.author_id)}>
               <ProfileImage
                 profile={makeProfile({
                   name:                post.author_name,
@@ -210,7 +211,7 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
                 imageSize={PROFILE_IMAGE_MICRO}
               />
               <div className="author-name">{post.author_name}</div>
-            </div>
+            </Link>
             <div className="right">{formattedDate}</div>
           </div>
           {embedly && embedly.provider_name ? (

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -14,7 +14,7 @@ import ProfileImage from "../containers/ProfileImage"
 import SharePopup from "./SharePopup"
 
 import { wait } from "../lib/util"
-import { postPermalink, postDetailURL } from "../lib/url"
+import { postPermalink, postDetailURL, profileURL } from "../lib/url"
 import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
@@ -92,6 +92,14 @@ describe("ExpandedPostDisplay", () => {
       authoredBy.find(".right").text(),
       moment(post.created).fromNow()
     )
+  })
+
+  it("should link to the post author's profile", () => {
+    const link = renderPostDisplay()
+      .find(".authored-by")
+      .find("Link")
+    assert.equal(link.text(), post.author_name)
+    assert.equal(link.props().to, profileURL(post.author_id))
   })
 
   it("should hide text content if passed showPermalinkUI", () => {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -121,6 +121,7 @@
     color: $font-grey;
     margin: 0 0 8px;
 
+    a,
     span.author-name {
       color: $font-black;
     }


### PR DESCRIPTION
#### What are the relevant tickets?

closes #993 

#### What's this PR do?

This just adds links from the profile and comment displays to our profile page, so that users can look at each other's profiles and stuff.

#### How should this be manually tested?

Make sure that you can navigate to the users profile by clicking on the username shown in the post list, post detail page, and on a comment.

Styling and so on should look like it did before.