### PR TITLE
Add subscriber when a moderator adds another moderator

### DIFF
--- a/cassettes/channels.views.subscribers_test.test_add_subscriber_mod.json
+++ b/cassettes/channels.views.subscribers_test.test_add_subscriber_mod.json
@@ -1,0 +1,667 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-09-14T15:14:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCAB6P6ZXHVQXM3ZEDBDQZV"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2tdA1cAlwNq5Ijs/w8naMyIzwNCmt8PTwSS1JKTFQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZuHlYVuQV5BYmehd4GyVH+Ud6pKVn5WUEu4SC9KSklmUmp8ZnpoAMhnCUagH8CRxXuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=szgFdyA1lqS33Cwai9; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 13-Sep-2020 15:14:19 GMT",
+            "loidcreated=2018-09-14T15%3A14%3A19.490Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 13-Sep-2020 15:14:19 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCAB6P6ZXHVQXM3ZEDBDQZV"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Dolorum+corporis+labore+minima+dolore.+Culpa+inventore+eum+accusamus+similique+similique+voluptates+cupiditate.%0AConsequuntur+dignissimos+blanditiis+perspiciatis+sequi+ad.+Laudantium+incidunt+nisi+voluptatem+eos+totam+ex.+Sapiente+cupiditate+pariatur+deleniti+rem+voluptate+consectetur+dolores.+Mollitia+natus+exercitationem+sed+non+quos+vel+omnis.+Illum+praesentium+mollitia+doloribus+quam+accusantium+deleniti+debitis.&link_type=any&name=1536938059_natus&public_description=Voluptatibus+cupiditate+inventore+repellat+dolores.+Eveniet+dolore+laboriosam+autem+alias+corrupti.&title=Iure+consectetur+possimus+molestias+doloremque.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 358-0DPC3xc_hJKAXiXI4uxIHLetdt0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "701"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "341"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCABD7C0AYE733CKG73FM1Z"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2tdTND3cPTvQL8043T3PL9rEscPR2DjcwcCtOTy9W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLY5OXuG+yTmJJunhnsluaRahhRFhVlk+jm7VwaC9KSklmUmp8ZnpoAMhnCUagHffP6guAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCABD7C0AYE733CKG73FM1Z"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCABGEG379XRANA5GVK9VK7"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2M9ANcY5P9XZLywsL8YgPNzZ1082NKK1ITUwztTBR0lFQSq0oyCxKLY7PBGkAqjcAioH1x5dUFqSCDElKTSxKLQKpLU7OhwhpgXhFqWlAjRmotvlalBsXFoW6RfpW+HikBAS66KabBAY5mXn7eoL0pKSWZSanxmemgAyGcJRqAayWwfy4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CQCABGEG379XRANA5GVK9VK7"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CQCABD7C0AYE733CKG73FM1Z&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 358-0DPC3xc_hJKAXiXI4uxIHLetdt0"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1536938059_natus/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "331"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1536938059_natus/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 359-oWGSaNVKg7fFkL9pAKCW00Fsggs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1536938059_natus/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "330"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1536938059_natus/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 359-oWGSaNVKg7fFkL9pAKCW00Fsggs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1536938059_natus/about/moderators/?user=01CQCABD7C0AYE733CKG73FM1Z&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1536938070.0, \"mod_permissions\": [\"all\"], \"name\": \"01CQCABD7C0AYE733CKG73FM1Z\", \"id\": \"t2_9z\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "330"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=nFaP%2F9fxhoMvUhRpy0A4ltb%2BOLTttPyF830NQcpqo6wTQPDQLAwARW7bU8H2UWeg8Wal7e8wTbj9gPDaFtnOWmOkScJAZtWG"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1536938059_natus/about/moderators/?user=01CQCABD7C0AYE733CKG73FM1Z&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-09-14T15:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1536938059_natus"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 360-TC_eKFfnVTH_W35F-mXuxeaf584"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=szgFdyA1lqS33Cwai9; loidcreated=2018-09-14T15%3A14%3A19.490Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.45.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 14 Sep 2018 15:14:30 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "330"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/views/subscribers.py
+++ b/channels/views/subscribers.py
@@ -10,14 +10,14 @@ from rest_framework.views import APIView
 
 from channels.api import Api
 from channels.serializers import SubscriberSerializer
-from open_discussions.permissions import IsStaffOrReadonlyPermission
+from open_discussions.permissions import IsStaffOrReadonlyPermission, IsStaffModeratorOrReadonlyPermission
 
 
 class SubscriberListView(CreateAPIView):
     """
     View to add subscribers in channels
     """
