### PR TITLE
Fix regression regarding loading behavior for post and channel moderation page

### DIFF
--- a/static/js/containers/ChannelModerationPage.js
+++ b/static/js/containers/ChannelModerationPage.js
@@ -49,7 +49,7 @@ type Props = {
   ignoreCommentReports: Function
 } & LoadingProps
 
-class ChannelModerationPage extends React.Component<Props> {
+export class ChannelModerationPage extends React.Component<Props> {
   componentDidMount() {
     this.loadData()
   }
@@ -63,7 +63,7 @@ class ChannelModerationPage extends React.Component<Props> {
     } catch (_) {} // eslint-disable-line no-empty
   }
 
-  renderReport = report => {
+  renderReport = (report: PostReportRecord | CommentReportRecord) => {
     const {
       isModerator,
       removePost,
@@ -88,7 +88,7 @@ class ChannelModerationPage extends React.Component<Props> {
       )
     } else {
       return (
-        <Card>
+        <Card key={`${report.comment.id}-${report.comment.post_id}`}>
           <CommentTree
             comments={[addDummyReplies(report.comment)]}
             commentReports={commentReports}
@@ -100,7 +100,6 @@ class ChannelModerationPage extends React.Component<Props> {
             approve={approveComment}
             remove={removeComment}
             ignoreCommentReports={ignoreCommentReports}
-            key={`${report.comment.id}-${report.comment.post_id}`}
             moderationUI
             isModerator={isModerator}
           />
@@ -111,6 +110,10 @@ class ChannelModerationPage extends React.Component<Props> {
 
   renderPage = () => {
     const { channel, reports, isModerator } = this.props
+
+    if (!channel) {
+      return null
+    }
 
     return isModerator ? (
       <div className="channel-moderation">

--- a/static/js/containers/ChannelModerationPage_test.js
+++ b/static/js/containers/ChannelModerationPage_test.js
@@ -1,0 +1,83 @@
+// @flow
+import R from "ramda"
+import { assert } from "chai"
+
+import ChannelModerationPage, {
+  ChannelModerationPage as InnerChannelModerationPage
+} from "./ChannelModerationPage"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { channelURL } from "../lib/url"
+import { makeChannel } from "../factories/channels"
+import { makeReportRecord } from "../factories/reports"
+
+describe("ChannelModerationPage", () => {
+  let helper, channel, renderPage
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    channel = makeChannel()
+    renderPage = helper.configureHOCRenderer(
+      ChannelModerationPage,
+      InnerChannelModerationPage,
+      {
+        channels: {
+          data:       new Map([[channel.name, channel]]),
+          loaded:     true,
+          processing: false
+        },
+        reports: {
+          data: {
+            reports: R.range(0, 5).map(makeReportRecord)
+          },
+          loaded:     true,
+          processing: false
+        },
+        forms: {},
+        posts: {
+          data:       [],
+          loaded:     true,
+          processing: false
+        },
+        focus:              {},
+        subscribedChannels: {
+          loaded:  true,
+          process: false,
+          data:    [channel.name]
+        },
+        ui: {
+          dialogs: new Map()
+        }
+      },
+      {
+        match: {
+          params: {
+            channelName: channel.name
+          }
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("redirects for non-moderator users", async () => {
+    channel.user_is_moderator = false
+    const { inner } = await renderPage()
+    const redirect = inner.find("Redirect")
+    assert.equal(redirect.length, 1)
+    assert.equal(redirect.props().to, channelURL(channel.name))
+  })
+
+  it("loads correctly if the channel is not yet available", async () => {
+    const { inner } = await renderPage({
+      channels: {
+        data:       new Map(),
+        loaded:     false,
+        processing: true
+      }
+    })
+    assert.equal(inner.find("Loading").length, 1)
+  })
+})

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -373,7 +373,7 @@ class PostPage extends React.Component<PostPageProps> {
       postShareMenuOpen
     } = this.props
 
-    if (!channel || !commentsTree) {
+    if (!channel || !commentsTree || !post) {
       return null
     }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1115 

#### What's this PR do?
Fixes post and channel moderation page initialization to work properly on fresh reloads

#### How should this be manually tested?
Go to a post page and do a full browser refresh. Go to the channel reports moderation page and refresh the browser again. It should work fine both times.

I also went through the other pages which were using the old `withLoader` hoc component and they appear to be working for me.

You should also be able to copy over the tests in this PR into master and reproduce the errors thrown.

