### PR TITLE
add material grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@material/button": "^0.3.11",
     "@material/dialog": "^0.27.0",
     "@material/drawer": "^0.36.0",
+    "@material/layout-grid": "^0.34.0",
     "@material/list": "^0.2.14",
     "@material/menu": "^0.4.3",
     "@material/radio": "^0.30.0",

--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -1,0 +1,55 @@
+// @flow
+import React from "react"
+
+type GridProps = {
+  children: any,
+  className?: string
+}
+
+const gridClassName = (className: ?string) =>
+  `mdc-layout-grid ${className || ""}`.trim()
+
+export const Grid = ({ children, className }: GridProps) => (
+  <div className={gridClassName(className)}>
+    <div className="mdc-layout-grid__inner">{children}</div>
+  </div>
+)
+
+// these are the cell widths that the material grid supports
+// this is cumbersome, but it lets us have some assurance from Flow
+// that we're always passing a good value
+const one: 1 = 1
+const two: 2 = 2
+const three: 3 = 3
+const four: 4 = 4
+const five: 5 = 5
+const six: 6 = 6
+const seven: 7 = 7
+const eight: 8 = 8
+const nine: 9 = 9
+const ten: 10 = 10
+const eleven: 11 = 11
+const twelve: 12 = 12
+
+type CellWidth =
+  | typeof one
+  | typeof two
+  | typeof three
+  | typeof four
+  | typeof five
+  | typeof six
+  | typeof seven
+  | typeof eight
+  | typeof nine
+  | typeof ten
+  | typeof eleven
+  | typeof twelve
+
+type CellProps = {
+  children: React$Element<*>,
+  width: CellWidth
+}
+
+export const Cell = ({ children, width }: CellProps) => (
+  <div className={`mdc-layout-grid__cell--span-${width}`}>{children}</div>
+)

--- a/static/js/components/Grid_test.js
+++ b/static/js/components/Grid_test.js
@@ -1,0 +1,35 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import { Grid, Cell } from "./Grid"
+
+describe("Grid components", () => {
+  it("should render a grid with children", () => {
+    const wrapper = shallow(
+      <Grid>
+        <div className="child" />
+      </Grid>
+    )
+    assert.equal(wrapper.props().className, "mdc-layout-grid")
+    assert.ok(wrapper.find(".mdc-layout-grid__inner").exists())
+    assert.ok(wrapper.find(".child").exists())
+  })
+
+  //
+  ;[1, 12].forEach(width => {
+    it(`should create a cell with width ${width}`, () => {
+      const wrapper = shallow(
+        <Cell width={width}>
+          <div className="child" />
+        </Cell>
+      )
+      assert.equal(
+        wrapper.props().className,
+        `mdc-layout-grid__cell--span-${width}`
+      )
+      assert.ok(wrapper.find(".child").exists())
+    })
+  })
+})

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -247,6 +247,12 @@ describe("ChannelPage", () => {
       SET_CHANNEL_DATA
     ])
     assert.isFalse(wrapper.find(NotFound).exists())
-    assert.include(wrapper.find(".main-content").text(), "Error loading page")
+    assert.include(
+      wrapper
+        .find(".main-content")
+        .at(0)
+        .text(),
+      "Error loading page"
+    )
   })
 })

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -696,7 +696,13 @@ describe("PostPage", function() {
         SET_CHANNEL_DATA
       ]
     )
-    assert.equal(wrapper.find(".main-content").text(), "Error loading page")
+    assert.equal(
+      wrapper
+        .find(".main-content")
+        .at(0)
+        .text(),
+      "Error loading page"
+    )
     assert.isFalse(wrapper.find(NotFound).exists())
   })
 

--- a/static/js/hoc/withChannelSidebar.js
+++ b/static/js/hoc/withChannelSidebar.js
@@ -4,6 +4,7 @@ import R from "ramda"
 
 import ChannelSidebar from "../components/ChannelSidebar"
 import Sidebar from "../components/Sidebar"
+import { Grid, Cell } from "../components/Grid"
 
 const withChannelSidebar = R.curry(
   (className: string, WrappedComponent: Class<React.Component<*, *>>) => {
@@ -12,12 +13,16 @@ const withChannelSidebar = R.curry(
 
       render() {
         return (
-          <div className={`main-content two-column ${className}`}>
-            <WrappedComponent {...this.props} />
-            <Sidebar className="sidebar-right">
-              <ChannelSidebar {...this.props} />
-            </Sidebar>
-          </div>
+          <Grid className={`main-content two-column ${className}`}>
+            <Cell width={8}>
+              <WrappedComponent {...this.props} />
+            </Cell>
+            <Cell width={4}>
+              <Sidebar className="sidebar-right">
+                <ChannelSidebar {...this.props} />
+              </Sidebar>
+            </Cell>
+          </Grid>
         )
       }
     }

--- a/static/js/hoc/withSingleColumn.js
+++ b/static/js/hoc/withSingleColumn.js
@@ -2,6 +2,8 @@
 import React from "react"
 import R from "ramda"
 
+import { Grid, Cell } from "../components/Grid"
+
 const withSingleColumn = R.curry(
   (className: string, WrappedComponent: Class<React.Component<*, *>>) => {
     class WithSingleColumn extends React.Component<*, *> {
@@ -9,9 +11,11 @@ const withSingleColumn = R.curry(
 
       render() {
         return (
-          <div className={`main-content one-column ${className}`}>
-            <WrappedComponent {...this.props} />
-          </div>
+          <Grid className={`main-content one-column ${className}`}>
+            <Cell width={12}>
+              <WrappedComponent {...this.props} />
+            </Cell>
+          </Grid>
         )
       }
     }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -61,6 +61,10 @@ body {
   width: 100%;
   min-height: 100vh;
 
+  .mdc-layout-grid {
+    padding: 0;
+  }
+
   .persistent-drawer-open ~ .content {
     padding-left: $drawer-width;
   }
@@ -103,24 +107,10 @@ body {
       }
 
       &.two-column {
-        display: flex;
         width: 90%;
 
         @include breakpoint(desktop) {
-          flex-direction: row;
-          justify-content: center;
-          margin-left: auto;
-          margin-right: auto;
           max-width: 1300px;
-
-          > :first-child {
-            width: 66%;
-            margin-right: 20px;
-          }
-        }
-
-        @include breakpoint(mobile) {
-          flex-direction: column;
         }
 
         @include breakpoint(phone) {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1007

#### What's this PR do?

This PR redoes our layout to use the material grid for column widths, instead of our own custom stuff. I added two react components, `<Grid />` and `<Cell />`, which are basically just divs with the right classes set on them. These can be used to make a material grid wherever we want. I went ahead and replaced the existing layout in our `singleColumn` and `withChannelSidebar` components with this setup.

#### How should this be manually tested?

Basically everything should look the same throughout the app, and things should behave at all screenwidths and so on. Code should make sense.