### PR TITLE
add material dropdown for picking sort method

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@material/drawer": "^0.36.0",
     "@material/layout-grid": "^0.34.0",
     "@material/list": "^0.2.14",
-    "@material/menu": "^0.4.3",
     "@material/radio": "^0.30.0",
     "@material/rtl": "^0.1.7",
     "@material/snackbar": "^0.25.0",

--- a/static/js/components/SortPicker.js
+++ b/static/js/components/SortPicker.js
@@ -1,30 +1,61 @@
 // @flow
 import React from "react"
 import R from "ramda"
+import { Menu, MenuItem, MenuAnchor } from "rmwc/Menu"
+
+import { DropDownArrow, DropUpArrow } from "./UserMenu"
 
 import {
   VALID_POST_SORT_LABELS,
   VALID_COMMENT_SORT_LABELS
 } from "../lib/sorting"
 
-type PostSortProps = {
+type Props = {
   updateSortParam: (t: string) => void,
   value: string
 }
 
-const SortPicker = R.curry(
-  (labels, { updateSortParam, value }: PostSortProps) => (
-    <div className="sorter">
-      <select onChange={updateSortParam} value={value}>
-        {labels.map(([type, label]) => (
-          <option label={label} value={type} key={type}>
-            {label}
-          </option>
-        ))}
-      </select>
-    </div>
-  )
-)
+type State = {
+  menuOpen: boolean
+}
+
+const SortPicker = labels => {
+  class SortPicker extends React.Component<Props, State> {
+    constructor(props: Props) {
+      super(props)
+      this.state = {
+        menuOpen: false
+      }
+    }
+
+    toggleMenuOpen = () => {
+      const { menuOpen } = this.state
+      this.setState({ menuOpen: !menuOpen })
+    }
+
+    render() {
+      const { updateSortParam, value } = this.props
+      const { menuOpen } = this.state
+
+      return (
+        <MenuAnchor className="sorter">
+          <Menu open={menuOpen} onClose={this.toggleMenuOpen}>
+            {labels.map(([type, label]) => (
+              <MenuItem key={label} onClick={updateSortParam(type)}>
+                {label}
+              </MenuItem>
+            ))}
+          </Menu>
+          <div className="current-sort" onClick={this.toggleMenuOpen}>
+            {R.fromPairs(labels)[value]}
+            {menuOpen ? <DropUpArrow /> : <DropDownArrow />}
+          </div>
+        </MenuAnchor>
+      )
+    }
+  }
+  return SortPicker
+}
 
 export const PostSortPicker = SortPicker(VALID_POST_SORT_LABELS)
 

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -134,10 +134,13 @@ describe("ChannelPage", () => {
           SET_POST_DATA
         ],
         () => {
-          const select = wrapper.find(".post-list-title").find("select")
-          select.simulate("change", { target: { value: sortType } })
+          const select = wrapper.find(".post-list-title").find("SortPicker")
+          select.props().updateSortParam(sortType, {
+            preventDefault: helper.sandbox.stub()
+          })
         }
       )
+      wrapper.update()
 
       assert.equal(
         wrapper.find(ChannelPage).props().location.search,

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -66,8 +66,10 @@ describe("HomePage", () => {
           SET_POST_DATA
         ],
         () => {
-          const select = wrapper.find(".post-list-title").find("select")
-          select.simulate("change", { target: { value: sortType } })
+          const select = wrapper.find(".post-list-title").find("SortPicker")
+          select.props().updateSortParam(sortType, {
+            preventDefault: helper.sandbox.stub()
+          })
         }
       )
 

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -431,8 +431,8 @@ class PostPage extends React.Component<PostPageProps> {
             />
           ) : null}
         </Dialog>
-        <Card>
-          <div className="post-card">
+        <Card className="post-card">
+          <div className="post-card-inner">
             <ExpandedPostDisplay
               post={post}
               isModerator={isModerator}

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -722,10 +722,13 @@ describe("PostPage", function() {
           actions.comments.get.successType
         ],
         () => {
-          const select = wrapper.find(".sorter").find("select")
-          select.simulate("change", { target: { value: sortType } })
+          const select = wrapper.find(".count-and-sort").find("SortPicker")
+          select.props().updateSortParam(sortType, {
+            preventDefault: helper.sandbox.stub()
+          })
         }
       )
+      wrapper.update()
 
       assert.equal(
         wrapper.find(PostPage).props().location.search,

--- a/static/js/lib/sorting.js
+++ b/static/js/lib/sorting.js
@@ -13,9 +13,9 @@ export const VALID_POST_SORT_TYPES = [
 ]
 
 export const VALID_POST_SORT_LABELS = [
-  [POSTS_SORT_HOT, "active"],
-  [POSTS_SORT_TOP, "top"],
-  [POSTS_SORT_NEW, "new"]
+  [POSTS_SORT_HOT, "Active"],
+  [POSTS_SORT_TOP, "Top"],
+  [POSTS_SORT_NEW, "New"]
 ]
 
 export const COMMENT_SORT_NEW = "new"
@@ -34,14 +34,11 @@ export const VALID_COMMENT_SORT_LABELS = [
   [COMMENT_SORT_BEST, "Best"]
 ]
 
-const updateSortParam = R.curry((validSortTypes, props, e) => {
+const updateSortParam = R.curry((validSortTypes, props, value, e) => {
   const {
     history,
     location: { pathname, search }
   } = props
-  const {
-    target: { value }
-  } = e
 
   e.preventDefault()
 

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -4,7 +4,7 @@
 
   @include breakpoint(desktop) {
     &:first-child {
-      margin-top: 45px; // margin to align with top of main-content card on desktop
+      margin-top: 57px; // margin to align with top of main-content card on desktop
     }
   }
 

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -15,8 +15,6 @@ $replyPaddingLeft: 30px;
   }
 
   .top-level-comment {
-    padding: 0 15px 0 0;
-
     @include breakpoint(phone) {
       padding: 0;
     }

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -8,6 +8,18 @@
       display: block;
     }
   }
+
+  select {
+    background: #f8f8f8;
+    border: 1px solid #bbb;
+    font-size: 15px;
+    color: rgba(0, 0, 0, 0.87);
+    border-radius: $std-border-radius;
+    height: 39px;
+    /* If you add too much padding here, the options won't show in IE */
+    padding: 8px 20px;
+    width: 100%;
+  }
 }
 
 .form .row,
@@ -128,17 +140,6 @@ input[type="checkbox"],
 input[type="radio"] {
   box-sizing: border-box;
   font-size: 16px;
-}
-
-select {
-  background: #f8f8f8;
-  border: 1px solid #bbb;
-  font-size: 15px;
-  color: rgba(0, 0, 0, 0.87);
-  border-radius: $std-border-radius;
-  height: 39px;
-  padding: 8px 20px; /* If you add too much padding here, the options won't show in IE */
-  width: 100%;
 }
 
 input::placeholder,

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -93,6 +93,11 @@ body {
         min-height: calc(100vh - #{$toolbar-height-mobile});
       }
 
+      &.home-page,
+      &.channel-page {
+        margin-top: 5px;
+      }
+
       &.one-column {
         width: 80%;
         max-width: 950px;

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -2,7 +2,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 15px;
+  padding-top: 6px;
+  padding-bottom: 10px;
 }
 
 .post-list {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -1,8 +1,12 @@
 .post-card {
-  padding: 6px 22px 0 22px;
+  margin-bottom: 0;
 
-  @include breakpoint(phone) {
-    padding: 4px 9px 0;
+  .post-card-inner {
+    padding: 6px 22px 0 22px;
+
+    @include breakpoint(phone) {
+      padding: 4px 9px 0;
+    }
   }
 }
 
@@ -321,7 +325,7 @@
 }
 
 .count-and-sort {
-  margin: 20px 0 20px 22px;
+  margin: 10px 0 10px 22px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/static/scss/sort-picker.scss
+++ b/static/scss/sort-picker.scss
@@ -1,15 +1,12 @@
 .sorter {
-  display: flex;
-  align-items: center;
-  height: 30px;
+  cursor: pointer;
 
-  select {
-    width: 90px;
-    height: 20px;
-    padding: 0 0;
-    text-align: center;
-    text-align-last: center;
-    border: none;
-    background-color: $app-background;
+  .current-sort {
+    display: flex;
+    align-items: center;
+  }
+
+  .mdc-list-item {
+    margin: 0 8px;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,16 +1065,6 @@
     "@material/theme" "^0.35.0"
     "@material/typography" "^0.35.0"
 
-"@material/menu@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-0.4.3.tgz#febc3b197ffdff10087e7698f33a711b3e13c372"
-  dependencies:
-    "@material/animation" "^0.3.1"
-    "@material/base" "^0.2.3"
-    "@material/elevation" "^0.1.11"
-    "@material/theme" "^0.1.7"
-    "@material/typography" "^0.3.0"
-
 "@material/notched-outline@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-0.35.0.tgz#df821f007ea84bf6d67859a2b7bcf5c44a248911"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

this closes #987

#### What's this PR do?

This uses a material dropdown for picking how posts and comments are sorted, instead of the native browser `<select>` we were using before.

#### How should this be manually tested?

Make sure you can pick how things are sorted, and that everything works as it should. It should be nice to look at and so on.