### PR TITLE
Fix image uploads on Edge and iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-eslint": "^8.2.5",
     "babel-loader": "^8.0.0",
     "babel-plugin-istanbul": "^4.1.6",
+    "blueimp-canvas-to-blob": "^3.14.0",
     "casual-browserify": "^1.5.12",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/static/js/entry/root.js
+++ b/static/js/entry/root.js
@@ -12,6 +12,9 @@ import Router, { routes } from "../Router"
 
 import Raven from "raven-js"
 
+// requirement for creating blob from crop canvas.
+import "blueimp-canvas-to-blob/js/canvas-to-blob.js"
+
 Raven.config(SETTINGS.sentry_dsn, {
   release:     SETTINGS.release_version,
   environment: SETTINGS.environment

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,6 +1879,10 @@ bluebird@~3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
+blueimp-canvas-to-blob@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.14.0.tgz#ea075ffbfb1436607b0c75e951fb1ceb3ca0288e"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1140

#### What's this PR do?
Adds a polyfill for `toBlob`

#### How should this be manually tested?
Image uploads (profile, banner) should still work on Mac/Linux
To test on Edge:
  - [Download, import, and run the Edge Virtualbox VM from Microsoft](https://dev.windows.com/en-us/microsoft-edge/tools/vms/windows/)
  - In your `.env` file, set `WEBPACK_DEV_SERVER_HOST=10.0.2.2` and restart docker containers
  - In the Edge VM, start Edge and navigate to `http://10.0.2.2:8063`
  - Log in with an email account, then upload an image for your profile and save.  It should work.