### PR TITLE
Make Session auth take priority over JWT tokens

### DIFF
--- a/channels/views/frontpage_test.py
+++ b/channels/views/frontpage_test.py
@@ -9,6 +9,7 @@ from channels.constants import (
     VALID_POST_SORT_TYPES,
 )
 from channels.utils import get_reddit_slug
+from open_discussions.constants import NOT_AUTHENTICATED_ERROR_TYPE
 from open_discussions.features import ANONYMOUS_ACCESS
 from profiles.utils import image_uri
 
@@ -151,4 +152,5 @@ def test_frontpage_anonymous(client, public_channel, settings, allow_anonymous):
         # Since the front page is shared between all channels it's hard to assert reproduceable results
         assert isinstance(resp.json()['posts'], list) is True
     else:
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert resp.data['error_type'] == NOT_AUTHENTICATED_ERROR_TYPE

--- a/channels/views/subscribers_test.py
+++ b/channels/views/subscribers_test.py
@@ -4,49 +4,50 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from open_discussions.constants import NOT_AUTHENTICATED_ERROR_TYPE
 from open_discussions.factories import UserFactory
 from open_discussions.features import ANONYMOUS_ACCESS
 
 pytestmark = pytest.mark.betamax
 
 
-def test_list_subscribers_not_allowed(client, staff_jwt_header):
+def test_list_subscribers_not_allowed(staff_client):
     """
     Get method not allowed on the list of subscribers
     """
     url = reverse('subscriber-list', kwargs={'channel_name': 'test_channel'})
