### PR TITLE
fix app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -89,7 +89,7 @@
     },
     "OPEN_DISCUSSIONS_DEFAULT_CHANNEL_BACKPOPULATE_BATCH_SIZE": {
       "description": "Number of users to sync per backpopulate batch",
-      "required": false,
+      "required": false
     },
     "OPEN_DISCUSSIONS_DEFAULT_SITE_KEY": {
       "description": "The default site key to use for JWT tokens missing one"


### PR DESCRIPTION
#### What are the relevant tickets?

`app.json` had a trailing comma, so PR builds were failing.

#### What's this PR do?

fixes that

#### How should this be manually tested?

PR build should build without an error