### PR TITLE
Add handling for AuthorizationFailed on expired JWTs

### DIFF
--- a/static/js/lib/fetch_auth.js
+++ b/static/js/lib/fetch_auth.js
@@ -8,7 +8,7 @@ import {
 } from "redux-hammock/django_csrf_fetch"
 
 import { AUTH_REQUIRED_URL } from "./url"
-import { NOT_AUTHENTICATED_ERROR_TYPE } from "../util/rest"
+import { isNotAuthenticatedErrorType } from "../util/rest"
 
 const renewSession = async () => {
   if (SETTINGS.is_authenticated) {
@@ -34,7 +34,7 @@ export const withAuthFailure = (fetchFunc: Function) => async (
   try {
     return await fetchFunc(...args)
   } catch (fetchError) {
-    if (!fetchError || fetchError.error_type !== NOT_AUTHENTICATED_ERROR_TYPE) {
+    if (!fetchError || !isNotAuthenticatedErrorType(fetchError)) {
       // not an authentication failure, rethrow
       throw fetchError
     }
@@ -76,7 +76,7 @@ export const fetchJSONWithToken = async (
       ...body
     })
   } catch (fetchError) {
-    if (fetchError.error_type !== NOT_AUTHENTICATED_ERROR_TYPE) {
+    if (!isNotAuthenticatedErrorType(fetchError)) {
       // not an authentication failure, rethrow
       throw fetchError
     }

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -42,15 +42,24 @@ export const anyErrorExcept404or410 = anyErrorExcept([404, 410])
 // Our auth endpoints return an error type in the response, and these values
 // can be matched to that error type to properly detect authentication errors.
 export const NOT_AUTHENTICATED_ERROR_TYPE = "NotAuthenticated"
+export const AUTHENTICATION_FAILED_ERROR_TYPE = "AuthenticationFailed"
 export const NOT_AUTHORIZED_ERROR_TYPE = "PermissionDenied"
+export const AUTHENTICATION_ERRORS = [
+  NOT_AUTHENTICATED_ERROR_TYPE,
+  AUTHENTICATION_FAILED_ERROR_TYPE
+]
 
-const anySpecificErrorType = errorType =>
+const anyErrorTypes = errorTypes =>
+  R.propSatisfies(R.contains(R.__, errorTypes), "error_type")
+
+const anySpecificErrorTypes = errorTypes =>
   R.compose(
-    R.any(R.propSatisfies(R.equals(errorType), "error_type")),
+    R.any(anyErrorTypes(errorTypes)),
     R.map(R.prop("error")),
     R.filter(hasError)
   )
 
-export const anyNotAuthorizedErrorType = anySpecificErrorType(
+export const isNotAuthenticatedErrorType = anyErrorTypes(AUTHENTICATION_ERRORS)
+export const anyNotAuthorizedErrorType = anySpecificErrorTypes([
   NOT_AUTHORIZED_ERROR_TYPE
-)
+])

--- a/static/js/util/rest_test.js
+++ b/static/js/util/rest_test.js
@@ -8,7 +8,10 @@ import {
   anyErrorExcept404,
   any404Error,
   anyNotAuthorizedErrorType,
-  NOT_AUTHORIZED_ERROR_TYPE
+  isNotAuthenticatedErrorType,
+  NOT_AUTHORIZED_ERROR_TYPE,
+  NOT_AUTHENTICATED_ERROR_TYPE,
+  AUTHENTICATION_FAILED_ERROR_TYPE
 } from "./rest"
 
 const makeError = n => ({ error: { errorStatusCode: n } })
@@ -157,5 +160,12 @@ describe("rest utils", () => {
         ])
       )
     })
+    ;[NOT_AUTHENTICATED_ERROR_TYPE, AUTHENTICATION_FAILED_ERROR_TYPE].forEach(
+      error => {
+        it(`should return true if the code is ${error}`, () => {
+          assert.isTrue(isNotAuthenticatedErrorType({ error_type: error }))
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1149

#### What's this PR do?
Additionally checks for an `error_type` of `"AuthorizationFailed"` for expired JWTs and other JWT failure modes

#### How should this be manually tested?
Test the following in master and this branch:
- In MM `.env` set:
  - `OPEN_DISCUSSIONS_JWT_EXPIRES_DELTA=30` (30 seconds).
  - `OPEN_DISCUSSIONS_REDIRECT_URL=http://od.dev.local:8063/`
- Login to MM and click the "view all" link for discussions
- Logout from MM
- Wait for your JWT to expire, reload the page:
  - This should give you the error page in master and the /auth_required/ page in this branch
  - If you don't see the expected behavior, you may need to delete your sessionid cookie, which production users encountering this issue would not have