### PR TITLE
Added banner message for PSA error messages

### DIFF
--- a/authentication/middleware.py
+++ b/authentication/middleware.py
@@ -1,0 +1,34 @@
+"""Authentication middleware"""
+from django.shortcuts import redirect
+from django.utils.http import urlquote
+
+from social_core.exceptions import SocialAuthBaseException
+from social_django.middleware import SocialAuthExceptionMiddleware
+
+
+class SocialAuthExceptionRedirectMiddleware(SocialAuthExceptionMiddleware):
+    """
+    This middleware subclasses SocialAuthExceptionMiddleware and overrides
+    process_exception to provide an implementation that does not use
+    django.contrib.messages and instead only issues a redirect
+    """
+    def process_exception(self, request, exception):
+        """
+        Note: this is a subset of the SocialAuthExceptionMiddleware implementation
+        """
+        strategy = getattr(request, 'social_strategy', None)
+        if strategy is None or self.raise_exception(request, exception):
+            return
+
+        if isinstance(exception, SocialAuthBaseException):
+            backend = getattr(request, 'backend', None)
+            backend_name = getattr(backend, 'name', 'unknown-backend')
+
+            message = self.get_message(request, exception)
+            url = self.get_redirect_uri(request, exception)
+
+            if url:
+                url += ('?' in url and '&' or '?') + \
+                       'message={0}&backend={1}'.format(urlquote(message),
+                                                        backend_name)
+                return redirect(url)

--- a/authentication/middleware_test.py
+++ b/authentication/middleware_test.py
@@ -1,0 +1,50 @@
+"""Tests for auth middleware"""
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.shortcuts import reverse
+from django.utils.http import urlquote
+from rest_framework import status
+from social_core.exceptions import AuthAlreadyAssociated
+from social_django.utils import load_backend, load_strategy
+
+from authentication.middleware import SocialAuthExceptionRedirectMiddleware
+
+
+def test_process_exception_no_strategy(rf, settings):
+    """Tests that if the request has no strategy it does nothing"""
+    settings.DEBUG = False
+    request = rf.get(reverse('social:complete', args=('email',)))
+    middleware = SocialAuthExceptionRedirectMiddleware()
+    assert middleware.process_exception(request, None) is None
+
+
+def test_process_exception(rf, settings):
+    """Tests that a process_exception handles auth exceptions correctly"""
+    settings.DEBUG = False
+    msg = 'error message'
+    request = rf.get(reverse('social:complete', args=('email',)))
+    # social_django depends on request.sesssion, so use the middleware to set that
+    SessionMiddleware().process_request(request)
+    strategy = load_strategy(request)
+    backend = load_backend(strategy, 'email', None)
+    request.social_strategy = strategy
+    request.backend = backend
+
+    middleware = SocialAuthExceptionRedirectMiddleware()
+    result = middleware.process_exception(request, AuthAlreadyAssociated(backend, msg))
+    assert result.status_code == status.HTTP_302_FOUND
+    assert result.url == '{}?message={}&backend={}'.format(reverse('login'), urlquote(msg), backend.name)
+
+
+def test_process_exception_non_auth_error(rf, settings):
+    """Tests that a process_exception handles non-auth exceptions correctly"""
+    settings.DEBUG = False
+    request = rf.get(reverse('social:complete', args=('email',)))
+    # social_django depends on request.sesssion, so use the middleware to set that
+    SessionMiddleware().process_request(request)
+    strategy = load_strategy(request)
+    backend = load_backend(strategy, 'email', None)
+    request.social_strategy = strategy
+    request.backend = backend
+
+    middleware = SocialAuthExceptionRedirectMiddleware()
+    assert middleware.process_exception(request, Exception("something bad happened")) is None

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -110,7 +110,7 @@ MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     'open_discussions.middleware.user_activity.UserActivityMiddleware',
     'open_discussions.middleware.channel_api.ChannelApiMiddleware',
-    'social_django.middleware.SocialAuthExceptionMiddleware',
+    'authentication.middleware.SocialAuthExceptionRedirectMiddleware',
 )
 
 # CORS

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -2,9 +2,11 @@
 import { deriveActions } from "redux-hammock"
 
 import { endpoints } from "../lib/redux_rest"
+import * as channel from "./channel"
 import * as forms from "./forms"
+import * as ui from "./ui"
 
-const actions: Object = { forms }
+const actions: Object = { forms, ui, channel }
 endpoints.forEach(endpoint => {
   actions[endpoint.name] = deriveActions(endpoint)
 })

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -4,6 +4,7 @@ import React from "react"
 import { Route, Redirect, Switch } from "react-router-dom"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
+import qs from "query-string"
 
 import HomePage from "./HomePage"
 import ChannelPage from "./ChannelPage"
@@ -38,6 +39,7 @@ import {
   setShowDrawerDesktop,
   showDropdown,
   hideDropdown,
+  setBannerMessage,
   hideBanner
 } from "../actions/ui"
 import { setChannelData } from "../actions/channel"
@@ -124,6 +126,19 @@ class App extends React.Component<AppProps> {
     dispatch(setChannelData(channels))
     if (SETTINGS.username) {
       await dispatch(actions.profiles.get(SETTINGS.username))
+    }
+    // wait to show messages
+    await this.showMessages()
+  }
+
+  showMessages = async () => {
+    const {
+      dispatch,
+      location: { search }
+    } = this.props
+    const params = qs.parse(search)
+    if (params.message) {
+      await dispatch(setBannerMessage(params.message))
     }
   }
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import sinon from "sinon"
 import { assert } from "chai"
+import qs from "query-string"
 
 import App from "./App"
 
@@ -41,6 +42,29 @@ describe("App", () => {
     await renderComponent("/missing", [])
     sinon.assert.calledWith(helper.getChannelsStub)
   })
+
+  it("shows messages in the banner on mount", async () => {
+    SETTINGS.username = null
+    const message = "Something strange is afoot at the Circle K"
+    const [wrapper] = await renderComponent(
+      `/missing?${qs.stringify({ message })}`,
+      [
+        actions.subscribedChannels.get.requestType,
+        actions.subscribedChannels.get.successType,
+        actions.channel.SET_CHANNEL_DATA,
+        actions.ui.SET_BANNER_MESSAGE
+      ]
+    )
+
+    wrapper.update()
+
+    assert.deepEqual(helper.store.getState().ui.banner, {
+      message,
+      visible: true
+    })
+  })
+
+  //
   ;[
     [true, true, 0, false],
     [true, false, 0, true],
@@ -79,6 +103,8 @@ describe("App", () => {
       })
     })
   })
+
+  //
   ;[SETTINGS_URL, `${SETTINGS_URL}tokenbasedauthtokentoken`].forEach(url => {
     it(`loads requirements after navigating away from settings url ${url}`, async () => {
       const [wrapper] = await renderComponent(url, [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1057

#### What's this PR do?
This fixes this issue by displaying a banner with the PSA error message in it. To do so, it also removes the `django.contrib.messages` app, since that causes PSA to write the messages to a cookie, which is more complex to handle and we're not actually using messages in any way elsewhere anyway.

#### How should this be manually tested?
- Login to discussions as one user via email (User A)
- Login to discussions as another user via MM (User B)
- You should remained logged in as User A, but see a banner message indicating the MM account was already linked.