### PR TITLE
Show domain and link icon next to post title

### DIFF
--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -160,7 +160,7 @@ describe("ExpandedPostDisplay", () => {
       .props()
     assert.equal(href, post.url)
     assert.equal(target, "_blank")
-    assert.equal(children, post.title)
+    assert.equal(children[0], post.title)
   })
 
   it("should display the domain, for a url post", () => {

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -63,6 +63,12 @@ export const formatPostTitle = (post: Post) =>
         rel="noopener noreferrer"
       >
         {post.title}
+        <span className="expanded-url-hostname">
+          ({urlHostname(post.url)}
+          <i className="material-icons open_in_new overlay-icon">
+            open_in_new
+          </i>)
+        </span>
       </a>
     </div>
   ) : (

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -10,7 +10,8 @@ import {
   newPostForm,
   formatCommentsCount,
   PostVotingButtons,
-  PostTitleAndHostname
+  PostTitleAndHostname,
+  formatPostTitle
 } from "./posts"
 import { makePost } from "../factories/posts"
 import { votingTooltipText } from "./util"
@@ -34,6 +35,18 @@ describe("Post utils", () => {
         post.num_comments = num
         assert.equal(formatCommentsCount(post), expectation)
       }
+    )
+  })
+
+  it("should include a domain and link icon for link posts", () => {
+    const post = makePost(true)
+    const postTitle = shallow(formatPostTitle(post))
+    assert.ok(postTitle.find(".open_in_new").exists())
+    assert.ok(
+      postTitle
+        .find(".expanded-url-hostname")
+        .text()
+        .startsWith(`(${urlHostname(post.url)}`)
     )
   })
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -101,6 +101,16 @@
   margin-left: 4px;
 }
 
+.expanded-url-hostname {
+  color: $font-grey-light;
+  font-size: 18px;
+  margin-left: 4px;
+
+  i {
+    vertical-align: middle;
+  }
+}
+
 .post-summary {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1052

#### What's this PR do?
On the post detail page for a link post, adds the domain and link icon in parentheses next to the title.

#### How should this be manually tested?
View a detail page for a link post, it should look similar to the [invision design](https://projects.invisionapp.com/share/DQNIO5IG2XA#/screens).


#### Screenshots (if appropriate)
<img width="749" alt="screen shot 2018-08-16 at 4 28 22 pm" src="https://user-images.githubusercontent.com/187676/44233292-74567680-a171-11e8-928a-52941828fde6.png">
