### PR TITLE
LoginPopup for comment reply buttons and post reply form

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -7,14 +7,13 @@ import { connect } from "react-redux"
 import { actions } from "../actions"
 import { setPostData } from "../actions/post"
 import { setBannerMessage } from "../actions/ui"
-import { isEmptyText, userIsAnonymous } from "../lib/util"
+import { isEmptyText, commentLoginText, userIsAnonymous } from "../lib/util"
 import Editor, { editorUpdateFormShim } from "./Editor"
+import LoginPopup from "./LoginPopup"
 
 import type { CommentForm, CommentInTree, Post } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
 import type { Dispatch } from "redux"
-import LoginPopup from "./LoginPopup"
-import { commentLoginText } from "./CommentTree"
 
 type CommentFormProps = {
   dispatch: Dispatch<*>,

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -82,7 +82,7 @@ const commentForm = (
             !disabled &&
             !isEmptyText(text)
           ) {
-            userIsAnonymous() && onTogglePopup ? onTogglePopup() : onSubmit(e)
+            onSubmit(e)
           }
         }}
       >
@@ -465,7 +465,7 @@ export const ReplyToPostForm: Class<React$Component<*, *>> = connect(
             onUpdate,
             cancelReply,
             false,
-            replying,
+            replying || userIsAnonymous(),
             false,
             false,
             this.onTogglePopup

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -72,7 +72,14 @@ const commentForm = (
   return (
     <div className="reply-form">
       <form
-        onSubmit={onSubmit}
+        onSubmit={
+          userIsAnonymous() && onTogglePopup
+            ? R.compose(
+              onTogglePopup,
+              e => e.preventDefault()
+            )
+            : onSubmit
+        }
         className="form"
         onKeyDown={e => {
           if (
@@ -110,7 +117,7 @@ const commentForm = (
         <button
           type="submit"
           className={`blue-button ${disabled ? "disabled" : ""}`}
-          disabled={disabled || isEmptyText(text)}
+          disabled={(disabled || isEmptyText(text)) && !userIsAnonymous()}
         >
           Submit
         </button>

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -458,6 +458,7 @@ export const ReplyToPostForm: Class<React$Component<*, *>> = connect(
             message={commentLoginText}
             visible={popupVisible}
             closePopup={this.onTogglePopup}
+            className="downshift"
           />
           {commentForm(
             this.onSubmit,

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -79,7 +79,7 @@ const commentForm = (
       onSubmit={
         userIsAnonymous() && onTogglePopup
           ? // $FlowFixMe - the above ensures onTogglePopup is defined
-          preventDefaultAndInvoke(() => onTogglePopup())
+          preventDefaultAndInvoke(onTogglePopup)
           : onSubmit
       }
       className="form"
@@ -107,7 +107,7 @@ const commentForm = (
             onClick={
               userIsAnonymous() && onTogglePopup
                 ? // $FlowFixMe: the above
-                preventDefaultAndInvoke(() => onTogglePopup())
+                preventDefaultAndInvoke(onTogglePopup)
                 : null
             }
             autoFocus={autoFocus}
@@ -124,7 +124,7 @@ const commentForm = (
       {isComment ? (
         <a
           href="#"
-          onClick={preventDefaultAndInvoke(() => cancelReply())}
+          onClick={preventDefaultAndInvoke(cancelReply)}
           className="cancel-button"
         >
           Cancel
@@ -433,7 +433,7 @@ export const ReplyToPostForm: Class<React$Component<*, *>> = connect(
       this.ensureInitialState()
     }
 
-    onTogglePopup = async () => {
+    onTogglePopup = () => {
       const { popupVisible } = this.state
       this.setState({
         popupVisible: !popupVisible

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -18,6 +18,7 @@ import {
   getCommentReplyInitialValue,
   editPostKey
 } from "./CommentForms"
+import Router from "../Router"
 
 import * as forms from "../actions/forms"
 import { actions } from "../actions"
@@ -26,6 +27,8 @@ import { SET_BANNER_MESSAGE } from "../actions/ui"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
 import IntegrationTestHelper from "../util/integration_test_helper"
+import * as utilFuncs from "../lib/util"
+import LoginPopup from "./LoginPopup"
 
 describe("CommentForms", () => {
   let helper, post, comment, postKeys, commentKeys
@@ -33,7 +36,9 @@ describe("CommentForms", () => {
   const renderPostForm = (props = {}) =>
     mount(
       <Provider store={helper.store}>
-        <ReplyToPostForm post={post} {...props} />
+        <Router store={helper.store} history={helper.browserHistory}>
+          <ReplyToPostForm post={post} {...props} />
+        </Router>
       </Provider>
     )
 
@@ -150,6 +155,14 @@ describe("CommentForms", () => {
         value:  expectedKeys,
         errors: {}
       })
+    })
+
+    it("should be disabled and display a login popup on click if user is anonymous", async () => {
+      helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+      wrapper = renderPostForm()
+      assert.isTrue(wrapper.find("button").props().disabled)
+      wrapper.find("textarea").simulate("click")
+      assert.isTrue(wrapper.find(LoginPopup).props().visible)
     })
 
     it("should submit the form", async () => {

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -157,10 +157,10 @@ describe("CommentForms", () => {
       })
     })
 
-    it("should be disabled and display a login popup on click if user is anonymous", async () => {
+    it("should be enabled but display a login popup on click if user is anonymous", async () => {
       helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
       wrapper = renderPostForm()
-      assert.isTrue(wrapper.find("button").props().disabled)
+      assert.isFalse(wrapper.find("button").props().disabled)
       wrapper.find("textarea").simulate("click")
       assert.isTrue(wrapper.find(LoginPopup).props().visible)
     })

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -19,16 +19,16 @@ import {
   editPostKey
 } from "./CommentForms"
 import Router from "../Router"
+import LoginPopup from "./LoginPopup"
 
 import * as forms from "../actions/forms"
+import * as utilFuncs from "../lib/util"
 import { actions } from "../actions"
 import { SET_POST_DATA, setPostData } from "../actions/post"
 import { SET_BANNER_MESSAGE } from "../actions/ui"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import * as utilFuncs from "../lib/util"
-import LoginPopup from "./LoginPopup"
 
 describe("CommentForms", () => {
   let helper, post, comment, postKeys, commentKeys

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -34,7 +34,6 @@ import type { FormsState } from "../flow/formTypes"
 import type { CommentRemoveFunc } from "./CommentRemovalForm"
 import type { CommentVoteFunc } from "./CommentVoteForm"
 
-
 type LoadMoreCommentsFunc = (comment: MoreCommentsInTree) => Promise<*>
 type ReportCommentFunc = (comment: CommentInTree) => void
 export type BeginEditingFunc = (fk: string, iv: Object, e: ?Object) => void
@@ -99,13 +98,6 @@ export default class CommentTree extends React.Component<Props, State> {
         </div>
       </li>
     )
-  }
-
-  onTogglePopup = async () => {
-    const { popupVisible } = this.state
-    this.setState({
-      popupVisible: !popupVisible
-    })
   }
 
   renderCommentActions = (comment: CommentInTree, atMaxDepth: boolean) => {

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -35,8 +35,8 @@ import type { CommentRemoveFunc } from "./CommentRemovalForm"
 import type { CommentVoteFunc } from "./CommentVoteForm"
 
 type LoadMoreCommentsFunc = (comment: MoreCommentsInTree) => Promise<*>
+type BeginEditingFunc = (fk: string, iv: Object, e: ?Object) => void
 type ReportCommentFunc = (comment: CommentInTree) => void
-export type BeginEditingFunc = (fk: string, iv: Object, e: ?Object) => void
 
 type Props = {
   comments: Array<GenericComment>,
@@ -126,9 +126,15 @@ export default class CommentTree extends React.Component<Props> {
         ) : null}
         {atMaxDepth || moderationUI || comment.deleted ? null : (
           <ReplyButton
-            beginEditing={beginEditing}
-            formKey={replyToCommentKey(comment)}
-            initialValue={getCommentReplyInitialValue(comment)}
+            beginEditing={e => {
+              if (beginEditing) {
+                beginEditing(
+                  replyToCommentKey(comment),
+                  getCommentReplyInitialValue(comment),
+                  e
+                )
+              }
+            }}
           />
         )}
         <div className="share-button-wrapper">

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -38,10 +38,6 @@ type LoadMoreCommentsFunc = (comment: MoreCommentsInTree) => Promise<*>
 type ReportCommentFunc = (comment: CommentInTree) => void
 export type BeginEditingFunc = (fk: string, iv: Object, e: ?Object) => void
 
-type State = {
-  popupVisible: boolean
-}
-
 type Props = {
   comments: Array<GenericComment>,
   forms?: FormsState,
@@ -69,14 +65,7 @@ export const commentDropdownKey = (c: CommentInTree) =>
 export const commentShareKey = (c: CommentInTree) =>
   `COMMENT_SHARE_MENU_${c.id}`
 
-export default class CommentTree extends React.Component<Props, State> {
-  constructor() {
-    super()
-    this.state = {
-      popupVisible: false
-    }
-  }
-
+export default class CommentTree extends React.Component<Props> {
   renderFollowButton = (comment: CommentInTree) => {
     const { toggleFollowComment } = this.props
 

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -69,8 +69,6 @@ export const commentDropdownKey = (c: CommentInTree) =>
 export const commentShareKey = (c: CommentInTree) =>
   `COMMENT_SHARE_MENU_${c.id}`
 
-export const commentLoginText = "Sign Up or Login to comment"
-
 export default class CommentTree extends React.Component<Props, State> {
   constructor() {
     super()

--- a/static/js/components/ReplyButton.js
+++ b/static/js/components/ReplyButton.js
@@ -1,0 +1,62 @@
+// @flow
+import React from "react"
+
+import LoginPopup from "./LoginPopup"
+import { commentLoginText } from "./CommentTree"
+import { userIsAnonymous } from "../lib/util"
+
+import type { BeginEditingFunc } from "./CommentTree"
+
+type Props = {
+  beginEditing?: BeginEditingFunc,
+  formKey: string,
+  initialValue: Object
+}
+
+type State = {
+  popupVisible: boolean
+}
+
+export default class ReplyButton extends React.Component<Props, State> {
+  constructor() {
+    super()
+    this.state = {
+      popupVisible: false
+    }
+  }
+
+  onTogglePopup = async () => {
+    const { popupVisible } = this.state
+    this.setState({
+      popupVisible: !popupVisible
+    })
+  }
+
+  render() {
+    const { beginEditing, formKey, initialValue } = this.props
+    const { popupVisible } = this.state
+    return (
+      <div>
+        <div
+          className="comment-action-button reply-button"
+          onClick={e => {
+            if (beginEditing && !userIsAnonymous()) {
+              beginEditing(formKey, initialValue, e)
+            } else {
+              this.onTogglePopup()
+            }
+          }}
+        >
+          reply
+        </div>
+        {userIsAnonymous() ? (
+          <LoginPopup
+            message={commentLoginText}
+            visible={popupVisible}
+            closePopup={this.onTogglePopup}
+          />
+        ) : null}
+      </div>
+    )
+  }
+}

--- a/static/js/components/ReplyButton.js
+++ b/static/js/components/ReplyButton.js
@@ -4,12 +4,8 @@ import React from "react"
 import LoginPopup from "./LoginPopup"
 import { commentLoginText, userIsAnonymous } from "../lib/util"
 
-import type { BeginEditingFunc } from "./CommentTree"
-
 type Props = {
-  beginEditing?: BeginEditingFunc,
-  formKey: string,
-  initialValue: Object
+  beginEditing?: Function
 }
 
 type State = {
@@ -32,7 +28,7 @@ export default class ReplyButton extends React.Component<Props, State> {
   }
 
   render() {
-    const { beginEditing, formKey, initialValue } = this.props
+    const { beginEditing } = this.props
     const { popupVisible } = this.state
     return (
       <div>
@@ -40,7 +36,7 @@ export default class ReplyButton extends React.Component<Props, State> {
           className="comment-action-button reply-button"
           onClick={e => {
             beginEditing && !userIsAnonymous()
-              ? beginEditing(formKey, initialValue, e)
+              ? beginEditing(e)
               : this.onTogglePopup()
           }}
         >

--- a/static/js/components/ReplyButton.js
+++ b/static/js/components/ReplyButton.js
@@ -39,11 +39,9 @@ export default class ReplyButton extends React.Component<Props, State> {
         <div
           className="comment-action-button reply-button"
           onClick={e => {
-            if (beginEditing && !userIsAnonymous()) {
-              beginEditing(formKey, initialValue, e)
-            } else {
-              this.onTogglePopup()
-            }
+            beginEditing && !userIsAnonymous()
+              ? beginEditing(formKey, initialValue, e)
+              : this.onTogglePopup()
           }}
         >
           reply

--- a/static/js/components/ReplyButton.js
+++ b/static/js/components/ReplyButton.js
@@ -2,8 +2,7 @@
 import React from "react"
 
 import LoginPopup from "./LoginPopup"
-import { commentLoginText } from "./CommentTree"
-import { userIsAnonymous } from "../lib/util"
+import { commentLoginText, userIsAnonymous } from "../lib/util"
 
 import type { BeginEditingFunc } from "./CommentTree"
 

--- a/static/js/components/ReplyButton_test.js
+++ b/static/js/components/ReplyButton_test.js
@@ -1,38 +1,26 @@
 // @flow
-import React from "react"
-import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import ReplyButton from "./ReplyButton"
 import LoginPopup from "./LoginPopup"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { getCommentReplyInitialValue, replyToCommentKey } from "./CommentForms"
-import { makeComment } from "../factories/comments"
-import { makePost } from "../factories/posts"
-import { shouldIf } from "../lib/test_utils"
+import { configureShallowRenderer, shouldIf } from "../lib/test_utils"
 import * as utilFuncs from "../lib/util"
 
 describe("ReplyButton", () => {
-  let helper, beginEditingStub, comment
+  let helper, beginEditingStub, renderButton
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     beginEditingStub = helper.sandbox.stub()
-    comment = makeComment(makePost())
+    renderButton = configureShallowRenderer(ReplyButton, {
+      beginEditing: beginEditingStub
+    })
   })
 
   afterEach(() => {
     helper.cleanup()
   })
-
-  const renderButton = () =>
-    shallow(
-      <ReplyButton
-        formKey={replyToCommentKey(comment)}
-        initialValue={getCommentReplyInitialValue(comment)}
-        beginEditing={beginEditingStub}
-      />
-    )
 
   it("should have a LoginPopup, if the user is anonymous", () => {
     helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
@@ -51,7 +39,7 @@ describe("ReplyButton", () => {
 
   //
   ;[true, false].forEach(isAnonymous => {
-    it(`clicking the follow button ${shouldIf(
+    it(`clicking the reply button ${shouldIf(
       isAnonymous
     )} set visible state to true and ${shouldIf(
       !isAnonymous
@@ -62,13 +50,7 @@ describe("ReplyButton", () => {
       if (isAnonymous) {
         assert.equal(wrapper.find(LoginPopup).props().visible, isAnonymous)
       }
-      assert.equal(
-        beginEditingStub.calledWith(
-          replyToCommentKey(comment),
-          getCommentReplyInitialValue(comment)
-        ),
-        !isAnonymous
-      )
+      assert.equal(beginEditingStub.calledOnce, !isAnonymous)
     })
   })
 })

--- a/static/js/components/ReplyButton_test.js
+++ b/static/js/components/ReplyButton_test.js
@@ -1,0 +1,77 @@
+// @flow
+import React from "react"
+import { mount } from "enzyme"
+import { assert } from "chai"
+
+import ReplyButton from "./ReplyButton"
+import LoginPopup from "./LoginPopup"
+import Router from "../Router"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { getCommentReplyInitialValue, replyToCommentKey } from "./CommentForms"
+import { makeComment } from "../factories/comments"
+import { makePost } from "../factories/posts"
+import { shouldIf } from "../lib/test_utils"
+import * as utilFuncs from "../lib/util"
+
+describe("ReplyButton", () => {
+  let helper, beginEditingStub, comment
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    beginEditingStub = helper.sandbox.stub()
+    comment = makeComment(makePost())
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  const renderButton = () =>
+    mount(
+      <Router store={helper.store} history={helper.browserHistory}>
+        <ReplyButton
+          formKey={replyToCommentKey(comment)}
+          initialValue={getCommentReplyInitialValue(comment)}
+          beginEditing={beginEditingStub}
+        />
+      </Router>
+    )
+
+  it("should have a LoginPopup, if the user is anonymous", () => {
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
+    const wrapper = renderButton()
+    wrapper.find(LoginPopup).exists()
+  })
+
+  it("should not have a LoginPopup, if the user is not anonymous", () => {
+    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(false)
+    assert.isNotOk(
+      renderButton()
+        .find(LoginPopup)
+        .exists()
+    )
+  })
+
+  //
+  ;[true, false].forEach(isAnonymous => {
+    it(`clicking the follow button ${shouldIf(
+      isAnonymous
+    )} set visible state to true and ${shouldIf(
+      !isAnonymous
+    )} trigger beginEditing function`, () => {
+      helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(isAnonymous)
+      const wrapper = renderButton()
+      wrapper.find(".reply-button").simulate("click")
+      if (isAnonymous) {
+        assert.equal(wrapper.find(LoginPopup).props().visible, isAnonymous)
+      }
+      assert.equal(
+        beginEditingStub.calledWith(
+          replyToCommentKey(comment),
+          getCommentReplyInitialValue(comment)
+        ),
+        !isAnonymous
+      )
+    })
+  })
+})

--- a/static/js/components/ReplyButton_test.js
+++ b/static/js/components/ReplyButton_test.js
@@ -1,11 +1,10 @@
 // @flow
 import React from "react"
-import { mount } from "enzyme"
+import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import ReplyButton from "./ReplyButton"
 import LoginPopup from "./LoginPopup"
-import Router from "../Router"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { getCommentReplyInitialValue, replyToCommentKey } from "./CommentForms"
 import { makeComment } from "../factories/comments"
@@ -27,14 +26,12 @@ describe("ReplyButton", () => {
   })
 
   const renderButton = () =>
-    mount(
-      <Router store={helper.store} history={helper.browserHistory}>
-        <ReplyButton
-          formKey={replyToCommentKey(comment)}
-          initialValue={getCommentReplyInitialValue(comment)}
-          beginEditing={beginEditingStub}
-        />
-      </Router>
+    shallow(
+      <ReplyButton
+        formKey={replyToCommentKey(comment)}
+        initialValue={getCommentReplyInitialValue(comment)}
+        beginEditing={beginEditingStub}
+      />
     )
 
   it("should have a LoginPopup, if the user is anonymous", () => {

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -43,12 +43,7 @@ import {
   toggleFollowPost,
   toggleFollowComment
 } from "../util/api_actions"
-import {
-  getChannelName,
-  getPostID,
-  getCommentID,
-  truncate
-} from "../lib/util"
+import { getChannelName, getPostID, getCommentID, truncate } from "../lib/util"
 import {
   anyErrorExcept404,
   anyErrorExcept404or410,

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -47,7 +47,6 @@ import {
   getChannelName,
   getPostID,
   getCommentID,
-  userIsAnonymous,
   truncate
 } from "../lib/util"
 import {
@@ -456,7 +455,7 @@ class PostPage extends React.Component<PostPageProps> {
               postShareMenuOpen={postShareMenuOpen}
               channel={channel}
             />
-            {showPermalinkUI || userIsAnonymous() ? null : (
+            {showPermalinkUI ? null : (
               <ReplyToPostForm
                 forms={forms}
                 post={post}

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -241,7 +241,7 @@ describe("PostPage", function() {
 
   //
   ;[true, false].forEach(userIsAnon => {
-    it(`should not show a ReplyToPostForm when userIsAnonymous() === ${userIsAnon}`, async () => {
+    it(`should show a ReplyToPostForm when userIsAnonymous() === ${userIsAnon}`, async () => {
       const anonStub = helper.sandbox.stub(utilFuncs, "userIsAnonymous")
       anonStub.returns(userIsAnon)
 
@@ -253,7 +253,7 @@ describe("PostPage", function() {
       )
       wrapper.update()
 
-      assert.equal(wrapper.find(ReplyToPostForm).exists(), !userIsAnon)
+      assert.ok(wrapper.find(ReplyToPostForm).exists())
     })
   })
 

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -63,6 +63,7 @@ export const preventDefaultAndInvoke = R.curry(
 export const userIsAnonymous = () => R.isNil(SETTINGS.username)
 
 export const votingTooltipText = "Sign Up or Login to vote"
+export const commentLoginText = "Sign Up or Login to comment"
 
 export const defaultProfileImageUrl = "/static/images/avatar_default.png"
 export const defaultChannelAvatarUrl =

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -133,7 +133,7 @@ button.cancel,
 button.disabled,
 button[disabled],
 a.buttonLink.cancel {
-  background: #cecece;
+  background-color: #cecece !important;
 }
 
 input[type="checkbox"],

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.downshift {
+  margin-top: 50px !important;
+}
+
 .share-popup {
   .triangle {
     right: 50%;

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -94,7 +94,7 @@
     border: 1px solid #972c37;
     color: #972c37;
     text-align: center;
-    margin: 10px 0 10px;
+    margin: 10px 5px 10px;
   }
 
   .red {

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -55,10 +55,6 @@
   }
 }
 
-.downshift {
-  margin-top: 50px !important;
-}
-
 .share-popup {
   .triangle {
     right: 50%;
@@ -70,6 +66,10 @@
   right: unset;
   margin-top: 10px;
   min-width: 255px;
+
+  &.downshift {
+    margin-top: 50px;
+  }
 
   .close-popup {
     position: absolute;


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1051

#### What's this PR do?
- Adds the `LoginPopup` to comment Reply buttons and the post reply text area.

#### How should this be manually tested?
- When logged in, the comment reply buttons and post reply form on a post detail page should work the same as before.
- When not logged in, the comment reply buttons and post reply form should still be rendered.  Clicking on a reply button or the text area of the post reply form should cause the `LoginPopup` to appear (just under the clicked Reply button, or over the post reply text area).  Clicking again outside the popup or text area should make the popup disappear.
