### PR TITLE
Allow reddit errors to fail user creation

### DIFF
--- a/authentication/api.py
+++ b/authentication/api.py
@@ -42,12 +42,9 @@ def create_user(username, email, profile_data=None, user_extra=None):
         profile_api.ensure_profile(user, profile_data=profile_data)
         notifications_api.ensure_notification_settings(user)
 
-    try:
         # this could fail if the reddit backend is down
-        # but we don't want it to hard-fail the user creation process
+        # so if it fails we want to rollback this entire transaction
         channels_api.get_or_create_auth_tokens(user)
-    except:  # pylint: disable=bare-except
-        log.exception('Exception trying to create auth tokens')
 
     return user
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1162 

#### What's this PR do?
This avoids creating the situation in #1162 by removing error catching around a reddit API and allowing that error to rollback the user transaction and avoid the user ending up in a partial state. 

In practice this means we're effectively adding a 500, but that is a valid response for what happened and we want to know because it means the backend is down and MM should retry the request later.

#### How should this be manually tested?

- Start, OD and MM, but make sure the reddit backend is stopped
- Register a new user and verify that the result fails with a 500 instead of a 200 and no user was created.