### PR TITLE
standard test pattern for 'shallow' rendered tests

### DIFF
--- a/static/js/components/AddLinkMenu_test.js
+++ b/static/js/components/AddLinkMenu_test.js
@@ -1,17 +1,14 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import sinon from "sinon"
 
 import CloseButton from "./CloseButton"
 import AddLinkMenu from "./AddLinkMenu"
 
-describe("AddLinkMenu", () => {
-  let sandbox, onSubmit, onChange, closeMenu, props
+import { configureShallowRenderer } from "../lib/test_utils"
 
-  const renderLinkMenu = (extraProps = {}) =>
-    shallow(<AddLinkMenu {...props} {...extraProps} />)
+describe("AddLinkMenu", () => {
+  let sandbox, onSubmit, onChange, closeMenu, props, renderLinkMenu
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -25,6 +22,7 @@ describe("AddLinkMenu", () => {
       text:      "hey!",
       url:       "https://en.wikipedia.org/wiki/United_States_war_crimes"
     }
+    renderLinkMenu = configureShallowRenderer(AddLinkMenu, props)
   })
 
   //

--- a/static/js/components/ChannelSidebar_test.js
+++ b/static/js/components/ChannelSidebar_test.js
@@ -1,8 +1,6 @@
 // @flow
-import React from "react"
 import { Link } from "react-router-dom"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 
 import Card from "./Card"
 import ChannelSidebar from "./ChannelSidebar"
@@ -10,20 +8,18 @@ import { Markdown } from "./Markdown"
 
 import { makeChannel } from "../factories/channels"
 import { editChannelBasicURL, channelModerationURL } from "../lib/url"
-
-import type { Channel } from "../flow/discussionTypes"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("ChannelSidebar", () => {
-  let channel
+  let channel, renderSidebar
 
   beforeEach(() => {
     channel = makeChannel()
+    renderSidebar = configureShallowRenderer(ChannelSidebar, {
+      channel,
+      isModerator: false
+    })
   })
-
-  const renderSidebar = (
-    chan: Channel = channel,
-    isModerator: boolean = false
-  ) => shallow(<ChannelSidebar channel={chan} isModerator={isModerator} />)
 
   it("should render sidebar", () => {
     const wrapper = renderSidebar()
@@ -33,7 +29,7 @@ describe("ChannelSidebar", () => {
   })
 
   it("should render sidebar with edit channel button for moderators ", () => {
-    const wrapper = renderSidebar(channel, true)
+    const wrapper = renderSidebar({ isModerator: true })
     const description = wrapper.find(Markdown)
     assert.equal(description.props().source, channel.description)
     assert.isTrue(wrapper.find(".edit-button").exists())
@@ -57,7 +53,7 @@ describe("ChannelSidebar", () => {
   })
 
   it("should show a moderation card, if isModerator === true", () => {
-    const wrapper = renderSidebar(channel, true)
+    const wrapper = renderSidebar({ isModerator: true })
     assert.lengthOf(wrapper.find(Card), 2)
     const moderationCard = wrapper.find(Card).at(1)
     assert.equal(moderationCard.props().title, "Moderation Tools")

--- a/static/js/components/CloseButton_test.js
+++ b/static/js/components/CloseButton_test.js
@@ -1,25 +1,23 @@
 // @flow
-import React from "react"
-import { shallow } from "enzyme"
 import sinon from "sinon"
 import { assert } from "chai"
 
 import CloseButton from "./CloseButton"
 
+import { configureShallowRenderer } from "../lib/test_utils"
+
 describe("CloseButton", () => {
-  let sandbox, onClick
+  let sandbox, onClick, renderButton
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     onClick = sandbox.stub()
+    renderButton = configureShallowRenderer(CloseButton, { onClick })
   })
 
   afterEach(() => {
     sandbox.restore
   })
-
-  const renderButton = (props = {}) =>
-    shallow(<CloseButton onClick={onClick} {...props} />)
 
   it("should have the class and icon we expect", () => {
     const wrapper = renderButton()

--- a/static/js/components/CommentVoteForm_test.js
+++ b/static/js/components/CommentVoteForm_test.js
@@ -1,18 +1,24 @@
 // @flow
-import React from "react"
 import sinon from "sinon"
-import { shallow } from "enzyme"
 import { assert } from "chai"
+
+import CommentVoteForm from "./CommentVoteForm"
+import LoginPopup from "./LoginPopup"
 
 import * as utilFuncs from "../lib/util"
 import { wait } from "../lib/util"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
-import CommentVoteForm from "./CommentVoteForm"
-import LoginPopup from "./LoginPopup"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("CommentVoteForm", () => {
-  let sandbox, upvoteStub, downvoteStub, comment, resolveUpvote, resolveDownvote
+  let sandbox,
+    upvoteStub,
+    downvoteStub,
+    comment,
+    resolveUpvote,
+    resolveDownvote,
+    renderForm
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -30,21 +36,17 @@ describe("CommentVoteForm", () => {
     comment = makeComment(makePost())
     comment.upvoted = false
     comment.downvoted = false
+
+    renderForm = configureShallowRenderer(CommentVoteForm, {
+      comment,
+      upvote:   upvoteStub,
+      downvote: downvoteStub
+    })
   })
 
   afterEach(() => {
     sandbox.restore()
   })
-
-  const renderForm = (props = {}) =>
-    shallow(
-      <CommentVoteForm
-        comment={comment}
-        upvote={upvoteStub}
-        downvote={downvoteStub}
-        {...props}
-      />
-    )
 
   const assertButtons = (wrapper, isUpvote, isClear, isVoting) => {
     const clickedButtonSelector = isUpvote

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -1,6 +1,4 @@
 // @flow
-import React from "react"
-import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 
@@ -12,28 +10,10 @@ import * as channels from "../lib/channels"
 import { makeChannel } from "../factories/channels"
 import { makeArticle } from "../factories/embedly"
 import { newPostForm } from "../lib/posts"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("CreatePostForm", () => {
-  let sandbox, isTextTabSelectedStub, isLinkTypeAllowedStub
-
-  const renderPostForm = (props = {}) =>
-    shallow(
-      <CreatePostForm
-        validation={{}}
-        channels={new Map()}
-        channel={makeChannel()}
-        postForm={newPostForm()}
-        embedlyInFlight={false}
-        embedly={{}}
-        history={{}}
-        onSubmit={sandbox.stub()}
-        onUpdate={sandbox.stub()}
-        updatePostType={sandbox.stub()}
-        processing={false}
-        updateChannelSelection={sandbox.stub()}
-        {...props}
-      />
-    )
+  let sandbox, isTextTabSelectedStub, isLinkTypeAllowedStub, renderPostForm
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -41,6 +21,20 @@ describe("CreatePostForm", () => {
     isTextTabSelectedStub.returns(true)
     isLinkTypeAllowedStub = sandbox.stub(channels, "isLinkTypeAllowed")
     isLinkTypeAllowedStub.returns(true)
+    renderPostForm = configureShallowRenderer(CreatePostForm, {
+      validation:             {},
+      channels:               new Map(),
+      channel:                makeChannel(),
+      postForm:               newPostForm(),
+      embedlyInFlight:        false,
+      embedly:                {},
+      history:                {},
+      onSubmit:               sandbox.stub(),
+      nUpdate:                sandbox.stub(),
+      updatePostType:         sandbox.stub(),
+      processing:             false,
+      updateChannelSelection: sandbox.stub()
+    })
   })
 
   afterEach(() => {

--- a/static/js/components/ExternalLogins_test.js
+++ b/static/js/components/ExternalLogins_test.js
@@ -1,25 +1,29 @@
 // @flow
 /* global SETTINGS:false */
-import React from "react"
-import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import ExternalLogins from "./ExternalLogins"
 
+import { configureShallowRenderer } from "../lib/test_utils"
+
 describe("ExternalLogins component", () => {
-  const mountExternalLogins = (props = {}) =>
-    shallow(<ExternalLogins {...props} />)
+  let renderExternalLogins
+
+  beforeEach(() => {
+    renderExternalLogins = configureShallowRenderer(ExternalLogins, {})
+  })
 
   it("should put className, if passed one", () => {
     SETTINGS.allow_saml_auth = true
-    const wrapper = mountExternalLogins({ className: "custom-class" })
+    const wrapper = renderExternalLogins({ className: "custom-class" })
     assert.equal(wrapper.props().className, "actions row custom-class")
   })
+
   //
   ;[true, false].forEach(allowSaml => {
     it(`should ${allowSaml ? "" : "not "}have a link to Touchstone`, () => {
       SETTINGS.allow_saml_auth = allowSaml
-      const wrapper = mountExternalLogins()
+      const wrapper = renderExternalLogins()
       const button = wrapper.find("TouchstoneLoginButton")
       assert.equal(button.exists(), allowSaml)
     })

--- a/static/js/components/LoginPopup_test.js
+++ b/static/js/components/LoginPopup_test.js
@@ -1,30 +1,26 @@
 // @flow
-import React from "react"
-import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 import { Link } from "react-router-dom"
 
 import { LoginPopupHelper } from "./LoginPopup"
 
-describe("LoginPopup", () => {
-  let closePopupStub, message, visible, sandbox
+import { configureShallowRenderer } from "../lib/test_utils"
 
-  const renderLoginPopupHelper = (props = {}) =>
-    shallow(
-      <LoginPopupHelper
-        closePopup={closePopupStub}
-        message={message}
-        visible={visible}
-        {...props}
-      />
-    )
+describe("LoginPopup", () => {
+  let closePopupStub, message, visible, sandbox, renderLoginPopupHelper
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     closePopupStub = sandbox.stub()
     message = "Login to do something"
     visible = true
+
+    renderLoginPopupHelper = configureShallowRenderer(LoginPopupHelper, {
+      message,
+      visible,
+      closePopup: closePopupStub
+    })
   })
 
   afterEach(() => {
@@ -66,8 +62,7 @@ describe("LoginPopup", () => {
   })
 
   it("should render null, if visible === false", () => {
-    visible = false
-    const wrapper = renderLoginPopupHelper()
+    const wrapper = renderLoginPopupHelper({ visible: false })
     assert.isNotOk(wrapper.find("div").exists())
   })
 })

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -1,7 +1,5 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import { Link } from "react-router-dom"
 import sinon from "sinon"
 
@@ -12,9 +10,14 @@ import * as channels from "../lib/channels"
 import { newPostURL, FRONTPAGE_URL, channelURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 import * as util from "../lib/util"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("Navigation", () => {
-  let sandbox, userIsAnonymousStub, defaultProps: Object, userCanPostStub
+  let sandbox,
+    userIsAnonymousStub,
+    defaultProps: Object,
+    userCanPostStub,
+    renderComponent
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -22,7 +25,6 @@ describe("Navigation", () => {
     userIsAnonymousStub.returns(false)
     userCanPostStub = sandbox.stub(channels, "userCanPost")
     userCanPostStub.returns(true)
-
     const subscribedChannels = makeChannelList(10)
     defaultProps = {
       pathname:           "/",
@@ -31,14 +33,12 @@ describe("Navigation", () => {
         subscribedChannels.map(channel => [channel.name, channel])
       )
     }
+    renderComponent = configureShallowRenderer(Navigation, defaultProps)
   })
 
   afterEach(() => {
     sandbox.restore()
   })
-
-  const renderComponent = (props = defaultProps) =>
-    shallow(<Navigation {...props} />)
 
   describe("create post link", () => {
     it("should not have channel name if channelName is not in URL", () => {
@@ -66,9 +66,9 @@ describe("Navigation", () => {
     })
 
     it("shouldn't highlight the homelink if not home!", () => {
-      defaultProps.pathname = "/hfodfo/asdfasdfasdf"
-      const wrapper = renderComponent()
-      defaultProps.pathname = "/hfodfo/asdfasdfasdf"
+      const wrapper = renderComponent({
+        pathname: "/hfodfo/asdfasdfasdf"
+      })
       assert.isNotOk(
         wrapper
           .find(".location.current-location")
@@ -79,7 +79,6 @@ describe("Navigation", () => {
 
     it("create post link should have channel name if channelName is in URL", () => {
       const wrapper = renderComponent({
-        ...defaultProps,
         pathname: channelURL("foobar")
       })
       const link = wrapper.find(".new-post-link")
@@ -103,7 +102,6 @@ describe("Navigation", () => {
       userCanPostStub.returns(false)
       const channel = defaultProps.subscribedChannels[3]
       const wrapper = renderComponent({
-        ...defaultProps,
         pathname: channelURL(channel.name)
       })
       assert.isNotOk(wrapper.find(".mdc-button").exists())
@@ -128,7 +126,6 @@ describe("Navigation", () => {
   it("should show a SubscriptionsList", () => {
     const channels = makeChannelList(10)
     const wrapper = renderComponent({
-      ...defaultProps,
       subscribedChannels: channels
     })
     assert.equal(
@@ -139,7 +136,6 @@ describe("Navigation", () => {
 
   it("should pass the current channel down to the SubscriptionsList", () => {
     const wrapper = renderComponent({
-      ...defaultProps,
       pathname: channelURL("foobar")
     })
     assert.equal(

--- a/static/js/components/PostListNavigation_test.js
+++ b/static/js/components/PostListNavigation_test.js
@@ -1,79 +1,76 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import { Link } from "react-router-dom"
 
 import PostListNavigation from "./PostListNavigation"
+
 import { channelURL } from "../lib/url"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("PostListNavigation", () => {
-  describe("component", () => {
-    const defaultProps = {
+  let renderComponent
+
+  beforeEach(() => {
+    renderComponent = configureShallowRenderer(PostListNavigation, {
       pathname:    "/",
       after:       undefined,
       afterCount:  undefined,
       before:      undefined,
       beforeCount: undefined
-    }
-    const renderComponent = (props = defaultProps) =>
-      shallow(<PostListNavigation {...props} />)
-
-    it("should show nothing if no pagination values provided", () => {
-      const wrapper = renderComponent()
-      assert.lengthOf(wrapper.find(Link), 0)
     })
+  })
 
-    it("renders a next link with the correct URL", () => {
-      const wrapper = renderComponent({
-        ...defaultProps,
-        after:      "abc",
-        afterCount: 5,
-        pathname:   channelURL("foobar")
-      })
-      const link = wrapper.find(Link)
-      assert.deepEqual(link.props().to, {
-        pathname: channelURL("foobar"),
-        search:   "?after=abc&count=5"
-      })
-      assert.equal(link.props().children, "next >")
-    })
+  it("should show nothing if no pagination values provided", () => {
+    const wrapper = renderComponent()
+    assert.lengthOf(wrapper.find(Link), 0)
+  })
 
-    it("renders a previous link with the correct URL", () => {
-      const wrapper = renderComponent({
-        ...defaultProps,
-        before:      "abc",
-        beforeCount: 5,
-        pathname:    channelURL("foobar")
-      })
-      const link = wrapper.find(Link)
-      assert.deepEqual(link.props().to, {
-        pathname: channelURL("foobar"),
-        search:   "?before=abc&count=5"
-      })
-      assert.equal(link.props().children, "< previous")
+  it("renders a next link with the correct URL", () => {
+    const wrapper = renderComponent({
+      after:      "abc",
+      afterCount: 5,
+      pathname:   channelURL("foobar")
     })
+    const link = wrapper.find(Link)
+    assert.deepEqual(link.props().to, {
+      pathname: channelURL("foobar"),
+      search:   "?after=abc&count=5"
+    })
+    assert.equal(link.props().children, "next >")
+  })
 
-    it("renders both a previous and next link with the correct URLs", () => {
-      const wrapper = renderComponent({
-        ...defaultProps,
-        before:      "abc",
-        beforeCount: 5,
-        after:       "abc",
-        afterCount:  5,
-        pathname:    channelURL("foobar")
-      })
-      const links = wrapper.find(Link)
-      assert.deepEqual(links.at(0).props().to, {
-        pathname: channelURL("foobar"),
-        search:   "?before=abc&count=5"
-      })
-      assert.equal(links.at(0).props().children, "< previous")
-      assert.deepEqual(links.at(1).props().to, {
-        pathname: channelURL("foobar"),
-        search:   "?after=abc&count=5"
-      })
-      assert.equal(links.at(1).props().children, "next >")
+  it("renders a previous link with the correct URL", () => {
+    const wrapper = renderComponent({
+      before:      "abc",
+      beforeCount: 5,
+      pathname:    channelURL("foobar")
     })
+    const link = wrapper.find(Link)
+    assert.deepEqual(link.props().to, {
+      pathname: channelURL("foobar"),
+      search:   "?before=abc&count=5"
+    })
+    assert.equal(link.props().children, "< previous")
+  })
+
+  it("renders both a previous and next link with the correct URLs", () => {
+    const wrapper = renderComponent({
+      before:      "abc",
+      beforeCount: 5,
+      after:       "abc",
+      afterCount:  5,
+      pathname:    channelURL("foobar")
+    })
+    const links = wrapper.find(Link)
+    assert.deepEqual(links.at(0).props().to, {
+      pathname: channelURL("foobar"),
+      search:   "?before=abc&count=5"
+    })
+    assert.equal(links.at(0).props().children, "< previous")
+    assert.deepEqual(links.at(1).props().to, {
+      pathname: channelURL("foobar"),
+      search:   "?after=abc&count=5"
+    })
+    assert.equal(links.at(1).props().children, "next >")
   })
 })

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -1,19 +1,23 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import sinon from "sinon"
 
 import PostList from "./PostList"
 import CompactPostDisplay from "./CompactPostDisplay"
 
 import { makeChannelPostList } from "../factories/posts"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("PostList", () => {
-  const renderPostList = (props = { posts: makeChannelPostList() }) =>
-    shallow(
-      <PostList reportPost={() => {}} toggleUpvote={() => {}} {...props} />
-    )
+  let renderPostList
+
+  beforeEach(() => {
+    renderPostList = configureShallowRenderer(PostList, {
+      reportPost:   sinon.stub(),
+      toggleUpvote: sinon.stub(),
+      posts:        makeChannelPostList()
+    })
+  })
 
   it("should render a list of posts", () => {
     const wrapper = renderPostList()
@@ -28,7 +32,6 @@ describe("PostList", () => {
 
   it("should pass the showChannelLinks prop to CompactPostDisplay", () => {
     const wrapper = renderPostList({
-      posts:            makeChannelPostList(),
       showChannelLinks: true
     })
     wrapper.find(CompactPostDisplay).forEach(postSummary => {
@@ -39,7 +42,6 @@ describe("PostList", () => {
   it("should pass the showPinUI prop to CompactPostDisplay", () => {
     [true, false].forEach(showPinUI => {
       const wrapper = renderPostList({
-        posts: makeChannelPostList(),
         showPinUI
       })
       wrapper.find(CompactPostDisplay).forEach(postSummary => {
@@ -51,7 +53,6 @@ describe("PostList", () => {
   it("should pass the isModerator prop to CompactPostDisplay", () => {
     [true, false].forEach(isModerator => {
       const wrapper = renderPostList({
-        posts: makeChannelPostList(),
         isModerator
       })
       wrapper.find(CompactPostDisplay).forEach(postSummary => {
@@ -63,7 +64,6 @@ describe("PostList", () => {
   it("should pass the togglePinPost prop to CompactPostDisplay", () => {
     const pinStub = sinon.stub()
     const wrapper = renderPostList({
-      posts:         makeChannelPostList(),
       togglePinPost: pinStub
     })
     wrapper.find(CompactPostDisplay).forEach(postSummary => {
@@ -74,7 +74,6 @@ describe("PostList", () => {
   it("should pass the reportPost prop to CompactPostDisplay", () => {
     const reportStub = sinon.stub()
     const wrapper = renderPostList({
-      posts:      makeChannelPostList(),
       reportPost: reportStub
     })
     wrapper
@@ -88,7 +87,6 @@ describe("PostList", () => {
   it("should pass the removePost prop to CompactPostDisplay", () => {
     const removeStub = sinon.stub()
     const wrapper = renderPostList({
-      posts:      makeChannelPostList(),
       removePost: removeStub
     })
     wrapper

--- a/static/js/components/ReportForm_test.js
+++ b/static/js/components/ReportForm_test.js
@@ -1,40 +1,34 @@
 // @flow
-import React from "react"
 import sinon from "sinon"
-import { mount } from "enzyme"
 import { assert } from "chai"
 
 import ReportForm from "./ReportForm"
 
+import { configureShallowRenderer } from "../lib/test_utils"
+
 describe("ReportForm", () => {
-  let sandbox, onUpdateStub
+  let sandbox, onUpdateStub, renderForm
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     onUpdateStub = sandbox.stub()
+
+    renderForm = configureShallowRenderer(ReportForm, {
+      reportForm: {
+        reason:     "reason",
+        reportType: "comment",
+        commentId:  "1"
+      },
+      validation:  { reason: "" },
+      onUpdate:    onUpdateStub,
+      description: "description",
+      label:       "label"
+    })
   })
 
   afterEach(() => {
     sandbox.restore()
   })
-
-  const renderForm = (
-    reportForm = {
-      reason:     "reason",
-      reportType: "comment",
-      commentId:  "1"
-    },
-    validation = { reason: "" }
-  ) =>
-    mount(
-      <ReportForm
-        reportForm={reportForm}
-        validation={validation}
-        onUpdate={onUpdateStub}
-        description="description"
-        label="label"
-      />
-    )
 
   it("displays the description and label", () => {
     const wrapper = renderForm()

--- a/static/js/components/SortPicker_test.js
+++ b/static/js/components/SortPicker_test.js
@@ -1,7 +1,5 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import R from "ramda"
 import sinon from "sinon"
 
@@ -11,25 +9,25 @@ import {
   VALID_POST_SORT_LABELS,
   VALID_COMMENT_SORT_LABELS
 } from "../lib/sorting"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("PostSortPicker", () => {
-  let updateSortParamStub
+  let updateSortParamStub, renderComponent
 
   beforeEach(() => {
     updateSortParamStub = sinon.stub()
+    renderComponent = Component =>
+      configureShallowRenderer(Component, {
+        updateSortParam: updateSortParamStub
+      })
   })
-
-  const renderComponent = (Component, props = {}) =>
-    shallow(
-      <Component updateSortParam={updateSortParamStub} value="hey" {...props} />
-    )
 
   it("should have all the options we expect", () => {
     [
       [VALID_POST_SORT_LABELS, PostSortPicker],
       [VALID_COMMENT_SORT_LABELS, CommentSortPicker]
     ].forEach(([labels, Component]) => {
-      const wrapper = renderComponent(Component)
+      const wrapper = renderComponent(Component)()
       // $FlowFixMe
       R.zip([...wrapper.find("option")], labels).forEach(
         ([optionWrapper, [postSortType, postSortLabel]]) => {
@@ -49,7 +47,7 @@ describe("PostSortPicker", () => {
       [CommentSortPicker, VALID_COMMENT_SORT_LABELS]
     ].forEach(([Component, labels]) => {
       labels.forEach(([value, label]) => {
-        const wrapper = renderComponent(Component, { value })
+        const wrapper = renderComponent(Component)({ value })
         assert.include(wrapper.find(".current-sort").props().children, label)
       })
     })
@@ -62,7 +60,9 @@ describe("PostSortPicker", () => {
     ].forEach(([Component, labels]) => {
       labels.forEach(([type, label], idx) => {
         updateSortParamStub = sinon.stub()
-        const wrapper = renderComponent(Component)
+        const wrapper = configureShallowRenderer(Component, {
+          updateSortParam: updateSortParamStub
+        })()
         const menuItem = wrapper.find("MenuItem").at(idx)
         assert.equal(menuItem.props().children, label)
         menuItem.simulate("click")
@@ -73,7 +73,7 @@ describe("PostSortPicker", () => {
 
   it("should open and close", () => {
     [PostSortPicker, CommentSortPicker].forEach(Component => {
-      const wrapper = renderComponent(Component)
+      const wrapper = renderComponent(Component)()
       assert.isFalse(wrapper.find("Menu").props().open)
       assert.isFalse(wrapper.state("menuOpen"))
       wrapper.instance().toggleMenuOpen()

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -1,18 +1,14 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 
 import SubscriptionsList from "./SubscriptionsList"
 
 import { channelURL, editChannelBasicURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("SubscriptionsList", function() {
-  let channels, myChannels, notMyChannels
-  const renderSubscriptionsList = (
-    props = { subscribedChannels: channels, currentChannel: channels[0].name }
-  ) => shallow(<SubscriptionsList {...props} />)
+  let channels, myChannels, notMyChannels, renderSubscriptionsList
 
   beforeEach(() => {
     channels = makeChannelList()
@@ -20,9 +16,12 @@ describe("SubscriptionsList", function() {
     channels.forEach((channel, i) => {
       channel.user_is_moderator = i % 2 === 0
     })
-
     myChannels = channels.filter(channel => channel.user_is_moderator)
     notMyChannels = channels.filter(channel => !channel.user_is_moderator)
+    renderSubscriptionsList = configureShallowRenderer(SubscriptionsList, {
+      subscribedChannels: channels,
+      currentChannel:     channels[0].name
+    })
   })
 
   it("should show each channel", () => {

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -1,8 +1,6 @@
 // @flow
 /* global SETTINGS:false */
-import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 import sinon from "sinon"
 import { Link } from "react-router-dom"
 
@@ -12,9 +10,10 @@ import DropdownMenu from "./DropdownMenu"
 import { profileURL, SETTINGS_URL } from "../lib/url"
 import * as utilFuncs from "../lib/util"
 import { defaultProfileImageUrl } from "../lib/util"
+import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("UserMenu", () => {
-  let toggleShowUserMenuStub, showUserMenu, profile, sandbox
+  let toggleShowUserMenuStub, showUserMenu, profile, sandbox, renderUserMenu
 
   beforeEach(() => {
     toggleShowUserMenuStub = sinon.stub()
@@ -34,21 +33,17 @@ describe("UserMenu", () => {
       bio:                  null,
       headline:             null
     }
+
+    renderUserMenu = configureShallowRenderer(UserMenu, {
+      toggleShowUserMenu: toggleShowUserMenuStub,
+      showUserMenu,
+      profile
+    })
   })
 
   afterEach(() => {
     sandbox.restore()
   })
-
-  const renderUserMenu = (props = {}) =>
-    shallow(
-      <UserMenu
-        toggleShowUserMenu={toggleShowUserMenuStub}
-        showUserMenu={showUserMenu}
-        profile={profile}
-        {...props}
-      />
-    )
 
   it("should include the profile image with onclick handler", () => {
     const wrapper = renderUserMenu()
@@ -109,8 +104,7 @@ describe("UserMenu", () => {
     } enabled`, async () => {
       SETTINGS.profile_ui_enabled = uiEnabled
       SETTINGS.username = profile.username
-      showUserMenu = true
-      const wrapper = renderUserMenu()
+      const wrapper = renderUserMenu({ showUserMenu: true })
       assert.equal(
         wrapper
           .find(Link)
@@ -122,8 +116,7 @@ describe("UserMenu", () => {
   })
 
   it("dropdown menu should have a settings link", () => {
-    showUserMenu = true
-    const wrapper = renderUserMenu()
+    const wrapper = renderUserMenu({ showUserMenu: true })
     const { to, children } = wrapper.find(Link).props()
     assert.equal(to, SETTINGS_URL)
     assert.equal(children, "Settings")
@@ -131,8 +124,7 @@ describe("UserMenu", () => {
 
   it("should include a logout link, if feature is enabled", () => {
     SETTINGS.allow_email_auth = true
-    showUserMenu = true
-    const wrapper = renderUserMenu()
+    const wrapper = renderUserMenu({ showUserMenu: true })
     const { href, children } = wrapper.find("a").props()
     assert.equal(href, "/logout")
     assert.equal(children, "Sign Out")

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -1,5 +1,6 @@
 // @flow
 import { assert } from "chai"
+import { shallow } from "enzyme"
 
 import { S } from "./sanctuary"
 import React from "react"
@@ -33,3 +34,9 @@ export class TestPage extends React.Component<*, *> {
     return <div />
   }
 }
+
+export const configureShallowRenderer = (
+  Component: Class<React.Component<*, *>> | Function,
+  defaultProps: Object
+) => (extraProps: Object = {}) =>
+  shallow(<Component {...defaultProps} {...extraProps} />)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

none, just a little refactor I wanted to do

#### What's this PR do?

We do a lot of testing of simple components using enzyme's `shallow`. A common pattern is to declare a method that looks something like this:

```js
const renderComponent = (props = {}) => shallow(
  <Component firstProp="hey" secondProp={someStub()} {...props} />
)
```

I think it's a good pattern, but we also do some other things in a few places. This PR basically just creates a new method, `configureShallowRenderer`, which lets you easily setup a simple test function which works like `renderComponent` above. You call it with your component and a default props object, and it returns a function which accepts optional extra props and returns an enzyme shallow wrapper. So using it looks like:

```js
let renderComponent

beforeEach(() => {
  renderComponent = configureShallowRenderer(
    Component,
    {
      firstProp: "hey",
      secondProp: someStub
    }
  )
})

it('should foobar', () => {
  const wrapper = renderComponent({ anotherProp: "cool" })
  assert(wrapper.find("Component").exists())
})
```

or something like that, haha. If the `defaultProps` aren't created in `beforeEach` I think you can get away with defining `renderComponent` at the top level too.

Anyway, I like this pattern, so I wanted to standardize on it. So I made this function, and converted all the tests which were reasonably easy to convert over to using this, instead of a straight call to `shallow` or something. A few component (i.e. non-container) tests need to use `mount`, e.g. because they use browser APIs, so I wasn't able to convert them to use this pattern, but there are only a few of those.

#### How should this be manually tested?

tests should pass, code should make sense.