### PR TITLE
Fix profile image upload bug

### DIFF
--- a/static/js/components/ProfileForm.js
+++ b/static/js/components/ProfileForm.js
@@ -41,14 +41,15 @@ export default class ProfileForm extends React.Component<Props> {
 
     return (
       <div>
+        <ProfileImage
+          profile={profile}
+          userName={profile.username}
+          editable={profile.username === SETTINGS.username}
+          imageSize={PROFILE_IMAGE_MEDIUM}
+          className="float-left"
+        />
         <form onSubmit={onSubmit} className="form">
           <div className="row image-and-name">
-            <ProfileImage
-              profile={profile}
-              userName={profile.username}
-              editable={profile.username === SETTINGS.username}
-              imageSize={PROFILE_IMAGE_MEDIUM}
-            />
             <div className="profile-name">
               <div>
                 <input

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -70,7 +70,7 @@ class ProfileImage extends React.Component<Props> {
 
     const isAdd = imageUrl === defaultProfileImageUrl
     return (
-      <div className={`profile-image-container ${className ? className : ""}`}>
+      <div className={`profile-image-container ${className || ""}`}>
         <div className="avatar">
           <img
             src={imageUrl}

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -25,7 +25,8 @@ type Props = {
   editable: boolean,
   getProfile: (username: string) => Promise<*>,
   submitImage: (username: string, edit: Blob, name: string) => Promise<*>,
-  processing: boolean
+  processing: boolean,
+  className?: string
 }
 
 const formatPhotoName = photo => `${photo.name.replace(/\.\w*$/, "")}.jpg`
@@ -53,7 +54,7 @@ class ProfileImage extends React.Component<Props> {
   }
 
   render() {
-    const { editable, profile, imageSize, processing } = this.props
+    const { editable, profile, imageSize, processing, className } = this.props
 
     let imageUrl, profileName
     if (profile) {
@@ -69,7 +70,7 @@ class ProfileImage extends React.Component<Props> {
 
     const isAdd = imageUrl === defaultProfileImageUrl
     return (
-      <div className="profile-image-container">
+      <div className={`profile-image-container ${className ? className : ""}`}>
         <div className="avatar">
           <img
             src={imageUrl}

--- a/static/js/containers/ProfileImage_test.js
+++ b/static/js/containers/ProfileImage_test.js
@@ -75,6 +75,13 @@ describe("ProfileImage", () => {
       }
     })
 
+    it("should use className props", () => {
+      const image = renderProfileImage({
+        className: "testcss"
+      })
+      assert.ok(image.find(".testcss").exists())
+    })
+
     it("should have a ImageUploaderForm only if editable === true", () => {
       for (const editable of [true, false]) {
         const image = renderProfileImage({ editable })

--- a/static/scss/basic.scss
+++ b/static/scss/basic.scss
@@ -47,3 +47,7 @@ a.button {
   background: $bg-grey;
   margin: 0 10px;
 }
+
+.float-left {
+  float: left;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #1080

#### What's this PR do?
Modifies the form layout and css so `ProfileImage` is not contained inside another form.

#### How should this be manually tested?
- On master branch, if you click on the profile image edit button on the profile edit form, one of several things may happen:
  - the form will close immediately and return you to the profile page; or 
  - the upload dialog will appear, but clicking on it closes the dialog
- On this branch, you should be able to upload a new profile image without any of the above issues.
