### PR TITLE
Use embedly image api to resize thumbnails in Embedly component

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -1,9 +1,10 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 
 import ContentLoader from "react-content-loader"
 
-import { urlHostname } from "../lib/url"
+import { embedlyImage, urlHostname } from "../lib/url"
 import { hasIframe } from "../lib/embed"
 
 export const EmbedlyLoader = (props: Object = {}) => (
@@ -57,7 +58,7 @@ export default class Embedly extends React.Component<Props> {
     if (embedly.type === "photo") {
       return (
         <div className="photo">
-          <img src={embedly.url} />
+          <img src={embedlyImage(SETTINGS.embedlyKey, embedly.url, 500)} />
         </div>
       )
     }
@@ -76,7 +77,13 @@ export default class Embedly extends React.Component<Props> {
         >
           {embedly.thumbnail_url ? (
             <div className={compactView ? "thumbnail compact" : "thumbnail"}>
-              <img src={embedly.thumbnail_url} />
+              <img
+                src={embedlyImage(
+                  SETTINGS.embedlyKey,
+                  embedly.thumbnail_url,
+                  500
+                )}
+              />
             </div>
           ) : null}
           <div className="link-summary">

--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -4,7 +4,7 @@ import React from "react"
 
 import ContentLoader from "react-content-loader"
 
-import { embedlyImage, urlHostname } from "../lib/url"
+import { embedlyResizeImage, urlHostname } from "../lib/url"
 import { hasIframe } from "../lib/embed"
 
 export const EmbedlyLoader = (props: Object = {}) => (
@@ -58,7 +58,9 @@ export default class Embedly extends React.Component<Props> {
     if (embedly.type === "photo") {
       return (
         <div className="photo">
-          <img src={embedlyImage(SETTINGS.embedlyKey, embedly.url, 600)} />
+          <img
+            src={embedlyResizeImage(SETTINGS.embedlyKey, embedly.url, 600)}
+          />
         </div>
       )
     }
@@ -78,7 +80,7 @@ export default class Embedly extends React.Component<Props> {
           {embedly.thumbnail_url ? (
             <div className={compactView ? "thumbnail compact" : "thumbnail"}>
               <img
-                src={embedlyImage(
+                src={embedlyResizeImage(
                   SETTINGS.embedlyKey,
                   embedly.thumbnail_url,
                   500

--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -58,7 +58,7 @@ export default class Embedly extends React.Component<Props> {
     if (embedly.type === "photo") {
       return (
         <div className="photo">
-          <img src={embedlyImage(SETTINGS.embedlyKey, embedly.url, 500)} />
+          <img src={embedlyImage(SETTINGS.embedlyKey, embedly.url, 600)} />
         </div>
       )
     }

--- a/static/js/components/Embedly_test.js
+++ b/static/js/components/Embedly_test.js
@@ -9,6 +9,7 @@ import Embedly from "./Embedly"
 import { urlHostname } from "../lib/url"
 import { makeArticle, makeYoutubeVideo, makeImage } from "../factories/embedly"
 import * as embedFuncs from "../lib/embed"
+import * as urlFuncs from "../lib/url"
 
 const renderEmbedly = embedlyResponse =>
   mount(<Embedly embedly={embedlyResponse} />)
@@ -32,17 +33,20 @@ describe("Embedly", () => {
 
   it("should render an image sensibly", () => {
     const image = makeImage()
+    const resizedImageUrl = `http://embedly/resize/?url=${image.url}`
+    sandbox.stub(urlFuncs, "embedlyResizeImage").returns(resizedImageUrl)
     const wrapper = renderEmbedly(image)
     assert.ok(wrapper.find(".photo"))
     const img = wrapper.find("img")
-    assert.ok(img.props().src.includes(encodeURIComponent(image.url)))
-    assert.ok(
-      img.props().src.startsWith("https://i.embed.ly/1/display/resize/")
-    )
+    assert.equal(img.props().src, resizedImageUrl)
   })
 
   it("should render generic article-type content sensibly", () => {
     const article = makeArticle()
+    const resizedImageUrl = `http://embedly/resize/?url=${
+      article.thumbnail_url
+    }`
+    sandbox.stub(urlFuncs, "embedlyResizeImage").returns(resizedImageUrl)
     const wrapper = renderEmbedly(article)
     assert.equal(
       wrapper
@@ -51,9 +55,7 @@ describe("Embedly", () => {
         .props().href,
       article.url
     )
-    const imgSrc = wrapper.find(".thumbnail img").props().src
-    assert.ok(imgSrc.includes(encodeURIComponent(article.thumbnail_url)))
-    assert.ok(imgSrc.startsWith("https://i.embed.ly/1/display/resize/"))
+    assert.equal(wrapper.find(".thumbnail img").props().src, resizedImageUrl)
     assert.equal(wrapper.find(".link-summary h2").text(), article.title)
     assert.equal(
       wrapper.find(".link-summary .description").text(),

--- a/static/js/components/Embedly_test.js
+++ b/static/js/components/Embedly_test.js
@@ -35,7 +35,10 @@ describe("Embedly", () => {
     const wrapper = renderEmbedly(image)
     assert.ok(wrapper.find(".photo"))
     const img = wrapper.find("img")
-    assert.equal(img.props().src, image.url)
+    assert.ok(img.props().src.includes(encodeURIComponent(image.url)))
+    assert.ok(
+      img.props().src.startsWith("https://i.embed.ly/1/display/resize/")
+    )
   })
 
   it("should render generic article-type content sensibly", () => {
@@ -48,10 +51,9 @@ describe("Embedly", () => {
         .props().href,
       article.url
     )
-    assert.equal(
-      wrapper.find(".thumbnail img").props().src,
-      article.thumbnail_url
-    )
+    const imgSrc = wrapper.find(".thumbnail img").props().src
+    assert.ok(imgSrc.includes(encodeURIComponent(article.thumbnail_url)))
+    assert.ok(imgSrc.startsWith("https://i.embed.ly/1/display/resize/"))
     assert.equal(wrapper.find(".link-summary h2").text(), article.title)
     assert.equal(
       wrapper.find(".link-summary .description").text(),

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -52,6 +52,11 @@ export const embedlyThumbnail = (
     url
   )}&height=${height}&width=${width}&grow=true&errorurl=${blankThumbnailUrl()}`
 
+export const embedlyImage = (key: string, url: string, height: number) =>
+  `https://i.embed.ly/1/display/resize/?key=${key}&url=${encodeURIComponent(
+    url
+  )}&height=${height}&grow=false&errorurl=${blankThumbnailUrl()}`
+
 export const postPermalink = (post: Post): string =>
   new URL(
     postDetailURL(post.channel_name, post.id),

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -52,7 +52,7 @@ export const embedlyThumbnail = (
     url
   )}&height=${height}&width=${width}&grow=true&errorurl=${blankThumbnailUrl()}`
 
-export const embedlyImage = (key: string, url: string, height: number) =>
+export const embedlyResizeImage = (key: string, url: string, height: number) =>
   `https://i.embed.ly/1/display/resize/?key=${key}&url=${encodeURIComponent(
     url
   )}&height=${height}&grow=false&errorurl=${blankThumbnailUrl()}`

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -20,7 +20,8 @@ import {
   channelModerationURL,
   postPermalink,
   embedlyThumbnail,
-  blankThumbnailUrl
+  blankThumbnailUrl,
+  embedlyImage
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -221,6 +222,18 @@ describe("url helper functions", () => {
       const embedlyUrl = embedlyThumbnail(key, url, height, width)
       assert.ok(embedlyUrl.includes(`height=${height}`))
       assert.ok(embedlyUrl.includes(`width=${width}`))
+      assert.ok(embedlyUrl.includes(`key=${key}`))
+      assert.ok(embedlyUrl.includes(`url=${encodeURIComponent(url)}`))
+    })
+  })
+
+  describe("embedlyImage", () => {
+    it("should return a good embedly image resize url", () => {
+      const key = "embedlyKey"
+      const height = 512
+      const url = "http://www.fake.url/fake.jpg"
+      const embedlyUrl = embedlyImage(key, url, height)
+      assert.ok(embedlyUrl.includes(`height=${height}`))
       assert.ok(embedlyUrl.includes(`key=${key}`))
       assert.ok(embedlyUrl.includes(`url=${encodeURIComponent(url)}`))
     })

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -21,7 +21,7 @@ import {
   postPermalink,
   embedlyThumbnail,
   blankThumbnailUrl,
-  embedlyImage
+  embedlyResizeImage
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -227,12 +227,12 @@ describe("url helper functions", () => {
     })
   })
 
-  describe("embedlyImage", () => {
+  describe("embedlyResizeImage", () => {
     it("should return a good embedly image resize url", () => {
       const key = "embedlyKey"
       const height = 512
       const url = "http://www.fake.url/fake.jpg"
-      const embedlyUrl = embedlyImage(key, url, height)
+      const embedlyUrl = embedlyResizeImage(key, url, height)
       assert.ok(embedlyUrl.includes(`height=${height}`))
       assert.ok(embedlyUrl.includes(`key=${key}`))
       assert.ok(embedlyUrl.includes(`url=${encodeURIComponent(url)}`))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1022 

#### What's this PR do?
Instead of displaying the embedly thumbnail url directly, makes another call to the embedly image api to resize it if necessary (max 500 or 600 pixels, based on embedly CSS styles `.photo img` and `.link .thumbnail img`).

#### How should this be manually tested?
Create some new link posts for links with images of various sizes; try direct links to images as well as links to URL's containing images.  Embedly should appear to work the same as before.  Inspect the URL of the displayed image; it should be in the form of `https://i.embed.ly/1/display/resize/?key=<key>&url=<source_url>&height=<500|600>&grow=false&errorurl=http://od.odl.local:8063/static/images/blank.png`
