### PR TITLE
Improvements to moderator/contributor UI

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -4,6 +4,7 @@ import { createAction } from "redux-actions"
 export const DIALOG_REMOVE_POST = "DIALOG_REMOVE_POST"
 export const DIALOG_REMOVE_COMMENT = "DIALOG_REMOVE_COMMENT"
 export const DIALOG_PROFILE_IMAGE = "DIALOG_PROFILE_IMAGE"
+export const DIALOG_REMOVE_MEMBER = "DIALOG_REMOVE_MEMBER"
 
 export const SET_SHOW_DRAWER_DESKTOP = "SET_SHOW_DRAWER_DESKTOP"
 export const setShowDrawerDesktop = createAction(SET_SHOW_DRAWER_DESKTOP)
@@ -25,6 +26,9 @@ export const showDialog = createAction(SHOW_DIALOG)
 
 export const HIDE_DIALOG = "HIDE_DIALOG"
 export const hideDialog = createAction(HIDE_DIALOG)
+
+export const SET_DIALOG_DATA = "SET_DIALOG_DATA"
+export const setDialogData = createAction(SET_DIALOG_DATA)
 
 export const SHOW_DROPDOWN = "SHOW_DROPDOWN"
 export const showDropdown = createAction(SHOW_DROPDOWN)

--- a/static/js/components/admin/MembersList.js
+++ b/static/js/components/admin/MembersList.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { Link } from "react-router-dom"
 
@@ -6,64 +7,130 @@ import { profileURL } from "../../lib/url"
 import { MISSING_TEXT } from "../../lib/channels"
 
 import type { Channel, Member } from "../../flow/discussionTypes"
