### PR TITLE
Move channel moderation page

### DIFF
--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -57,7 +57,6 @@ urlpatterns = [
     url(r'^channel/', channel_redirect),
     url(r'^manage/', index),
     url(r'^create_post/', index),
-    url(r'^moderation/', index),
     url(r'^settings/', index),
     url(r'^saml/metadata/', saml_metadata, name='saml-metadata'),
     url(r'^profile/[A-Za-z0-9_]+/', index, name='profile'),

--- a/static/js/components/ChannelBreadcrumbs.js
+++ b/static/js/components/ChannelBreadcrumbs.js
@@ -2,7 +2,7 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
-import { FRONTPAGE_URL, channelURL, channelModerationURL } from "../lib/url"
+import { FRONTPAGE_URL, channelURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type BreadCrumbProps = {
@@ -17,22 +17,6 @@ export const ChannelBreadcrumbs = (props: BreadCrumbProps) => {
       <Link to={FRONTPAGE_URL}>Home</Link>&nbsp;&nbsp;
       <span>&gt;</span>&nbsp;&nbsp;
       <Link to={channelURL(channel.name)}>{channel.title}</Link>
-    </div>
-  )
-}
-
-export const ChannelModerationBreadcrumbs = (props: BreadCrumbProps) => {
-  const { channel } = props
-
-  return (
-    <div className="breadcrumbs">
-      <Link to={FRONTPAGE_URL}>Home</Link>&nbsp;&nbsp;
-      <span>&gt;</span>&nbsp;&nbsp;
-      <Link to={channelURL(channel.name)}>{channel.title}</Link>&nbsp;&nbsp;
-      <span>&gt;</span>&nbsp;&nbsp;
-      <Link to={channelModerationURL(channel.name)}>
-        Reported Posts & Comments
-      </Link>
     </div>
   )
 }

--- a/static/js/components/ChannelBreadcrumbs_test.js
+++ b/static/js/components/ChannelBreadcrumbs_test.js
@@ -3,13 +3,10 @@ import { assert } from "chai"
 import { shallow } from "enzyme"
 import { Link } from "react-router-dom"
 
-import {
-  ChannelBreadcrumbs,
-  ChannelModerationBreadcrumbs
-} from "./ChannelBreadcrumbs"
+import { ChannelBreadcrumbs } from "./ChannelBreadcrumbs"
 
 import { makeChannel } from "../factories/channels"
-import { channelModerationURL, channelURL } from "../lib/url"
+import { channelURL } from "../lib/url"
 
 describe("ChannelBreadcrumbs", () => {
   it("should render breadcrumbs", () => {
@@ -20,17 +17,5 @@ describe("ChannelBreadcrumbs", () => {
     assert.equal(first.props.children, "Home")
     assert.equal(second.props.to, channelURL(channel.name))
     assert.equal(second.props.children, channel.title)
-  })
-
-  it("should render moderation breadcrumbs", () => {
-    const channel = makeChannel()
-    const wrapper = shallow(<ChannelModerationBreadcrumbs channel={channel} />)
-    const [first, second, third] = wrapper.find(Link)
-    assert.equal(first.props.to, "/")
-    assert.equal(first.props.children, "Home")
-    assert.equal(second.props.to, channelURL(channel.name))
-    assert.equal(second.props.children, channel.title)
-    assert.equal(third.props.to, channelModerationURL(channel.name))
-    assert.equal(third.props.children, "Reported Posts & Comments")
   })
 })

--- a/static/js/components/ChannelSidebar.js
+++ b/static/js/components/ChannelSidebar.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom"
 import Card from "./Card"
 import { Markdown } from "./Markdown"
 
-import { editChannelBasicURL, channelModerationURL } from "../lib/url"
+import { editChannelBasicURL } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
@@ -35,15 +35,6 @@ const ChannelSidebar = ({ channel, isModerator }: ChannelSidebarProps) => {
           className="description"
         />
       </Card>
-      {isModerator ? (
-        <Card title="Moderation Tools" className="channel-about">
-          <div className="mod-link-wrapper">
-            <Link to={channelModerationURL(channel.name)}>
-              View reported posts & comments
-            </Link>
-          </div>
-        </Card>
-      ) : null}
     </div>
   )
 }

--- a/static/js/components/ChannelSidebar_test.js
+++ b/static/js/components/ChannelSidebar_test.js
@@ -7,7 +7,7 @@ import ChannelSidebar from "./ChannelSidebar"
 import { Markdown } from "./Markdown"
 
 import { makeChannel } from "../factories/channels"
-import { editChannelBasicURL, channelModerationURL } from "../lib/url"
+import { editChannelBasicURL } from "../lib/url"
 import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("ChannelSidebar", () => {
@@ -50,16 +50,6 @@ describe("ChannelSidebar", () => {
       description.props().source,
       "(There is no description of this channel)"
     )
-  })
-
-  it("should show a moderation card, if isModerator === true", () => {
-    const wrapper = renderSidebar({ isModerator: true })
-    assert.lengthOf(wrapper.find(Card), 2)
-    const moderationCard = wrapper.find(Card).at(1)
-    assert.equal(moderationCard.props().title, "Moderation Tools")
-    const modLink = moderationCard.find(Link)
-    assert.equal(modLink.props().to, channelModerationURL(channel.name))
-    assert.equal(modLink.props().children, "View reported posts & comments")
   })
 
   it("should not show moderation card, if isModerator !== true", () => {

--- a/static/js/components/CommentRemovalForm.js
+++ b/static/js/components/CommentRemovalForm.js
@@ -33,7 +33,7 @@ const CommentRemovalForm = ({
       }-button`}
       onClick={preventDefaultAndInvoke(() => commentAction(comment))}
     >
-      <a href="#">{comment.removed ? "approve" : "remove"}</a>
+      <a href="#">{comment.removed ? "Approve content" : "Remove content"}</a>
     </div>
   )
 }

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -5,6 +5,7 @@ import R from "ramda"
 import moment from "moment"
 import { Link } from "react-router-dom"
 
+import ReportCount from "./ReportCount"
 import Card from "./Card"
 import SpinnerButton from "./SpinnerButton"
 import { ReplyToCommentForm, EditCommentForm } from "./CommentForms"
@@ -81,7 +82,7 @@ export default class CommentTree extends React.Component<Props> {
             }
           })}
         >
-          <a href="#">{comment.subscribed ? "unfollow" : "follow"}</a>
+          <a href="#">{comment.subscribed ? "Unfollow" : "Follow"}</a>
         </div>
       </li>
     )
@@ -154,14 +155,10 @@ export default class CommentTree extends React.Component<Props> {
         <i className="material-icons more_vert" onClick={showDropdown}>
           more_vert
         </i>
+        <ReportCount count={comment.num_reports} />
         {commentMenuOpen ? (
           <DropdownMenu closeMenu={hideDropdown}>
             {userIsAnonymous() ? null : this.renderFollowButton(comment)}
-            {comment.num_reports ? (
-              <li className="comment-action-button report-count">
-                Reports: {comment.num_reports}
-              </li>
-            ) : null}
             {SETTINGS.username === comment.author_id && !moderationUI ? (
               <li>
                 <div
@@ -172,7 +169,7 @@ export default class CommentTree extends React.Component<Props> {
                     }
                   }}
                 >
-                  <a href="#">edit</a>
+                  <a href="#">Edit</a>
                 </div>
               </li>
             ) : null}
@@ -184,7 +181,7 @@ export default class CommentTree extends React.Component<Props> {
                     deleteComment(comment)
                   )}
                 >
-                  <a href="#">delete</a>
+                  <a href="#">Delete</a>
                 </div>
               </li>
             ) : null}
@@ -196,12 +193,12 @@ export default class CommentTree extends React.Component<Props> {
                     ignoreCommentReports(comment)
                   )}
                 >
-                  <a href="#">ignore all reports</a>
+                  <a href="#">Ignore report</a>
                 </div>
               </li>
             ) : null}
             <li className="comment-action-button permalink-button">
-              <Link to={commentPermalink(comment.id)}>permalink</Link>
+              <Link to={commentPermalink(comment.id)}>Show this thread</Link>
             </li>
             <li>
               <CommentRemovalForm
@@ -219,7 +216,7 @@ export default class CommentTree extends React.Component<Props> {
                     reportComment(comment)
                   )}
                 >
-                  <a href="#">report</a>
+                  <a href="#">Report</a>
                 </div>
               </li>
             )}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -227,7 +227,7 @@ describe("CommentTree", () => {
   })
 
   //
-  ;[[true, "unfollow"], [false, "follow"]].forEach(
+  ;[[true, "Unfollow"], [false, "Follow"]].forEach(
     ([subscribed, buttonText]) => {
       it(`should include a ${buttonText} button when subscribed === ${subscribed}`, () => {
         comments[0].subscribed = subscribed
@@ -359,7 +359,7 @@ describe("CommentTree", () => {
         ...openDropdownMenu(report.comment)
       })
       assert.ok(wrapper.find(".report-count").exists())
-      assert.equal(wrapper.find(".report-count").text(), "Reports: 2")
+      assert.equal(wrapper.find(".report-count").text(), "Reported 2 times")
     })
 
     it("should not render a report count, if comment has no report data", () => {
@@ -377,7 +377,7 @@ describe("CommentTree", () => {
         ...openDropdownMenu(report.comment)
       })
       const ignoreButton = wrapper.find(".ignore-button")
-      assert.equal(ignoreButton.text(), "ignore all reports")
+      assert.equal(ignoreButton.text(), "Ignore report")
       const eventStub = {
         preventDefault: helper.sandbox.stub()
       }

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom"
 
 import Card from "./Card"
 import DropdownMenu from "./DropdownMenu"
+import ReportCount from "./ReportCount"
 
 import {
   channelURL,
@@ -128,8 +129,9 @@ export class CompactPostDisplay extends React.Component<Props> {
           ) : null}
         </div>
         <div className="row">
-          <div>
+          <div className="left">
             <PostVotingButtons post={post} toggleUpvote={toggleUpvote} />
+            <ReportCount count={post.num_reports} />
           </div>
           <div className="comments-and-menu">
             <Link
@@ -151,35 +153,26 @@ export class CompactPostDisplay extends React.Component<Props> {
             )}
             {menuOpen ? (
               <DropdownMenu closeMenu={hidePostMenu}>
-                {post.num_reports ? (
-                  <li>
-                    <div className="report-count">
-                      Reports: {post.num_reports}
-                    </div>
-                  </li>
-                ) : null}
                 {showPinUI && post.text && isModerator && togglePinPost ? (
                   <li>
                     <a onClick={() => togglePinPost(post)}>
-                      {post.stickied ? "unpin" : "pin"}
+                      {post.stickied ? "Unpin" : "Pin"}
                     </a>
                   </li>
                 ) : null}
                 {isModerator && removePost ? (
                   <li>
-                    <a onClick={() => removePost(post)}>remove</a>
+                    <a onClick={() => removePost(post)}>Remove content</a>
                   </li>
                 ) : null}
                 {isModerator && ignorePostReports ? (
                   <li>
-                    <a onClick={() => ignorePostReports(post)}>
-                      ignore all reports
-                    </a>
+                    <a onClick={() => ignorePostReports(post)}>Ignore report</a>
                   </li>
                 ) : null}
                 {!userIsAnonymous() && reportPost ? (
                   <li>
-                    <a onClick={() => reportPost(post)}>report</a>
+                    <a onClick={() => reportPost(post)}>Report</a>
                   </li>
                 ) : null}
               </DropdownMenu>

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -207,7 +207,7 @@ describe("CompactPostDisplay", () => {
     it("should show a report link", () => {
       const reportPost = helper.sandbox.stub()
       const wrapper = renderPostDisplay({ post, reportPost })
-      const link = wrapper.find({ children: "report" })
+      const link = wrapper.find({ children: "Report" })
       link.props().onClick()
       assert.ok(reportPost.called)
     })
@@ -215,7 +215,7 @@ describe("CompactPostDisplay", () => {
     it("should hide the report link for anon users", () => {
       SETTINGS.username = null
       const wrapper = renderPostDisplay({ post })
-      const link = wrapper.find({ children: "report" })
+      const link = wrapper.find({ children: "Report" })
       assert.isNotOk(link.exists())
     })
 
@@ -245,7 +245,7 @@ describe("CompactPostDisplay", () => {
     })
 
     it('should include a "pinning" link, if isModerator and showPinUI', () => {
-      [[true, "unpin"], [false, "pin"]].forEach(([pinned, linkText]) => {
+      [[true, "Unpin"], [false, "Pin"]].forEach(([pinned, linkText]) => {
         post.stickied = pinned
         const wrapper = renderPostDisplay({
           post,
@@ -270,7 +270,7 @@ describe("CompactPostDisplay", () => {
       const count = wrapper.find(".report-count")
       assert.ok(count.exists())
       // $FlowFixMe: thinks this doesn't exist
-      assert.equal(count.text(), `Reports: ${post.num_reports}`)
+      assert.equal(count.text(), `Reported ${post.num_reports} times`)
     })
 
     it("should not render a report count, if post has no report data", () => {
@@ -286,7 +286,7 @@ describe("CompactPostDisplay", () => {
         isModerator: true,
         removePost:  removePostStub
       })
-      const link = wrapper.find({ children: "remove" })
+      const link = wrapper.find({ children: "Remove content" })
       assert(link.exists())
       link.simulate("click")
       assert.ok(removePostStub.calledWith(post))
@@ -299,7 +299,7 @@ describe("CompactPostDisplay", () => {
         isModerator:       true,
         ignorePostReports: ignorePostStub
       })
-      const link = wrapper.find({ children: "ignore all reports" })
+      const link = wrapper.find({ children: "Ignore report" })
       assert(link.exists())
       link.simulate("click")
       assert.ok(ignorePostStub.calledWith(post))

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -5,6 +5,7 @@ import moment from "moment"
 import R from "ramda"
 import { Link } from "react-router-dom"
 
+import ReportCount from "./ReportCount"
 import { EditPostForm } from "./CommentForms"
 import { renderTextContent } from "./Markdown"
 import Embedly from "./Embedly"
@@ -97,6 +98,7 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
             className="expanded"
             toggleUpvote={toggleUpvote}
           />
+          <ReportCount count={post.num_reports} />
         </div>
         <div className="right">
           {SETTINGS.username === post.author_id && post.text ? (
@@ -132,34 +134,31 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
           )}
           {postDropdownMenuOpen ? (
             <DropdownMenu closeMenu={hidePostMenu}>
-              {post.num_reports ? (
-                <div className="report-count">Reports: {post.num_reports}</div>
-              ) : null}
               {SETTINGS.username === post.author_id ? (
                 <li className="comment-action-button delete-post">
                   <a onClick={showPostDeleteDialog} href="#">
-                    delete
+                    Delete
                   </a>
                 </li>
               ) : null}
               {isModerator && !post.removed ? (
                 <li className="comment-action-button remove-post">
                   <a onClick={this.removePost.bind(this)} href="#">
-                    remove
+                    Remove content
                   </a>
                 </li>
               ) : null}
               {isModerator && post.removed ? (
                 <li className="comment-action-button approve-post">
                   <a onClick={this.approvePost.bind(this)} href="#">
-                    approve
+                    Approve content
                   </a>
                 </li>
               ) : null}
               {!userIsAnonymous() ? (
                 <li className="comment-action-button report-post">
                   <a onClick={showPostReportDialog} href="#">
-                    report
+                    Report
                   </a>
                 </li>
               ) : null}

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -367,7 +367,7 @@ describe("ExpandedPostDisplay", () => {
     const count = wrapper.find(".report-count")
     assert.ok(count.exists())
     // $FlowFixMe: thinks this doesn't exist
-    assert.equal(count.text(), `Reports: ${post.num_reports}`)
+    assert.equal(count.text(), `Reported ${post.num_reports} times`)
   })
 
   it("should not render a report count, if post has no report data", () => {

--- a/static/js/components/ReportCount.js
+++ b/static/js/components/ReportCount.js
@@ -1,0 +1,21 @@
+// @flow
+import React from "react"
+
+type Props = {
+  count: ?number
+}
+
+export default class ReportCount extends React.Component<Props> {
+  render() {
+    const { count } = this.props
+    if (!count) {
+      return null
+    }
+
+    return (
+      <div className="report-count">
+        Reported {count} {count === 1 ? "time" : "times"}
+      </div>
+    )
+  }
+}

--- a/static/js/components/admin/EditChannelNavbar.js
+++ b/static/js/components/admin/EditChannelNavbar.js
@@ -6,7 +6,8 @@ import R from "ramda"
 import {
   editChannelBasicURL,
   editChannelAppearanceURL,
-  editChannelModeratorsURL
+  editChannelModeratorsURL,
+  channelModerationURL
 } from "../../lib/url"
 
 type Props = {
@@ -29,6 +30,9 @@ export default class EditChannelNavbar extends React.Component<Props> {
           isActive={membersIsActive(channelName)}
         >
           Members
+        </NavLink>
+        <NavLink to={channelModerationURL(channelName)}>
+          Reported Content
         </NavLink>
       </div>
     )

--- a/static/js/components/admin/EditChannelNavbar_test.js
+++ b/static/js/components/admin/EditChannelNavbar_test.js
@@ -8,7 +8,8 @@ import {
   editChannelBasicURL,
   editChannelAppearanceURL,
   editChannelModeratorsURL,
-  editChannelContributorsURL
+  editChannelContributorsURL,
+  channelModerationURL
 } from "../../lib/url"
 
 describe("EditChannelNavbar", () => {
@@ -31,7 +32,8 @@ describe("EditChannelNavbar", () => {
     const linkPairs = [
       ["Basic", editChannelBasicURL(channelName)],
       ["Appearance", editChannelAppearanceURL(channelName)],
-      ["Members", editChannelModeratorsURL(channelName)]
+      ["Members", editChannelModeratorsURL(channelName)],
+      ["Reported Content", channelModerationURL(channelName)]
     ]
 
     assert.equal(links.length, linkPairs.length)

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -12,7 +12,6 @@ import ContentPolicyPage from "./ContentPolicyPage"
 import AdminPage from "./admin/AdminPage"
 import AuthRequiredPage from "./auth/AuthRequiredPage"
 import CreatePostPage from "./CreatePostPage"
-import ChannelModerationPage from "./ChannelModerationPage"
 import SettingsPage from "./SettingsPage"
 import AccountSettingsPage from "./AccountSettingsPage"
 import PasswordChangePage from "./PasswordChangePage"
@@ -166,10 +165,6 @@ class App extends React.Component<AppProps> {
         />
         <div className="content">
           <Route exact path={match.url} component={HomePage} />
-          <Route
-            path={`${match.url}moderation/c/:channelName`}
-            component={ChannelModerationPage}
-          />
           <Route
             exact
             path={`${match.url}c/:channelName`}

--- a/static/js/containers/admin/AdminPage.js
+++ b/static/js/containers/admin/AdminPage.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { Route } from "react-router-dom"
 
+import ChannelModerationPage from "./ChannelModerationPage"
 import CreateChannelPage from "./CreateChannelPage"
 import EditChannelAppearancePage from "./EditChannelAppearancePage"
 import EditChannelBasicPage from "./EditChannelBasicPage"
@@ -35,6 +36,10 @@ export default class AdminPage extends React.Component<Props> {
         <Route
           path={`${match.url}/c/edit/:channelName/members/contributors`}
           component={EditChannelContributorsPage}
+        />
+        <Route
+          path={`${match.url}/c/edit/:channelName/moderation`}
+          component={ChannelModerationPage}
         />
       </React.Fragment>
     )

--- a/static/js/containers/admin/ChannelModerationPage.js
+++ b/static/js/containers/admin/ChannelModerationPage.js
@@ -62,12 +62,10 @@ export class ChannelModerationPage extends React.Component<Props> {
 
     try {
       if (!loaded) {
-        const promises = [
-          dispatch(actions.channels.get(channelName)),
-          dispatch(actions.reports.get(channelName))
-        ]
-        await Promise.all(promises)
+        await dispatch(actions.channels.get(channelName))
       }
+      // force refresh of reports whenever the user revisits the page
+      await dispatch(actions.reports.get(channelName))
     } catch (_) {} // eslint-disable-line no-empty
   }
 

--- a/static/js/containers/admin/ChannelModerationPage.js
+++ b/static/js/containers/admin/ChannelModerationPage.js
@@ -6,26 +6,23 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 import { Redirect } from "react-router"
 
-import Card from "../components/Card"
+import Card from "../../components/Card"
 import {
   withPostModeration,
   postModerationSelector
-} from "../hoc/withPostModeration"
+} from "../../hoc/withPostModeration"
 import {
   withCommentModeration,
   commentModerationSelector
-} from "../hoc/withCommentModeration"
-import { withSpinnerLoading } from "../components/Loading"
-import withChannelSidebar from "../hoc/withChannelSidebar"
-import CompactPostDisplay from "../components/CompactPostDisplay"
-import CommentTree from "../components/CommentTree"
-import { ChannelModerationBreadcrumbs } from "../components/ChannelBreadcrumbs"
-import CanonicalLink from "../components/CanonicalLink"
+} from "../../hoc/withCommentModeration"
+import { withSpinnerLoading } from "../../components/Loading"
+import CompactPostDisplay from "../../components/CompactPostDisplay"
+import CommentTree from "../../components/CommentTree"
 
-import { commentPermalink, channelURL } from "../lib/url"
-import { actions } from "../actions"
-import { formatTitle } from "../lib/title"
-import { dropdownMenuFuncs } from "../lib/ui"
+import { commentPermalink, channelURL } from "../../lib/url"
+import { actions } from "../../actions"
+import { formatTitle } from "../../lib/title"
+import { dropdownMenuFuncs } from "../../lib/ui"
 
 import type { Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -33,7 +30,9 @@ import type {
   Channel,
   PostReportRecord,
   ReportRecord
-} from "../flow/discussionTypes"
+} from "../../flow/discussionTypes"
+import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
+import withSingleColumn from "../../hoc/withSingleColumn"
 
 const addDummyReplies = R.over(R.lensPath(["replies"]), () => [])
 
@@ -49,7 +48,8 @@ type Props = {
   approveComment: Function,
   removeComment: Function,
   ignoreCommentReports: Function,
-  dropdownMenus: Set<string>
+  dropdownMenus: Set<string>,
+  loaded: boolean
 }
 
 export class ChannelModerationPage extends React.Component<Props> {
@@ -58,11 +58,16 @@ export class ChannelModerationPage extends React.Component<Props> {
   }
 
   loadData = async () => {
-    const { dispatch, channelName } = this.props
+    const { dispatch, channelName, loaded } = this.props
 
     try {
-      await dispatch(actions.channels.get(channelName))
-      await dispatch(actions.reports.get(channelName))
+      if (!loaded) {
+        const promises = [
+          dispatch(actions.channels.get(channelName)),
+          dispatch(actions.reports.get(channelName))
+        ]
+        await Promise.all(promises)
+      }
     } catch (_) {} // eslint-disable-line no-empty
   }
 
@@ -113,23 +118,25 @@ export class ChannelModerationPage extends React.Component<Props> {
   }
 
   render() {
-    const { channel, reports, isModerator, match } = this.props
+    const { channel, reports, isModerator } = this.props
 
     return isModerator ? (
-      <div className="channel-moderation">
+      <React.Fragment>
         <MetaTags>
-          <title>{formatTitle(`${channel.title} moderation`)}</title>
-          <CanonicalLink match={match} />
+          <title>{formatTitle("Edit Channel")}</title>
         </MetaTags>
-        <ChannelModerationBreadcrumbs channel={channel} />
-        {reports.length === 0 ? (
-          <Card title="Reported Posts & Comments">
-            <div className="empty-message">No outstanding reports</div>
-          </Card>
-        ) : (
-          reports.map(this.renderReport)
-        )}
-      </div>
+        <EditChannelNavbar channelName={channel.name} />
+
+        <div className="channel-moderation">
+          {reports.length === 0 ? (
+            <Card title="Reported Posts & Comments">
+              <div className="empty-message">No outstanding reports</div>
+            </Card>
+          ) : (
+            reports.map(this.renderReport)
+          )}
+        </div>
+      </React.Fragment>
     ) : (
       <Redirect to={channelURL(channel.name)} />
     )
@@ -147,6 +154,6 @@ export default R.compose(
   connect(mapStateToProps),
   withPostModeration,
   withCommentModeration,
-  withChannelSidebar("channel-moderation-page"),
+  withSingleColumn("edit-channel"),
   withSpinnerLoading
 )(ChannelModerationPage)

--- a/static/js/containers/admin/ChannelModerationPage_test.js
+++ b/static/js/containers/admin/ChannelModerationPage_test.js
@@ -225,7 +225,7 @@ describe("ChannelModerationPage", () => {
           const actions = store.getActions()
           if (!canRemove) {
             assert.equal(helper.updateRemovedStub.callCount, 0)
-            assert.equal(helper.getReportsStub.callCount, 0)
+            sinon.assert.calledWith(helper.getReportsStub, channel.name)
           } else {
             sinon.assert.calledWith(helper.updateRemovedStub, post.id, true)
             sinon.assert.calledWith(helper.getReportsStub, channel.name)
@@ -399,7 +399,7 @@ describe("ChannelModerationPage", () => {
           const actions = store.getActions()
           if (!canRemove) {
             assert.equal(helper.updateRemovedStub.callCount, 0)
-            assert.equal(helper.getReportsStub.callCount, 0)
+            sinon.assert.calledWith(helper.getReportsStub, channel.name)
           } else {
             sinon.assert.calledWith(helper.updateCommentStub, comment.id, {
               removed: true

--- a/static/js/containers/admin/ChannelModerationPage_test.js
+++ b/static/js/containers/admin/ChannelModerationPage_test.js
@@ -6,29 +6,33 @@ import ChannelModerationPage, {
   ChannelModerationPage as InnerChannelModerationPage
 } from "./ChannelModerationPage"
 
-import { actions } from "../actions"
-import { SET_CHANNEL_DATA } from "../actions/channel"
+import { actions } from "../../actions"
+import { SET_CHANNEL_DATA } from "../../actions/channel"
 import {
   CLEAR_FOCUSED_COMMENT,
   CLEAR_FOCUSED_POST,
   SET_FOCUSED_COMMENT,
   SET_FOCUSED_POST
-} from "../actions/focus"
+} from "../../actions/focus"
 import {
   DIALOG_REMOVE_COMMENT,
   DIALOG_REMOVE_POST,
   HIDE_DIALOG,
   SET_SNACKBAR_MESSAGE
-} from "../actions/ui"
-import { makeChannelList } from "../factories/channels"
-import { makeChannelPostList } from "../factories/posts"
+} from "../../actions/ui"
+import { makeChannelList } from "../../factories/channels"
+import { makeChannelPostList } from "../../factories/posts"
 import {
   makeCommentReport,
   makePostReport,
   makeReportRecord
-} from "../factories/reports"
-import { channelModerationURL, channelURL, commentPermalink } from "../lib/url"
-import IntegrationTestHelper from "../util/integration_test_helper"
+} from "../../factories/reports"
+import {
+  channelModerationURL,
+  channelURL,
+  commentPermalink
+} from "../../lib/url"
+import IntegrationTestHelper from "../../util/integration_test_helper"
 
 describe("ChannelModerationPage", () => {
   let render, channels, channel, postList, postIds, reports, helper

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -7,7 +7,7 @@ import type { Post } from "../flow/discussionTypes"
 export const channelURL = (channelName: string) => `/c/${channelName}`
 
 export const channelModerationURL = (channelName: string) =>
-  `/moderation/c/${channelName}`
+  `/manage/c/edit/${channelName}/moderation/`
 
 export const editChannelBasicURL = (channelName: string) =>
   `/manage/c/edit/${channelName}/basic/`

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -36,7 +36,7 @@ describe("url helper functions", () => {
     it("should return a good URL", () => {
       assert.equal(
         channelModerationURL("foochannel"),
-        "/moderation/c/foochannel"
+        "/manage/c/edit/foochannel/moderation/"
       )
     })
   })

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -18,7 +18,7 @@ $validation-text: #f07183;
 $bg-grey: #dad9d9;
 $bg-light-grey: #f5f5f5;
 $footer-link-color: #4e8398;
-$report-count-red: #e21d13;
+$report-count-red: #ead1d5;
 $navigation-text: rgba(0, 0, 0, 0.77);
 $subscribed-yellow: #fcffb0;
 $toolbar-height-desktop: 76px;

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -29,9 +29,13 @@
 
     a {
       margin-right: 25px;
+      color: $navigation-text;
+      padding-bottom: 20px;
 
       &.active {
         font-weight: 700;
+        background: linear-gradient(to right, black, black) repeat-x 0 1.5em;
+        background-size: 8px 5px;
       }
     }
   }

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -85,6 +85,10 @@ $replyPaddingLeft: 30px;
           right: inherit;
         }
 
+        .report-count {
+          margin-left: 10px;
+        }
+
         i {
           cursor: pointer;
         }
@@ -216,6 +220,7 @@ $replyPaddingLeft: 30px;
   }
 
   .comment-action-button {
+    color: $font-grey-light;
     font-size: 0.9em;
     font-weight: 400;
     cursor: pointer;

--- a/static/scss/dropdown-menu.scss
+++ b/static/scss/dropdown-menu.scss
@@ -11,7 +11,7 @@ ul.dropdown-menu {
 
   a {
     text-decoration: none;
-    color: $navigation-text;
+    color: $font-grey-light;
     white-space: nowrap;
   }
 
@@ -22,5 +22,11 @@ ul.dropdown-menu {
     &:last-child {
       margin-bottom: 0;
     }
+  }
+}
+
+.user-menu {
+  a {
+    color: $navigation-text;
   }
 }

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -209,10 +209,22 @@
     a {
       margin: 0 5px;
     }
+  }
+}
+
+.expanded,
+.compact-post-summary {
+  .left {
+    display: flex;
+    align-items: center;
 
     .report-count {
       margin-left: 10px;
     }
+  }
+
+  .right {
+    color: $font-grey;
   }
 }
 
@@ -280,15 +292,6 @@
 
     .profile-image-container {
       padding: 0 10px 0 0;
-    }
-
-    .left {
-      display: flex;
-      align-items: center;
-    }
-
-    .right {
-      color: $font-grey;
     }
 
     span.author-name {

--- a/static/scss/reports.scss
+++ b/static/scss/reports.scss
@@ -1,7 +1,9 @@
 .report-count {
   background-color: $report-count-red;
-  color: white;
-  padding: 2px 5px;
+  color: black !important;
+  padding: 3px 15px;
+  font-size: 0.9em;
+  border-radius: 15px;
 }
 
 .channel-moderation {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1125 

#### What's this PR do?
Moves the moderation page into a tab in the edit channel pages, and makes modifications to the look and feel specified by the mockups

#### How should this be manually tested?
View the moderation page and interact with it