### PR TITLE
Extract correct channel name from edit pages

### DIFF
--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -68,8 +68,8 @@ export const postPermalink = (post: Post): string =>
 // https://github.com/mitodl/open-discussions/pull/118#discussion_r135284591
 export const getChannelNameFromPathname = R.compose(
   R.defaultTo(null),
-  R.view(R.lensIndex(1)),
-  R.match(/c\/([^/]+)\/?/)
+  R.view(R.lensIndex(2)),
+  R.match(/c\/(edit\/)?([^/]+)\/?/)
 )
 
 export const FRONTPAGE_URL = "/"

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -125,7 +125,9 @@ describe("url helper functions", () => {
         ["/c/Foobarbaz9/boz", "Foobarbaz9"],
         ["/c/fOObar_Baz9/boz", "fOObar_Baz9"],
         ["/moderation/c/foobar", "foobar"],
-        ["/moderation/c/bippity/boppity", "bippity"]
+        ["/moderation/c/bippity/boppity", "bippity"],
+        ["/manage/c/edit/FooBar", "FooBar"],
+        ["/manage/c/edit/BippitY/boppity", "BippitY"]
       ].forEach(([url, expectation]) => {
         assert.equal(expectation, getChannelNameFromPathname(url))
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1167 

#### What's this PR do?
Modifies the `getChannelNameFromPathname` function to account for a possible `edit/` between the `c/` and the channel name in the URL.

#### How should this be manually tested?
- Go to any channel URL.  The channel should be highlighted in the left `Navigation` bar.
- Click 'Edit' for a channel you have edit access to.  Switch between 'Appearance', 'Basic', and 'Members' tabs.  The channel should remain highlighted in the navigation bar.