-    assert client.get(url, **staff_jwt_header).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+    assert staff_client.get(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_add_subscriber(client, staff_jwt_header):
+def test_add_subscriber(staff_client):
     """
     Adds a subscriber to a channel
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse('subscriber-list', kwargs={'channel_name': 'admin_channel'})
-    resp = client.post(url, data={'subscriber_name': subscriber.username}, format='json', **staff_jwt_header)
+    resp = staff_client.post(url, data={'subscriber_name': subscriber.username}, format='json')
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == {'subscriber_name': subscriber.username}
 
 
-def test_add_subscriber_again(client, staff_jwt_header):
+def test_add_subscriber_again(staff_client):
     """
     If a user is already part of a channel we should return a 201 status
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse('subscriber-list', kwargs={'channel_name': 'admin_channel'})
-    resp = client.post(url, data={'subscriber_name': subscriber.username}, format='json', **staff_jwt_header)
+    resp = staff_client.post(url, data={'subscriber_name': subscriber.username}, format='json')
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == {'subscriber_name': subscriber.username}
 
 
-def test_add_subscriber_forbidden(client, staff_jwt_header):
+def test_add_subscriber_forbidden(staff_client):
     """
     If a user gets a 403 from praw we should return a 403 status
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse('subscriber-list', kwargs={'channel_name': 'admin_channel'})
-    resp = client.post(url, data={'subscriber_name': subscriber.username}, format='json', **staff_jwt_header)
+    resp = staff_client.post(url, data={'subscriber_name': subscriber.username}, format='json')
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -59,10 +60,11 @@ def test_add_subscriber_anonymous(client, settings, allow_anonymous):
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse('subscriber-list', kwargs={'channel_name': 'admin_channel'})
     resp = client.post(url, data={'subscriber_name': subscriber.username}, format='json')
-    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+    assert resp.data['error_type'] == NOT_AUTHENTICATED_ERROR_TYPE
 
 
-def test_detail_subscriber(client, jwt_header, private_channel_and_contributor):
+def test_detail_subscriber(user_client, private_channel_and_contributor):
     """
     Detail of a subscriber in a channel
     """
@@ -73,12 +75,12 @@ def test_detail_subscriber(client, jwt_header, private_channel_and_contributor):
             'subscriber_name': contributor.username,
         }
     )
-    resp = client.get(url, **jwt_header)
+    resp = user_client.get(url)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {'subscriber_name': contributor.username}
 
 
-def test_detail_subscriber_missing(client, jwt_header, private_channel, user):
+def test_detail_subscriber_missing(user_client, private_channel, user):
     """
     A missing subscriber should generate a 404
     """
@@ -88,7 +90,7 @@ def test_detail_subscriber_missing(client, jwt_header, private_channel, user):
             'subscriber_name': user.username,
         }
     )
-    resp = client.get(url, **jwt_header)
+    resp = user_client.get(url)
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -100,28 +102,29 @@ def test_detail_subscriber_anonymous(client, settings, allow_anonymous):
     url = reverse(
         'subscriber-detail', kwargs={'channel_name': 'admin_channel', 'subscriber_name': subscriber.username})
     resp = client.get(url)
-    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+    assert resp.data['error_type'] == NOT_AUTHENTICATED_ERROR_TYPE
 
 
-def test_remove_subscriber(client, staff_jwt_header):
+def test_remove_subscriber(staff_client):
     """
     Removes a subscriber from a channel
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse(
         'subscriber-detail', kwargs={'channel_name': 'admin_channel', 'subscriber_name': subscriber.username})
-    resp = client.delete(url, **staff_jwt_header)
+    resp = staff_client.delete(url)
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_remove_subscriber_again(client, staff_jwt_header):
+def test_remove_subscriber_again(staff_client):
     """
     The API should return a 204 even if the user isn't there
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse(
         'subscriber-detail', kwargs={'channel_name': 'admin_channel', 'subscriber_name': subscriber.username})
-    resp = client.delete(url, **staff_jwt_header)
+    resp = staff_client.delete(url)
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
@@ -133,4 +136,5 @@ def test_remove_subscriber_anonymous(client, settings, allow_anonymous):
     url = reverse(
         'subscriber-detail', kwargs={'channel_name': 'admin_channel', 'subscriber_name': subscriber.username})
     resp = client.delete(url)
-    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+    assert resp.data['error_type'] == NOT_AUTHENTICATED_ERROR_TYPE

--- a/embedly/views_test.py
+++ b/embedly/views_test.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from channels.models import LinkMeta
+from open_discussions.constants import NOT_AUTHENTICATED_ERROR_TYPE
 from open_discussions.features import ANONYMOUS_ACCESS
 
 
@@ -81,4 +82,5 @@ def test_get_embedly_anon(client, mocker, settings, allow_anonymous):
         assert resp.status_code == status.HTTP_200_OK
         get_stub.assert_called_once_with("https://en.wikipedia.org/wiki/Giant_panda/")
     else:
-        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert resp.data['error_type'] == NOT_AUTHENTICATED_ERROR_TYPE

--- a/fixtures/users.py
+++ b/fixtures/users.py
@@ -37,17 +37,6 @@ def logged_in_profile(client):
 
 
 @pytest.fixture
-def staff_jwt_token(db, staff_user):
-    """Creates a JWT token for a staff user"""
-    jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-    jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-
-    payload = jwt_payload_handler(staff_user)
-    payload['roles'] = ['staff']
-    return jwt_encode_handler(payload)
-
-
-@pytest.fixture
 def jwt_token(db, user):
     """Creates a JWT token for a regular user"""
     jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
@@ -58,23 +47,18 @@ def jwt_token(db, user):
 
 
 @pytest.fixture
-def staff_jwt_header(staff_jwt_token):
-    """Generate a staff Authorization HTTP header"""
-    return dict(HTTP_AUTHORIZATION='Bearer {}'.format(staff_jwt_token))
-
-
-@pytest.fixture
-def jwt_header(jwt_token):
-    """Generate a nonstaff Authorization HTTP header"""
-    return dict(HTTP_AUTHORIZATION='Bearer {}'.format(jwt_token))
-
-
-@pytest.fixture
 def client(db):
     """
     Similar to the builtin client but this provides the DRF client instead of the Django test client.
     """
     return APIClient()
+
+
+@pytest.fixture
+def user_client(client, user):
+    """Version of the client that is authenticated with the user"""
+    client.force_login(user)
+    return client
 
 
 @pytest.fixture

--- a/open_discussions/constants.py
+++ b/open_discussions/constants.py
@@ -1,0 +1,4 @@
+"""open_discussions constants"""
+
+PERMISSION_DENIED_ERROR_TYPE = 'PermissionDenied'
+NOT_AUTHENTICATED_ERROR_TYPE = 'NotAuthenticated'

--- a/open_discussions/exceptions.py
+++ b/open_discussions/exceptions.py
@@ -1,4 +1,21 @@
 """Exceptions for open discussions"""
+from rest_framework.views import exception_handler
+
+
+def api_exception_handler(exc, context):
+    """
+    Handles API exceptions by appending extra info
+    """
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+
+    # now add the error type to the response
+    # sometimes this is a list() if such an api was called
+    if response is not None and isinstance(response.data, dict):
+        response.data['error_type'] = exc.__class__.__name__
+
+    return response
 
 
 class NoRequestException(Exception):

--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -1,15 +1,12 @@
 """Custom permissions"""
-import jwt
 from prawcore.exceptions import (
     Forbidden as PrawForbidden,
     Redirect as PrawRedirect,
 )
 from rest_framework import permissions
-from rest_framework_jwt.settings import api_settings
-
-from open_discussions import features
 
 from channels.models import Channel
+from open_discussions import features
 
 
 def is_staff_user(request):
@@ -20,20 +17,7 @@ def is_staff_user(request):
     Returns:
         bool: True if user is staff
     """
-    if request.auth is None:
-        if request.user and request.user.is_authenticated:
-            return request.user.is_staff
-
-        return False
-
-    jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
-
-    try:
-        payload = jwt_decode_handler(request.auth)
-    except jwt.InvalidTokenError:
-        return False
-
-    return 'roles' in payload and 'staff' in payload['roles']
+    return request.user is not None and request.user.is_staff
 
 
 def is_moderator(request, view):
@@ -95,8 +79,8 @@ def is_readonly(request):
     return request.method in permissions.SAFE_METHODS
 
 
-class JwtIsStaffPermission(permissions.BasePermission):
-    """Checks the JWT payload for the staff permission"""
+class IsStaffPermission(permissions.BasePermission):
+    """Checks the user for the staff permission"""
 
     def has_permission(self, request, view):
         """Returns True if the user has the staff role"""
@@ -104,7 +88,7 @@ class JwtIsStaffPermission(permissions.BasePermission):
 
 
 class IsStaffOrReadonlyPermission(permissions.BasePermission):
-    """Checks the JWT payload for the staff permission"""
+    """Checks the user for the staff permission"""
 
     def has_permission(self, request, view):
         """Returns True if the user has the staff role or if the request is readonly"""

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -680,9 +680,10 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
     ),
