### PR TITLE
Don't show an error page if comment posting fails

### DIFF
--- a/static/js/actions/comment.js
+++ b/static/js/actions/comment.js
@@ -3,3 +3,6 @@ import { createAction } from "redux-actions"
 
 export const REPLACE_MORE_COMMENTS = "REPLACE_MORE_COMMENTS"
 export const replaceMoreComments = createAction(REPLACE_MORE_COMMENTS)
+
+export const CLEAR_COMMENT_ERROR = "CLEAR_COMMENT_ERROR"
+export const clearCommentError = createAction(CLEAR_COMMENT_ERROR)

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -195,64 +195,65 @@ const mapDispatchToProps = (dispatch: any, ownProps: CommentFormProps) => {
     },
     cancelReply:  cancelReply(dispatch, formKey),
     beginEditing: beginEditing(dispatch, formKey),
-    onSubmit:     R.curry((postID, text, commentID, post, e) => {
+    onSubmit:     R.curry(async (postID, text, commentID, post, e) => {
       e.preventDefault()
-      return dispatch(actions.comments.post(postID, text, commentID))
-        .then(() => {
+      try {
+        await dispatch(actions.comments.post(postID, text, commentID))
+        dispatch(
+          setPostData({
+            ...post,
+            num_comments: post.num_comments + 1
+          })
+        )
+        cancelReply(dispatch, formKey)()
+      } catch (err) {
+        dispatch(clearCommentError())
+        if (err.errorStatusCode === 410) {
+          // Comment was deleted
           dispatch(
-            setPostData({
-              ...post,
-              num_comments: post.num_comments + 1
-            })
+            setBannerMessage(
+              "This comment has been deleted and cannot be replied to"
+            )
           )
           cancelReply(dispatch, formKey)()
-        })
-        .catch(err => {
-          dispatch(clearCommentError())
-          if (err.errorStatusCode === 410) {
-            // Comment was deleted
-            dispatch(
-              setBannerMessage(
-                "This comment has been deleted and cannot be replied to"
-              )
+        } else {
+          // Unknown errors
+          dispatch(
+            setBannerMessage(
+              `Something went wrong creating your comment. Please try again or contact us at ${
+                SETTINGS.support_email
+              }`
             )
-          } else {
-            // Unknown errors
-            dispatch(
-              setBannerMessage(
-                `Something went wrong creating your comment. Please try again or contact us at ${
-                  SETTINGS.support_email
-                }`
-              )
-            )
-          }
-        })
+          )
+        }
+      }
     }),
-    patchComment: comment =>
-      dispatch(actions.comments.patch(comment.id, comment))
-        .then(() => {
+    patchComment: async comment => {
+      try {
+        await dispatch(actions.comments.patch(comment.id, comment))
+        cancelReply(dispatch, formKey)()
+      } catch (err) {
+        dispatch(clearCommentError())
+        if (err.errorStatusCode === 410) {
+          // Comment was deleted
+          dispatch(
+            setBannerMessage(
+              "This comment has been deleted and cannot be edited"
+            )
+          )
           cancelReply(dispatch, formKey)()
-        })
-        .catch(err => {
-          dispatch(clearCommentError())
-          if (err.errorStatusCode === 410) {
-            // Comment was deleted
-            dispatch(
-              setBannerMessage(
-                "This comment has been deleted and cannot be edited"
-              )
+        } else {
+          // Unknown errors
+          dispatch(
+            setBannerMessage(
+              `Something went wrong editing your comment. Please try again or contact us at ${
+                SETTINGS.support_email
+              }`
             )
-          } else {
-            // Unknown errors
-            dispatch(
-              setBannerMessage(
-                `Something went wrong editing your comment. Please try again or contact us at ${
-                  SETTINGS.support_email
-                }`
-              )
-            )
-          }
-        }),
+          )
+        }
+      }
+    },
     patchPost: post =>
       dispatch(actions.posts.patch(post.id, post)).then(() => {
         cancelReply(dispatch, formKey)()

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -5,6 +5,7 @@ import R from "ramda"
 import { connect } from "react-redux"
 
 import { actions } from "../actions"
+import { clearCommentError } from "../actions/comment"
 import { setPostData } from "../actions/post"
 import { setBannerMessage } from "../actions/ui"
 import {
@@ -207,6 +208,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: CommentFormProps) => {
           cancelReply(dispatch, formKey)()
         })
         .catch(err => {
+          dispatch(clearCommentError())
           if (err.errorStatusCode === 410) {
             // Comment was deleted
             dispatch(

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -229,9 +229,30 @@ const mapDispatchToProps = (dispatch: any, ownProps: CommentFormProps) => {
         })
     }),
     patchComment: comment =>
-      dispatch(actions.comments.patch(comment.id, comment)).then(() => {
-        cancelReply(dispatch, formKey)()
-      }),
+      dispatch(actions.comments.patch(comment.id, comment))
+        .then(() => {
+          cancelReply(dispatch, formKey)()
+        })
+        .catch(err => {
+          dispatch(clearCommentError())
+          if (err.errorStatusCode === 410) {
+            // Comment was deleted
+            dispatch(
+              setBannerMessage(
+                "This comment has been deleted and cannot be edited"
+              )
+            )
+          } else {
+            // Unknown errors
+            dispatch(
+              setBannerMessage(
+                `Something went wrong editing your comment. Please try again or contact us at ${
+                  SETTINGS.support_email
+                }`
+              )
+            )
+          }
+        }),
     patchPost: post =>
       dispatch(actions.posts.patch(post.id, post)).then(() => {
         cancelReply(dispatch, formKey)()

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -24,6 +24,7 @@ import LoginPopup from "./LoginPopup"
 import * as forms from "../actions/forms"
 import * as utilFuncs from "../lib/util"
 import { actions } from "../actions"
+import { CLEAR_COMMENT_ERROR } from "../actions/comment"
 import { SET_POST_DATA, setPostData } from "../actions/post"
 import { SET_BANNER_MESSAGE } from "../actions/ui"
 import { makePost } from "../factories/posts"
@@ -459,7 +460,7 @@ describe("CommentForms", () => {
           })
         })
         const state = await helper.listenForActions(
-          [requestType, failureType, SET_BANNER_MESSAGE],
+          [requestType, failureType, CLEAR_COMMENT_ERROR, SET_BANNER_MESSAGE],
           () => {
             wrapper.find("form").simulate("submit")
           }

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -35,7 +35,7 @@ import {
 } from "../lib/posts"
 import { validateContentReportForm } from "../lib/validation"
 import { actions } from "../actions"
-import { replaceMoreComments } from "../actions/comment"
+import { clearCommentError, replaceMoreComments } from "../actions/comment"
 import { setFocusedComment, clearFocusedComment } from "../actions/focus"
 import { formBeginEdit, formEndEdit } from "../actions/forms"
 import { setSnackbarMessage, showDialog, hideDialog } from "../actions/ui"
@@ -143,6 +143,7 @@ class PostPage extends React.Component<PostPageProps> {
 
     if (errored || notFound) {
       dispatch(clearPostError())
+      dispatch(clearCommentError())
     }
   }
 

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -8,7 +8,7 @@ import {
   INITIAL_STATE
 } from "redux-hammock/constants"
 
-import { REPLACE_MORE_COMMENTS } from "../actions/comment"
+import { CLEAR_COMMENT_ERROR, REPLACE_MORE_COMMENTS } from "../actions/comment"
 import { findComment } from "../lib/comments"
 import * as api from "../lib/api"
 
@@ -303,7 +303,8 @@ export const commentsEndpoint = {
         ...state,
         data: update
       }
-    }
+    },
+    [CLEAR_COMMENT_ERROR]: R.dissoc("error")
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Fixes #1069

#### What's this PR do?
- Adds a `clearCommentError` dispatch action, similar to `clearPostError`, to prevent an error page being shown after an error occurs creating a comment.

#### How should this be manually tested?
- Go to a post detail page.
- Make comment posting certain to fail by turning off the reddit vagrant box; or adding `raise Exception()` to the beginning of the `channels.api.create_comment` method.
- Reply to the post or an existing comment with a new comment and click Submit.
- An error banner should appear at the top of the page and the post page should still display correctly.
- The same should happen if you edit one of your existing comments and click Submit.