-    permission_classes = (IsAuthenticated, IsStaffOrReadonlyPermission, )
+    permission_classes = (IsAuthenticated, IsStaffModeratorOrReadonlyPermission, )
     serializer_class = SubscriberSerializer
 
     def get_serializer_context(self):
@@ -46,6 +46,7 @@ class SubscriberDetailView(APIView):
         api = Api(user=request.user)
         subscriber_name = self.kwargs['subscriber_name']
         channel_name = self.kwargs['channel_name']
+
         if not api.is_subscriber(subscriber_name, channel_name):
             raise NotFound('User {} is not a subscriber of {}'.format(subscriber_name, channel_name))
         return Response(

--- a/channels/views/subscribers_test.py
+++ b/channels/views/subscribers_test.py
@@ -21,13 +21,29 @@ def test_list_subscribers_not_allowed(staff_client):
 
 def test_add_subscriber(staff_client):
     """
-    Adds a subscriber to a channel
+    Adds a subscriber to a channel as a staff user
     """
     subscriber = UserFactory.create(username='01BTN6G82RKTS3WF61Q33AA0ND')
     url = reverse('subscriber-list', kwargs={'channel_name': 'admin_channel'})
     resp = staff_client.post(url, data={'subscriber_name': subscriber.username}, format='json')
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == {'subscriber_name': subscriber.username}
+
+
+def test_add_subscriber_mod(client, public_channel, staff_api, reddit_factories):
+    """
+    Adds a subscriber to a channel as a moderator
+    """
+    moderator = reddit_factories.user("new_mod_user")
+    new_subscriber = reddit_factories.user("new_sub_user")
+    staff_api.add_moderator(moderator.username, public_channel.name)
+    client.force_login(moderator)
+    url = reverse('subscriber-list', kwargs={'channel_name': public_channel.name})
+    resp = client.post(url, data={'subscriber_name': new_subscriber.username}, format='json')
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.json() == {
+        'subscriber_name': new_subscriber.username,
+    }
 
 
 def test_add_subscriber_again(staff_client):

--- a/factory_data/channels.views.subscribers_test.test_add_subscriber_mod.json
+++ b/factory_data/channels.views.subscribers_test.test_add_subscriber_mod.json
@@ -1,0 +1,22 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Dolorum corporis labore minima dolore. Culpa inventore eum accusamus similique similique voluptates cupiditate.\nConsequuntur dignissimos blanditiis perspiciatis sequi ad. Laudantium incidunt nisi voluptatem eos totam ex. Sapiente cupiditate pariatur deleniti rem voluptate consectetur dolores. Mollitia natus exercitationem sed non quos vel omnis. Illum praesentium mollitia doloribus quam accusantium deleniti debitis.",
+      "name": "1536938059_natus",
+      "public_description": "Voluptatibus cupiditate inventore repellat dolores. Eveniet dolore laboriosam autem alias corrupti.",
+      "title": "Iure consectetur possimus molestias doloremque."
+    }
+  },
+  "users": {
+    "new_mod_user": {
+      "username": "01CQCABD7C0AYE733CKG73FM1Z"
+    },
+    "new_sub_user": {
+      "username": "01CQCABGEG379XRANA5GVK9VK7"
+    },
+    "staff_user": {
+      "username": "01CQCAB6P6ZXHVQXM3ZEDBDQZV"
+    }
+  }
+}

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -169,13 +169,14 @@ const mapStateToProps = (state, ownProps) => {
 const loadMembers = (channelName: string) =>
   actions.channelModerators.get(channelName)
 const loadChannel = (channelName: string) => actions.channels.get(channelName)
-const addMember = (channel: Channel, email: string) =>
+const addModerator = (channel: Channel, email: string) =>
   actions.channelModerators.post(channel.name, email)
+const addSubscriber = (channel: Channel, username: string) =>
+  actions.channelSubscribers.post(channel.name, username)
 const removeMember = (channel: Channel, username: string) =>
   actions.channelModerators.delete(channel.name, username)
 const onSubmitError = formValidate =>
   formValidate({ email: `Error adding new moderator` })
-const onSubmit = (channel, { email }) => addMember(channel, email)
 
 const mergeProps = mergeAndInjectProps(
   (
@@ -183,7 +184,8 @@ const mergeProps = mergeAndInjectProps(
     {
       loadMembers,
       loadChannel,
-      onSubmit,
+      addModerator,
+      addSubscriber,
       formValidate,
       formBeginEdit,
       setSnackbarMessage
@@ -193,7 +195,9 @@ const mergeProps = mergeAndInjectProps(
     loadChannel:    () => loadChannel(channelName),
     onSubmitResult: formBeginEdit,
     onSubmit:       async form => {
-      const newMember = await onSubmit(channel, form)
+      const newMember = await addModerator(channel, form.email)
+      await addSubscriber(channel, newMember.moderator.moderator_name)
+
       setSnackbarMessage({
         message: `Successfully added ${
           newMember.moderator.email
@@ -210,9 +214,9 @@ export default R.compose(
     {
       loadMembers,
       loadChannel,
-      addMember,
+      addModerator,
+      addSubscriber,
       removeMember,
-      onSubmit,
       onSubmitError,
       setSnackbarMessage,
       setDialogData: (data: any) =>

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -11,7 +11,8 @@ import EditChannelModeratorsPage, {
 import {
   makeChannel,
   makeModerator,
-  makeModerators
+  makeModerators,
+  makeSubscriber
 } from "../../factories/channels"
 import { actions } from "../../actions"
 import { SET_CHANNEL_DATA } from "../../actions/channel"
@@ -235,7 +236,9 @@ describe("EditChannelModeratorsPage", () => {
 
     it("adds a new moderator", async () => {
       const newModerator = makeModerator(null, true)
+      const newSubscriber = makeSubscriber(newModerator.moderator_name)
       helper.addChannelModeratorStub.returns(Promise.resolve(newModerator))
+      helper.addChannelSubscriberStub.returns(Promise.resolve(newSubscriber))
 
       const email = "new@email.com"
       const { inner, store } = await render({
@@ -259,6 +262,11 @@ describe("EditChannelModeratorsPage", () => {
         helper.addChannelModeratorStub,
         channel.name,
         email
+      )
+      sinon.assert.calledWith(
+        helper.addChannelSubscriberStub,
+        channel.name,
+        newModerator.moderator_name
       )
 
       const actions = store.getActions()

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -10,7 +10,9 @@ import type {
   Contributor,
   ChannelContributors,
   ChannelModerators,
-  Moderator
+  ChannelSubscribers,
+  Moderator,
+  Subscriber
 } from "../flow/discussionTypes"
 
 const incr = incrementer()
@@ -78,6 +80,19 @@ export const makeModerators = (
   makeModerator(username, isModerator),
   makeModerator(null, isModerator),
   makeModerator(null, isModerator)
+]
+
+export const makeSubscriber = (username: ?string = null): Subscriber => ({
+  // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
+  subscriber_name: username || `${casual.word}_${incr.next().value}`
+})
+
+export const makeSubscribers = (
+  username: ?string = null
+): ChannelSubscribers => [
+  makeSubscriber(username),
+  makeSubscriber(null),
+  makeSubscriber(null)
 ]
 
 export const makeImage = (imageName: string) => ({

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -194,6 +194,12 @@ export type Contributor = {
 
 export type ChannelContributors = Array<Contributor>
 
+export type Subscriber = {
+  subscriber_name: string
+}
+
+export type ChannelSubscribers = Array<Subscriber>
+
 export type Member = Contributor | Moderator
 
 export type Report = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -26,6 +26,7 @@ import type {
   ChannelModerators,
   Contributor,
   Moderator,
+  Subscriber,
   GenericComment,
   CreatePostPayload,
   PostListPaginationParams,
@@ -125,6 +126,31 @@ export function deleteChannelContributor(
 ): Promise<void> {
   return fetchWithAuthFailure(
     `/api/v0/channels/${channelName}/contributors/${username}/`,
+    { method: DELETE }
+  )
+}
+
+export function addChannelSubscriber(
+  channelName: string,
+  username: string
+): Promise<Subscriber> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/subscribers/`,
+    {
+      method: POST,
+      body:   JSON.stringify({
+        subscriber_name: username
+      })
+    }
+  )
+}
+
+export function deleteChannelSubscriber(
+  channelName: string,
+  username: string
+): Promise<void> {
+  return fetchWithAuthFailure(
+    `/api/v0/channels/${channelName}/subscribers/${username}/`,
     { method: DELETE }
   )
 }

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -8,6 +8,7 @@ import { commentsEndpoint, moreCommentsEndpoint } from "../reducers/comments"
 import { postUpvotesEndpoint } from "../reducers/post_upvotes"
 import { channelContributorsEndpoint } from "../reducers/channel_contributors"
 import { channelModeratorsEndpoint } from "../reducers/channel_moderators"
+import { channelSubscribersEndpoint } from "../reducers/channel_subscribers"
 import { postRemovedEndpoint } from "../reducers/post_removed"
 import { reportsEndpoint } from "../reducers/reports"
 import { settingsEndpoint } from "../reducers/settings"
@@ -29,6 +30,7 @@ export const endpoints = [
   channelsEndpoint,
   channelContributorsEndpoint,
   channelModeratorsEndpoint,
+  channelSubscribersEndpoint,
   postsForChannelEndpoint,
   frontPageEndpoint,
   commentsEndpoint,

--- a/static/js/reducers/channel_contributors.js
+++ b/static/js/reducers/channel_contributors.js
@@ -69,8 +69,8 @@ export const channelContributorsEndpoint = {
     update.set(channelName, response)
     return update
   },
-  postFunc: async (channelName: string, username: string) => {
-    const contributor = await api.addChannelContributor(channelName, username)
+  postFunc: async (channelName: string, email: string) => {
+    const contributor = await api.addChannelContributor(channelName, email)
     return { channelName, contributor }
   },
   postSuccessHandler: addContributor,

--- a/static/js/reducers/channel_moderators.js
+++ b/static/js/reducers/channel_moderators.js
@@ -67,8 +67,8 @@ export const channelModeratorsEndpoint = {
     update.set(channelName, response)
     return update
   },
-  postFunc: async (channelName: string, username: string) => {
-    const moderator = await api.addChannelModerator(channelName, username)
+  postFunc: async (channelName: string, email: string) => {
+    const moderator = await api.addChannelModerator(channelName, email)
     return { channelName, moderator }
   },
   postSuccessHandler: addModerator,

--- a/static/js/reducers/channel_subscribers.js
+++ b/static/js/reducers/channel_subscribers.js
@@ -1,0 +1,18 @@
+// @flow
+import { GET, POST, DELETE, INITIAL_STATE } from "redux-hammock/constants"
+
+import * as api from "../lib/api"
+
+export const channelSubscribersEndpoint = {
+  name:         "channelSubscribers",
+  verbs:        [GET, POST, DELETE],
+  initialState: { ...INITIAL_STATE, data: null },
+  postFunc:     async (channelName: string, username: string) => {
+    const subscriber = await api.addChannelSubscriber(channelName, username)
+    return { channelName, subscriber }
+  },
+  deleteFunc: async (channelName: string, username: string) => {
+    await api.deleteChannelSubscriber(channelName, username)
+    return { channelName, username }
+  }
+}

--- a/static/js/reducers/channel_subscribers_test.js
+++ b/static/js/reducers/channel_subscribers_test.js
@@ -1,0 +1,54 @@
+// @flow
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeSubscriber } from "../factories/channels"
+
+describe("channelSubscribers reducers", () => {
+  let helper, dispatchThen, newSubscriber
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    newSubscriber = makeSubscriber("new_mod")
+    dispatchThen = helper.store.createDispatchThen(
+      state => state.channelSubscribers
+    )
+    helper.addChannelSubscriberStub.returns(Promise.resolve(newSubscriber))
+    helper.deleteChannelSubscriberStub.returns(Promise.resolve())
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should add a new subscriber", async () => {
+    const channelName = "a_channel"
+
+    await dispatchThen(
+      actions.channelSubscribers.post(
+        channelName,
+        newSubscriber.subscriber_name
+      ),
+      [
+        actions.channelSubscribers.post.requestType,
+        actions.channelSubscribers.post.successType
+      ]
+    )
+    // if we got this far everything should have succeeded
+  })
+
+  it("should remove a subscriber", async () => {
+    const channelName = "a_channel"
+
+    await dispatchThen(
+      actions.channelSubscribers.delete(
+        channelName,
+        newSubscriber.subscriber_name
+      ),
+      [
+        actions.channelSubscribers.delete.requestType,
+        actions.channelSubscribers.delete.successType
+      ]
+    )
+    // if we got this far we should have succeeded
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1168 

#### What's this PR do?
The UI for adding a moderator now also makes a call to add the user as a subscriber also. 

The permissions for adding a subscriber are altered slightly so moderators can add other moderators for the channels they moderate as a subscriber. *Note*: this means that via the REST API any moderator can add any user as a subscriber to their channel, even if they are not also adding the user as a moderator.

#### How should this be manually tested?
Add a moderator and view the network tab. You should see a successful addition of the moderator user as a subscriber.

Log in as the moderator user and verify that they have the channel listed on the left side.