### PR TITLE
Add description to basic channel form

### DIFF
--- a/static/js/components/admin/EditChannelBasicForm.js
+++ b/static/js/components/admin/EditChannelBasicForm.js
@@ -105,7 +105,6 @@ export default class EditChannelBasicForm extends React.Component<Props> {
             <textarea
               type="text"
               name="description"
-              className="no-height"
               placeholder="Description"
               value={form.description}
               onChange={onUpdate}

--- a/static/js/components/admin/EditChannelBasicForm.js
+++ b/static/js/components/admin/EditChannelBasicForm.js
@@ -100,6 +100,18 @@ export default class EditChannelBasicForm extends React.Component<Props> {
           </div>
           <div className="row">{validationMessage(validation.link_type)}</div>
         </Card>
+        <Card title="Description">
+          <div className="row">
+            <textarea
+              type="text"
+              name="description"
+              className="no-height"
+              placeholder="Description"
+              value={form.description}
+              onChange={onUpdate}
+            />
+          </div>
+        </Card>
         <div className="row actions">
           <button
             className="cancel"

--- a/static/js/components/admin/EditChannelBasicForm.js
+++ b/static/js/components/admin/EditChannelBasicForm.js
@@ -59,6 +59,17 @@ export default class EditChannelBasicForm extends React.Component<Props> {
     } = this.props
     return (
       <form onSubmit={onSubmit} className="form channel-form">
+        <Card title="Description">
+          <div className="row">
+            <textarea
+              type="text"
+              name="description"
+              placeholder="Description"
+              value={form.description}
+              onChange={onUpdate}
+            />
+          </div>
+        </Card>
         <Card title="Type">
           {makeChannelTypeOption(
             CHANNEL_TYPE_PUBLIC,
@@ -99,17 +110,6 @@ export default class EditChannelBasicForm extends React.Component<Props> {
             </Checkbox>
           </div>
           <div className="row">{validationMessage(validation.link_type)}</div>
-        </Card>
-        <Card title="Description">
-          <div className="row">
-            <textarea
-              type="text"
-              name="description"
-              placeholder="Description"
-              value={form.description}
-              onChange={onUpdate}
-            />
-          </div>
         </Card>
         <div className="row actions">
           <button

--- a/static/js/components/admin/EditChannelBasicForm_test.js
+++ b/static/js/components/admin/EditChannelBasicForm_test.js
@@ -8,8 +8,8 @@ import {
   CHANNEL_TYPE_PUBLIC,
   CHANNEL_TYPE_PRIVATE,
   CHANNEL_TYPE_RESTRICTED,
-  editChannelForm,
-  LINK_TYPE_TEXT
+  LINK_TYPE_TEXT,
+  editChannelForm
 } from "../../lib/channels"
 import { makeChannel } from "../../factories/channels"
 

--- a/static/js/components/admin/EditChannelBasicForm_test.js
+++ b/static/js/components/admin/EditChannelBasicForm_test.js
@@ -8,7 +8,8 @@ import {
   CHANNEL_TYPE_PUBLIC,
   CHANNEL_TYPE_PRIVATE,
   CHANNEL_TYPE_RESTRICTED,
-  editChannelForm
+  editChannelForm,
+  LINK_TYPE_TEXT
 } from "../../lib/channels"
 import { makeChannel } from "../../factories/channels"
 
@@ -49,6 +50,7 @@ describe("EditChannelBasicForm", () => {
     assert.equal(restrictedOption.props.checked, false)
     assert.equal(privateOption.props.value, CHANNEL_TYPE_PRIVATE)
     assert.equal(privateOption.props.checked, false)
+    assert.equal(wrapper.find("description").value, null)
   })
 
   describe("callbacks", () => {
@@ -67,15 +69,22 @@ describe("EditChannelBasicForm", () => {
       })
     })
 
-    describe("onUpdate", () => {
-      it(`should be called when input is modified`, () => {
-        const event = { target: { value: "text" } }
-        assert.isNotOk(onSubmit.called)
-        wrapper
-          .find(`[name="channel_type"]`)
-          .at(0)
-          .simulate("change", event)
-        assert.isOk(onUpdate.calledWith(event))
+    //
+    ;[
+      ["channel_type", CHANNEL_TYPE_PUBLIC],
+      ["link_type", LINK_TYPE_TEXT],
+      ["description", "Channel description"]
+    ].forEach(([name, value]) => {
+      describe("onUpdate", () => {
+        it(`should be called when ${name} input is modified`, () => {
+          const event = { target: { name: { name }, value: { value } } }
+          assert.isNotOk(onSubmit.called)
+          wrapper
+            .find(`[name="${name}"]`)
+            .at(0)
+            .simulate("change", event)
+          assert.isOk(onUpdate.calledWith(event))
+        })
       })
     })
   })

--- a/static/js/containers/admin/EditChannelBasicPage.js
+++ b/static/js/containers/admin/EditChannelBasicPage.js
@@ -72,19 +72,22 @@ class EditChannelBasicPage extends React.Component<Props> {
 
   onUpdate = (e: Object) => {
     const { dispatch, channelForm } = this.props
-    const linkType = updateLinkType(
-      channelForm.value.link_type,
-      e.target.value,
-      e.target.checked
-    )
+    const updates = {
+      [e.target.name]: e.target.value
+    }
+    if (e.target.name === "link_type") {
+      // $FlowFixMe
+      updates.link_type = updateLinkType(
+        channelForm.value.link_type,
+        e.target.value,
+        e.target.checked
+      )
+    }
 
     dispatch(
       actions.forms.formUpdate(
         R.merge(EDIT_CHANNEL_PAYLOAD, {
-          value: {
-            [e.target.name]: e.target.value,
-            link_type:       linkType
-          }
+          value: updates
         })
       )
     )

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -41,17 +41,24 @@ describe("EditChannelBasicPage", () => {
     helper.cleanup()
   })
 
-  const makeEvent = (name, checked) => ({ target: { checked, name } })
+  const makeEvent = (name, value, checked) => ({
+    target: { checked, name, value }
+  })
 
   const setChannelType = (wrapper, value) =>
     wrapper
       .find(`input[value='${value}']`)
-      .simulate("change", makeEvent("channel_type", true))
+      .simulate("change", makeEvent("channel_type", value, true))
 
   const setPostType = (wrapper, value) =>
     wrapper
       .find(`input[value='${value}']`)
-      .simulate("change", makeEvent("link_type", true))
+      .simulate("change", makeEvent("link_type", value, true))
+
+  const setDescription = (wrapper, value) =>
+    wrapper
+      .find(`[name="description"]`)
+      .simulate("change", makeEvent("description", value, null))
 
   const submit = wrapper => wrapper.find(".save-changes").simulate("submit")
 
@@ -74,14 +81,17 @@ describe("EditChannelBasicPage", () => {
 
   it("should set the channel and post types, submit, and navigate back to the channel page", async () => {
     const wrapper = await renderPage()
+    const description = "Test description"
     const expected = {
       ...channel,
       post_type:    LINK_TYPE_TEXT,
-      channel_type: CHANNEL_TYPE_RESTRICTED
+      channel_type: CHANNEL_TYPE_RESTRICTED,
+      description
     }
 
-    setChannelType(wrapper, expected.channel_type)
     setPostType(wrapper, expected.post_type)
+    setChannelType(wrapper, expected.channel_type)
+    setDescription(wrapper, description)
 
     await listenForActions(
       [


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1188 
Fixes #1198

#### What's this PR do?
Adds `description` (different from `public_description`) to the basic channel form, and tweaks the `onUpdate` function to fix a bug (#1198)

#### How should this be manually tested?
- Go to the basic tab of the channel edit page. 
- Uncheck one or both of the `Allowed post type` checkboxes.
- Change the 'Type' option (public, reserved, private).  `Allowed post type` should not change as a result.
- Enter text for the description.  `Allowed post type` checkboxes should not change as a result.
- Save the form.  There should be no errors.  Reload the page.  Your changes should still be in effect.

