### PR TITLE
Fixed snackbar UI bugs

### DIFF
--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -35,18 +35,16 @@ export default class Snackbar extends React.Component<Props> {
 
   render() {
     return (
-      <div>
-        <div
-          className="mdc-snackbar"
-          aria-live="assertive"
-          aria-atomic="true"
-          aria-hidden="true"
-          ref={node => (this.snackbarRoot = node)}
-        >
-          <div className="mdc-snackbar__text" />
-          <div className="mdc-snackbar__action-wrapper">
-            <button type="button" className="mdc-snackbar__action-button" />
-          </div>
+      <div
+        className="mdc-snackbar"
+        aria-live="assertive"
+        aria-atomic="true"
+        aria-hidden="true"
+        ref={node => (this.snackbarRoot = node)}
+      >
+        <div className="mdc-snackbar__text" />
+        <div className="mdc-snackbar__action-wrapper">
+          <button type="button" className="mdc-snackbar__action-button" />
         </div>
       </div>
     )

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -153,7 +153,6 @@ class App extends React.Component<AppProps> {
         <MetaTags>
           <title>MIT Open Discussions</title>
         </MetaTags>
-        <Snackbar snackbar={snackbar} />
         <Toolbar
           toggleShowDrawer={this.toggleShowDrawer}
           toggleShowUserMenu={this.toggleShowUserMenu}
@@ -161,6 +160,7 @@ class App extends React.Component<AppProps> {
           profile={profile}
         />
         <Drawer />
+        <Snackbar snackbar={snackbar} />
         <Banner
           banner={banner}
           hide={preventDefaultAndInvoke(this.hideBanner)}

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -24,6 +24,8 @@ $subscribed-yellow: #fcffb0;
 $toolbar-height-desktop: 76px;
 $toolbar-height-mobile: 68px;
 $drawer-width: 300px;
+$std-border-radius: 3px;
+$message-component-bg-color: #323232;
 $banner-height: 60px;
 $banner-slide-timing: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 $banner-slide-trans: top 300ms $banner-slide-timing;

--- a/static/scss/banner.scss
+++ b/static/scss/banner.scss
@@ -12,8 +12,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #323232;
-  opacity: 0.7;
+  background-color: $message-component-bg-color;
   text-align: center;
   color: #ffffff;
 

--- a/static/scss/createPost.scss
+++ b/static/scss/createPost.scss
@@ -20,7 +20,7 @@
       color: $font-grey;
       background-color: $app-background;
       border: 1px solid $border-grey;
-      border-radius: 3px;
+      border-radius: $std-border-radius;
       padding: 3px 10px;
       cursor: pointer;
 

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -39,7 +39,7 @@ input[type="password"] {
   width: 100%;
   padding: 10px 10px;
   font-size: 15px;
-  border-radius: 3px;
+  border-radius: $std-border-radius;
   border: 1px solid #b7b7b7;
   transition: width 0.4s ease-in-out;
   box-sizing: border-box;
@@ -55,7 +55,7 @@ textarea {
   height: 110px;
   padding: 12px 10px;
   box-sizing: border-box;
-  border-radius: 3px;
+  border-radius: $std-border-radius;
   border: 1px solid #b7b7b7;
   background-color: #fff;
   resize: auto;
@@ -126,7 +126,7 @@ select {
   border: 1px solid #bbb;
   font-size: 15px;
   color: rgba(0, 0, 0, 0.87);
-  border-radius: 3px;
+  border-radius: $std-border-radius;
   height: 39px;
   padding: 8px 20px; /* If you add too much padding here, the options won't show in IE */
   width: 100%;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -40,6 +40,7 @@
 @import "cropper";
 @import "drawer";
 @import "banner";
+@import "snackbar";
 @import "dropdown-menu";
 @import "auth";
 @import "share-popup";

--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -1,0 +1,26 @@
+.mdc-snackbar {
+  z-index: 10;
+  background-color: $message-component-bg-color;
+  left: 50%;
+  border-radius: $std-border-radius;
+
+  @include breakpoint(materialmobile) {
+    left: 0;
+  }
+
+  &.mdc-snackbar--active {
+    bottom: 10px;
+  }
+
+  .mdc-snackbar__text {
+    margin: 5px 0;
+    padding: 0;
+    min-width: 100%;
+    width: 100%;
+    overflow: hidden;
+  }
+}
+
+.persistent-drawer-open ~ .mdc-snackbar {
+  left: calc(50% + (#{$drawer-width}/ 2));
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #1012 

#### What's this PR do?
Fixes various snackbar UI bugs (see the issue)

#### How should this be manually tested?
Check that the snackbar shows up correctly at various screen widths, with/without drawer, with long text, etc. 

The patch in this
![ss 2018-08-09 at 17 19 49](https://user-images.githubusercontent.com/14932219/43927376-5c743d20-9bfb-11e8-95bc-a34326dca278.png)
 gist adds a button to the content window that brings up a snackbar on click: https://gist.github.com/gsidebo/ea013f645e04a25f9e3518751aa99c7a

#### Any background context you want to provide?
I simply set overflow to hidden, so any very long text will just be partially hidden

#### Screenshots (if appropriate)
![ss 2018-08-09 at 17 17 54](https://user-images.githubusercontent.com/14932219/43927357-414dca98-9bfb-11e8-927d-8e933a32df5b.png)
![ss 2018-08-09 at 17 18 07](https://user-images.githubusercontent.com/14932219/43927361-46a5ddb4-9bfb-11e8-9aa1-40435032fbbc.png)
![ss 2018-08-09 at 17 18 48](https://user-images.githubusercontent.com/14932219/43927365-518c7ba2-9bfb-11e8-9a20-047245abe92e.png)
![ss 2018-08-09 at 17 26 32](https://user-images.githubusercontent.com/14932219/43927387-68eba9da-9bfb-11e8-8bd8-19c0d0bbfa44.png)