+import { Dialog } from "@mitodl/mdl-react-components"
 
 type Props = {
   channel: Channel,
+  dialogOpen: boolean,
+  setDialogVisibility: (b: boolean) => void,
+  memberToRemove: ?Member,
+  setDialogData: (data: any) => void,
   editable: boolean,
   members: Array<Member>,
   usernameGetter: (member: Member) => string,
-  removeMember: (channel: Channel, username: string) => Promise<*>
+  removeMember: (channel: Channel, username: string) => Promise<*>,
+  memberTypeDescription: string
 }
 
 export default class MembersList extends React.Component<Props> {
+  removeMember = (event: Event) => {
+    if (event.type !== "MDCDialog:accept") {
+      // filter out click event to avoid double execution
+      return
+    }
+    const { removeMember, channel, memberToRemove, usernameGetter } = this.props
+    if (!memberToRemove) {
+      throw new Error("Expected memberToRemove to be set")
+    }
+
+    return removeMember(channel, usernameGetter(memberToRemove))
+  }
+
+  showRemoveDialog = (member: Member): void => {
+    const { setDialogData, setDialogVisibility } = this.props
+
+    setDialogVisibility(true)
+    setDialogData(member)
+  }
+
   render() {
     const {
-      channel,
       members,
       editable,
       usernameGetter,
-      removeMember
+      setDialogVisibility,
+      dialogOpen,
+      memberToRemove,
+      memberTypeDescription
     } = this.props
 
     return (
-      <table>
-        <tbody>
-          {members.map((member, index) => (
-            <tr
-              key={index}
-              className={`row ${editable ? "three-cols" : "two-cols"}`}
-            >
-              <td>
-                {member.full_name ? (
-                  <Link
-                    className="name"
-                    to={profileURL(usernameGetter(member))}
-                  >
-                    {member.full_name}
-                  </Link>
+      <React.Fragment>
+        <table>
+          <tbody>
+            {members.map((member, index) => (
+              <tr
+                key={index}
+                className={`row ${editable ? "three-cols" : "two-cols"}`}
+              >
+                {usernameGetter(member) === SETTINGS.username ? (
+                  <React.Fragment>
+                    <td colSpan="2">
+                      You are a {memberTypeDescription} of this channel
+                    </td>
+                    {editable ? (
+                      <td>
+                        <a
+                          className="remove"
+                          onClick={() => this.showRemoveDialog(member)}
+                        >
+                          Leave
+                        </a>
+                      </td>
+                    ) : null}
+                  </React.Fragment>
                 ) : (
-                  <span className="name">{MISSING_TEXT}</span>
+                  <React.Fragment>
+                    <td>
+                      {member.full_name ? (
+                        <Link
+                          className="name"
+                          to={profileURL(usernameGetter(member))}
+                        >
+                          {member.full_name}
+                        </Link>
+                      ) : (
+                        <span className="name">{MISSING_TEXT}</span>
+                      )}
+                    </td>
+                    <td>
+                      <span className="email">
+                        {member.email || MISSING_TEXT}
+                      </span>
+                    </td>
+                    {editable ? (
+                      <td>
+                        {member.can_remove === false ? (
+                          <span className="cant_remove">Can't remove</span>
+                        ) : (
+                          <a
+                            className="remove"
+                            onClick={() => this.showRemoveDialog(member)}
+                          >
+                            Remove
+                          </a>
+                        )}
+                      </td>
+                    ) : null}
+                  </React.Fragment>
                 )}
-              </td>
-              <td>
-                <span className="email">{member.email || MISSING_TEXT}</span>
-              </td>
-              {editable ? (
-                <td>
-                  <a
-                    className="remove"
-                    onClick={() =>
-                      removeMember(channel, usernameGetter(member))
-                    }
-                  >
-                    Remove
-                  </a>
-                </td>
-              ) : null}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Dialog
+          id="remove-member"
+          open={dialogOpen}
+          onAccept={this.removeMember}
+          hideDialog={() => setDialogVisibility(false)}
+          submitText="Remove"
+          title={`Remove ${(memberToRemove &&
+            (usernameGetter(memberToRemove) === SETTINGS.username
+              ? "yourself"
+              : memberToRemove.full_name)) ||
+            "member"}?`}
+        />
+      </React.Fragment>
     )
   }
 }

--- a/static/js/components/admin/MembersList_test.js
+++ b/static/js/components/admin/MembersList_test.js
@@ -83,6 +83,10 @@ describe("MembersList", () => {
         }render remove links when the channel is ${
           editable ? "" : "not "
         }editable`, () => {
+          members.forEach(member => {
+            member.can_remove = true
+          })
+
           const removeMember = sandbox.stub()
           const yourIndex = 1
           SETTINGS.username = usernameGetter(members[yourIndex])
@@ -104,6 +108,9 @@ describe("MembersList", () => {
       })
 
       it("shows a dialog box when the user clicks remove or leave", () => {
+        members.forEach(member => {
+          member.can_remove = true
+        })
         const setDialogVisibility = sandbox.stub()
         const setDialogData = sandbox.stub()
         const removeMember = sandbox.stub()

--- a/static/js/components/admin/MembersList_test.js
+++ b/static/js/components/admin/MembersList_test.js
@@ -1,3 +1,4 @@
+/* global SETTINGS */
 import React from "react"
 import sinon from "sinon"
 import R from "ramda"
@@ -25,15 +26,15 @@ describe("MembersList", () => {
     sandbox.restore()
   })
   ;[
-    ["contributors", R.prop("contributor_name")],
-    ["moderators", R.prop("moderator_name")]
-  ].forEach(([pageDescription, usernameGetter]) => {
-    describe(pageDescription, () => {
+    ["contributor", R.prop("contributor_name")],
+    ["moderator", R.prop("moderator_name")]
+  ].forEach(([memberTypeDescription, usernameGetter]) => {
+    describe(memberTypeDescription, () => {
       let members
 
       beforeEach(() => {
         members =
-          pageDescription === "contributors"
+          memberTypeDescription === "contributor"
             ? makeContributors()
             : makeModerators(null, true)
       })
@@ -44,6 +45,7 @@ describe("MembersList", () => {
             members={members}
             usernameGetter={usernameGetter}
             channel={channel}
+            memberTypeDescription={memberTypeDescription}
             {...props}
           />
         )
@@ -78,10 +80,12 @@ describe("MembersList", () => {
       ;[true, false].forEach(editable => {
         it(`should ${
           editable ? "" : "not "
-        }render 'remove' links when the channel is ${
+        }render remove links when the channel is ${
           editable ? "" : "not "
-        } editable`, () => {
+        }editable`, () => {
           const removeMember = sandbox.stub()
+          const yourIndex = 1
+          SETTINGS.username = usernameGetter(members[yourIndex])
           const wrapper = renderForm({ removeMember, editable })
           const rows = wrapper.find(".row")
           members.forEach((member, i) => {
@@ -92,15 +96,126 @@ describe("MembersList", () => {
               assert.equal(link.length, 0)
             } else {
               assert.equal(link.length, 1)
-              link.props().onClick()
-              sinon.assert.calledWith(
-                removeMember,
-                channel,
-                usernameGetter(member)
-              )
+
+              assert.equal(link.text(), i === yourIndex ? "Leave" : "Remove")
             }
           })
         })
+      })
+
+      it("shows a dialog box when the user clicks remove or leave", () => {
+        const setDialogVisibility = sandbox.stub()
+        const setDialogData = sandbox.stub()
+        const removeMember = sandbox.stub()
+        const yourIndex = 1
+        SETTINGS.username = usernameGetter(members[yourIndex])
+        const wrapper = renderForm({
+          editable: true,
+          setDialogVisibility,
+          setDialogData,
+          removeMember
+        })
+        const rows = wrapper.find(".row")
+        members.forEach((member, i) => {
+          const row = rows.at(i)
+          const link = row.find(".remove")
+
+          link.props().onClick()
+          sinon.assert.calledWith(setDialogVisibility, true)
+          setDialogVisibility.reset()
+          sinon.assert.calledWith(setDialogData, member)
+          setDialogData.reset()
+        })
+
+        assert.equal(removeMember.callCount, 0)
+      })
+      ;[true, false].forEach(isYou => {
+        it(`removes ${
+          isYou ? "you" : "a member"
+        } from the member list when the dialog box accept button is clicked`, () => {
+          const memberToRemove = members[0]
+          if (isYou) {
+            SETTINGS.username = usernameGetter(memberToRemove)
+          }
+          const removeMember = sandbox.stub()
+          const wrapper = renderForm({
+            editable:   true,
+            removeMember,
+            dialogOpen: true,
+            memberToRemove
+          })
+          const dialog = wrapper.find("Dialog")
+          const name = isYou ? "yourself" : memberToRemove.full_name
+          assert.equal(dialog.props().title, `Remove ${name}?`)
+
+          // verify that only MDCDialog:accept will work
+          dialog.props().onAccept({ type: "click" })
+          assert.equal(removeMember.callCount, 0)
+
+          dialog.props().onAccept({
+            type: "MDCDialog:accept"
+          })
+          assert.equal(removeMember.callCount, 1)
+          sinon.assert.calledWith(
+            removeMember,
+            channel,
+            usernameGetter(memberToRemove)
+          )
+        })
+      })
+
+      it("dismisses the dialog box", () => {
+        const memberToRemove = members[0]
+        const setDialogVisibility = sandbox.stub()
+        const removeMember = sandbox.stub()
+        const wrapper = renderForm({
+          editable:   true,
+          removeMember,
+          dialogOpen: true,
+          memberToRemove,
+          setDialogVisibility
+        })
+        wrapper
+          .find("Dialog")
+          .props()
+          .hideDialog()
+
+        assert.equal(removeMember.callCount, 0)
+        assert.equal(setDialogVisibility.callCount, 1)
+        sinon.assert.calledWith(setDialogVisibility, false)
+      })
+
+      it(`should tell the user it can't remove if the field is explicitly set that way`, () => {
+        const member = members[0]
+        member.can_remove = false
+
+        const wrapper = renderForm({ editable: true })
+        const text = wrapper
+          .find(".row")
+          .first()
+          .find(".cant_remove")
+        assert.equal(text.text(), "Can't remove")
+        assert.equal(
+          wrapper
+            .find(".row")
+            .first()
+            .find(".remove").length,
+          0
+        )
+      })
+
+      it("should show a special message in place of the user's own name", () => {
+        const member = members[0]
+        SETTINGS.username = usernameGetter(member)
+
+        const wrapper = renderForm({ editable: true })
+        const text = wrapper
+          .find(".row")
+          .first()
+          .find("td")
+          .first()
+          .text()
+        assert.equal(text, `You are a ${memberTypeDescription} of this channel`)
       })
     })
   })

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -701,6 +701,7 @@ describe("PostPage", function() {
   })
 
   it("should switch the sorting method when an option is selected", async () => {
+    post.num_comments = 5
     const wrapper = await renderPage()
 
     for (const sortType of VALID_COMMENT_SORT_TYPES) {

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -117,7 +117,7 @@ describe("ProfileImage", () => {
         await wait(0)
         assert.isTrue(helper.patchProfileImageStub.called)
         sinon.assert.calledWith(helper.getProfileStub, username)
-        assert.deepEqual(helper.store.getState().ui.dialogs, new Set())
+        assert.deepEqual(helper.store.getState().ui.dialogs, new Map())
       })
 
       it("should show a validation message if the image upload fails", async () => {

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -13,6 +13,7 @@ import { newMemberForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { editChannelContributorsURL } from "../../lib/url"
 import IntegrationTestHelper from "../../util/integration_test_helper"
+import { SET_DIALOG_DATA, SHOW_DIALOG } from "../../actions/ui"
 
 describe("EditChannelContributorsPage", () => {
   let helper, renderComponent, listenForActions, channel, contributors
@@ -89,6 +90,7 @@ describe("EditChannelContributorsPage", () => {
       contributors[0].contributor_name
     )
     assert.deepEqual(props.channel, channel)
+    assert.equal(props.memberTypeDescription, "contributor")
   })
 
   describe("editable", () => {
@@ -197,6 +199,8 @@ describe("EditChannelContributorsPage", () => {
 
       await listenForActions(
         [
+          SHOW_DIALOG,
+          SET_DIALOG_DATA,
           actions.channelContributors.delete.requestType,
           actions.channelContributors.delete.successType
         ],
@@ -206,6 +210,14 @@ describe("EditChannelContributorsPage", () => {
             .first()
             .props()
             .onClick({ preventDefault: helper.sandbox.stub() })
+
+          wrapper.update()
+          wrapper
+            .find("#remove-member button.edit-button")
+            .props()
+            .onClick({
+              type: "MDCDialog:accept"
+            })
         }
       )
 

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -11,7 +11,7 @@ import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
 import { newMemberForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
-import { editChannelContributorsURL } from "../../lib/url"
+import { channelURL, editChannelContributorsURL } from "../../lib/url"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import { SET_DIALOG_DATA, SHOW_DIALOG } from "../../actions/ui"
 
@@ -20,6 +20,7 @@ describe("EditChannelContributorsPage", () => {
 
   beforeEach(() => {
     channel = makeChannel()
+    channel.user_is_moderator = true
     contributors = makeContributors()
     helper = new IntegrationTestHelper()
     helper.getChannelStub.returns(Promise.resolve(channel))
@@ -47,7 +48,7 @@ describe("EditChannelContributorsPage", () => {
     helper.cleanup()
   })
 
-  const renderPage = async () => {
+  const renderPage = async (extraActions = []) => {
     const [wrapper] = await renderComponent(
       editChannelContributorsURL(channel.name),
       [
@@ -60,7 +61,8 @@ describe("EditChannelContributorsPage", () => {
         actions.profiles.get.requestType,
         actions.profiles.get.successType,
         SET_CHANNEL_DATA,
-        actions.forms.FORM_BEGIN_EDIT
+        actions.forms.FORM_BEGIN_EDIT,
+        ...extraActions
       ]
     )
     return wrapper.update()
@@ -91,6 +93,18 @@ describe("EditChannelContributorsPage", () => {
     )
     assert.deepEqual(props.channel, channel)
     assert.equal(props.memberTypeDescription, "contributor")
+  })
+
+  it("redirects if the user is not a moderator", async () => {
+    channel.user_is_moderator = false
+    await renderPage([
+      actions.channels.get.requestType,
+      actions.channels.get.successType,
+      actions.forms.FORM_END_EDIT
+    ])
+
+    const history = helper.browserHistory
+    assert.equal(history.location.pathname, channelURL(channel.name))
   })
 
   describe("editable", () => {

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -17,6 +17,7 @@ import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
 import { actions } from "../../actions"
 import { mergeAndInjectProps } from "../../lib/redux_props"
+import { channelURL } from "../../lib/url"
 import { getChannelName } from "../../lib/util"
 import { validateMembersForm } from "../../lib/validation"
 import {
@@ -36,14 +37,15 @@ const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 
 type Props = {
   channel: Channel,
-  loadChannel: () => Promise<*>,
+  loadChannel: () => Promise<Channel>,
   loadMembers: () => Promise<*>,
   members: Array<Member>,
   removeMember: (channel: Channel, email: string) => Promise<*>,
   memberToRemove: ?Member,
   dialogOpen: boolean,
   setDialogVisibility: (visibility: boolean) => void,
-  setDialogData: (data: any) => void
+  setDialogData: (data: any) => void,
+  history: Object
 } & WithFormProps<AddMemberForm>
 
 export class EditChannelModeratorsPage extends React.Component<Props> {
@@ -58,17 +60,29 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
   }
 
   loadData = async () => {
-    const { channel, loadChannel, loadMembers, members } = this.props
-
-    const promises = []
-    if (!channel) {
-      promises.push(loadChannel())
-    }
+    const { channel, loadMembers, members } = this.props
 
     if (!members) {
-      promises.push(loadMembers())
+      loadMembers()
     }
-    await Promise.all(promises)
+    if (!channel) {
+      this.validateModerator()
+    }
+  }
+
+  validateModerator = async () => {
+    const { loadChannel, history } = this.props
+
+    const channel = await loadChannel()
+    if (!channel.user_is_moderator) {
+      history.push(channelURL(channel.name))
+    }
+  }
+
+  removeMember = async (channel: Channel, email: string) => {
+    const { removeMember } = this.props
+    await removeMember(channel, email)
+    this.validateModerator()
   }
 
   render() {
@@ -77,7 +91,6 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
       form,
       channel,
       members,
-      removeMember,
       memberToRemove,
       dialogOpen,
       setDialogData,
@@ -109,7 +122,7 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
           )}
           <MembersList
             channel={channel}
-            removeMember={removeMember}
+            removeMember={this.removeMember}
             editable={editable}
             members={members}
             usernameGetter={R.prop("moderator_name")}

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -9,6 +9,7 @@ import {
 } from "../../factories/channels"
 import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
+import { SHOW_DIALOG, SET_DIALOG_DATA } from "../../actions/ui"
 import { newMemberForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { editChannelModeratorsURL } from "../../lib/url"
@@ -89,6 +90,7 @@ describe("EditChannelModeratorsPage", () => {
       moderators[0].moderator_name
     )
     assert.deepEqual(props.channel, channel)
+    assert.equal(props.memberTypeDescription, "moderator")
   })
 
   describe("editable", () => {
@@ -197,6 +199,8 @@ describe("EditChannelModeratorsPage", () => {
 
       await listenForActions(
         [
+          SHOW_DIALOG,
+          SET_DIALOG_DATA,
           actions.channelModerators.delete.requestType,
           actions.channelModerators.delete.successType
         ],
@@ -206,6 +210,14 @@ describe("EditChannelModeratorsPage", () => {
             .first()
             .props()
             .onClick({ preventDefault: helper.sandbox.stub() })
+
+          wrapper.update()
+          wrapper
+            .find("#remove-member button.edit-button")
+            .props()
+            .onClick({
+              type: "MDCDialog:accept"
+            })
         }
       )
 

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -56,7 +56,7 @@ export const makeModerator = (
     ? {
       email:      casual.email,
       full_name:  casual.full_name,
-      can_remove: casual.coin_clip
+      can_remove: casual.coin_flip
     }
     : {})
 })

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -54,8 +54,9 @@ export const makeModerator = (
   moderator_name: username || casual.word,
   ...(isModerator
     ? {
-      email:     casual.email,
-      full_name: casual.full_name
+      email:      casual.email,
+      full_name:  casual.full_name,
+      can_remove: casual.coin_clip
     }
     : {})
 })

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -165,7 +165,8 @@ export type ReplaceMoreCommentsPayload = {
 export type Moderator = {
   moderator_name: string,
   email?:         string,
-  full_name?:     string
+  full_name?:     string,
+  can_remove?:    boolean
 }
 
 export type ChannelModerators = Array<Moderator>

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,6 +1,4 @@
 // @flow
-import R from "ramda"
-
 import {
   SET_SHOW_DRAWER_DESKTOP,
   SET_SHOW_DRAWER_MOBILE,
@@ -10,7 +8,8 @@ import {
   SHOW_DIALOG,
   HIDE_DIALOG,
   SHOW_DROPDOWN,
-  HIDE_DROPDOWN
+  HIDE_DROPDOWN,
+  SET_DIALOG_DATA
 } from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
@@ -32,8 +31,8 @@ export type UIState = {
   showDrawerMobile: boolean,
   snackbar: ?SnackbarState,
   banner: BannerState,
-  dialogs: Set<string>,
-  dropdownMenus: Set<string>
+  dialogs: Map<string, any>,
+  dropdownMenus: Map<string, any>
 }
 
 const INITIAL_BANNER_STATE = {
@@ -46,8 +45,8 @@ export const INITIAL_UI_STATE: UIState = {
   showDrawerMobile:  false,
   snackbar:          null,
   banner:            INITIAL_BANNER_STATE,
-  dialogs:           new Set(),
-  dropdownMenus:     new Set()
+  dialogs:           new Map(),
+  dropdownMenus:     new Map()
 }
 
 // this generates a new sequential id for each snackbar state that is pushed
@@ -56,13 +55,27 @@ const nextSnackbarId = (snackbar: ?SnackbarState): number =>
   snackbar ? snackbar.id + 1 : 0
 
 const updateVisibilitySet = (
-  dialogs: Set<string>,
+  dialogs: Map<string, any>,
   dialogKey: string,
   show: boolean
-) =>
-  show
-    ? new Set([...dialogs, dialogKey])
-    : new Set([...dialogs].filter(R.complement(R.equals)(dialogKey)))
+) => {
+  const copy: Map<string, any> = new Map(dialogs)
+  copy.delete(dialogKey)
+  if (show) {
+    copy.set(dialogKey, null)
+  }
+  return copy
+}
+
+const setDialogData = (
+  dialogs: Map<string, any>,
+  dialogKey: string,
+  data: any
+) => {
+  const copy: Map<string, any> = new Map(dialogs)
+  copy.set(dialogKey, data)
+  return copy
+}
 
 export const ui = (
   state: UIState = INITIAL_UI_STATE,
@@ -106,6 +119,15 @@ export const ui = (
     return {
       ...state,
       dialogs: updateVisibilitySet(state.dialogs, action.payload, false)
+    }
+  case SET_DIALOG_DATA:
+    return {
+      ...state,
+      dialogs: setDialogData(
+        state.dialogs,
+        action.payload.dialogKey,
+        action.payload.data
+      )
     }
   case SHOW_DROPDOWN:
     return {

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -9,6 +9,7 @@ import {
   SET_SNACKBAR_MESSAGE,
   SHOW_DIALOG,
   HIDE_DIALOG,
+  SET_DIALOG_DATA,
   SHOW_DROPDOWN,
   HIDE_DROPDOWN,
   SET_BANNER_MESSAGE,
@@ -18,6 +19,7 @@ import {
   setSnackbarMessage,
   showDialog,
   hideDialog,
+  setDialogData,
   showDropdown,
   hideDropdown,
   setBannerMessage,
@@ -86,13 +88,35 @@ describe("ui reducer", () => {
       ...payload
     })
   })
+  ;[true, false].forEach(show => {
+    it(`should let you ${show ? "show" : "hide"} a dialog`, async () => {
+      const dialogKey = "key!"
+      const data = { a: { b: "c" } }
+      const actionFunc = show ? showDialog : hideDialog
+      const actionType = show ? SHOW_DIALOG : HIDE_DIALOG
 
-  it("should let you show and hide a dialog", async () => {
+      await dispatchThen(showDialog(dialogKey), [SHOW_DIALOG])
+      let state = await dispatchThen(setDialogData({ dialogKey, data }), [
+        SET_DIALOG_DATA
+      ])
+      // make sure we start with dialog state so we can assert that it's cleared
+      assert.deepEqual(state.dialogs.get(dialogKey), data)
+
+      state = await dispatchThen(actionFunc(dialogKey), [actionType])
+      assert.equal(state.dialogs.has(dialogKey), show)
+      assert.equal(state.dialogs.get(dialogKey), null)
+    })
+  })
+
+  it("should set data for the dialog", async () => {
     const dialogKey = "key!"
-    let state = await dispatchThen(showDialog(dialogKey), [SHOW_DIALOG])
-    assert.isTrue(state.dialogs.has(dialogKey))
-    state = await dispatchThen(hideDialog(dialogKey), [HIDE_DIALOG])
-    assert.isFalse(state.dialogs.has(dialogKey))
+    const data = [1, 2, 3]
+    await dispatchThen(showDialog(dialogKey), [SHOW_DIALOG])
+    const state = await dispatchThen(setDialogData({ dialogKey, data }), [
+      SET_DIALOG_DATA
+    ])
+    // make sure we start with dialog state so we can assert that it's cleared
+    assert.deepEqual(state.dialogs.get(dialogKey), data)
   })
 
   it("should support multiple dialogs at once", async () => {

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -97,6 +97,10 @@
     cursor: pointer;
   }
 
+  .cant_remove {
+    color: grey;
+  }
+
   .membership-notice {
     padding: 5px;
     font-weight: 500;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1004 
Fixes #971 
Fixes #938 

#### What's this PR do?
 - Adds "Can't remove" text if the moderator is not removable due to being older than logged in user
 - Adds confirmation dialog for removing a user
 - Changes in text when the user you're removing is yourself

#### How should this be manually tested?
Go to the moderators page. You should likely see some moderator which says "Can't remove" instead of a "Remove" link. If not, add a new moderator, log in as that moderator and view the list again.

You should also see `You are a moderator of this channel` in the list, and `Leave` instead of `Remove` in the text. Click the link and you should see a dialog "Remove yourself?"

Find a user you can remove and remove them via the dialog to confirm that behavior still works. You should also be able to dismiss the dialog without anyone getting removed.

All of this should be exactly the same for contributors