### PR TITLE
Banner message if creating a post on reddit fails

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -1,11 +1,12 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import R from "ramda"
 import { connect } from "react-redux"
 
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
-import { setSnackbarMessage } from "../actions/ui"
+import { setBannerMessage } from "../actions/ui"
 import { isEmptyText } from "../lib/util"
 
 import type { CommentForm, CommentInTree, Post } from "../flow/discussionTypes"
@@ -184,17 +185,18 @@ const mapDispatchToProps = (dispatch: any, ownProps: CommentFormProps) => {
           if (err.errorStatusCode === 410) {
             // Comment was deleted
             dispatch(
-              setSnackbarMessage({
-                message:
-                  "This comment has been deleted and cannot be replied to"
-              })
+              setBannerMessage(
+                "This comment has been deleted and cannot be replied to"
+              )
             )
           } else {
             // Unknown errors
             dispatch(
-              setSnackbarMessage({
-                message: "Unknown error replying to comment"
-              })
+              setBannerMessage(
+                `Something went wrong creating your comment. Please try again or contact us at ${
+                  SETTINGS.support_email
+                }`
+              )
             )
           }
         })

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -21,7 +21,7 @@ import {
 import * as forms from "../actions/forms"
 import { actions } from "../actions"
 import { SET_POST_DATA, setPostData } from "../actions/post"
-import { SET_SNACKBAR_MESSAGE } from "../actions/ui"
+import { SET_BANNER_MESSAGE } from "../actions/ui"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
 import IntegrationTestHelper from "../util/integration_test_helper"
@@ -421,7 +421,7 @@ describe("CommentForms", () => {
     })
     ;[
       [410, "This comment has been deleted and cannot be replied to"],
-      [500, "Unknown error replying to comment"]
+      [500, "Something went wrong creating your comment"]
     ].forEach(([errorStatusCode, message]) => {
       it(`should display a toast message if ${errorStatusCode} error on form submit`, async () => {
         const { requestType, failureType } = actions.comments.post
@@ -438,12 +438,12 @@ describe("CommentForms", () => {
           })
         })
         const state = await helper.listenForActions(
-          [requestType, failureType, SET_SNACKBAR_MESSAGE],
+          [requestType, failureType, SET_BANNER_MESSAGE],
           () => {
             wrapper.find("form").simulate("submit")
           }
         )
-        assert.equal(state.ui.snackbar.message, message)
+        assert.ok(state.ui.banner.message.startsWith(message))
         assert.equal(
           state.posts.data.get(post.id).num_comments,
           post.num_comments

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -184,11 +184,8 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       const isText = isTextTabSelected(postType, channel)
       const data: CreatePostPayload = isText ? { title, text } : { title, url }
       // $FlowFixMe
-      dispatch(actions.posts.post(channelName, data))
-        .then(post => {
-          history.push(postDetailURL(channelName, post.id, post.slug))
-        })
-        .catch(() => {
+      const post = await dispatch(actions.posts.post(channelName, data)).catch(
+        () => {
           dispatch(
             setBannerMessage(
               `Something went wrong creating your post. Please try again or contact us at ${
@@ -196,7 +193,11 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
               }`
             )
           )
-        })
+        }
+      )
+      if (post) {
+        history.push(postDetailURL(channelName, post.id, post.slug))
+      }
     }
   }
 

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -26,6 +26,7 @@ import type {
 import type { RestState } from "../flow/restTypes"
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
+import { setBannerMessage } from "../actions/ui"
 
 type PostFormValue = {
   value: PostForm,
@@ -174,9 +175,15 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       const { postType, title, url, text } = postForm.value
       const isText = isTextTabSelected(postType, channel)
       const data: CreatePostPayload = isText ? { title, text } : { title, url }
-      dispatch(actions.posts.post(channelName, data)).then(post => {
-        history.push(postDetailURL(channelName, post.id, post.slug))
-      })
+      dispatch(actions.posts.post(channelName, data))
+        .catch(() => {
+          dispatch(
+            setBannerMessage("Unknown error creating post, please try again.")
+          )
+        })
+        .then(post => {
+          history.push(postDetailURL(channelName, post.id, post.slug))
+        })
     }
   }
 

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
@@ -27,6 +28,8 @@ import type { RestState } from "../flow/restTypes"
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
 import { setBannerMessage } from "../actions/ui"
+import { clearPostError } from "../actions/post"
+import { anyErrorExcept404 } from "../util/rest"
 
 type PostFormValue = {
   value: PostForm,
@@ -42,7 +45,8 @@ type CreatePostPageProps = {
   history: Object,
   processing: boolean,
   embedly: Object,
-  embedlyInFlight: boolean
+  embedlyInFlight: boolean,
+  errored: boolean
 }
 
 export const CREATE_POST_KEY = "post:new"
@@ -104,8 +108,11 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
   }
 
   componentWillUnmount() {
-    const { dispatch } = this.props
+    const { dispatch, errored } = this.props
     dispatch(actions.forms.formEndEdit(CREATE_POST_PAYLOAD))
+    if (errored) {
+      dispatch(clearPostError())
+    }
   }
 
   onUpdate = async (e: Object) => {
@@ -128,6 +135,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
           key:  actions.embedly.get.requestType
         }
       }
+      // $FlowFixMe
       const embedlyResponse = await dispatch(embedlyGetFunc)
       handleTwitterWidgets(embedlyResponse)
     }
