### PR TITLE
Add channel avatar to sidebar

### DIFF
--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -38,22 +38,22 @@ const Navigation = (props: NavigationProps) => {
 
   return (
     <div className="navigation">
-      {showPostButton ? (
-        <Link
-          className="mdc-button mdc-button--raised blue-button"
-          to={newPostURL(channelName)}
-        >
-          Submit a New Post
-        </Link>
-      ) : null}
       <div className="location-list">
         <div className={homeClassName}>
           <Link className="home-link" to={FRONTPAGE_URL}>
             <i className="material-icons home">home</i>
-            Home
+            <span className="title">Home</span>
           </Link>
         </div>
       </div>
+      {showPostButton ? (
+        <div className="new-post-link-container">
+          <Link className="new-post-link" to={newPostURL(channelName)}>
+            <i className="material-icons add">add</i>
+            <span className="title">Compose</span>
+          </Link>
+        </div>
+      ) : null}
       <SubscriptionsList
         currentChannel={channelName}
         subscribedChannels={subscribedChannels}

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -44,12 +44,15 @@ describe("Navigation", () => {
     it("should not have channel name if channelName is not in URL", () => {
       const wrapper = renderComponent()
       assert.lengthOf(wrapper.find(Link), 2)
-      const props = wrapper
-        .find(Link)
-        .at(0)
-        .props()
-      assert.equal(props.to, "/create_post/")
-      assert.equal(props.children, "Submit a New Post")
+      const link = wrapper.find(".new-post-link")
+      assert.equal(link.props().to, "/create_post/")
+      assert.equal(
+        link
+          .children()
+          .at(1)
+          .text(),
+        "Compose"
+      )
     })
 
     it("should highlight the home link if, well, home", () => {
@@ -79,9 +82,15 @@ describe("Navigation", () => {
         ...defaultProps,
         pathname: channelURL("foobar")
       })
-      const link = wrapper.find(Link).first()
+      const link = wrapper.find(".new-post-link")
       assert.equal(link.props().to, newPostURL("foobar"))
-      assert.equal(link.props().children, "Submit a New Post")
+      assert.equal(
+        link
+          .children()
+          .at(1)
+          .text(),
+        "Compose"
+      )
     })
 
     it("should not show the create post link if an anonymous user", () => {
@@ -140,13 +149,9 @@ describe("Navigation", () => {
   })
 
   it("should have to link to home", () => {
-    const { to, className, children } = renderComponent()
-      .find(Link)
-      .at(1)
-      .props()
-    assert.equal(children[1], "Home")
-    assert.equal(className, "home-link")
-    assert.equal(to, FRONTPAGE_URL)
+    const wrapper = renderComponent().find(".home-link")
+    assert.equal(wrapper.find(".title").text(), "Home")
+    assert.equal(wrapper.props().to, FRONTPAGE_URL)
   })
 
   it("should hide the link to settings, if the user is anonymous", () => {

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -1,7 +1,6 @@
 // @flow
 import React from "react"
 import { Link } from "react-router-dom"
-import R from "ramda"
 
 import ChannelAvatar from "../containers/ChannelAvatar"
 import { channelURL, editChannelBasicURL } from "../lib/url"
@@ -16,7 +15,7 @@ const channelClassName = (channelName, currentChannel) =>
   currentChannel === channelName ? "location current-location" : "location"
 
 export default class SubscriptionsList extends React.Component<Props> {
-  makeChannelLink = R.curry((channel: Channel) => {
+  makeChannelLink = (channel: Channel) => {
     const { currentChannel } = this.props
 
     return (
@@ -38,7 +37,7 @@ export default class SubscriptionsList extends React.Component<Props> {
         ) : null}
       </div>
     )
-  })
+  }
 
   render() {
     const { subscribedChannels } = this.props

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -1,8 +1,10 @@
 // @flow
 import React from "react"
 import { Link } from "react-router-dom"
+import R from "ramda"
 
-import { channelURL } from "../lib/url"
+import ChannelAvatar from "../containers/ChannelAvatar"
+import { channelURL, editChannelBasicURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type Props = {
@@ -14,19 +16,54 @@ const channelClassName = (channelName, currentChannel) =>
   currentChannel === channelName ? "location current-location" : "location"
 
 export default class SubscriptionsList extends React.Component<Props> {
+  makeChannelLink = R.curry((channel: Channel) => {
+    const { currentChannel } = this.props
+
+    return (
+      <div
+        className={channelClassName(channel.name, currentChannel)}
+        key={channel.name}
+      >
+        <Link to={channelURL(channel.name)} className="channel-link">
+          <ChannelAvatar channel={channel} imageSize="small" />
+          <span className="title">{channel.title}</span>
+        </Link>
+        {channel.user_is_moderator ? (
+          <Link
+            to={editChannelBasicURL(channel.name)}
+            className="material-icons settings-link"
+          >
+            settings
+          </Link>
+        ) : null}
+      </div>
+    )
+  })
+
   render() {
-    const { subscribedChannels, currentChannel } = this.props
+    const { subscribedChannels } = this.props
+
+    const myChannels = subscribedChannels.filter(
+      channel => channel.user_is_moderator
+    )
+    const otherChannels = subscribedChannels.filter(
+      channel => !channel.user_is_moderator
+    )
 
     return (
       <div className="location-list subscribed-channels">
-        {subscribedChannels.map(channel => (
-          <div
-            className={channelClassName(channel.name, currentChannel)}
-            key={channel.name}
-          >
-            <Link to={channelURL(channel.name)}>{channel.title}</Link>
+        {myChannels.length > 0 ? (
+          <div className="my-channels">
+            <div className="heading">Channels you moderate</div>
+            {myChannels.map(this.makeChannelLink)}
           </div>
-        ))}
+        ) : null}
+        {otherChannels.length > 0 ? (
+          <div className="channels">
+            <div className="heading">Channels</div>
+            {otherChannels.map(this.makeChannelLink)}
+          </div>
+        ) : null}
       </div>
     )
   }

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -31,9 +31,9 @@ export default class SubscriptionsList extends React.Component<Props> {
         {channel.user_is_moderator ? (
           <Link
             to={editChannelBasicURL(channel.name)}
-            className="material-icons settings-link"
+            className="settings-link"
           >
-            settings
+            Edit
           </Link>
         ) : null}
       </div>

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -2,30 +2,73 @@
 import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
-import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
 
-import { channelURL } from "../lib/url"
+import { channelURL, editChannelBasicURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 
 describe("SubscriptionsList", function() {
-  let channels
+  let channels, myChannels, notMyChannels
   const renderSubscriptionsList = (
     props = { subscribedChannels: channels, currentChannel: channels[0].name }
   ) => shallow(<SubscriptionsList {...props} />)
 
   beforeEach(() => {
     channels = makeChannelList()
+    // make sure there are some of each and they're not grouped together
+    channels.forEach((channel, i) => {
+      channel.user_is_moderator = i % 2 === 0
+    })
+
+    myChannels = channels.filter(channel => channel.user_is_moderator)
+    notMyChannels = channels.filter(channel => !channel.user_is_moderator)
   })
 
   it("should show each channel", () => {
     const wrapper = renderSubscriptionsList()
-    assert.equal(wrapper.find(Link).length, channels.length)
-    wrapper.find(Link).forEach((link, index) => {
-      assert.equal(link.props().to, channelURL(channels[index].name))
-      assert.equal(link.props().children, channels[index].title)
+
+    assert.equal(wrapper.find(".channel-link").length, channels.length)
+    assert.equal(
+      wrapper.find(".my-channels .channel-link").length,
+      myChannels.length
+    )
+    assert.equal(
+      wrapper.find(".channels .channel-link").length,
+      notMyChannels.length
+    )
+
+    wrapper.find(".my-channels .channel-link").forEach((link, index) => {
+      assert.equal(link.find(".title").text(), myChannels[index].title)
+      assert.equal(link.props().to, channelURL(myChannels[index].name))
+      assert.deepEqual(
+        link.find("Connect(ChannelAvatar)").props().channel,
+        myChannels[index]
+      )
     })
+
+    wrapper.find(".channels .channel-link").forEach((link, index) => {
+      assert.equal(link.find(".title").text(), notMyChannels[index].title)
+      assert.equal(link.props().to, channelURL(notMyChannels[index].name))
+      assert.deepEqual(
+        link.find("Connect(ChannelAvatar)").props().channel,
+        notMyChannels[index]
+      )
+    })
+  })
+
+  it("should show settings links for channels you are moderator of", () => {
+    const wrapper = renderSubscriptionsList()
+
+    assert.equal(
+      wrapper.find(".my-channels .settings-link").length,
+      myChannels.length
+    )
+    wrapper.find(".my-channels .settings-link").forEach((link, index) => {
+      assert.equal(link.props().to, editChannelBasicURL(myChannels[index].name))
+    })
+
+    assert.equal(wrapper.find(".channels .settings-link").length, 0)
   })
 
   it("should highlight the current channel", () => {
@@ -33,9 +76,12 @@ describe("SubscriptionsList", function() {
     const currentLocation = wrapper.find(".current-location")
     assert.lengthOf(currentLocation, 1)
     assert.equal(currentLocation.props().className, "location current-location")
-    assert.equal(currentLocation.children().props().children, channels[0].title)
+    assert.equal(currentLocation.find(".title").text(), channels[0].title)
     assert.equal(
-      currentLocation.children().props().to,
+      currentLocation
+        .find(".channel-link")
+        .at(0)
+        .props().to,
       channelURL(channels[0].name)
     )
   })

--- a/static/js/components/admin/EditChannelAppearanceForm.js
+++ b/static/js/components/admin/EditChannelAppearanceForm.js
@@ -49,6 +49,7 @@ export default class EditChannelAppearanceForm extends React.Component<Props> {
               form.avatar.edit &&
               URL.createObjectURL(form.avatar.edit)
             }
+            imageSize="medium"
           />
 
           <div className="row description">

--- a/static/js/containers/ChannelAvatar.js
+++ b/static/js/containers/ChannelAvatar.js
@@ -13,15 +13,25 @@ import { initials } from "../lib/profile"
 import type { Dispatch } from "redux"
 import type { Channel } from "../flow/discussionTypes"
 
+export const CHANNEL_AVATAR_SMALL: "small" = "small"
+export const CHANNEL_AVATAR_MEDIUM: "medium" = "medium"
+
+type ImageSize = typeof CHANNEL_AVATAR_SMALL | typeof CHANNEL_AVATAR_MEDIUM
+
 type Props = {
-  editable: boolean,
+  imageSize: ImageSize,
   channel: Channel,
-  channelName?: ?string,
-  formImageUrl: ?string,
-  showDialog: () => any,
-  name: string,
-  onUpdate: (event: Object) => Promise<*>
+  editable?: boolean,
+  formImageUrl?: ?string,
+  showDialog?: () => any,
+  name?: string,
+  onUpdate?: (event: Object) => Promise<*>
 }
+
+const getImage = (channel: Channel, imageSize: ImageSize) =>
+  imageSize === CHANNEL_AVATAR_SMALL
+    ? channel.avatar_small
+    : channel.avatar_medium
 
 class ChannelAvatar extends React.Component<Props> {
   static defaultProps = {
@@ -35,14 +45,16 @@ class ChannelAvatar extends React.Component<Props> {
       formImageUrl,
       showDialog,
       onUpdate,
-      name
+      name,
+      imageSize
     } = this.props
 
-    const imageUrl = formImageUrl || channel.avatar || defaultChannelAvatarUrl
+    const imageUrl =
+      formImageUrl || getImage(channel, imageSize) || defaultChannelAvatarUrl
     const isAdd = imageUrl === defaultChannelAvatarUrl
 
     return (
-      <div className="avatar-container row">
+      <div className={`avatar-container row ${imageSize}-size`}>
         <div className="avatar">
           {isAdd ? (
             <div
@@ -81,8 +93,10 @@ class ChannelAvatar extends React.Component<Props> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
+  // $FlowFixMe
   bindActionCreators(
     {
+      // $FlowFixMe
       showDialog: () => showDialog(makeDialogKey(ownProps.name))
     },
     dispatch

--- a/static/js/containers/ChannelAvatar_test.js
+++ b/static/js/containers/ChannelAvatar_test.js
@@ -24,90 +24,113 @@ describe("ChannelAvatar", () => {
     )
     channel = makeChannel()
     channel.avatar = null
+    channel.avatar_small = null
+    channel.avatar_medium = null
   })
 
   afterEach(() => {
     helper.cleanup()
   })
+  ;["small", "medium"].forEach(imageSize => {
+    describe(imageSize, () => {
+      it("renders an image when there is an avatar", async () => {
+        channel.avatar_small = "avatar_small"
+        channel.avatar_medium = "avatar_medium"
+        const { inner } = await renderPage({}, { channel, imageSize })
 
-  it("renders an image when there is an avatar", async () => {
-    channel.avatar = "avatar"
-    const { inner } = await renderPage({}, { channel })
-
-    assert.equal(
-      inner.find("img").props().alt,
-      `Channel avatar for ${channel.name}`
-    )
-    assert.equal(inner.find("img").props().src, channel.avatar)
-    assert.equal(inner.find(".avatar-initials").length, 0)
-  })
-
-  it("renders initials when there isn't an avatar", async () => {
-    channel.avatar = null
-    const { inner } = await renderPage({}, { channel })
-
-    assert.equal(inner.find("img").length, 0)
-    assert.equal(inner.find(".avatar-initials").text(), initials(channel.title))
-  })
-  ;[true, false].forEach(editable => {
-    it(`${
-      editable ? "renders" : "doesn't render"
-    } an ImageUploader and link`, async () => {
-      const { inner } = await renderPage({}, { channel, editable })
-      assert.equal(
-        inner.find("Connect(withForm(ImageUploader))").length,
-        editable ? 1 : 0
-      )
-
-      assert.equal(inner.find(".upload-avatar").length, editable ? 1 : 0)
-    })
-  })
-
-  describe(`shows the right icon when the channel`, () => {
-    [true, false].forEach(hasAvatar => {
-      it(`${hasAvatar ? "has" : "doesn't have"} a avatar`, async () => {
-        channel.avatar = hasAvatar ? "avatar" : null
-        const { inner } = await renderPage({}, { channel, editable: true })
-        const imageUploader = inner.find("Connect(withForm(ImageUploader))")
-        assert.equal(imageUploader.props().isAdd, !hasAvatar)
+        assert.equal(
+          inner.find("img").props().alt,
+          `Channel avatar for ${channel.name}`
+        )
+        assert.equal(
+          inner.find("img").props().src,
+          channel[`avatar_${imageSize}`]
+        )
+        assert.equal(inner.find(".avatar-initials").length, 0)
       })
-    })
-    ;[true, false].forEach(hasFormImageUrl => {
-      it(`${
-        hasFormImageUrl ? "provides" : "doesn't provide"
-      } a formImageUrl`, async () => {
+
+      it("renders initials when there isn't an avatar", async () => {
+        channel.avatar_medium = null
+        channel.avatar_small = null
+        const { inner } = await renderPage({}, { channel, imageSize })
+
+        assert.equal(inner.find("img").length, 0)
+        assert.equal(
+          inner.find(".avatar-initials").text(),
+          initials(channel.title)
+        )
+      })
+      ;[true, false].forEach(editable => {
+        it(`${
+          editable ? "renders" : "doesn't render"
+        } an ImageUploader and link`, async () => {
+          const { inner } = await renderPage(
+            {},
+            { channel, editable, imageSize }
+          )
+          assert.equal(
+            inner.find("Connect(withForm(ImageUploader))").length,
+            editable ? 1 : 0
+          )
+
+          assert.equal(inner.find(".upload-avatar").length, editable ? 1 : 0)
+        })
+      })
+
+      describe(`shows the right icon when the channel`, () => {
+        [true, false].forEach(hasAvatar => {
+          it(`${hasAvatar ? "has" : "doesn't have"} a avatar`, async () => {
+            channel[`avatar_${imageSize}`] = hasAvatar ? "avatar" : null
+            const { inner } = await renderPage(
+              {},
+              { channel, editable: true, imageSize }
+            )
+            const imageUploader = inner.find("Connect(withForm(ImageUploader))")
+            assert.equal(imageUploader.props().isAdd, !hasAvatar)
+          })
+        })
+        ;[true, false].forEach(hasFormImageUrl => {
+          it(`${
+            hasFormImageUrl ? "provides" : "doesn't provide"
+          } a formImageUrl`, async () => {
+            const { inner } = await renderPage(
+              {},
+              {
+                channel,
+                imageSize,
+                editable:     true,
+                formImageUrl: hasFormImageUrl ? "url" : null
+              }
+            )
+            const imageUploader = inner.find("Connect(withForm(ImageUploader))")
+            assert.equal(imageUploader.props().isAdd, !hasFormImageUrl)
+          })
+        })
+      })
+      ;["name", "onUpdate"].forEach(field => {
+        it(`passes in ${field}`, async () => {
+          const value = field
+          const { inner } = await renderPage(
+            {},
+            { channel, [field]: value, editable: true, imageSize }
+          )
+          const imageUploader = inner.find("Connect(withForm(ImageUploader))")
+          assert.equal(imageUploader.props()[field], value)
+        })
+      })
+
+      it("has a link to upload avatar which shows the dialog", async () => {
+        const showDialogStub = helper.sandbox
+          .stub(uiActions, "showDialog")
+          .returns({ type: "action" })
         const { inner } = await renderPage(
           {},
-          {
-            channel,
-            editable:     true,
-            formImageUrl: hasFormImageUrl ? "url" : null
-          }
+          { channel, editable: true, imageSize }
         )
-        const imageUploader = inner.find("Connect(withForm(ImageUploader))")
-        assert.equal(imageUploader.props().isAdd, !hasFormImageUrl)
+        const imageUploader = inner.find(".upload-avatar")
+        imageUploader.props().onClick()
+        sinon.assert.calledWith(showDialogStub)
       })
     })
-  })
-  ;["name", "onUpdate"].forEach(field => {
-    it(`passes in ${field}`, async () => {
-      const value = field
-      const { inner } = await renderPage(
-        {},
-        { channel, [field]: value, editable: true }
-      )
-      const imageUploader = inner.find("Connect(withForm(ImageUploader))")
-      assert.equal(imageUploader.props()[field], value)
-    })
-  })
-
-  it("has a link to upload avatar which shows the dialog", async () => {
-    const showDialogStub = helper.sandbox
-      .stub(uiActions, "showDialog")
-      .returns({ type: "action" })
-    const { inner } = await renderPage({}, { channel, editable: true })
-    const imageUploader = inner.find(".upload-avatar")
-    imageUploader.props().onClick()
-    sinon.assert.calledWith(showDialogStub)
   })
 })

--- a/static/js/containers/ChannelBanner.js
+++ b/static/js/containers/ChannelBanner.js
@@ -13,13 +13,12 @@ import type { Dispatch } from "redux"
 import type { Channel } from "../flow/discussionTypes"
 
 type Props = {
-  editable: boolean,
   channel: Channel,
-  channelName?: ?string,
-  formImageUrl: ?string,
-  showDialog: () => any,
-  name: string,
-  onUpdate: (event: Object) => Promise<*>
+  editable?: boolean,
+  formImageUrl?: ?string,
+  showDialog?: () => any,
+  name?: string,
+  onUpdate?: (event: Object) => Promise<*>
 }
 
 class ChannelBanner extends React.Component<Props> {
@@ -70,8 +69,10 @@ class ChannelBanner extends React.Component<Props> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
+  // $FlowFixMe
   bindActionCreators(
     {
+      // $FlowFixMe
       showDialog: () => showDialog(makeDialogKey(ownProps.name))
     },
     dispatch

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -15,22 +15,27 @@ import type {
 
 const incr = incrementer()
 
-export const makeChannel = (privateChannel: boolean = false): Channel => ({
-  // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
-  name:                  `channel_${incr.next().value}`,
-  title:                 casual.title,
-  channel_type:          privateChannel ? "private" : "public",
-  link_type:             LINK_TYPE_ANY,
-  description:           casual.description,
-  public_description:    casual.description,
-  num_users:             casual.integer(0, 500),
-  user_is_contributor:   casual.coin_flip,
-  user_is_moderator:     casual.coin_flip,
-  membership_is_managed: casual.coin_flip,
-  ga_tracking_id:        casual.random_element(["UA-FAKE-01", null]),
-  avatar:                casual.coin_flip ? "http://avatar.url" : null,
-  banner:                casual.coin_flip ? "http://banner.url" : null
-})
+export const makeChannel = (privateChannel: boolean = false): Channel => {
+  const hasAvatar = casual.coin_flip
+  return {
+    // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
+    name:                  `channel_${incr.next().value}`,
+    title:                 casual.title,
+    channel_type:          privateChannel ? "private" : "public",
+    link_type:             LINK_TYPE_ANY,
+    description:           casual.description,
+    public_description:    casual.description,
+    num_users:             casual.integer(0, 500),
+    user_is_contributor:   casual.coin_flip,
+    user_is_moderator:     casual.coin_flip,
+    membership_is_managed: casual.coin_flip,
+    ga_tracking_id:        casual.random_element(["UA-FAKE-01", null]),
+    avatar:                hasAvatar ? "http://avatar.url" : null,
+    avatar_small:          hasAvatar ? "http://avatar.small.url" : null,
+    avatar_medium:         hasAvatar ? "http://avatar.medium.url" : null,
+    banner:                casual.coin_flip ? "http://banner.url" : null
+  }
+}
 
 export const makeChannelList = (numChannels: number = 20) => {
   return R.range(0, numChannels).map(() => makeChannel(Math.random() > 0.5))

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -19,6 +19,8 @@ export type Channel = {
   membership_is_managed: boolean,
   ga_tracking_id:      ?string,
   avatar: string|null,
+  avatar_small: string|null,
+  avatar_medium: string|null,
   banner: string|null,
 }
 

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -116,44 +116,16 @@
   }
 }
 
-$avatar-dimension: 90px;
-
-.avatar-container {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  a {
-    margin-left: 20px;
-  }
-
-  .avatar {
-    display: table;
-  }
-
-  .avatar-image {
-    border-radius: 15px;
-    color: #fff;
-    width: $avatar-dimension;
-    height: $avatar-dimension;
-    display: table;
-    overflow: hidden;
-  }
-
-  .avatar-initials {
-    border-radius: 15px;
-    width: $avatar-dimension;
-    height: $avatar-dimension;
-    text-align: center;
-    display: table-cell;
-    vertical-align: middle;
-    color: #fff;
-    font-size: 24px;
-    font-weight: 600;
-  }
-
+.avatar-container,
+.banner-container {
   .cropper-view-box {
     border-radius: inherit;
+  }
+}
+
+.avatar-container {
+  .upload-avatar {
+    margin-left: 20px;
   }
 }
 
@@ -161,10 +133,6 @@ $avatar-dimension: 90px;
   .banner-image {
     width: 100%;
     display: block;
-  }
-
-  .cropper-view-box {
-    border-radius: inherit;
   }
 
   .upload-banner {

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -32,3 +32,55 @@
     right: 15px;
   }
 }
+
+$avatar-dimension-medium: 90px;
+$avatar-dimension-small: 22px;
+
+.avatar-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .avatar {
+    display: table;
+  }
+
+  .avatar-image {
+    display: table;
+    overflow: hidden;
+  }
+
+  .avatar-initials {
+    text-align: center;
+    display: table-cell;
+    vertical-align: middle;
+    color: #fff;
+    font-weight: 600;
+  }
+
+  &.small-size {
+    img,
+    .avatar,
+    .avatar-initials {
+      width: $avatar-dimension-small;
+      height: $avatar-dimension-small;
+    }
+
+    .avatar-initials {
+      font-size: $avatar-dimension-small / 2;
+    }
+  }
+
+  &.medium-size {
+    img,
+    .avatar,
+    .avatar-initials {
+      width: $avatar-dimension-medium;
+      height: $avatar-dimension-medium;
+    }
+
+    .avatar-initials {
+      font-size: $avatar-dimension-medium / 4;
+    }
+  }
+}

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -4,6 +4,11 @@ a.mitlogo {
   }
 }
 
+$red-link-color: #9a2a33;
+$icon-padding-left: 19px;
+$text-padding-left: 26px;
+$link-padding: 11px 20px 11px 19px;
+
 .navbar {
   .mdc-toolbar {
     background-color: #fff;
@@ -49,12 +54,21 @@ a.mitlogo {
 .navigation {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding-top: 16px;
 
-  .settings-link {
-    width: 90%;
-    margin-left: 36px;
+  .title {
+    margin-left: $text-padding-left;
+  }
+
+  .new-post-link-container {
+    .new-post-link {
+      color: $red-link-color;
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 20px 5px 5px;
+      margin-left: 13px;
+      border: 1px solid $red-link-color;
+      border-radius: 30px;
+    }
   }
 
   .mdc-button {
@@ -116,31 +130,43 @@ a.mitlogo {
     border-width: 1px 0;
     padding: 16px 0 18px 0;
     margin: 15px 0 20px;
+
+    .heading {
+      margin-left: $icon-padding-left;
+      font-weight: 600;
+      color: #8a8b8c;
+      padding: 11px 0;
+    }
   }
 
   .location {
-    margin: 0 0 0 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 
-    .home-link {
+    .channel-link {
       display: flex;
+      flex-direction: row;
       align-items: center;
-      margin-top: 10px;
       color: $navigation-text;
-
-      i {
-        margin-right: 10px;
-      }
+      font-size: 15px;
+      padding: $link-padding;
+      flex-grow: 1;
     }
 
-    a {
-      color: $navigation-text;
-      display: block;
-      font-size: 15px;
-      padding: 11px 20px 11px 34px;
+    .settings-link {
+      padding: 11px 20px 11px 0;
     }
 
     a:hover {
       background: rgba(0, 0, 0, 0.05);
+    }
+
+    .home-link {
+      display: flex;
+      align-items: center;
+      padding: $link-padding;
+      color: $navigation-text;
     }
 
     &.current-location {

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -126,8 +126,6 @@ $link-padding: 11px 20px 11px 19px;
   margin: 10px 0 5px;
 
   &.subscribed-channels {
-    border: 1px solid $border-grey-alt;
-    border-width: 1px 0;
     padding: 16px 0 18px 0;
     margin: 15px 0 20px;
 

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -168,7 +168,8 @@ $link-padding: 11px 20px 11px 19px;
     }
 
     &.current-location {
-      background-color: $bg-grey;
+      background-color: #e7ebf5;
+      font-weight: 600;
     }
   }
 }

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -153,7 +153,9 @@ $link-padding: 11px 20px 11px 19px;
     }
 
     .settings-link {
-      padding: 11px 20px 11px 0;
+      padding: 11px 20px;
+      color: $red-link-color;
+      font-weight: 600;
     }
 
     a:hover {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #928 
Fixes #1061 

#### What's this PR do?
Adds channel avatars to sidebar and does some refactoring to make it look more like the mockup

#### How should this be manually tested?
View the channel sidebar and verify that the channels are grouped according to moderator status. Channels you're moderator of should have gear buttons which open the corresponding settings page for that channel