### PR TITLE
remove 'MicroMasters' from community guidelines

### DIFF
--- a/static/js/containers/policies/ContentPolicyPage.js
+++ b/static/js/containers/policies/ContentPolicyPage.js
@@ -22,13 +22,13 @@ export default class ContentPolicyPage extends React.Component<Props> {
       <div className="content content-policy-page">
         <MetaTags>
           <title>
-            {formatTitle("MicroMasters Discussions Community Guidelines")}
+            {formatTitle("Community Guidelines")}
           </title>
           <CanonicalLink match={match} />
         </MetaTags>
         <div className="main-content">
           <Card className="site-policy content-policy">
-            <h1>MicroMasters Discussions Community Guidelines</h1>
+            <h1>Community Guidelines</h1>
             <p>
               MITx offers these discussion forums as a place for you to grow
               your understanding of learning topics and your connection with
@@ -84,7 +84,7 @@ export default class ContentPolicyPage extends React.Component<Props> {
                 accurate to avoid any confusion down the line.
               </li>
               <li>
-                Read MicroMasters Discussions rules and guidelines before
+                Read these rules and guidelines before
                 posting for the first time. Read it again every once in a while.
               </li>
             </ul>

--- a/static/js/containers/policies/ContentPolicyPage.js
+++ b/static/js/containers/policies/ContentPolicyPage.js
@@ -21,9 +21,7 @@ export default class ContentPolicyPage extends React.Component<Props> {
     return (
       <div className="content content-policy-page">
         <MetaTags>
-          <title>
-            {formatTitle("Community Guidelines")}
-          </title>
+          <title>{formatTitle("Community Guidelines")}</title>
           <CanonicalLink match={match} />
         </MetaTags>
         <div className="main-content">
@@ -84,8 +82,8 @@ export default class ContentPolicyPage extends React.Component<Props> {
                 accurate to avoid any confusion down the line.
               </li>
               <li>
-                Read these rules and guidelines before
-                posting for the first time. Read it again every once in a while.
+                Read these rules and guidelines before posting for the first
+                time. Read it again every once in a while.
               </li>
             </ul>
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

fixes #1173 

#### What's this PR do?

removes mention of MicroMasters-specific text from the Community Guidelines page

#### How should this be manually tested?

take a look at /content_policy and command-find for 'MicroMasters'