@@ -150,7 +158,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
     )
   }
 
-  onSubmit = (e: Object) => {
+  onSubmit = async (e: Object) => {
     const { dispatch, history, postForm, channel } = this.props
 
     e.preventDefault()
@@ -175,14 +183,19 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       const { postType, title, url, text } = postForm.value
       const isText = isTextTabSelected(postType, channel)
       const data: CreatePostPayload = isText ? { title, text } : { title, url }
+      // $FlowFixMe
       dispatch(actions.posts.post(channelName, data))
-        .catch(() => {
-          dispatch(
-            setBannerMessage("Unknown error creating post, please try again.")
-          )
-        })
         .then(post => {
           history.push(postDetailURL(channelName, post.id, post.slug))
+        })
+        .catch(() => {
+          dispatch(
+            setBannerMessage(
+              `Something went wrong creating your post. Please try again or contact us at ${
+                SETTINGS.support_email
+              }`
+            )
+          )
         })
     }
   }
@@ -250,6 +263,7 @@ const mapStateToProps = (state, props) => {
 
   return {
     postForm,
+    errored: anyErrorExcept404([state.posts]),
     channel,
     channels,
     processing,

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -10,6 +10,8 @@ import CreatePostForm from "../components/CreatePostForm"
 import withSingleColumn from "../hoc/withSingleColumn"
 
 import { actions } from "../actions"
+import { setBannerMessage } from "../actions/ui"
+import { clearPostError } from "../actions/post"
 import { isTextTabSelected, LINK_TYPE_ANY } from "../lib/channels"
 import { newPostForm } from "../lib/posts"
 import { postDetailURL } from "../lib/url"
@@ -17,6 +19,7 @@ import { getChannelName } from "../lib/util"
 import { formatTitle } from "../lib/title"
 import { validatePostCreateForm } from "../lib/validation"
 import { ensureTwitterEmbedJS, handleTwitterWidgets } from "../lib/embed"
+import { anyErrorExcept404 } from "../util/rest"
 
 import type {
   Channel,
@@ -27,9 +30,6 @@ import type {
 import type { RestState } from "../flow/restTypes"
 import type { Dispatch } from "redux"
 import type { Match } from "react-router"
-import { setBannerMessage } from "../actions/ui"
-import { clearPostError } from "../actions/post"
-import { anyErrorExcept404 } from "../util/rest"
 
 type PostFormValue = {
   value: PostForm,
@@ -183,20 +183,18 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       const { postType, title, url, text } = postForm.value
       const isText = isTextTabSelected(postType, channel)
       const data: CreatePostPayload = isText ? { title, text } : { title, url }
-      // $FlowFixMe
-      const post = await dispatch(actions.posts.post(channelName, data)).catch(
-        () => {
-          dispatch(
-            setBannerMessage(
-              `Something went wrong creating your post. Please try again or contact us at ${
-                SETTINGS.support_email
-              }`
-            )
-          )
-        }
-      )
-      if (post) {
+      try {
+        // $FlowFixMe
+        const post = await dispatch(actions.posts.post(channelName, data))
         history.push(postDetailURL(channelName, post.id, post.slug))
+      } catch (err) {
+        dispatch(
+          setBannerMessage(
+            `Something went wrong creating your post. Please try again or contact us at ${
+              SETTINGS.support_email
+            }`
+          )
+        )
       }
     }
   }

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -258,7 +258,7 @@ describe("CreatePostPage", () => {
     submitPost(wrapper)
     assert.lengthOf(wrapper.find(".channel-select .validation-message"), 0)
   })
-  //
+
   it(`should display a banner message if error on form submit`, async () => {
     helper.createPostStub.returns(Promise.reject({ errorStatusCode: 500 }))
     const wrapper = await renderPage()

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -26,6 +26,7 @@ import * as embedUtil from "../lib/embed"
 import { newPostForm } from "../lib/posts"
 
 import type { CreatePostPayload } from "../flow/discussionTypes"
+import { SET_BANNER_MESSAGE } from "../actions/ui"
 
 describe("CreatePostPage", () => {
   let helper,
@@ -255,6 +256,30 @@ describe("CreatePostPage", () => {
     select.simulate("change", { target: { value: channels[6].name } })
     submitPost(wrapper)
     assert.lengthOf(wrapper.find(".channel-select .validation-message"), 0)
+  })
+  //
+  it(`should display a banner message if error on form submit`, async () => {
+    helper.createPostStub.returns(Promise.reject({ errorStatusCode: 500 }))
+    const wrapper = await renderPage()
+    setTitle(wrapper, post.title)
+    setTextPost(wrapper)
+    setText(wrapper, post.text)
+
+    const state = await listenForActions(
+      [
+        actions.posts.post.requestType,
+        actions.posts.post.failureType,
+        SET_BANNER_MESSAGE
+      ],
+      () => {
+        submitPost(wrapper)
+      }
+    )
+    assert.ok(
+      state.ui.banner.message.startsWith(
+        "Something went wrong creating your post."
+      )
+    )
   })
 
   it("goes back when cancel is clicked", async () => {

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import { assert } from "chai"
 import sinon from "sinon"
 
@@ -261,6 +262,8 @@ describe("CreatePostPage", () => {
   it(`should display a banner message if error on form submit`, async () => {
     helper.createPostStub.returns(Promise.reject({ errorStatusCode: 500 }))
     const wrapper = await renderPage()
+    const email = "fakesupport@example.com"
+    SETTINGS.support_email = email
     setTitle(wrapper, post.title)
     setTextPost(wrapper)
     setText(wrapper, post.text)
@@ -275,10 +278,9 @@ describe("CreatePostPage", () => {
         submitPost(wrapper)
       }
     )
-    assert.ok(
-      state.ui.banner.message.startsWith(
-        "Something went wrong creating your post."
-      )
+    assert.equal(
+      state.ui.banner.message,
+      `Something went wrong creating your post. Please try again or contact us at ${email}`
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Closes #911

#### What's this PR do?
If anything goes wrong with creating a new post or comment on reddit, a banner message should be displayed with the text "Something went wrong creating your <post|comment>. Please try again or contact us at <support_email>"

#### How should this be manually tested?
- Temporarily add a line to `channels.models.api.Api.create_post` to make it always raise an Exception:
  ```
  raise ValueError('Fake Error')
  ```
- Go to the the post creation page, enter valid values, and submit the form.  The banner message should appear.
- Remove the modification to `Api.create_post` and resubmit the post form.  You should be redirected to the new post's detail page.

- Temporarily add a line to `channels.models.api.Api.create_comment` to make it always raise an Exception
- Go to the a post detail page, enter a comment, and submit the form.  A banner message should appear instead of a snackbar, however the detail page will also reload as an error page (see #1069).  