### PR TITLE
Fix sidebar scrolling

### DIFF
--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -188,6 +188,7 @@ $link-padding: 11px 20px 11px 19px;
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: scroll;
 
   .navigation {
     flex: 1 0 auto;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1113 

#### What's this PR do?
Tweaks CSS to enable sidebar scrolling

#### How should this be manually tested?
Try out different browser window sizes and make sure the sidebar scrolling looks good.

If there is enough room for everything the channel links should be on the top and the footer should be on the bottom. There should be no scroll bar visible and scrolling should not have any effect on the sidebar.

If there isn't enough room the channels should be right above the footer and you should see a scrollbar. If you scroll up or down it should act as expected