+    'EXCEPTION_HANDLER': 'open_discussions.exceptions.api_exception_handler',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 

--- a/profiles/permissions_test.py
+++ b/profiles/permissions_test.py
@@ -5,12 +5,12 @@ from open_discussions.factories import UserFactory
 from profiles.permissions import HasEditPermission
 
 
-def test_can_edit_profile_staff(mocker, staff_jwt_token, user):
+def test_can_edit_profile_staff(mocker, staff_user):
     """
     Test that staff users are allowed to view/edit profiles
     """
-    request = mocker.Mock(auth=staff_jwt_token, user=user)
-    profile = user.profile
+    request = mocker.Mock(user=staff_user)
+    profile = staff_user.profile
     assert HasEditPermission().has_permission(request, mocker.Mock()) is True
     assert HasEditPermission().has_object_permission(request, mocker.Mock(), profile) is True
 
@@ -23,20 +23,20 @@ def test_can_edit_profile_staff(mocker, staff_jwt_token, user):
     ('PUT', False),
 ])
 @pytest.mark.parametrize('is_super', [True, False])  # pylint: disable=too-many-arguments
-def test_can_edit_other_profile(mocker, method, result, jwt_token, user, is_super):
+def test_can_edit_other_profile(mocker, method, result, user, is_super):
     """
     Test that non-staff users are not allowed to edit another user's profile
     """
