### PR TITLE
Added empty post loading animation when posts are being loaded

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -6,11 +6,12 @@ import ContentLoader from "react-content-loader"
 
 import { embedlyResizeImage, urlHostname } from "../lib/url"
 import { hasIframe } from "../lib/embed"
+import { contentLoaderSpeed } from "../lib/constants"
 
 export const EmbedlyLoader = (props: Object = {}) => (
-  <div className="content-loader">
+  <div className="embedly-content-loader">
     <ContentLoader
-      speed={2}
+      speed={contentLoaderSpeed}
       style={{ width: "100%", height: "300px" }}
       width="100%"
       height={300}

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -1,7 +1,11 @@
 // @flow
 import React from "react"
+import R from "ramda"
+import ContentLoader from "react-content-loader"
 
 import { NotFound, NotAuthorized } from "../components/ErrorPages"
+import Card from "./Card"
+import { contentLoaderSpeed } from "../lib/constants"
 
 type LoadingProps = {
   loaded: boolean,
@@ -14,6 +18,8 @@ type SpinnerProps = {
   className?: string
 }
 
+const emptyPostsToRender = 5
+
 export const Loading = (props: SpinnerProps) => (
   <div className={`loading ${props.className ? props.className : ""}`}>
     <div className="sk-three-bounce">
@@ -24,35 +30,82 @@ export const Loading = (props: SpinnerProps) => (
   </div>
 )
 
-const withLoading = (LoadedComponent: Class<React.Component<*, *>>) => {
-  class WithLoading extends LoadedComponent {
-    props: LoadingProps
-    static WrappedComponent: Class<React.Component<*, *>>
-
-    render() {
-      const { loaded, errored, notAuthorized, notFound } = this.props
-
-      if (notFound) {
-        return <NotFound />
-      }
-
-      if (notAuthorized) {
-        return <NotAuthorized />
-      }
-
-      if (errored) {
-        return <div className="errored">Error loading page</div>
-      }
-
-      if (!loaded) {
-        return <Loading />
-      }
-
-      return <div className="loaded">{super.render()}</div>
-    }
-  }
-  WithLoading.WrappedComponent = LoadedComponent
-  return WithLoading
+const AnimatedEmptyPost = (i: number) => {
+  return (
+    <div className="post-content-loader" key={`loader-${i}`}>
+      <Card className="compact-post-summary">
+        <div className="post-toprow">
+          <ContentLoader
+            speed={contentLoaderSpeed}
+            style={{ width: "100%", height: "137px" }}
+            width="100%"
+            height={137}
+          >
+            <rect x="0" y="0" rx="5" ry="5" width="70%" height="20" />
+            <rect x="0" y="40" rx="5" ry="5" width="70%" height="16" />
+            <rect x="0" y="58" rx="5" ry="5" width="70%" height="16" />
+            <rect x="0" y="113" rx="5" ry="5" width="35" height="24" />
+            <rect x="75%" y="0" rx="5" ry="5" width="25%" height="103" />
+            <rect x="89%" y="113" rx="5" ry="5" width="11%" height="24" />
+          </ContentLoader>
+        </div>
+      </Card>
+    </div>
+  )
 }
 
-export default withLoading
+const PostLoading = () => (
+  <React.Fragment>
+    <div className="post-list-title">
+      <ContentLoader
+        speed={contentLoaderSpeed}
+        style={{ width: "100%", height: "24px" }}
+        width="100%"
+        height={24}
+      >
+        <rect x="0" y="0" rx="5" ry="5" width="100%" height="100%" />
+      </ContentLoader>
+    </div>
+    {R.times(AnimatedEmptyPost, emptyPostsToRender)}
+  </React.Fragment>
+)
+
+export const withLoading = R.curry(
+  (
+    LoadingComponent: Class<React.Component<*, *>> | Function,
+    LoadedComponent: Class<React.Component<*, *>>
+  ) => {
+    class WithLoading extends LoadedComponent {
+      props: LoadingProps
+      static WrappedComponent: Class<React.Component<*, *>>
+
+      render() {
+        const { loaded, errored, notAuthorized, notFound } = this.props
+
+        if (notFound) {
+          return <NotFound />
+        }
+
+        if (notAuthorized) {
+          return <NotAuthorized />
+        }
+
+        if (errored) {
+          return <div className="errored">Error loading page</div>
+        }
+
+        if (!loaded) {
+          return <LoadingComponent />
+        }
+
+        return <div className="loaded">{super.render()}</div>
+      }
+    }
+
+    WithLoading.WrappedComponent = LoadedComponent
+    return WithLoading
+  }
+)
+
+export const withSpinnerLoading = withLoading(Loading)
+export const withPostLoading = withLoading(PostLoading)

--- a/static/js/containers/ChannelModerationPage.js
+++ b/static/js/containers/ChannelModerationPage.js
@@ -15,7 +15,7 @@ import {
   withCommentModeration,
   commentModerationSelector
 } from "../hoc/withCommentModeration"
-import withLoading from "../components/Loading"
+import { withSpinnerLoading } from "../components/Loading"
 import withChannelSidebar from "../hoc/withChannelSidebar"
 import CompactPostDisplay from "../components/CompactPostDisplay"
 import CommentTree from "../components/CommentTree"
@@ -153,5 +153,5 @@ export default R.compose(
   withPostModeration,
   withCommentModeration,
   withChannelSidebar("channel-moderation-page"),
-  withLoading
+  withSpinnerLoading
 )(ChannelModerationPage)

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -7,7 +7,7 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
 import CanonicalLink from "../components/CanonicalLink"
-import withLoading from "../components/Loading"
+import { withPostLoading } from "../components/Loading"
 import withChannelSidebar from "../hoc/withChannelSidebar"
 import { PostSortPicker } from "../components/SortPicker"
 import {
@@ -204,5 +204,5 @@ export default R.compose(
   withChannelSidebar("channel-page"),
   withChannelTracker,
   withPostList,
-  withLoading
+  withPostLoading
 )(ChannelPage)

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -187,7 +187,7 @@ describe("ChannelPage", () => {
         }
       }
     )
-    assert.lengthOf(inner.find("Loading"), 1)
+    assert.lengthOf(inner.find("PostLoading"), 1)
   })
 
   it("should clear the error if present on load", async () => {

--- a/static/js/containers/HomePage.js
+++ b/static/js/containers/HomePage.js
@@ -6,7 +6,7 @@ import qs from "query-string"
 import { MetaTags } from "react-meta-tags"
 
 import CanonicalLink from "../components/CanonicalLink"
-import withLoading from "../components/Loading"
+import { withPostLoading } from "../components/Loading"
 import withSingleColumn from "../hoc/withSingleColumn"
 import { PostSortPicker } from "../components/SortPicker"
 import {
@@ -139,5 +139,5 @@ export default R.compose(
   withPostModeration,
   withSingleColumn("home-page"),
   withPostList,
-  withLoading
+  withPostLoading
 )(HomePage)

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -9,7 +9,7 @@ import qs from "query-string"
 import { MetaTags } from "react-meta-tags"
 
 import Card from "../components/Card"
-import withLoading from "../components/Loading"
+import { withSpinnerLoading } from "../components/Loading"
 import ExpandedPostDisplay from "../components/ExpandedPostDisplay"
 import CommentTree from "../components/CommentTree"
 import ReportForm from "../components/ReportForm"
@@ -555,5 +555,5 @@ export default R.compose(
   withCommentModeration,
   withSingleColumn("post-page"),
   withChannelTracker,
-  withLoading
+  withSpinnerLoading
 )(PostPage)

--- a/static/js/containers/ProfileEditPage.js
+++ b/static/js/containers/ProfileEditPage.js
@@ -7,7 +7,7 @@ import { MetaTags } from "react-meta-tags"
 
 import ProfileForm from "../components/ProfileForm"
 import Card from "../components/Card"
-import withLoading from "../components/Loading"
+import { withSpinnerLoading } from "../components/Loading"
 import withSingleColumn from "../hoc/withSingleColumn"
 import CanonicalLink from "../components/CanonicalLink"
 
@@ -168,5 +168,5 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withSingleColumn("profile-edit-page"),
-  withLoading
+  withSpinnerLoading
 )(ProfileEditPage)

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -7,7 +7,7 @@ import { MetaTags } from "react-meta-tags"
 
 import Card from "../components/Card"
 import ProfileImage, { PROFILE_IMAGE_MEDIUM } from "./ProfileImage"
-import withLoading from "../components/Loading"
+import { withSpinnerLoading } from "../components/Loading"
 import withSingleColumn from "../hoc/withSingleColumn"
 import CanonicalLink from "../components/CanonicalLink"
 
@@ -134,5 +134,5 @@ const mapStateToProps = (state, ownProps) => {
 export default R.compose(
   connect(mapStateToProps),
   withSingleColumn("profile-view-page"),
-  withLoading
+  withSpinnerLoading
 )(ProfilePage)

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -1,0 +1,1 @@
+export const contentLoaderSpeed = 2

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -101,6 +101,10 @@ export default class IntegrationTestHelper {
     })
   }
 
+  isLoadingComponentClass(cls) {
+    return cls.name === "WithLoading" || cls.name === "WithPostLoading"
+  }
+
   configureHOCRenderer(
     WrappedComponent: Class<React.Component<*, *>>,
     InnerComponent: Class<React.Component<*, *>>,
@@ -132,7 +136,7 @@ export default class IntegrationTestHelper {
         // determine the type before we dive
         const cls = inner.type()
         if (
-          cls.name === "WithLoading" &&
+          this.isLoadingComponentClass(cls) &&
           InnerComponent === cls.WrappedComponent
         ) {
           // WithLoading is actually subclassing the component, not rendering it as an inner component so there's

--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -1,4 +1,4 @@
-.content-loader {
+.embedly-content-loader {
   width: 100%;
   height: 300px;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1050

#### What's this PR do?
Adds a loading animation that shows some dummy empty post elements while posts are being loaded

#### How should this be manually tested?
Visit the home page or any channel page and observe the loading behavior. If you want to render the loading animation permanently, you can change `static/js/components/PostLoading.js` line 63 to: `if (true) {`

#### Where should the reviewer start?
`static/js/components/PostLoading.js`

#### Any background context you want to provide?
- ~~Some of the `PostLoading.js` code was copied over from `Loading.js`. I figured this was small, isolated, and unlikely to be repeated~~ No longer relevant
- I was thinking about possibly rendering this animation HTML by default and hiding/revealing it instead of rendering it fresh every time a list of posts needs to load. I figured any performance penalty would be small enough that it wasn't worth spending a lot of time on for this PR, but I'd be interested in other opinions

#### Screenshots (if appropriate)
![ss 2018-09-10 at 12 20 38](https://user-images.githubusercontent.com/14932219/45320330-5847ba00-b510-11e8-9057-229966be2d81.png)
