### PR TITLE
Silence warning with empty profile fields

### DIFF
--- a/static/js/components/ProfileForm.js
+++ b/static/js/components/ProfileForm.js
@@ -54,7 +54,7 @@ export default class ProfileForm extends React.Component<Props> {
                 <label>Full Name</label>
                 <input
                   type="text"
-                  value={form.name}
+                  value={form.name || ""}
                   placeholder="Your name"
                   className="name"
                   name="name"
@@ -69,7 +69,7 @@ export default class ProfileForm extends React.Component<Props> {
             <input
               type="text"
               name="headline"
-              value={form.headline}
+              value={form.headline || ""}
               placeholder="Add a headline (For example: 'Post Doc, Photonics MIT')"
               onChange={onUpdate}
             />
@@ -77,7 +77,7 @@ export default class ProfileForm extends React.Component<Props> {
           <div className="row bio">
             <label>Biography</label>
             <textarea
-              value={form.bio}
+              value={form.bio || ""}
               name="bio"
               onChange={onUpdate}
               placeholder="Add a short description of yourself"

--- a/static/js/components/ProfileForm_test.js
+++ b/static/js/components/ProfileForm_test.js
@@ -129,4 +129,13 @@ describe("ProfileForm", () => {
     submitBtn.simulate("click")
     assert.isNotOk(onSubmitStub.called)
   })
+
+  it("renders an empty form", () => {
+    ["name", "bio", "headline"].forEach(field => {
+      // $FlowFixMe
+      profile[field] = null
+      const wrapper = renderForm()
+      assert.equal(wrapper.find(`[name="${field}"]`).props().value, "")
+    })
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Sets `value` to an empty string instead of null to silence warnings on uncontrolled React components

#### How should this be manually tested?
Edit the profile and make `bio` and `headline` empty. Save and refresh, then edit the profile. On master you should see an exception in the browser and a warning when running the tests. On this branch you shouldn't see any warning.