### PR TITLE
Updated ref usages

### DIFF
--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -10,16 +10,22 @@ type Props = {
 }
 
 export default class CropperWrapper extends React.Component<Props> {
-  cropper: Cropper
+  cropperRef: Cropper
+
+  constructor(props: Props) {
+    super(props)
+    this.cropperRef = React.createRef()
+  }
 
   cropperHelper = () => {
     const { updatePhotoEdit } = this.props
     let canvas
-    if (this.cropper) {
+    if (this.cropperRef.current) {
+      const cropper = this.cropperRef.current
       if (browser.name === "safari" || browser.name === "ios") {
-        canvas = this.cropper.getCroppedCanvas()
+        canvas = cropper.getCroppedCanvas()
       } else {
-        canvas = this.cropper.getCroppedCanvas({
+        canvas = cropper.getCroppedCanvas({
           width:  512,
           height: 512
         })
@@ -33,7 +39,7 @@ export default class CropperWrapper extends React.Component<Props> {
 
     return (
       <Cropper
-        ref={cropper => (this.cropper = cropper)}
+        ref={this.cropperRef}
         style={{ height: uploaderBodyHeight() }}
         className="photo-upload-dialog photo-active-item cropper"
         src={photo.preview}

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -18,8 +18,15 @@ export default class Toolbar extends React.Component<Props> {
   toolbarRoot: HTMLElement | null
   toolbar: Object
 
+  constructor(props: Props) {
+    super(props)
+    this.toolbarRef = React.createRef()
+  }
+
   componentDidMount() {
-    this.toolbar = new MDCToolbar(this.toolbarRoot)
+    if (this.toolbarRef.current) {
+      this.toolbar = new MDCToolbar(this.toolbarRef.current)
+    }
   }
 
   componentWillUnmount() {
@@ -39,7 +46,7 @@ export default class Toolbar extends React.Component<Props> {
 
     return (
       <div className="navbar">
-        <header className="mdc-toolbar" ref={div => (this.toolbarRoot = div)}>
+        <header className="mdc-toolbar" ref={this.toolbarRef}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
               <a

--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -12,10 +12,17 @@ type Props = {
 
 export default class Snackbar extends React.Component<Props> {
   snackbar = null
-  snackbarRoot = null
+  snackbarRef = null
+
+  constructor(props: Props) {
+    super(props)
+    this.snackbarRef = React.createRef()
+  }
 
   componentDidMount() {
-    this.snackbar = new MDCSnackbar(this.snackbarRoot)
+    if (this.snackbarRef.current) {
+      this.snackbar = new MDCSnackbar(this.snackbarRef.current)
+    }
   }
 
   // see here: https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops
@@ -41,7 +48,7 @@ export default class Snackbar extends React.Component<Props> {
           aria-live="assertive"
           aria-atomic="true"
           aria-hidden="true"
-          ref={node => (this.snackbarRoot = node)}
+          ref={this.snackbarRef}
         >
           <div className="mdc-snackbar__text" />
           <div className="mdc-snackbar__action-wrapper">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] ~Migrations~
  - [x] ~Migration is backwards-compatible with current production code~
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested
- [x] ~Settings~
  - [x] ~New settings are documented and present in `app.json`~
  - [x] ~New settings have reasonable development defaults, if applicable~

#### What are the relevant tickets?
Fixes #1035 

#### What's this PR do?
Updates callback-style `ref` usages to `createRef()`