-    request = mocker.Mock(auth=jwt_token, user=user, method=method)
+    request = mocker.Mock(user=user, method=method)
     profile = UserFactory.create(is_superuser=is_super).profile
     assert HasEditPermission().has_object_permission(request, mocker.Mock(), profile) is result or is_super
 
 
 @pytest.mark.parametrize('method', ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT'])
-def test_can_edit_own_profile(mocker, method, jwt_token, user):
+def test_can_edit_own_profile(mocker, method, user):
     """
     Test that users are allowed to edit their own profile
     """
-    request = mocker.Mock(auth=jwt_token, user=user, method=method)
+    request = mocker.Mock(user=user, method=method)
     profile = user.profile
     assert HasEditPermission().has_object_permission(request, mocker.Mock(), profile) is True

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from cairosvg import svg2png  # pylint:disable=no-name-in-module
 
-from open_discussions.permissions import JwtIsStaffPermission
+from open_discussions.permissions import IsStaffPermission
 from profiles.models import Profile
 from profiles.permissions import HasEditPermission
 from profiles.serializers import UserSerializer, ProfileSerializer
@@ -19,7 +19,7 @@ from profiles.utils import generate_svg_avatar, DEFAULT_PROFILE_IMAGE
 
 class UserViewSet(viewsets.ModelViewSet):
     """View for users"""
-    permission_classes = (IsAuthenticated, JwtIsStaffPermission,)
+    permission_classes = (IsAuthenticated, IsStaffPermission,)
 
     serializer_class = UserSerializer
     queryset = get_user_model().objects.all()

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -54,7 +54,7 @@ import {
   anyErrorExcept404,
   anyErrorExcept404or410,
   any404Error,
-  any403Error
+  anyNotAuthorizedErrorType
 } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { beginEditing } from "../components/CommentForms"
@@ -507,7 +507,7 @@ const mapStateToProps = (state, ownProps) => {
     post && post.url ? embedly.data.get(post.url) : undefined
 
   const notFound = any404Error([posts, comments])
-  const notAuthorized = any403Error([posts, comments])
+  const notAuthorized = anyNotAuthorizedErrorType([posts, comments])
 
   const loaded = notFound
     ? true

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -40,6 +40,7 @@ import { makeArticle, makeTweet } from "../factories/embedly"
 import * as utilFuncs from "../lib/util"
 import * as embedUtil from "../lib/embed"
 import { truncate } from "../lib/util"
+import { NOT_AUTHORIZED_ERROR_TYPE } from "../util/rest"
 
 describe("PostPage", function() {
   let helper,
@@ -628,8 +629,10 @@ describe("PostPage", function() {
     assert(wrapper.find(NotFound).exists())
   })
 
-  it("should show a 403 page", async () => {
-    helper.getPostStub.returns(Promise.reject({ errorStatusCode: 403 }))
+  it("should show an unauthorized page", async () => {
+    helper.getPostStub.returns(
+      Promise.reject({ error_type: NOT_AUTHORIZED_ERROR_TYPE })
+    )
     const [wrapper] = await renderComponent(
       postDetailURL(channel.name, post.id),
       [

--- a/static/js/lib/fetch_auth.js
+++ b/static/js/lib/fetch_auth.js
@@ -8,6 +8,7 @@ import {
 } from "redux-hammock/django_csrf_fetch"
 
 import { AUTH_REQUIRED_URL } from "./url"
+import { NOT_AUTHENTICATED_ERROR_TYPE } from "../util/rest"
 
 const renewSession = async () => {
   if (SETTINGS.is_authenticated) {
@@ -33,7 +34,7 @@ export const withAuthFailure = (fetchFunc: Function) => async (
   try {
     return await fetchFunc(...args)
   } catch (fetchError) {
-    if (!fetchError || fetchError.errorStatusCode !== 401) {
+    if (!fetchError || fetchError.error_type !== NOT_AUTHENTICATED_ERROR_TYPE) {
       // not an authentication failure, rethrow
       throw fetchError
     }
@@ -75,7 +76,7 @@ export const fetchJSONWithToken = async (
       ...body
     })
   } catch (fetchError) {
-    if (fetchError.errorStatusCode !== 401) {
+    if (fetchError.error_type !== NOT_AUTHENTICATED_ERROR_TYPE) {
       // not an authentication failure, rethrow
       throw fetchError
     }

--- a/static/js/lib/fetch_auth_test.js
+++ b/static/js/lib/fetch_auth_test.js
@@ -7,12 +7,13 @@ import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 import * as auth from "./fetch_auth"
 
 import { AUTH_REQUIRED_URL } from "./url"
+import { NOT_AUTHENTICATED_ERROR_TYPE } from "../util/rest"
 
-describe("auth", function() {
+describe("fetch_auth", function() {
   this.timeout(5000) // eslint-disable-line no-invalid-this
 
   const error500 = { errorStatusCode: 500 }
-  const error401 = { errorStatusCode: 401 }
+  const error401 = { error_type: NOT_AUTHENTICATED_ERROR_TYPE }
   const typeError = new TypeError()
 
   let sandbox, fetchStub

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -35,6 +35,22 @@ const anySpecificError = code =>
   )
 
 export const any404Error = anySpecificError(404)
-export const any403Error = anySpecificError(403)
 export const anyErrorExcept404 = anyErrorExcept([404])
 export const anyErrorExcept404or410 = anyErrorExcept([404, 410])
+
+// 401/403 status codes are unreliable for detecting authentication errors.
+// Our auth endpoints return an error type in the response, and these values
+// can be matched to that error type to properly detect authentication errors.
+export const NOT_AUTHENTICATED_ERROR_TYPE = "NotAuthenticated"
+export const NOT_AUTHORIZED_ERROR_TYPE = "PermissionDenied"
+
+const anySpecificErrorType = errorType =>
+  R.compose(
+    R.any(R.propSatisfies(R.equals(errorType), "error_type")),
+    R.map(R.prop("error")),
+    R.filter(hasError)
+  )
+
+export const anyNotAuthorizedErrorType = anySpecificErrorType(
+  NOT_AUTHORIZED_ERROR_TYPE
+)

--- a/static/js/util/rest_test.js
+++ b/static/js/util/rest_test.js
@@ -7,10 +7,12 @@ import {
   anyError,
   anyErrorExcept404,
   any404Error,
-  any403Error
+  anyNotAuthorizedErrorType,
+  NOT_AUTHORIZED_ERROR_TYPE
 } from "./rest"
 
 const makeError = n => ({ error: { errorStatusCode: n } })
+const makeErrorType = e => ({ error: { error_type: e } })
 
 describe("rest utils", () => {
   describe("anyProcessing", () => {
@@ -122,29 +124,37 @@ describe("rest utils", () => {
     })
   })
 
-  describe("any403Error", () => {
+  describe("anyNotAuthorizedErrorType", () => {
     it("should return false for empty array", () => {
-      assert.isFalse(any403Error([]))
+      assert.isFalse(anyNotAuthorizedErrorType([]))
     })
 
-    it("should return false if all codes are not 404", () => {
+    it("should return false if all codes are not NotAuthorized", () => {
       assert.isFalse(
-        any403Error([
-          makeError(303),
-          makeError(400),
-          makeError(500),
-          { error: {} }
+        anyNotAuthorizedErrorType([
+          makeErrorType("Some"),
+          makeErrorType("Other"),
+          makeErrorType("Error"),
+          { data: {} }
         ])
       )
     })
 
-    it("should return true if some or all codes are 404", () => {
+    it("should return true if some or all codes are NotAuthorized", () => {
       assert.isTrue(
-        any403Error([makeError(403), makeError(500), makeError(4932)])
+        anyNotAuthorizedErrorType([
+          makeErrorType(NOT_AUTHORIZED_ERROR_TYPE),
+          makeErrorType("Not"),
+          makeErrorType("It")
+        ])
       )
 
       assert.isTrue(
-        any403Error([makeError(403), makeError(403), makeError(403)])
+        anyNotAuthorizedErrorType([
+          makeErrorType("Not"),
+          makeErrorType("It"),
+          makeErrorType(NOT_AUTHORIZED_ERROR_TYPE)
+        ])
       )
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1100

#### What's this PR do?

- Swaps the order of the authentication classes
- This caused a change to status code handling for unauthenticated users: status codes that used to be 401 changed to 403 as the first authentication class error handling is used if no auth is provided and a 401 does not make sense for session auth (See https://github.com/encode/django-rest-framework/issues/5968#issuecomment-386519574 and http://www.django-rest-framework.org/api-guide/authentication/#unauthorized-and-forbidden-responses)
- Added an `error_type` field to error responses that serializes the value of `exc.__class__.__name__`
- Updated frontend checks against status codes of 401 and 403 to use this new field (`PostPage.js` and `fetch_auth.js` primarily).

#### How should this be manually tested?
- Verify the app works as usual as a logged in user
  - Particularly, verify that you get the `NotAuthenticated` page if you try to view a private channel you're not a contributor on
- Verify as an unauthenticated user the app works as usual
  - Particularly, verify if you try to visit a channel/post that is private you are prompted to login