### PR TITLE
Grouped channel post view tests together w/ common test scenario

### DIFF
--- a/cassettes/channels.views.posts_test.test_post_anonymous[False].json
+++ b/cassettes/channels.views.posts_test.test_post_anonymous[False].json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.posts_test.test_post_anonymous[True].json
+++ b/cassettes/channels.views.posts_test.test_post_anonymous[True].json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket - related to #1192 and relevant to the pytest tech talk

#### What's this PR do?
Groups into a class some similar tests that test a single endpoint and need similar test data setup.

#### How should this be manually tested?
Test suite should pass, and tests should make sense

#### Any background context you want to provide?
- This finishes some refactoring work that was started in #1192
- This PR (hopefully) provides a good example for fixture-ization, using named properties for related test data, and general reduction of boilerplate
