### PR TITLE
Changed unrecognized email UX to a validation message

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -32,7 +32,7 @@ class SocialAuthSerializer(serializers.Serializer):
     partial_token = serializers.CharField(source='partial.token', default=None)
     flow = serializers.ChoiceField(choices=(
         (SocialAuthState.FLOW_LOGIN, "Login"),
-        (SocialAuthState.FLOW_REGISTER, "Reigster"),
+        (SocialAuthState.FLOW_REGISTER, "Register"),
     ))
     provider = serializers.CharField(read_only=True)
     state = serializers.CharField(read_only=True)
@@ -130,12 +130,12 @@ class LoginEmailSerializer(SocialAuthSerializer):
         """Try to 'save' the request"""
         try:
             result = super()._authenticate(SocialAuthState.FLOW_LOGIN)
-        except RequireRegistrationException as exc:
-            # tried to login to a nonexistent account, so needs to register
-            result = SocialAuthState(SocialAuthState.STATE_REGISTER_EMAIL, partial=exc.partial)
+        except RequireRegistrationException:
+            result = SocialAuthState(SocialAuthState.STATE_ERROR, errors=[
+                "Couldn't find your MIT OPEN Account"
+            ])
         except RequirePasswordException as exc:
             result = SocialAuthState(SocialAuthState.STATE_LOGIN_PASSWORD, partial=exc.partial)
-
         return result
 
 

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -154,11 +154,11 @@ def login_email_not_exists(client):
                 'email': NEW_EMAIL,
             },
             {
-                'errors': [],
+                'errors': ["Couldn't find your MIT OPEN Account"],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
-                'partial_token': any_instance_of(str),
-                'state': SocialAuthState.STATE_REGISTER_EMAIL,
+                'partial_token': None,
+                'state': SocialAuthState.STATE_ERROR,
             }
         )
         assert User.objects.filter(email=NEW_EMAIL).exists() is False
@@ -277,32 +277,6 @@ def login_password_invalid(client, user):
 
 
 @pytest.fixture()
-def register_continue_from_login(client, mock_email_send):
-    """Yield a function for this step"""
-    def run_step(last_result):
-        """Run the step"""
-        result = assert_api_call(
-            client,
-            'psa-register-email',
-            {
-                'flow': SocialAuthState.FLOW_REGISTER,
-                'partial_token': last_result['partial_token'],
-            },
-            {
-                'errors': [],
-                'flow': SocialAuthState.FLOW_REGISTER,
-                'provider': EmailAuth.name,
-                'partial_token': None,
-                'state': SocialAuthState.STATE_REGISTER_CONFIRM_SENT,
-            }
-        )
-        mock_email_send.assert_called_once()
-        assert User.objects.filter(email=NEW_EMAIL).exists() is False
-        return result
-    yield run_step
-
-
-@pytest.fixture()
 def redeem_confirmation_code(client, mock_email_send):
     """Yield a function for this step"""
     def run_step(last_result):  # pylint: disable=unused-argument
@@ -370,9 +344,6 @@ def register_profile_details(client):
     ],
     [
         'login_email_not_exists',
-        'register_continue_from_login',
-        'redeem_confirmation_code',
-        'register_profile_details',
     ],
     [
         'register_email_exists',

--- a/cassettes/authentication.views_test.test_login_register_flows[login_email_not_exists].json
+++ b/cassettes/authentication.views_test.test_login_register_flows[login_email_not_exists].json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -29,31 +29,47 @@ import ExternalLogins from "../../components/ExternalLogins"
 
 type LoginPageProps = {
   history: Object,
-  formError: ?string
+  formError: ?string,
+  clearEndpointState: Function
 } & WithFormProps<EmailForm>
 
-export const LoginPage = ({ renderForm, formError }: LoginPageProps) => (
-  <div className="content auth-page login-page">
-    <div className="main-content">
-      <Card className="login-card">
-        <h3>Log In</h3>
-        <MetaTags>
-          <title>{formatTitle("Log In")}</title>
-        </MetaTags>
-        {renderForm({ formError })}
-        <ExternalLogins />
-        <div className="alternate-auth-link">
-          Not a member? <Link to={REGISTER_URL}>Sign up &gt;</Link>
+export class LoginPage extends React.Component<LoginPageProps> {
+  componentWillUnmount() {
+    const { formError, clearEndpointState } = this.props
+    if (formError) {
+      clearEndpointState()
+    }
+  }
+
+  render() {
+    const { renderForm, formError } = this.props
+
+    return (
+      <div className="content auth-page login-page">
+        <div className="main-content">
+          <Card className="login-card">
+            <h3>Login</h3>
+            <MetaTags>
+              <title>{formatTitle("Login")}</title>
+            </MetaTags>
+            {renderForm({ formError })}
+            <ExternalLogins />
+            <div className="alternate-auth-link">
+              Not a member? <Link to={REGISTER_URL}>Sign up</Link>
+            </div>
+          </Card>
         </div>
-      </Card>
-    </div>
-  </div>
-)
+      </div>
+    )
+  }
+}
 
 const newEmailForm = () => ({ email: "" })
 
 const onSubmit = ({ email }: EmailForm) =>
   actions.auth.loginEmail(FLOW_LOGIN, email)
+
+const clearEndpointState = actions.auth.clear
 
 const onSubmitResult = R.curry(processAuthResponse)
 
@@ -85,6 +101,7 @@ export default R.compose(
     mapStateToProps,
     {
       onSubmit,
+      clearEndpointState,
       ...actionCreators
     },
     mergeProps

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -1,5 +1,6 @@
 // @flow
 /* global SETTINGS:false */
+import R from "ramda"
 import { assert } from "chai"
 import sinon from "sinon"
 
@@ -58,6 +59,20 @@ describe("LoginPage", () => {
     const form = inner.find("AuthEmailForm")
     assert.ok(form.exists())
     assert.equal(form.props().formError, "error")
+  })
+
+  it("should clear the auth endpoint state when unmounting if form errors exist", async () => {
+    const { inner, store } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
+    })
+    inner.unmount()
+
+    const dispatchedActions = store.getActions()
+    assert.equal(R.last(dispatchedActions).type, actions.auth.clearType)
   })
 
   it("should render an ExternalLogins component", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #931 

#### What's this PR do?
Changes the unrecognized email UX so a validation message is shown instead of redirecting the user to the signup page where they would click a button to continue signing up.

#### How should this be manually tested?
Enter an unrecognized email address in the login page

#### Any background context you want to provide?
Back-end errors for the auth pipeline are essentially considered non-field errors. Getting the unrecognized email address to show up directly beneath the email input (as it does for normal front-end validation errors) would require some extra work. If we want to put in that extra work, that could be done in a different issue.

#### Screenshots (if appropriate)
![ss 2018-08-06 at 12 28 00](https://user-images.githubusercontent.com/14932219/43796814-47f00068-9a53-11e8-9ccb-a588795163e6.png)
