### PR TITLE
Updated staff permission to check user.is_staff for authenticated users

### DIFF
--- a/channels/views/channels.py
+++ b/channels/views/channels.py
@@ -12,8 +12,8 @@ from channels.serializers import ChannelSerializer
 from channels.utils import translate_praw_exceptions
 from open_discussions.permissions import (
     AnonymousAccessReadonlyPermission,
-    JwtIsStaffOrReadonlyPermission,
-    JwtIsStaffModeratorOrReadonlyPermission,
+    IsStaffOrReadonlyPermission,
+    IsStaffModeratorOrReadonlyPermission,
 )
 
 
@@ -21,7 +21,7 @@ class ChannelListView(ListCreateAPIView):
     """
     View for listing and creating channels
     """
-    permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffOrReadonlyPermission,)
+    permission_classes = (AnonymousAccessReadonlyPermission, IsStaffOrReadonlyPermission,)
     serializer_class = ChannelSerializer
 
     def get_serializer_context(self):
@@ -50,7 +50,7 @@ class ChannelDetailView(RetrieveUpdateAPIView):
     """
     View for getting information about or updating a specific channel
     """
-    permission_classes = (AnonymousAccessReadonlyPermission, JwtIsStaffModeratorOrReadonlyPermission,)
+    permission_classes = (AnonymousAccessReadonlyPermission, IsStaffModeratorOrReadonlyPermission,)
     serializer_class = ChannelSerializer
 
     def get_serializer_context(self):

--- a/channels/views/moderators.py
+++ b/channels/views/moderators.py
@@ -15,7 +15,7 @@ from open_discussions.permissions import (
     AnonymousAccessReadonlyPermission,
     ModeratorPermissions,
     is_moderator,
-    is_staff_jwt,
+    is_staff_user,
 )
 
 
@@ -32,7 +32,7 @@ class ModeratorListView(ListCreateAPIView):
         Pick private serializer if user is moderator of this channel, else use public one
         """
         return ModeratorPrivateSerializer if (
-            is_staff_jwt(self.request) or is_moderator(self.request, self)
+            is_staff_user(self.request) or is_moderator(self.request, self)
         ) else ModeratorPublicSerializer
 
     def get_serializer_context(self):

--- a/channels/views/reports.py
+++ b/channels/views/reports.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from open_discussions.permissions import JwtIsStaffOrModeratorPermission
+from open_discussions.permissions import IsStaffOrModeratorPermission
 from channels.api import Api
 from channels.serializers import ReportSerializer, ReportedContentSerializer
 from channels.utils import translate_praw_exceptions
@@ -46,7 +46,7 @@ class ChannelReportListView(APIView):
     Moderator view for reported comments and posts in a channels
     """
 
-    permission_classes = (IsAuthenticated, JwtIsStaffOrModeratorPermission)
+    permission_classes = (IsAuthenticated, IsStaffOrModeratorPermission)
 
     def get_serializer_context(self):
         """Context for the request and view"""

--- a/channels/views/subscribers.py
+++ b/channels/views/subscribers.py
@@ -10,14 +10,14 @@ from rest_framework.views import APIView
 
 from channels.api import Api
 from channels.serializers import SubscriberSerializer
-from open_discussions.permissions import JwtIsStaffOrReadonlyPermission
+from open_discussions.permissions import IsStaffOrReadonlyPermission
 
 
 class SubscriberListView(CreateAPIView):
     """
     View to add subscribers in channels
     """
-    permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
+    permission_classes = (IsAuthenticated, IsStaffOrReadonlyPermission, )
     serializer_class = SubscriberSerializer
 
     def get_serializer_context(self):
@@ -32,7 +32,7 @@ class SubscriberDetailView(APIView):
     """
     View to retrieve and remove subscribers in channels
     """
-    permission_classes = (IsAuthenticated, JwtIsStaffOrReadonlyPermission, )
+    permission_classes = (IsAuthenticated, IsStaffOrReadonlyPermission, )
 
     def get_serializer_context(self):
         """Context for the request and view"""

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -46,7 +46,7 @@ def reddit_staff_user(reddit_factories):
     """Override the staff_user fixture to use reddit_factories"""
     from channels.test_utils import no_ssl_verification
     with no_ssl_verification():
-        return reddit_factories.user("staff_user")
+        return reddit_factories.user("staff_user", is_staff=True)
 
 
 @pytest.fixture()

--- a/fixtures/users.py
+++ b/fixtures/users.py
@@ -25,7 +25,7 @@ def staff_user(db, use_betamax, request):
     if use_betamax:
         request.getfixturevalue('configure_betamax')
         return request.getfixturevalue('reddit_staff_user')
-    return UserFactory.create()
+    return UserFactory.create(is_staff=True)
 
 
 @pytest.fixture()

--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -1,7 +1,7 @@
 """ Permissions for profiles """
 from rest_framework import permissions
 
-from open_discussions.permissions import is_staff_jwt
+from open_discussions.permissions import is_staff_user
 
 
 class HasEditPermission(permissions.BasePermission):
@@ -16,4 +16,4 @@ class HasEditPermission(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return obj.user == request.user or request.user.is_superuser or is_staff_jwt(request)
+        return obj.user == request.user or request.user.is_superuser or is_staff_user(request)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #929 

#### What's this PR do?
Adds support for `user.is_staff`on our permission checks.

#### How should this be manually tested?
Go to `/manage/c/new` and verify you can create a channel in this branch but not in master.