### PR TITLE
fix toolbar z-index

### DIFF
--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -13,7 +13,7 @@ $link-padding: 11px 20px 11px 19px;
   .mdc-toolbar {
     background-color: #fff;
     box-shadow: 0px 4px 6px -3px rgba(0, 0, 0, 0.2);
-    z-index: 4;
+    z-index: 40;
     position: fixed;
 
     .mdc-toolbar__row {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1200

#### What's this PR do?

this fixes the `z-index` on the toolbar (top nav bar thingy) so that the comment menu can't show up on top of it. the dropdown menus have a `z-index` of 10, so that they show up on top of everything around them. the toolbar previously had 4, I set it to 40 (somewhat arbitrarily).


#### How should this be manually tested?

make sure you can reproduce the bug described in the linked issue, then make sure this fixes it
