### PR TITLE
Fixed incorrect password UI bug

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -35,6 +35,9 @@ export const showDropdown = createAction(SHOW_DROPDOWN)
 export const HIDE_DROPDOWN = "HIDE_DROPDOWN"
 export const hideDropdown = createAction(HIDE_DROPDOWN)
 
+export const SET_AUTH_USER_DETAIL = "SET_AUTH_USER_DETAIL"
+export const setAuthUserDetail = createAction(SET_AUTH_USER_DETAIL)
+
 // this is a hack :/
 // needed to debounce just a little bit to get around a race
 // condition with the post dropdown menu

--- a/static/js/containers/PasswordChangePage_test.js
+++ b/static/js/containers/PasswordChangePage_test.js
@@ -75,11 +75,11 @@ describe("PasswordChangePage", () => {
 
     const { onSubmit } = inner.find("PasswordChangeForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.passwordChange.post.requestType

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -5,11 +5,13 @@ import { assert } from "chai"
 import sinon from "sinon"
 
 import { actions } from "../../actions"
+import { SET_AUTH_USER_DETAIL } from "../../actions/ui"
 import { FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import ConnectedLoginPage, { LoginPage, FORM_KEY } from "./LoginPage"
 import { REGISTER_URL } from "../../lib/url"
 
+const TEST_EMAIL = "test@example.com"
 const DEFAULT_STATE = {
   auth: {
     data:       {},
@@ -18,7 +20,7 @@ const DEFAULT_STATE = {
   forms: {
     [FORM_KEY]: {
       value: {
-        email: "test@example.com"
+        email: TEST_EMAIL
       },
       errors: {}
     }
@@ -101,17 +103,43 @@ describe("LoginPage", () => {
 
     const { onSubmit } = inner.find("AuthEmailForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(dispatchedActions[2].type, actions.auth.loginEmail.requestType)
     sinon.assert.calledOnce(helper.postEmailLoginStub)
-    sinon.assert.calledWith(
-      helper.postEmailLoginStub,
-      FLOW_LOGIN,
-      "test@example.com"
+    sinon.assert.calledWith(helper.postEmailLoginStub, FLOW_LOGIN, TEST_EMAIL)
+  })
+
+  it("sets some detail in the state about the user after form submission", async () => {
+    const extraData = {
+      name:                "Testuser",
+      profile_image_small: "http://example.com/abc.jpg"
+    }
+    const { inner, store } = await renderPage()
+
+    const { onSubmit } = inner.find("AuthEmailForm").props()
+
+    helper.postEmailLoginStub.returns(
+      Promise.resolve({
+        flow:       FLOW_LOGIN,
+        state:      STATE_SUCCESS,
+        extra_data: extraData
+      })
     )
+
+    await onSubmit()
+
+    const dispatchedActions = store.getActions()
+
+    assert.isAtLeast(dispatchedActions.length, 5)
+    const authDetailAction = dispatchedActions[4]
+    assert.equal(authDetailAction.type, SET_AUTH_USER_DETAIL)
+    assert.deepEqual(authDetailAction.payload, {
+      email: TEST_EMAIL,
+      ...extraData
+    })
   })
 })

--- a/static/js/containers/auth/LoginPasswordPage.js
+++ b/static/js/containers/auth/LoginPasswordPage.js
@@ -18,12 +18,14 @@ import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
   getAuthPartialTokenSelector,
   getAuthFlowSelector,
-  getAuthEmailSelector,
   isProcessing,
-  getFormErrorSelector,
-  getAuthNameSelector,
-  getAuthProfileImageSelector
+  getFormErrorSelector
 } from "../../reducers/auth"
+import {
+  getAuthUiNameSelector,
+  getAuthUiEmailSelector,
+  getAuthUiImgSelector
+} from "../../reducers/ui"
 
 import type { PasswordForm, AuthFlow } from "../../flow/authTypes"
 import type { WithFormProps } from "../../flow/formTypes"
@@ -102,9 +104,9 @@ const mapStateToProps = state => {
   const authFlow = getAuthFlowSelector(state)
   const partialToken = getAuthPartialTokenSelector(state)
   const formError = getFormErrorSelector(state)
-  const email = getAuthEmailSelector(state)
-  const name = getAuthNameSelector(state)
-  const profileImageUrl = getAuthProfileImageSelector(state)
+  const name = getAuthUiNameSelector(state)
+  const email = getAuthUiEmailSelector(state)
+  const profileImageUrl = getAuthUiImgSelector(state)
   return {
     form,
     partialToken,

--- a/static/js/containers/auth/LoginPasswordPage_test.js
+++ b/static/js/containers/auth/LoginPasswordPage_test.js
@@ -27,6 +27,9 @@ const DEFAULT_STATE = {
       },
       errors: {}
     }
+  },
+  ui: {
+    authUserDetail: {}
   }
 }
 
@@ -63,21 +66,17 @@ describe("LoginPasswordPage", () => {
     [undefined, undefined, "a@b.com", "does not exist"]
   ].forEach(([extraDataName, extraDataImg, email, descriptor]) => {
     it(`should render the page with correct messages when extra user data ${descriptor}`, async () => {
-      const expectedProfileInfo = R.none(R.isNil)([extraDataName, extraDataImg])
-      let expectedGreeting, extraData
-      if (expectedProfileInfo) {
-        expectedGreeting = `Hi ${String(extraDataName)}`
-        extraData = { name: extraDataName, profile_image_small: extraDataImg }
-      } else {
-        expectedGreeting = "Welcome Back!"
-        extraData = null
-      }
+      const expectedProfileInfo = R.none(R.isNil, [extraDataName, extraDataImg])
+      const expectedGreeting = expectedProfileInfo
+        ? `Hi ${String(extraDataName)}`
+        : "Welcome Back!"
 
       const { inner } = await renderPage({
-        auth: {
-          data: {
-            email:      email,
-            extra_data: extraData
+        ui: {
+          authUserDetail: {
+            email:               email,
+            name:                extraDataName,
+            profile_image_small: extraDataImg
           }
         }
       })
@@ -132,11 +131,11 @@ describe("LoginPasswordPage", () => {
 
     const { onSubmit } = inner.find("AuthPasswordForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.auth.loginPassword.requestType

--- a/static/js/containers/auth/PasswordResetConfirmPage_test.js
+++ b/static/js/containers/auth/PasswordResetConfirmPage_test.js
@@ -78,11 +78,11 @@ describe("PasswordResetConfirmPage", () => {
 
     const { onSubmit } = inner.find("PasswordResetConfirmForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.passwordReset.postNewPassword.requestType

--- a/static/js/containers/auth/PasswordResetPage_test.js
+++ b/static/js/containers/auth/PasswordResetPage_test.js
@@ -74,11 +74,11 @@ describe("PasswordResetPage", () => {
 
     const { onSubmit } = inner.find("PasswordResetForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.passwordReset.postEmail.requestType

--- a/static/js/containers/auth/RegisterDetailsPage_test.js
+++ b/static/js/containers/auth/RegisterDetailsPage_test.js
@@ -71,11 +71,11 @@ describe("RegisterDetailsPage", () => {
 
     const { onSubmit } = inner.find("AuthDetailsForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.auth.registerDetails.requestType

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -88,11 +88,11 @@ describe("RegisterPage", () => {
 
     const { onSubmit } = inner.find("AuthEmailForm").props()
 
-    onSubmit()
+    await onSubmit()
 
     const dispatchedActions = store.getActions()
 
-    assert.lengthOf(dispatchedActions, 3)
+    assert.isAtLeast(dispatchedActions.length, 3)
     assert.equal(
       dispatchedActions[2].type,
       actions.auth.registerEmail.requestType

--- a/static/js/reducers/auth.js
+++ b/static/js/reducers/auth.js
@@ -29,25 +29,11 @@ export const getAuthPartialTokenSelector = R.path([
   "partial_token"
 ])
 export const getAuthFlowSelector = R.path(["auth", "data", "flow"])
-export const getAuthStateSelector = R.path(["auth", "data", "state"])
 export const getAuthProviderSelector = R.path(["auth", "data", "provider"])
-export const getAuthEmailSelector = R.path(["auth", "data", "email"])
 export const getFormErrorSelector = R.compose(
   R.head,
   R.pathOr([], ["auth", "data", "errors"])
 )
-export const getAuthNameSelector = R.path([
-  "auth",
-  "data",
-  "extra_data",
-  "name"
-])
-export const getAuthProfileImageSelector = R.path([
-  "auth",
-  "data",
-  "extra_data",
-  "profile_image_small"
-])
 export const isProcessing = R.path(["auth", "processing"])
 
 export const authEndpoint = {

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -11,7 +11,8 @@ import {
   HIDE_DIALOG,
   SHOW_DROPDOWN,
   HIDE_DROPDOWN,
-  SET_DIALOG_DATA
+  SET_DIALOG_DATA,
+  SET_AUTH_USER_DETAIL
 } from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
@@ -34,7 +35,8 @@ export type UIState = {
   snackbar: ?SnackbarState,
   banner: BannerState,
   dialogs: Map<string, any>,
-  dropdownMenus: Set<string>
+  dropdownMenus: Set<string>,
+  authUserDetail: Object
 }
 
 const INITIAL_BANNER_STATE = {
@@ -48,7 +50,8 @@ export const INITIAL_UI_STATE: UIState = {
   snackbar:          null,
   banner:            INITIAL_BANNER_STATE,
   dialogs:           new Map(),
-  dropdownMenus:     new Set()
+  dropdownMenus:     new Set(),
+  authUserDetail:    {}
 }
 
 // this generates a new sequential id for each snackbar state that is pushed
@@ -87,6 +90,14 @@ const setDialogData = (
   copy.set(dialogKey, data)
   return copy
 }
+
+export const getAuthUiNameSelector = R.path(["ui", "authUserDetail", "name"])
+export const getAuthUiEmailSelector = R.path(["ui", "authUserDetail", "email"])
+export const getAuthUiImgSelector = R.path([
+  "ui",
+  "authUserDetail",
+  "profile_image_small"
+])
 
 export const ui = (
   state: UIState = INITIAL_UI_STATE,
@@ -157,6 +168,11 @@ export const ui = (
         action.payload,
         false
       )
+    }
+  case SET_AUTH_USER_DETAIL:
+    return {
+      ...state,
+      authUserDetail: action.payload
     }
   }
   return state


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1085 

#### What's this PR do?
Fixes a bug where entering an incorrect password removed the greeting, profile image, and email from the password login UI

#### How should this be manually tested?
Enter a bad password using the email auth flow, make sure that the profile image/greeting/email address are all still visible

#### Any background context you want to provide?
I made several changes to JS test files that are not directly related to the bugfix. @rhysyngsun and I discovered that our tests for form submission events were not properly accounting for asynchronous requests, and that usage was preventing the testing of the action I added in this PR. It was an easy enough fix for the rest of the test cases so I went ahead and did that as part of this PR

#### Screenshots (if appropriate)
<img width="496" alt="ss 2018-08-20 at 13 55 48" src="https://user-images.githubusercontent.com/14932219/44357721-c86a9f00-a480-11e8-9005-2246efa5625d.png">

