### PR TITLE
Remove edit button from profile image on profile view page

### DIFF
--- a/static/js/components/ProfileForm_test.js
+++ b/static/js/components/ProfileForm_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { mount } from "enzyme"
 import { assert } from "chai"
@@ -93,9 +94,17 @@ describe("ProfileForm", () => {
     )
   })
 
-  it("includes a ProfileImage container", () => {
-    const wrapper = renderForm()
-    assert.isTrue(wrapper.find(ProfileImage).exists())
+  //
+  ;[true, false].forEach(sameUser => {
+    it(`ProfileImage should ${
+      sameUser ? "" : "not"
+    } include an edit profile button`, async () => {
+      SETTINGS.username = sameUser ? profile.username : "other_user"
+      const wrapper = renderForm()
+      const profileImage = wrapper.find(ProfileImage)
+      assert.isTrue(profileImage.exists())
+      assert.equal(profileImage.props().editable, sameUser)
+    })
   })
 
   it("calls onUpdate", () => {

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -59,7 +59,6 @@ class ProfilePage extends React.Component<Props> {
     if (!profile) {
       return null
     }
-    const editable = userName === SETTINGS.username
 
     return (
       <div className="profile-page">
@@ -73,7 +72,7 @@ class ProfilePage extends React.Component<Props> {
                 <ProfileImage
                   profile={profile}
                   userName={userName}
-                  editable={editable}
+                  editable={false}
                   imageSize={PROFILE_IMAGE_MEDIUM}
                 />
                 <div className="row image-and-name">

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -82,12 +82,17 @@ describe("ProfilePage", function() {
     )
   })
   ;[true, false].forEach(sameUser => {
-    it(`should ${
+    it(`should not include an edit profile button on this page when profile is ${
       sameUser ? "" : "not"
-    } never include an edit profile button on this page regardless of user`, async () => {
+    } for the logged in user`, async () => {
       SETTINGS.username = sameUser ? profile.username : "other_user"
       const wrapper = await renderPage()
-      assert.notOk(wrapper.find(".profile-edit-button").exists())
+      assert.isNotOk(
+        wrapper
+          .find("ProfileImage")
+          .at(1)
+          .props().editable
+      )
     })
   })
 })

--- a/static/js/containers/ProfilePage_test.js
+++ b/static/js/containers/ProfilePage_test.js
@@ -84,12 +84,10 @@ describe("ProfilePage", function() {
   ;[true, false].forEach(sameUser => {
     it(`should ${
       sameUser ? "" : "not"
-    } include an edit profile button`, async () => {
+    } never include an edit profile button on this page regardless of user`, async () => {
       SETTINGS.username = sameUser ? profile.username : "other_user"
-      const wrapper = await renderPage(
-        sameUser ? [actions.forms.FORM_BEGIN_EDIT] : []
-      )
-      assert.equal(wrapper.find(".profile-edit-button").exists(), sameUser)
+      const wrapper = await renderPage()
+      assert.notOk(wrapper.find(".profile-edit-button").exists())
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1048

#### What's this PR do?
Removes edit button from the profile image on the profile view page

#### How should this be manually tested?
- View your profile.  The image should not have an edit button (pencil icon) on it.
- Edit your profile.  The image should have a working edit button.
