### PR TITLE
Configured login flow to show greeting for external auth providers

### DIFF
--- a/authentication/exceptions.py
+++ b/authentication/exceptions.py
@@ -4,8 +4,12 @@ from social_core.exceptions import AuthException
 
 class RequireProviderException(AuthException):
     """The user is required to authenticate via a specific provider/backend"""
-    def __init__(self, backend, provider):
-        self.provider = provider
+    def __init__(self, backend, social_auth):
+        """
+        Args:
+            social_auth (social_django.models.UserSocialAuth): A social auth objects
+        """
+        self.social_auth = social_auth
         super().__init__(backend)
 
 

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -22,7 +22,6 @@ from djoser.utils import ActionViewMixin
 from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 
 from open_discussions import features
-from open_discussions.utils import filter_dict_keys
 from authentication.serializers import (
     LoginEmailSerializer,
     LoginPasswordSerializer,
@@ -30,9 +29,8 @@ from authentication.serializers import (
     RegisterConfirmSerializer,
     RegisterDetailsSerializer,
 )
-from authentication.utils import load_drf_strategy, SocialAuthState
+from authentication.utils import load_drf_strategy
 from mail.api import render_email_templates, send_messages
-from profiles.serializers import ProfileSerializer
 
 User = get_user_model()
 
@@ -71,30 +69,6 @@ class LoginEmailView(SocialAuthAPIView):
     def get_serializer_cls(self):
         """Return the serializer cls"""
         return LoginEmailSerializer
-
-    def post(self, request):
-        resp = super().post(request)
-        if (
-                status.is_success(resp.status_code) and
-                resp.data['state'] == SocialAuthState.STATE_LOGIN_PASSWORD
-        ):
-            # We show some extra information to the user if they enter a recognized
-            # email into the login form. Before returning the response, use the email
-            # to fetch that information and add it to the response data.
-            email_auth = (
-                UserSocialAuth.objects
-                .filter(uid=request.data['email'], provider=EmailAuth.name)
-                .select_related('user__profile')
-                .first()
-            )
-            profile_data = ProfileSerializer(email_auth.user.profile).data
-            resp.data['extra_data'] = filter_dict_keys(
-                profile_data, [
-                    'profile_image_small',
-                    'name'
-                ]
-            )
-        return resp
 
 
 class LoginPasswordView(SocialAuthAPIView):

--- a/cassettes/authentication.views_test.test_login_register_flows[login_email_saml_exists].json
+++ b/cassettes/authentication.views_test.test_login_register_flows[login_email_saml_exists].json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-08-28T17:18:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CP0RP3YZMCDGQGXS9GS2989H"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIyM9WNLIzwtQhIDPVMSvQIcc8o9HcKDA4rD0pLi3dV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFecYXZ5k6xmfqlmQHp/v4Zvklm1aYFnimFYNtS0kty0xOjc9MARkM4SjVAgB2teqTuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Aug 2018 17:18:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=bW7E8OaUd8Kma5jk4o; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 27-Aug-2020 17:18:22 GMT",
+            "loidcreated=2018-08-28T17%3A18%3A22.078Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 27-Aug-2020 17:18:22 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CP0RP3YZMCDGQGXS9GS2989H"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/factory_data/authentication.views_test.test_login_register_flows[login_email_saml_exists].json
+++ b/factory_data/authentication.views_test.test_login_register_flows[login_email_saml_exists].json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "contributor": {
+      "username": "01CP0RP3YZMCDGQGXS9GS2989H"
+    }
+  }
+}

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -2,9 +2,11 @@
 Factory for Users
 """
 import ulid
+from django.conf import settings
 from django.contrib.auth.models import User
+from social_core.backends.saml import SAMLAuth
 from social_django.models import UserSocialAuth
-from factory import LazyFunction, RelatedFactory, SubFactory, Trait
+from factory import LazyFunction, RelatedFactory, SubFactory, Trait, post_generation
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
@@ -29,6 +31,13 @@ class UserSocialAuthFactory(DjangoModelFactory):
     """Factory for UserSocialAuth"""
     provider = FuzzyText()
     user = SubFactory(UserFactory)
+    uid = FuzzyText()
 
     class Meta:
         model = UserSocialAuth
+
+    @post_generation
+    def post_gen(self, create, extracted, **kwargs):  # pylint: disable=unused-argument
+        """Set uid appropriately if the given provider is 'saml'"""
+        if self.provider == SAMLAuth.name:
+            self.uid = '{}:{}'.format(settings.SOCIAL_AUTH_DEFAULT_IDP_KEY, self.user.email)

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -227,6 +227,10 @@ SOCIAL_AUTH_EMAIL_VALIDATION_FUNCTION = 'mail.verification_api.send_verification
 SOCIAL_AUTH_EMAIL_VALIDATION_URL = '/'
 
 SOCIAL_AUTH_PIPELINE = (
+    # Checks if the user is attempting to log in with an email and has authenticated via SAML,
+    # in which case we want to force them to log in via SAML
+    'authentication.pipeline.user.require_touchstone_login',
+
     # Get the information we can about the user and return it in a simple
     # format to create the user instance later. On some cases the details are
     # already part of the auth response from the provider, but sometimes this
@@ -371,8 +375,9 @@ SOCIAL_AUTH_SAML_TECHNICAL_CONTACT = {
     "emailAddress": EMAIL_SUPPORT
 }
 SOCIAL_AUTH_SAML_SUPPORT_CONTACT = SOCIAL_AUTH_SAML_TECHNICAL_CONTACT
+SOCIAL_AUTH_DEFAULT_IDP_KEY = "default"
 SOCIAL_AUTH_SAML_ENABLED_IDPS = {
-    "default": {
+    SOCIAL_AUTH_DEFAULT_IDP_KEY: {
         "entity_id": SOCIAL_AUTH_SAML_IDP_ENTITY_ID,
         "url": SOCIAL_AUTH_SAML_IDP_URL,
         "attr_user_permanent_id": SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_PERM_ID,

--- a/static/js/components/ExternalLogins.js
+++ b/static/js/components/ExternalLogins.js
@@ -1,7 +1,8 @@
 // @flow
 /* global SETTINGS:false */
 import React from "react"
-import { TOUCHSTONE_URL } from "../lib/url"
+
+import TouchstoneLoginButton from "./auth/TouchstoneLoginButton"
 
 type ExternalLoginProps = {
   className?: string
@@ -11,11 +12,7 @@ const ExternalLogins = ({ className }: ExternalLoginProps) =>
   SETTINGS.allow_saml_auth ? (
     <div className={`actions row ${className || ""}`}>
       <div className="textline">Or</div>
-      <a className="link-button touchstone-text-logo" href={TOUCHSTONE_URL}>
-        Touchstone
-        <span className="ampersand">@</span>
-        MIT
-      </a>
+      <TouchstoneLoginButton />
     </div>
   ) : null
 

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -4,7 +4,6 @@ import React from "react"
 import { shallow } from "enzyme"
 import { assert } from "chai"
 
-import { TOUCHSTONE_URL } from "../lib/url"
 import ExternalLogins from "./ExternalLogins"
 
 describe("ExternalLogins component", () => {
@@ -21,15 +20,8 @@ describe("ExternalLogins component", () => {
     it(`should ${allowSaml ? "" : "not "}have a link to Touchstone`, () => {
       SETTINGS.allow_saml_auth = allowSaml
       const wrapper = mountExternalLogins()
-      const link = wrapper.find(".link-button")
-      assert.equal(link.exists(), allowSaml)
+      const button = wrapper.find("TouchstoneLoginButton")
+      assert.equal(button.exists(), allowSaml)
     })
-  })
-
-  it("should have the correct URL for Touchstone", () => {
-    SETTINGS.allow_saml_auth = true
-    const wrapper = mountExternalLogins()
-    const link = wrapper.find(".link-button")
-    assert.equal(link.props().href, TOUCHSTONE_URL)
   })
 })

--- a/static/js/components/auth/LoginGreeting.js
+++ b/static/js/components/auth/LoginGreeting.js
@@ -1,0 +1,37 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+
+type LoginGreetingProps = {
+  email: string,
+  name: ?string,
+  profileImageUrl: ?string
+}
+
+const LoginGreeting = ({
+  email,
+  name,
+  profileImageUrl
+}: LoginGreetingProps) => {
+  const heading = name ? `Hi ${name}` : "Welcome Back!"
+
+  return (
+    <div>
+      <h3>{heading}</h3>
+      {name && profileImageUrl ? (
+        <div key="greeting-body" className="form-header">
+          <div className="row profile-image-email">
+            <img
+              src={profileImageUrl}
+              alt={`Profile image for ${name}`}
+              className="profile-image small"
+            />
+            <span>{email}</span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default LoginGreeting

--- a/static/js/components/auth/LoginGreeting_test.js
+++ b/static/js/components/auth/LoginGreeting_test.js
@@ -1,0 +1,41 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import R from "ramda"
+import { mount } from "enzyme"
+import { assert } from "chai"
+
+import LoginGreeting from "./LoginGreeting"
+
+describe("LoginGreeting", () => {
+  [
+    ["Testuser", "x.jpg", "a@b.com", "exists"],
+    [undefined, undefined, "a@b.com", "does not exist"]
+  ].forEach(([name, profileImageUrl, email, descriptor]) => {
+    it(`should render the page with correct messages when user data ${descriptor}`, async () => {
+      const expectedProfileInfo = R.none(R.isNil, [name, profileImageUrl])
+      const expectedGreeting = expectedProfileInfo
+        ? `Hi ${String(name)}`
+        : "Welcome Back!"
+
+      const wrapper = mount(
+        <LoginGreeting
+          name={name}
+          profileImageUrl={profileImageUrl}
+          email={email}
+        />
+      )
+
+      assert.equal(wrapper.find("h3").text(), expectedGreeting)
+      const profileInfoSection = wrapper.find(".profile-image-email")
+      assert.equal(profileInfoSection.exists(), expectedProfileInfo)
+      if (expectedProfileInfo) {
+        assert.equal(
+          profileInfoSection.find("img").prop("src"),
+          profileImageUrl
+        )
+        assert.equal(profileInfoSection.find("span").text(), email)
+      }
+    })
+  })
+})

--- a/static/js/components/auth/TouchstoneLoginButton.js
+++ b/static/js/components/auth/TouchstoneLoginButton.js
@@ -1,0 +1,15 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+
+import { TOUCHSTONE_URL } from "../../lib/url"
+
+const TouchstoneLoginButton = () => (
+  <a className="link-button touchstone-text-logo" href={TOUCHSTONE_URL}>
+    Touchstone
+    <span className="ampersand">@</span>
+    MIT
+  </a>
+)
+
+export default TouchstoneLoginButton

--- a/static/js/containers/auth/LoginPasswordPage.js
+++ b/static/js/containers/auth/LoginPasswordPage.js
@@ -6,6 +6,7 @@ import { MetaTags } from "react-meta-tags"
 
 import Card from "../../components/Card"
 import AuthPasswordForm from "../../components/auth/AuthPasswordForm"
+import LoginGreeting from "../../components/auth/LoginGreeting"
 import withForm from "../../hoc/withForm"
 
 import { actions } from "../../actions"
@@ -54,22 +55,14 @@ export class LoginPasswordPage extends React.Component<Props> {
       <div className="content auth-page login-password-page">
         <div className="main-content">
           <Card className="login-card">
-            <h3>{name && profileImageUrl ? `Hi ${name}` : "Welcome Back!"}</h3>
             <MetaTags>
-              <title>{formatTitle("Log In")}</title>
+              <title>{formatTitle("Welcome Back!")}</title>
             </MetaTags>
-            {name && profileImageUrl ? (
-              <div className="form-header">
-                <div className="row profile-image-email">
-                  <img
-                    src={profileImageUrl}
-                    alt={`Profile image for ${name}`}
-                    className="profile-image small"
-                  />
-                  <span>{email}</span>
-                </div>
-              </div>
-            ) : null}
+            <LoginGreeting
+              email={email}
+              name={name}
+              profileImageUrl={profileImageUrl}
+            />
             {renderForm({ formError })}
           </Card>
         </div>

--- a/static/js/containers/auth/LoginPasswordPage_test.js
+++ b/static/js/containers/auth/LoginPasswordPage_test.js
@@ -1,7 +1,6 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import R from "ramda"
 
 import { actions } from "../../actions"
 import { FLOW_REGISTER, FLOW_LOGIN, STATE_SUCCESS } from "../../reducers/auth"
@@ -58,41 +57,6 @@ describe("LoginPasswordPage", () => {
 
   afterEach(() => {
     helper.cleanup()
-  })
-
-  //
-  ;[
-    ["Testuser", "x.jpg", "a@b.com", "exists"],
-    [undefined, undefined, "a@b.com", "does not exist"]
-  ].forEach(([extraDataName, extraDataImg, email, descriptor]) => {
-    it(`should render the page with correct messages when extra user data ${descriptor}`, async () => {
-      const expectedProfileInfo = R.none(R.isNil, [extraDataName, extraDataImg])
-      const expectedGreeting = expectedProfileInfo
-        ? `Hi ${String(extraDataName)}`
-        : "Welcome Back!"
-
-      const { inner } = await renderPage({
-        ui: {
-          authUserDetail: {
-            email:               email,
-            name:                extraDataName,
-            profile_image_small: extraDataImg
-          }
-        }
-      })
-
-      const form = inner.find("AuthPasswordForm")
-      assert.ok(form.exists())
-      assert.equal(inner.find("h3").text(), expectedGreeting)
-      const profileInfoSection = inner.find(".profile-image-email")
-      assert.equal(profileInfoSection.exists(), expectedProfileInfo)
-      if (expectedProfileInfo) {
-        assert.equal(profileInfoSection.find("img").prop("src"), extraDataImg)
-        assert.equal(profileInfoSection.find("span").text(), email)
-      }
-
-      assert.lengthOf(helper.browserHistory, 1)
-    })
   })
 
   it("should render errors", async () => {

--- a/static/js/containers/auth/LoginProviderRequiredPage.js
+++ b/static/js/containers/auth/LoginProviderRequiredPage.js
@@ -4,44 +4,82 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
 import Card from "../../components/Card"
+import TouchstoneLoginButton from "../../components/auth/TouchstoneLoginButton"
+import LoginGreeting from "../../components/auth/LoginGreeting"
+import { NotFound } from "../../components/ErrorPages"
+
 import { formatTitle } from "../../lib/title"
 import { getAuthProviderSelector } from "../../reducers/auth"
+import {
+  getAuthUiNameSelector,
+  getAuthUiEmailSelector,
+  getAuthUiImgSelector
+} from "../../reducers/ui"
 
 type LoginProviderRequiredPageProps = {
-  provider: string
+  provider: string,
+  email: string,
+  name: string,
+  profileImageUrl: string
 }
 
-const getProviderLabel = (provider: string) => {
+const renderExternalProviderLink = (provider: string) => {
   switch (provider) {
   case "micromasters":
-    return "MicroMasters"
+    return (
+      <a href={`/login/${provider}/`} className="link-button">
+          MicroMasters
+      </a>
+    )
+  case "saml":
+    return <TouchstoneLoginButton />
   default:
     return null
   }
 }
 
 export const LoginProviderRequiredPage = ({
-  provider
-}: LoginProviderRequiredPageProps) => (
-  <div className="content auth-page login-provider-page">
-    <div className="main-content">
-      <Card className="login-provider-card">
-        <h3>Welcome Back!</h3>
-        <MetaTags>
-          <title>{formatTitle("Welcome Back!")}</title>
-        </MetaTags>
-        <p>You already have a login with</p>
-        <a href={`/login/${provider}/`} className="link-button">
-          {getProviderLabel(provider)}
-        </a>
-      </Card>
+  provider,
+  email,
+  name,
+  profileImageUrl
+}: LoginProviderRequiredPageProps) => {
+  const externalLink = renderExternalProviderLink(provider)
+  if (!externalLink) {
+    return <NotFound />
+  }
+
+  return (
+    <div className="content auth-page login-provider-page">
+      <div className="main-content">
+        <Card className="login-provider-card">
+          <MetaTags>
+            <title>{formatTitle("Welcome Back!")}</title>
+          </MetaTags>
+          <LoginGreeting
+            email={email}
+            name={name}
+            profileImageUrl={profileImageUrl}
+          />
+          <p>You already have a login with</p>
+          {externalLink}
+        </Card>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 const mapStateToProps = state => {
   const provider = getAuthProviderSelector(state)
-  return { provider }
+  const email = getAuthUiEmailSelector(state)
+  const name = getAuthUiNameSelector(state)
+  const profileImageUrl = getAuthUiImgSelector(state)
+  return {
+    provider,
+    email,
+    name,
+    profileImageUrl
+  }
 }
 
 export default connect(mapStateToProps)(LoginProviderRequiredPage)

--- a/static/js/containers/auth/LoginProviderRequiredPage_test.js
+++ b/static/js/containers/auth/LoginProviderRequiredPage_test.js
@@ -35,18 +35,29 @@ describe("LoginProviderRequiredPage", () => {
 
   //
   ;[
-    ["micromasters", "/login/micromasters/", "MicroMasters"],
-    ["invalid", "/login/invalid/", ""]
-  ].forEach(([provider, url, name]) => {
-    it(`should render the page given the provider: ${provider}`, async () => {
+    ["micromasters", 'a[href="/login/micromasters/"]'],
+    ["saml", "TouchstoneLoginButton"]
+  ].forEach(([provider, expectedElementSel]) => {
+    it(`should render the page with the right elements given the '${provider}' provider`, async () => {
       const { inner } = await renderPage({
         auth: {
           data: { provider }
         }
       })
 
-      assert.equal(inner.find("a").props().href, url)
-      assert.equal(inner.find("a").text(), name)
+      assert.isTrue(inner.find(expectedElementSel).exists())
     })
+  })
+
+  it("should render an error page when the provider isn't recognized", async () => {
+    const { inner } = await renderPage({
+      auth: {
+        data: {
+          provider: "unrecognized"
+        }
+      }
+    })
+
+    assert.include(inner.html(), "404 error")
   })
 })

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -22,7 +22,7 @@ import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
 import { LOGIN_URL } from "../../lib/url"
-import { validateEmailForm as validateForm } from "../../lib/validation"
+import { validateNewEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 
 import type { EmailForm, AuthResponse } from "../../flow/authTypes"

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -139,19 +139,29 @@ export const validationMessage = (message: ?string) =>
     <div className="validation-message">{message}</div>
   )
 
-export const validateEmailForm = validate([
-  validation(
-    R.complement(SETTINGS.allow_saml_auth ? validNotMIT : R.always(true)),
-    R.lensPath(["value", "email"]),
-    "MIT users please login with Touchstone below"
-  ),
+const emailValidators = [
   validation(
     R.complement(validEmail),
     R.lensPath(["value", "email"]),
     "Email is not formatted correctly"
   ),
   validation(emptyOrNil, R.lensPath(["value", "email"]), "Email is required")
-])
+]
+
+export const validateEmailForm = validate(emailValidators)
+
+export const validateNewEmailForm = validate(
+  R.append(
+    validation(
+      R.complement(email => {
+        return SETTINGS.allow_saml_auth ? validNotMIT(email) : true
+      }),
+      R.lensPath(["value", "email"]),
+      "MIT users please login with Touchstone below"
+    ),
+    emailValidators
+  )
+)
 
 export const validatePasswordForm = validate([
   validation(

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -13,6 +13,7 @@ import {
   validateChannelBasicEditForm,
   validateContentReportForm,
   validateEmailForm,
+  validateNewEmailForm,
   validateMembersForm,
   validatePasswordForm,
   validatePasswordResetForm,
@@ -227,23 +228,46 @@ describe("validation library", () => {
     })
   })
 
-  describe("validateEmailForm", () => {
-    it("should complain about no email", () => {
-      const form = { value: { email: "" } }
-      assert.deepEqual(validateEmailForm(form), {
-        value: {
-          email: "Email is required"
-        }
-      })
-    })
+  describe("email validator", () => {
+    [
+      [validateEmailForm, "existing email", "", "Email is required"],
+      [
+        validateEmailForm,
+        "existing email",
+        "abbbb@ddd",
+        "Email is not formatted correctly"
+      ],
+      [validateNewEmailForm, "new email", "", "Email is required"],
+      [
+        validateNewEmailForm,
+        "new email",
+        "abbbb@ddd",
+        "Email is not formatted correctly"
+      ],
+      [
+        validateNewEmailForm,
+        "new email",
+        "user@mit.edu",
+        "MIT users please login with Touchstone below"
+      ]
+    ].forEach(
+      ([validatorFunc, validatorDesc, emailInput, expectedErrorMsg]) => {
+        it(`for ${validatorDesc} should show the right error message given an email='${emailInput}'`, () => {
+          SETTINGS.allow_saml_auth = true
+          const form = { value: { email: emailInput } }
+          assert.deepEqual(validatorFunc(form), {
+            value: {
+              email: expectedErrorMsg
+            }
+          })
+        })
+      }
+    )
 
-    it("should complain about invalid email", () => {
-      const form = { value: { email: "abbbb@ddd" } }
-      assert.deepEqual(validateEmailForm(form), {
-        value: {
-          email: "Email is not formatted correctly"
-        }
-      })
+    it("for new email should not invalidate an MIT email if allow_saml_auth=false", () => {
+      SETTINGS.allow_saml_auth = false
+      const form = { value: { email: "user@mit.edu" } }
+      assert.deepEqual(validateNewEmailForm(form), {})
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1058

#### What's this PR do?
Changes the login flow so that emails that match micromasters- or touchstone-authenticated users are shown a personalized greeting after the email is submitted

#### How should this be manually tested?
On the `/login` page...
- Enter an email for a user that has _only_ authenticated via Micromasters
- Enter an email for a user that has authenticated via Touchstone at any time (if you're running locally, you may have to fudge this - ask me for details if you need to do that)

In both cases, the name, email, and profile image should be shown to the user after submission, just like we do for users that have an email authentication

#### Screenshots (if appropriate)
![ss 2018-08-29 at 10 32 26](https://user-images.githubusercontent.com/14932219/44794637-e027de80-ab76-11e8-9ae8-51b976e3469d.png)
![ss 2018-08-29 at 10 32 18](https://user-images.githubusercontent.com/14932219/44794638-e027de80-ab76-11e8-82b4-27468aa68b39.png)

