### PR TITLE
Changed login UI to show image & name when email entered

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -31,7 +31,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         return image_uri(obj, IMAGE_MEDIUM)
 
     def get_profile_image_small(self, obj):
-        """ Custom getter for medium profile image """
+        """ Custom getter for small profile image """
         return image_uri(obj, IMAGE_SMALL)
 
     def update(self, instance, validated_data):

--- a/static/js/containers/auth/LoginPasswordPage.js
+++ b/static/js/containers/auth/LoginPasswordPage.js
@@ -18,9 +18,11 @@ import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
   getAuthPartialTokenSelector,
   getAuthFlowSelector,
-  isLoginFlow,
+  getAuthEmailSelector,
   isProcessing,
-  getFormErrorSelector
+  getFormErrorSelector,
+  getAuthNameSelector,
+  getAuthProfileImageSelector
 } from "../../reducers/auth"
 
 import type { PasswordForm, AuthFlow } from "../../flow/authTypes"
@@ -30,8 +32,10 @@ type Props = {
   history: Object,
   partialToken: string,
   authFlow: AuthFlow,
-  isLoginFlow: boolean,
-  formError: ?string
+  formError: ?string,
+  email: string,
+  name: ?string,
+  profileImageUrl: ?string
 } & WithFormProps<PasswordForm>
 
 export class LoginPasswordPage extends React.Component<Props> {
@@ -43,19 +47,27 @@ export class LoginPasswordPage extends React.Component<Props> {
   }
 
   render() {
-    const { renderForm, isLoginFlow, formError } = this.props
+    const { renderForm, formError, email, name, profileImageUrl } = this.props
     return (
       <div className="content auth-page login-password-page">
         <div className="main-content">
           <Card className="login-card">
-            <h3>
-              {isLoginFlow
-                ? "Welcome Back!"
-                : "There is already an account with this email"}
-            </h3>
+            <h3>{name && profileImageUrl ? `Hi ${name}` : "Welcome Back!"}</h3>
             <MetaTags>
               <title>{formatTitle("Log In")}</title>
             </MetaTags>
+            {name && profileImageUrl ? (
+              <div className="form-header">
+                <div className="row profile-image-email">
+                  <img
+                    src={profileImageUrl}
+                    alt={`Profile image for ${name}`}
+                    className="profile-image small"
+                  />
+                  <span>{email}</span>
+                </div>
+              </div>
+            ) : null}
             {renderForm({ formError })}
           </Card>
         </div>
@@ -90,6 +102,9 @@ const mapStateToProps = state => {
   const authFlow = getAuthFlowSelector(state)
   const partialToken = getAuthPartialTokenSelector(state)
   const formError = getFormErrorSelector(state)
+  const email = getAuthEmailSelector(state)
+  const name = getAuthNameSelector(state)
+  const profileImageUrl = getAuthProfileImageSelector(state)
   return {
     form,
     partialToken,
@@ -98,7 +113,9 @@ const mapStateToProps = state => {
     onSubmitResult,
     validateForm,
     formError,
-    isLoginFlow: isLoginFlow(state)
+    email,
+    name,
+    profileImageUrl
   }
 }
 

--- a/static/js/containers/auth/LoginPasswordPage_test.js
+++ b/static/js/containers/auth/LoginPasswordPage_test.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
+import R from "ramda"
 
 import { actions } from "../../actions"
 import { FLOW_REGISTER, FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
@@ -58,26 +59,54 @@ describe("LoginPasswordPage", () => {
 
   //
   ;[
-    [FLOW_LOGIN, "Welcome Back!"],
-    [FLOW_REGISTER, "There is already an account with this email"]
-  ].forEach(([flow, title]) => {
-    it(`should render the page if flow = ${flow}`, async () => {
+    ["Testuser", "x.jpg", "a@b.com", "exists"],
+    [undefined, undefined, "a@b.com", "does not exist"]
+  ].forEach(([extraDataName, extraDataImg, email, descriptor]) => {
+    it(`should render the page with correct messages when extra user data ${descriptor}`, async () => {
+      const expectedProfileInfo = R.none(R.isNil)([extraDataName, extraDataImg])
+      let expectedGreeting, extraData
+      if (expectedProfileInfo) {
+        expectedGreeting = `Hi ${String(extraDataName)}`
+        extraData = { name: extraDataName, profile_image_small: extraDataImg }
+      } else {
+        expectedGreeting = "Welcome Back!"
+        extraData = null
+      }
+
       const { inner } = await renderPage({
         auth: {
           data: {
-            flow,
-            errors: ["error"]
+            email:      email,
+            extra_data: extraData
           }
         }
       })
 
       const form = inner.find("AuthPasswordForm")
       assert.ok(form.exists())
-      assert.equal(form.props().formError, "error")
-      assert.equal(inner.find("h3").text(), title)
+      assert.equal(inner.find("h3").text(), expectedGreeting)
+      const profileInfoSection = inner.find(".profile-image-email")
+      assert.equal(profileInfoSection.exists(), expectedProfileInfo)
+      if (expectedProfileInfo) {
+        assert.equal(profileInfoSection.find("img").prop("src"), extraDataImg)
+        assert.equal(profileInfoSection.find("span").text(), email)
+      }
 
       assert.lengthOf(helper.browserHistory, 1)
     })
+  })
+
+  it("should render errors", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          errors: ["error"]
+        }
+      }
+    })
+
+    const form = inner.find("AuthPasswordForm")
+    assert.equal(form.props().formError, "error")
   })
 
   //

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -46,3 +46,10 @@ export type AuthResponse = {
   errors:        Array<string>,
   email?:        string
 }
+
+export type EmailDetailAuthResponse = {
+  extra_data?: {
+    name: string,
+    profile_image_small: string
+  }
+} & AuthResponse

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -15,7 +15,11 @@ import {
 import { toQueryString } from "../lib/url"
 import { getPaginationSortParams } from "../lib/posts"
 
-import type { AuthResponse, AuthFlow } from "../flow/authTypes"
+import type {
+  AuthResponse,
+  EmailDetailAuthResponse,
+  AuthFlow
+} from "../flow/authTypes"
 import type {
   Channel,
   ChannelContributors,
@@ -353,7 +357,7 @@ export function updateProfile(
 export const postEmailLogin = (
   flow: AuthFlow,
   email: string
-): Promise<AuthResponse> =>
+): Promise<EmailDetailAuthResponse> =>
   fetchJSONWithCSRF("/api/v0/login/email/", {
     method: POST,
     body:   JSON.stringify({ flow, email })

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -25,11 +25,11 @@ import {
   STATE_INACTIVE
 } from "../reducers/auth"
 
-import type { AuthResponse } from "../flow/authTypes"
+import type { AuthResponse, EmailDetailAuthResponse } from "../flow/authTypes"
 
 export const processAuthResponse = (
   history: Object,
-  { state }: AuthResponse
+  { state }: AuthResponse | EmailDetailAuthResponse
 ) => {
   if (state === STATE_LOGIN_EMAIL) {
     history.push(LOGIN_URL)

--- a/static/js/reducers/auth.js
+++ b/static/js/reducers/auth.js
@@ -36,13 +36,19 @@ export const getFormErrorSelector = R.compose(
   R.head,
   R.pathOr([], ["auth", "data", "errors"])
 )
-export const isLoginFlow = R.pathEq(["auth", "data", "flow"], FLOW_LOGIN)
+export const getAuthNameSelector = R.path([
+  "auth",
+  "data",
+  "extra_data",
+  "name"
+])
+export const getAuthProfileImageSelector = R.path([
+  "auth",
+  "data",
+  "extra_data",
+  "profile_image_small"
+])
 export const isProcessing = R.path(["auth", "processing"])
-
-export const isPasswordLogin = R.compose(
-  R.equals(STATE_LOGIN_PASSWORD),
-  getAuthStateSelector
-)
 
 export const authEndpoint = {
   name:         "auth",

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -8,17 +8,18 @@
       display: block;
     }
   }
+}
 
-  .row {
-    margin: 10px 10px 24px 15px;
+.form .row,
+.form-header .row {
+  margin: 10px 10px 24px 15px;
+}
 
-    .validation-message {
-      background-color: $validation-bg;
-      color: $validation-text;
-      font-size: 14px;
-      padding: 5px;
-    }
-  }
+.form .row .validation-message {
+  background-color: $validation-bg;
+  color: $validation-text;
+  font-size: 14px;
+  padding: 5px;
 }
 
 .form-field {

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -1,9 +1,11 @@
+$profile-image-small-size: 45px;
+
 .profile-image {
   border-radius: 100%;
   background-color: #579cf9;
   color: #fff;
-  width: 45px;
-  height: 45px;
+  width: $profile-image-small-size;
+  height: $profile-image-small-size;
   display: block;
   overflow: hidden;
 }
@@ -15,8 +17,8 @@
 }
 
 .small {
-  width: 45px;
-  height: 45px;
+  width: $profile-image-small-size;
+  height: $profile-image-small-size;
   font-size: 16px;
 }
 
@@ -53,7 +55,7 @@
       top: 0;
       right: 0;
       text-align: center;
-      line-height: 45px;
+      line-height: $profile-image-small-size;
 
       img {
         width: 22px;
@@ -138,4 +140,14 @@
   text-align: center;
   display: table-cell;
   vertical-align: middle;
+}
+
+.profile-image-email {
+  display: flex;
+  justify-content: start;
+  line-height: $profile-image-small-size;
+
+  img {
+    margin-right: 10px;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #934

#### What's this PR do?
Changes the login UI to show a profile image and a greeting which includes the user's name when they enter a recognized email into the login form

#### How should this be manually tested?
Enter an email into the `/login` page that is associated with some email-authed user. Check that the profile image and name match. Also enter an email that doesn't exist and make sure that works as before

#### Screenshots (if appropriate)
![ss 2018-08-09 at 13 53 18](https://user-images.githubusercontent.com/14932219/43916485-aa1689d6-9bdb-11e8-8221-49b1b6f718ce.png)


