### PR TITLE
Show snackbar when user adds/removes a moderator/contributor

### DIFF
--- a/static/js/components/admin/MembersList.js
+++ b/static/js/components/admin/MembersList.js
@@ -18,7 +18,7 @@ type Props = {
   editable: boolean,
   members: Array<Member>,
   usernameGetter: (member: Member) => string,
-  removeMember: (channel: Channel, username: string) => Promise<*>,
+  removeMember: (channel: Channel, member: Member) => Promise<*>,
   memberTypeDescription: string
 }
 
@@ -28,12 +28,12 @@ export default class MembersList extends React.Component<Props> {
       // filter out click event to avoid double execution
       return
     }
-    const { removeMember, channel, memberToRemove, usernameGetter } = this.props
+    const { removeMember, channel, memberToRemove } = this.props
     if (!memberToRemove) {
       throw new Error("Expected memberToRemove to be set")
     }
 
-    return removeMember(channel, usernameGetter(memberToRemove))
+    return removeMember(channel, memberToRemove)
   }
 
   showRemoveDialog = (member: Member): void => {

--- a/static/js/components/admin/MembersList_test.js
+++ b/static/js/components/admin/MembersList_test.js
@@ -163,11 +163,7 @@ describe("MembersList", () => {
             type: "MDCDialog:accept"
           })
           assert.equal(removeMember.callCount, 1)
-          sinon.assert.calledWith(
-            removeMember,
-            channel,
-            usernameGetter(memberToRemove)
-          )
+          sinon.assert.calledWith(removeMember, channel, memberToRemove)
         })
       })
 

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -21,6 +21,7 @@ import { getChannelName } from "../../lib/util"
 import { validateMembersForm } from "../../lib/validation"
 import {
   setDialogData,
+  setSnackbarMessage,
   showDialog,
   hideDialog,
   DIALOG_REMOVE_MEMBER
@@ -37,6 +38,7 @@ const { getForm, actionCreators } = configureForm(
 )
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
+const usernameGetter = R.prop("contributor_name")
 
 type Props = {
   channel: Channel,
@@ -48,7 +50,8 @@ type Props = {
   dialogOpen: boolean,
   setDialogVisibility: (visibility: boolean) => void,
   setDialogData: (data: any) => void,
-  history: Object
+  history: Object,
+  setSnackbarMessage: (obj: Object) => void
 } & WithFormProps<AddMemberForm>
 
 export class EditChannelContributorsPage extends React.Component<Props> {
@@ -82,13 +85,20 @@ export class EditChannelContributorsPage extends React.Component<Props> {
     }
   }
 
+  removeMember = async (channel: Channel, member: Member) => {
+    const { removeMember, setSnackbarMessage } = this.props
+    await removeMember(channel, usernameGetter(member))
+    setSnackbarMessage({
+      message: `Successfully removed ${String(member.email)} as a contributor`
+    })
+  }
+
   render() {
     const {
       renderForm,
       form,
       channel,
       members,
-      removeMember,
       memberToRemove,
       dialogOpen,
       setDialogData,
@@ -120,10 +130,10 @@ export class EditChannelContributorsPage extends React.Component<Props> {
           )}
           <MembersList
             channel={channel}
-            removeMember={removeMember}
+            removeMember={this.removeMember}
             editable={editable}
             members={members}
-            usernameGetter={R.prop("contributor_name")}
+            usernameGetter={usernameGetter}
             memberTypeDescription="contributor"
             memberToRemove={memberToRemove}
             dialogOpen={dialogOpen}
@@ -165,6 +175,9 @@ const addMember = (channel: Channel, email: string) =>
   actions.channelContributors.post(channel.name, email)
 const removeMember = (channel: Channel, username: string) =>
   actions.channelContributors.delete(channel.name, username)
+const onSubmitError = formValidate =>
+  formValidate({ email: `Error adding new contributor` })
+const onSubmit = (channel, { email }) => addMember(channel, email)
 
 const mergeProps = mergeAndInjectProps(
   (
@@ -175,21 +188,24 @@ const mergeProps = mergeAndInjectProps(
       onSubmit,
       onSubmitError,
       formValidate,
-      formBeginEdit
+      formBeginEdit,
+      setSnackbarMessage
     }
   ) => ({
     loadMembers:    () => loadMembers(channelName),
     loadChannel:    () => loadChannel(channelName),
     onSubmitResult: formBeginEdit,
-    onSubmit:       form => onSubmit(channel, form),
-    onSubmitError:  () => onSubmitError(formValidate)
+    onSubmit:       async form => {
+      const newMember = await onSubmit(channel, form)
+      setSnackbarMessage({
+        message: `Successfully added ${
+          newMember.contributor.email
+        } as a contributor`
+      })
+    },
+    onSubmitError: () => onSubmitError(formValidate)
   })
 )
-
-const onSubmitError = formValidate =>
-  formValidate({ email: `Error adding new contributor` })
-
-const onSubmit = (channel, { email }) => addMember(channel, email)
 
 export default R.compose(
   connect(
@@ -201,6 +217,7 @@ export default R.compose(
       removeMember,
       onSubmit,
       onSubmitError,
+      setSnackbarMessage,
       setDialogData: (data: any) =>
         setDialogData({ dialogKey: DIALOG_REMOVE_MEMBER, data: data }),
       setDialogVisibility: (visibility: boolean) =>

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -31,7 +31,7 @@ import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
 import type { WithFormProps } from "../../flow/formTypes"
 import { channelURL } from "../../lib/url"
 
-const CONTRIBUTORS_KEY = "channel:edit:contributors"
+export const CONTRIBUTORS_KEY = "channel:edit:contributors"
 const { getForm, actionCreators } = configureForm(
   CONTRIBUTORS_KEY,
   newMemberForm

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -31,7 +31,7 @@ import {
 import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
 import type { WithFormProps } from "../../flow/formTypes"
 
-const MODERATORS_KEY = "channel:edit:moderators"
+export const MODERATORS_KEY = "channel:edit:moderators"
 const { getForm, actionCreators } = configureForm(MODERATORS_KEY, newMemberForm)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -22,6 +22,7 @@ import { getChannelName } from "../../lib/util"
 import { validateMembersForm } from "../../lib/validation"
 import {
   setDialogData,
+  setSnackbarMessage,
   showDialog,
   hideDialog,
   DIALOG_REMOVE_MEMBER
@@ -34,6 +35,7 @@ const MODERATORS_KEY = "channel:edit:moderators"
 const { getForm, actionCreators } = configureForm(MODERATORS_KEY, newMemberForm)
 
 const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
+const usernameGetter = R.prop("moderator_name")
 
 type Props = {
   channel: Channel,
@@ -45,7 +47,8 @@ type Props = {
   dialogOpen: boolean,
   setDialogVisibility: (visibility: boolean) => void,
   setDialogData: (data: any) => void,
-  history: Object
+  history: Object,
+  setSnackbarMessage: (obj: Object) => void
 } & WithFormProps<AddMemberForm>
 
 export class EditChannelModeratorsPage extends React.Component<Props> {
@@ -79,10 +82,13 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
     }
   }
 
-  removeMember = async (channel: Channel, email: string) => {
-    const { removeMember } = this.props
-    await removeMember(channel, email)
+  removeMember = async (channel: Channel, member: Member) => {
+    const { removeMember, setSnackbarMessage } = this.props
+    await removeMember(channel, usernameGetter(member))
     this.validateModerator()
+    setSnackbarMessage({
+      message: `Successfully removed ${String(member.email)} as a moderator`
+    })
   }
 
   render() {
@@ -125,7 +131,7 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
             removeMember={this.removeMember}
             editable={editable}
             members={members}
-            usernameGetter={R.prop("moderator_name")}
+            usernameGetter={usernameGetter}
             memberTypeDescription="moderator"
             memberToRemove={memberToRemove}
             dialogOpen={dialogOpen}
@@ -167,24 +173,36 @@ const addMember = (channel: Channel, email: string) =>
   actions.channelModerators.post(channel.name, email)
 const removeMember = (channel: Channel, username: string) =>
   actions.channelModerators.delete(channel.name, username)
+const onSubmitError = formValidate =>
+  formValidate({ email: `Error adding new moderator` })
+const onSubmit = (channel, { email }) => addMember(channel, email)
 
 const mergeProps = mergeAndInjectProps(
   (
     { channelName, channel },
-    { loadMembers, loadChannel, onSubmit, formValidate, formBeginEdit }
+    {
+      loadMembers,
+      loadChannel,
+      onSubmit,
+      formValidate,
+      formBeginEdit,
+      setSnackbarMessage
+    }
   ) => ({
     loadMembers:    () => loadMembers(channelName),
     loadChannel:    () => loadChannel(channelName),
     onSubmitResult: formBeginEdit,
-    onSubmit:       form => onSubmit(channel, form),
-    onSubmitError:  () => onSubmitError(formValidate)
+    onSubmit:       async form => {
+      const newMember = await onSubmit(channel, form)
+      setSnackbarMessage({
+        message: `Successfully added ${
+          newMember.moderator.email
+        } as a moderator`
+      })
+    },
+    onSubmitError: () => onSubmitError(formValidate)
   })
 )
-
-const onSubmitError = formValidate =>
-  formValidate({ email: `Error adding new moderator` })
-
-const onSubmit = (channel, { email }) => addMember(channel, email)
 
 export default R.compose(
   connect(
@@ -196,6 +214,7 @@ export default R.compose(
       removeMember,
       onSubmit,
       onSubmitError,
+      setSnackbarMessage,
       setDialogData: (data: any) =>
         setDialogData({ dialogKey: DIALOG_REMOVE_MEMBER, data: data }),
       setDialogVisibility: (visibility: boolean) =>

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -1,6 +1,12 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
+import R from "ramda"
+
+import EditChannelModeratorsPage, {
+  EditChannelModeratorsPage as InnerEditChannelModeratorsPage,
+  MODERATORS_KEY
+} from "./EditChannelModeratorsPage"
 
 import {
   makeChannel,
@@ -9,20 +15,34 @@ import {
 } from "../../factories/channels"
 import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
-import { SHOW_DIALOG, SET_DIALOG_DATA } from "../../actions/ui"
+import { FORM_VALIDATE, FORM_UPDATE } from "../../actions/forms"
+import {
+  DIALOG_REMOVE_MEMBER,
+  SHOW_DIALOG,
+  HIDE_DIALOG,
+  SET_DIALOG_DATA,
+  SET_SNACKBAR_MESSAGE
+} from "../../actions/ui"
+
 import { newMemberForm } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { editChannelModeratorsURL, channelURL } from "../../lib/url"
+import { wait } from "../../lib/util"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 
 describe("EditChannelModeratorsPage", () => {
-  let helper, renderComponent, listenForActions, channel, moderators
+  let helper, renderPage, channel, moderators
 
   beforeEach(() => {
     channel = makeChannel()
     channel.user_is_moderator = true
-    moderators = makeModerators()
+    moderators = makeModerators(null, true)
     helper = new IntegrationTestHelper()
+    renderPage = helper.configureHOCRenderer(
+      EditChannelModeratorsPage,
+      InnerEditChannelModeratorsPage,
+      {}
+    )
     helper.getChannelStub.returns(Promise.resolve(channel))
     helper.getChannelsStub.returns(Promise.resolve([channel]))
     helper.getChannelModeratorsStub.returns(Promise.resolve(moderators))
@@ -39,8 +59,6 @@ describe("EditChannelModeratorsPage", () => {
       })
     )
     helper.getProfileStub.returns(Promise.resolve(""))
-    renderComponent = helper.renderComponent.bind(helper)
-    listenForActions = helper.listenForActions.bind(helper)
     window.scrollTo = helper.sandbox.stub()
   })
 
@@ -48,43 +66,60 @@ describe("EditChannelModeratorsPage", () => {
     helper.cleanup()
   })
 
-  const renderPage = async (extraActions = []) => {
-    const [wrapper] = await renderComponent(
-      editChannelModeratorsURL(channel.name),
-      [
-        actions.subscribedChannels.get.requestType,
-        actions.subscribedChannels.get.successType,
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
-        actions.channelModerators.get.requestType,
-        actions.channelModerators.get.successType,
-        actions.profiles.get.requestType,
-        actions.profiles.get.successType,
-        SET_CHANNEL_DATA,
-        actions.forms.FORM_BEGIN_EDIT,
-        ...extraActions
-      ]
+  const render = (extraProps = {}, extraState = {}) =>
+    renderPage(
+      R.mergeDeepRight(
+        {
+          channels: {
+            data:       new Map([[channel.name, channel]]),
+            processing: false
+          },
+          channelModerators: {
+            processing: false,
+            data:       new Map([[channel.name, moderators]])
+          },
+          forms: {
+            [MODERATORS_KEY]: {
+              value:  newMemberForm(),
+              errors: {}
+            }
+          },
+          ui: {
+            dialogs: new Map()
+          }
+        },
+        extraProps
+      ),
+      R.mergeDeepRight(
+        {
+          match: {
+            params: {
+              channelName: channel.name
+            }
+          },
+          channel: channel
+        },
+        extraState
+      )
     )
-    return wrapper.update()
-  }
 
   it("should set the document title", async () => {
-    await renderPage()
-    assert.equal(document.title, formatTitle("Edit Channel"))
+    const { inner } = await render()
+    assert.equal(inner.find("title").text(), formatTitle("Edit Channel"))
   })
 
   it("displays a notice that membership is managed by micromasters", async () => {
     channel.membership_is_managed = true
-    const wrapper = await renderPage()
+    const { inner } = await render()
     assert.equal(
-      wrapper.find(".membership-notice").text(),
+      inner.find(".membership-notice").text(),
       "Membership is managed via MicroMasters"
     )
   })
 
   it("renders the member list", async () => {
-    const wrapper = await renderPage()
-    const props = wrapper.find("MembersList").props()
+    const { inner } = await render()
+    const props = inner.find("MembersList").props()
     assert.deepEqual(props.members, moderators)
     assert.equal(props.editable, !channel.membership_is_managed)
     assert.equal(
@@ -95,16 +130,44 @@ describe("EditChannelModeratorsPage", () => {
     assert.equal(props.memberTypeDescription, "moderator")
   })
 
-  it("redirects if the user is not a moderator", async () => {
-    channel.user_is_moderator = false
-    await renderPage([
-      actions.channels.get.requestType,
-      actions.channels.get.successType,
-      actions.forms.FORM_END_EDIT
-    ])
+  describe("mounted tests", () => {
+    let mountedRenderComponent
 
-    const history = helper.browserHistory
-    assert.equal(history.location.pathname, channelURL(channel.name))
+    beforeEach(() => {
+      mountedRenderComponent = helper.renderComponent.bind(helper)
+    })
+
+    const mountedRenderPage = async (extraActions = []) => {
+      const [wrapper] = await mountedRenderComponent(
+        editChannelModeratorsURL(channel.name),
+        [
+          actions.subscribedChannels.get.requestType,
+          actions.subscribedChannels.get.successType,
+          actions.channels.get.requestType,
+          actions.channels.get.successType,
+          actions.channelModerators.get.requestType,
+          actions.channelModerators.get.successType,
+          actions.profiles.get.requestType,
+          actions.profiles.get.successType,
+          SET_CHANNEL_DATA,
+          actions.forms.FORM_BEGIN_EDIT,
+          ...extraActions
+        ]
+      )
+      return wrapper.update()
+    }
+
+    it("redirects if the user is not a moderator", async () => {
+      channel.user_is_moderator = false
+      await mountedRenderPage([
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
+        actions.forms.FORM_END_EDIT
+      ])
+
+      const history = helper.browserHistory
+      assert.equal(history.location.pathname, channelURL(channel.name))
+    })
   })
 
   describe("editable", () => {
@@ -113,155 +176,190 @@ describe("EditChannelModeratorsPage", () => {
     })
 
     it("renders the form", async () => {
-      const wrapper = await renderPage()
-      const props = wrapper.find("EditChannelMembersForm").props()
+      const { inner } = await render()
+      const props = inner.find("EditChannelMembersForm").props()
       assert.deepEqual(props.memberTypeDescription, "moderator")
       assert.deepEqual(props.form, newMemberForm())
     })
 
-    it("tries to add a new moderator but fails validation", async () => {
-      const wrapper = await renderPage()
-      await listenForActions([actions.forms.FORM_VALIDATE], () => {
-        wrapper
-          .find("form")
-          .props()
-          .onSubmit({ preventDefault: helper.sandbox.stub() })
-      })
+    it("updates the email", async () => {
+      const { inner, store } = await render()
+      const props = inner.find("EditChannelMembersForm").props()
+      const email = "new@email.com"
+      props.onUpdate({ target: { name: "email", value: email } })
 
-      assert.equal(
-        helper.store.getState().forms["channel:edit:moderators"].errors.email,
-        "Email must not be blank"
-      )
+      const actions = store.getActions()
+      assert.deepEqual(actions[actions.length - 1], {
+        type:    FORM_UPDATE,
+        payload: {
+          formKey: MODERATORS_KEY,
+          value:   { email }
+        }
+      })
     })
 
     it("tries to add a new moderator but the API request fails", async () => {
-      const wrapper = await renderPage()
+      helper.addChannelModeratorStub.returns(Promise.reject("an error"))
+
       const email = "new@email.com"
-
-      helper.addChannelModeratorStub.returns(Promise.reject())
-
-      wrapper
-        .find("input[name='email']")
-        .props()
-        .onChange({
-          target: { name: "email", value: email }
-        })
-      await listenForActions(
-        [
-          actions.channelModerators.post.requestType,
-          actions.channelModerators.post.failureType,
-          actions.forms.FORM_VALIDATE,
-          actions.forms.FORM_VALIDATE
-        ],
-        () => {
-          wrapper
-            .find("form")
-            .props()
-            .onSubmit({ preventDefault: helper.sandbox.stub() })
+      const { inner, store } = await render({
+        forms: {
+          [MODERATORS_KEY]: {
+            value: {
+              email
+            },
+            errors: {}
+          }
         }
-      )
+      })
 
+      const props = inner.find("EditChannelMembersForm").props()
+      props.onSubmit({ preventDefault: helper.sandbox.stub() })
+
+      // let promise resolve
+      await wait(0)
       sinon.assert.calledWith(
         helper.addChannelModeratorStub,
         channel.name,
         email
       )
-      assert.equal(
-        helper.store.getState().forms["channel:edit:moderators"].errors.email,
-        "Error adding new moderator"
-      )
+
+      const actions = store.getActions()
+      assert.deepEqual(actions[actions.length - 1], {
+        type:    FORM_VALIDATE,
+        payload: {
+          formKey: MODERATORS_KEY,
+          errors:  {
+            email: "Error adding new moderator"
+          }
+        }
+      })
     })
 
     it("adds a new moderator", async () => {
-      const wrapper = await renderPage()
-      const email = "new@email.com"
-
-      const newModerator = makeModerator()
+      const newModerator = makeModerator(null, true)
       helper.addChannelModeratorStub.returns(Promise.resolve(newModerator))
 
-      wrapper
-        .find("input[name='email']")
-        .props()
-        .onChange({
-          target: { name: "email", value: email }
-        })
-      await listenForActions(
-        [
-          actions.channelModerators.post.requestType,
-          actions.channelModerators.post.successType,
-          actions.forms.FORM_VALIDATE
-        ],
-        () => {
-          wrapper
-            .find("form")
-            .props()
-            .onSubmit({ preventDefault: helper.sandbox.stub() })
+      const email = "new@email.com"
+      const { inner, store } = await render({
+        forms: {
+          [MODERATORS_KEY]: {
+            value: {
+              email
+            },
+            errors: {}
+          }
         }
-      )
+      })
 
+      inner
+        .find("EditChannelMembersForm")
+        .props()
+        .onSubmit({ preventDefault: helper.sandbox.stub() })
+
+      await wait(0)
       sinon.assert.calledWith(
         helper.addChannelModeratorStub,
         channel.name,
         email
       )
+
+      const actions = store.getActions()
+      assert.deepEqual(actions[actions.length - 2], {
+        type:    SET_SNACKBAR_MESSAGE,
+        payload: {
+          message: `Successfully added ${String(
+            newModerator.email
+          )} as a moderator`
+        }
+      })
     })
-    ;[true, false].forEach(isYou => {
-      it(`removes ${
-        isYou ? "yourself from being a moderator" : "a moderator"
-      }`, async () => {
-        const wrapper = await renderPage()
+  })
+  ;[true, false].forEach(isYou => {
+    it(`removes ${
+      isYou ? "yourself from being a moderator" : "a moderator"
+    }`, async () => {
+      const { inner, store } = await render(
+        {},
+        { history: helper.browserHistory }
+      )
 
-        helper.deleteChannelModeratorStub.returns(Promise.resolve())
+      helper.deleteChannelModeratorStub.returns(Promise.resolve())
 
-        const redirectActions = isYou
-          ? [
-            actions.channels.get.requestType,
-            actions.channels.get.successType,
-            actions.forms.FORM_END_EDIT
-          ]
-          : []
-        await listenForActions(
-          [
-            SHOW_DIALOG,
-            SET_DIALOG_DATA,
-            actions.channelModerators.delete.requestType,
-            actions.channelModerators.delete.successType,
-            ...redirectActions
-          ],
-          () => {
-            if (isYou) {
-              // this will be checked after the refresh
-              channel.user_is_moderator = false
-              helper.getChannelStub.returns(Promise.resolve(channel))
-            }
-            wrapper
-              .find(".remove")
-              .first()
-              .props()
-              .onClick({ preventDefault: helper.sandbox.stub() })
+      if (isYou) {
+        // this will be checked after the refresh
+        channel.user_is_moderator = false
+        helper.getChannelStub.returns(Promise.resolve(channel))
+      }
+      inner
+        .find("MembersList")
+        .props()
+        .removeMember(channel, moderators[0])
 
-            wrapper.update()
-            wrapper
-              .find("#remove-member button.edit-button")
-              .props()
-              .onClick({
-                type: "MDCDialog:accept"
-              })
-          }
-        )
-
-        sinon.assert.calledWith(
-          helper.deleteChannelModeratorStub,
-          channel.name,
-          moderators[0].moderator_name
-        )
+      // wait for promise to resolve
+      await wait(0)
+      sinon.assert.calledWith(
+        helper.deleteChannelModeratorStub,
+        channel.name,
+        moderators[0].moderator_name
+      )
+      if (isYou) {
         assert.equal(
           helper.browserHistory.location.pathname,
-          isYou
-            ? channelURL(channel.name)
-            : editChannelModeratorsURL(channel.name)
+          channelURL(channel.name)
         )
+      }
+
+      const actions = store.getActions()
+
+      assert.deepEqual(actions[actions.length - 2], {
+        type:    SET_SNACKBAR_MESSAGE,
+        payload: {
+          message: `Successfully removed ${String(
+            moderators[0].email
+          )} as a moderator`
+        }
       })
+    })
+  })
+  ;[true, false].forEach(hasDialog => {
+    it(`passes a dialog value of ${String(hasDialog)}`, async () => {
+      const { inner } = await render({
+        ui: {
+          dialogs: new Map(hasDialog ? [[DIALOG_REMOVE_MEMBER, true]] : [])
+        }
+      })
+
+      assert.equal(inner.find("MembersList").props().dialogOpen, hasDialog)
+    })
+  })
+  ;[true, false].forEach(dialogVisibility => {
+    it(`sets dialog visibility to ${String(dialogVisibility)}`, async () => {
+      const { inner, store } = await render()
+      inner
+        .find("MembersList")
+        .props()
+        .setDialogVisibility(dialogVisibility)
+
+      const actions = store.getActions()
+      assert.deepEqual(actions[actions.length - 1], {
+        type:    dialogVisibility ? SHOW_DIALOG : HIDE_DIALOG,
+        payload: DIALOG_REMOVE_MEMBER
+      })
+    })
+  })
+
+  it("sets dialog data", async () => {
+    const { inner, store } = await render()
+    const data = { a: "data" }
+    inner
+      .find("MembersList")
+      .props()
+      .setDialogData(data)
+    const actions = store.getActions()
+    assert.deepEqual(actions[actions.length - 1], {
+      type:    SET_DIALOG_DATA,
+      payload: { data, dialogKey: DIALOG_REMOVE_MEMBER }
     })
   })
 })

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -214,10 +214,7 @@ describe("EditChannelModeratorsPage", () => {
       })
 
       const props = inner.find("EditChannelMembersForm").props()
-      props.onSubmit({ preventDefault: helper.sandbox.stub() })
-
-      // let promise resolve
-      await wait(0)
+      await props.onSubmit({ preventDefault: helper.sandbox.stub() })
       sinon.assert.calledWith(
         helper.addChannelModeratorStub,
         channel.name,

--- a/static/js/hoc/withSingleColumn.js
+++ b/static/js/hoc/withSingleColumn.js
@@ -17,7 +17,7 @@ const withSingleColumn = R.curry(
     }
 
     WithSingleColumn.WrappedComponent = WrappedComponent
-
+    WithSingleColumn.displayName = `withSingleColumn(${WrappedComponent.name})`
     return WithSingleColumn
   }
 )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1068 

#### What's this PR do?
Shows the snackbar with an appropriate success message when the user adds or removes a moderator or contributor

#### How should this be manually tested?
Add and remove moderators and contributors

#### Any background context you want to provide?
The PR is split in two commits, the first which adds the functionality and the second larger one which adds tests and does refactoring to move away from integration tests
