### PR TITLE
remove problematic CSS to fix scrolling

### DIFF
--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -94,25 +94,27 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
             onClose={this.onDrawerClose}
           >
             <DrawerContent>
-              {isMobile ? (
-                <div className="drawer-mobile-header">
-                  <a
-                    href="#"
-                    className="material-icons"
-                    onClick={this.onDrawerClose}
-                  >
-                    menu
-                  </a>
-                  <a href="http://www.mit.edu" className="mitlogo">
-                    <img src="/static/images/mit-logo-transparent3.svg" />
-                  </a>
-                </div>
-              ) : null}
-              <Navigation
-                subscribedChannels={subscribedChannels}
-                pathname={pathname}
-                channels={channels}
-              />
+              <div>
+                {isMobile ? (
+                  <div className="drawer-mobile-header">
+                    <a
+                      href="#"
+                      className="material-icons"
+                      onClick={this.onDrawerClose}
+                    >
+                      menu
+                    </a>
+                    <a href="http://www.mit.edu" className="mitlogo">
+                      <img src="/static/images/mit-logo-transparent3.svg" />
+                    </a>
+                  </div>
+                ) : null}
+                <Navigation
+                  subscribedChannels={subscribedChannels}
+                  pathname={pathname}
+                  channels={channels}
+                />
+              </div>
               <Footer />
             </DrawerContent>
           </Drawer>

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -189,13 +189,9 @@ $link-padding: 11px 20px 11px 19px;
   flex-direction: column;
   height: 100%;
   overflow: scroll;
-
-  .navigation {
-    flex: 1 0 auto;
-  }
+  justify-content: space-between;
 
   .footer {
-    flex-shrink: 0;
     font-size: 12px;
     padding: $icon-padding-left;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

address this additional scrolling issue:

![scrolling-fix](https://user-images.githubusercontent.com/6207644/44594537-7aada980-a794-11e8-999d-d6baede11651.png)


#### What's this PR do?

this fixes an issue with the `flex` property, which seems to only show up in Chrome. I changed it to use `justify-content` to space things out instead.