### PR TITLE
Validate a new link post URL before calling embedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "spinkit": "^1.2.5",
     "style-loader": "^0.21.0",
     "url-loader": "^1.0.1",
+    "validator": "^10.7.1",
     "webpack": "^3.12.0",
     "webpack-bundle-tracker": "^0.3.0",
     "webpack-dev-middleware": "^1.12.2",

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux"
 import R from "ramda"
 import { MetaTags } from "react-meta-tags"
 import { FETCH_PROCESSING } from "redux-hammock/constants"
+import isURL from "validator/lib/isURL"
 
 import CreatePostForm from "../components/CreatePostForm"
 import withSingleColumn from "../hoc/withSingleColumn"
@@ -128,7 +129,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
         }
       })
     )
-    if (name === "url" && value !== "") {
+    if (name === "url" && isURL(value, { allow_underscores: true })) {
       const embedlyGetFunc = actions.embedly.get(value)
       embedlyGetFunc.meta = {
         debounce: {

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -224,6 +224,27 @@ describe("CreatePostPage", () => {
     assert.ok(window.twttr.widgets.load.called)
   })
 
+  //
+  ;[
+    ["http", false],
+    ["http://", false],
+    ["http://foo", false],
+    ["http://foo.bar", true],
+    ["foo.bar", true],
+    ["https://foo.bar/fake_url/fake.html?param1=val1&param2=val2", true],
+    ["foo.bar/fake_url/fake.html?param1=val1&param2=val2", true]
+  ].forEach(([link, isValid]) => {
+    it(`${
+      isValid ? "should" : "shouldn't"
+    } call Embedly when the URL is ${link}`, async () => {
+      const wrapper = await renderPage()
+      setLinkPost(wrapper)
+      setUrl(wrapper, link)
+      await wait(100) // 🙃
+      assert.equal(isValid, helper.getEmbedlyStub.calledOnce)
+    })
+  })
+
   it("should show validation errors when title of post is empty", async () => {
     const wrapper = await renderPage()
     submitPost(wrapper)

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -13,6 +13,7 @@ import { makeCommentsResponse } from "../factories/comments"
 import { makePost, makeChannelPostList } from "../factories/posts"
 import { newPostURL } from "../lib/url"
 import { actions } from "../actions"
+import { SET_BANNER_MESSAGE } from "../actions/ui"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import {
   userCanPost,
@@ -25,9 +26,9 @@ import { makeArticle, makeTweet } from "../factories/embedly"
 import { wait } from "../lib/util"
 import * as embedUtil from "../lib/embed"
 import { newPostForm } from "../lib/posts"
+import { shouldIf } from "../lib/test_utils"
 
 import type { CreatePostPayload } from "../flow/discussionTypes"
-import { SET_BANNER_MESSAGE } from "../actions/ui"
 
 describe("CreatePostPage", () => {
   let helper,
@@ -234,9 +235,9 @@ describe("CreatePostPage", () => {
     ["https://foo.bar/fake_url/fake.html?param1=val1&param2=val2", true],
     ["foo.bar/fake_url/fake.html?param1=val1&param2=val2", true]
   ].forEach(([link, isValid]) => {
-    it(`${
-      isValid ? "should" : "shouldn't"
-    } call Embedly when the URL is ${link}`, async () => {
+    it(`${shouldIf(
+      isValid
+    )} call Embedly when the URL is ${link}`, async () => {
       const wrapper = await renderPage()
       setLinkPost(wrapper)
       setUrl(wrapper, link)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8863,6 +8863,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^10.7.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.7.1.tgz#dd4cc750c2134ce4a15a2acfc7b233669d659c5b"
+
 value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1156

#### What's this PR do?
Installs the [validator.js](https://www.npmjs.com/package/validator) module and uses its `isURL` function to validate a new link post's URL before calling embedly.

#### How should this be manually tested?
Create a new link post and enter different values for the URL.  Embedly should not be called until a valid URL is entered, such as `http://reddit.com` or `reddit.com`.
