### PR TITLE
Changed HTTP response error handling to behave like form validation

### DIFF
--- a/static/js/components/auth/AuthEmailForm.js
+++ b/static/js/components/auth/AuthEmailForm.js
@@ -1,7 +1,6 @@
 // @flow
 /* global SETTINGS:false */
 import React from "react"
-import R from "ramda"
 import ReCAPTCHA from "react-google-recaptcha"
 
 import { validationMessage } from "../../lib/validation"
@@ -9,19 +8,14 @@ import { validationMessage } from "../../lib/validation"
 import type { EmailForm } from "../../flow/authTypes"
 import type { FormProps } from "../../flow/formTypes"
 
-type LoginFormProps = {
-  formError: ?string
-} & FormProps<EmailForm>
-
 const AuthEmailForm = ({
   form,
   validation,
   onSubmit,
   onUpdate,
   onRecaptcha,
-  processing,
-  formError
-}: LoginFormProps) => {
+  processing
+}: FormProps<EmailForm>) => {
   return (
     <form onSubmit={onSubmit} className="form">
       <div className="emailfield row">
@@ -40,11 +34,6 @@ const AuthEmailForm = ({
           {validationMessage(validation.recaptcha)}
         </div>
       ) : null}
-      <div className="error row">
-        {!processing && R.isEmpty(validation)
-          ? validationMessage(formError)
-          : null}
-      </div>
       <div className="actions row right-aligned">
         <button
           type="submit"

--- a/static/js/components/auth/AuthEmailForm_test.js
+++ b/static/js/components/auth/AuthEmailForm_test.js
@@ -67,17 +67,6 @@ describe("AuthEmailForm component", () => {
     assert.isNotOk(wrapper.find(".row.error .validation-message").exists())
   })
 
-  it("should show a form level error", () => {
-    const wrapper = mountForm({ formError: "backend error" })
-    assert.equal(
-      wrapper
-        .find(".validation-message")
-        .at(0)
-        .text(),
-      "backend error"
-    )
-  })
-
   it("should call onUpdate when the input text changes", () => {
     const wrapper = mountForm({ processing: true })
     const event = {

--- a/static/js/components/auth/AuthPasswordForm.js
+++ b/static/js/components/auth/AuthPasswordForm.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react"
-import R from "ramda"
 import { Link } from "react-router-dom"
 
 import { validationMessage } from "../../lib/validation"
@@ -8,18 +7,13 @@ import { validationMessage } from "../../lib/validation"
 import type { PasswordForm } from "../../flow/authTypes"
 import type { FormProps } from "../../flow/formTypes"
 
-type LoginPasswordFormProps = {
-  formError: ?string
-} & FormProps<PasswordForm>
-
 const AuthPasswordForm = ({
   form,
   validation,
   onSubmit,
   onUpdate,
-  processing,
-  formError
-}: LoginPasswordFormProps) => (
+  processing
+}: FormProps<PasswordForm>) => (
   <form onSubmit={onSubmit} className="form">
     <div className="passwordfield row">
       <input
@@ -29,11 +23,6 @@ const AuthPasswordForm = ({
         onChange={onUpdate}
       />
       {validationMessage(validation.password)}
-    </div>
-    <div className="error row">
-      {!processing && R.isEmpty(validation)
-        ? validationMessage(formError)
-        : null}
     </div>
     <div className="row">
       <Link className="password-reset" to="/password_reset">

--- a/static/js/components/auth/AuthPasswordForm_test.js
+++ b/static/js/components/auth/AuthPasswordForm_test.js
@@ -74,17 +74,6 @@ describe("AuthPasswordForm component", () => {
     assert.isNotOk(wrapper.find(".row.error .validation-message").exists())
   })
 
-  it("should show a form level error", () => {
-    const wrapper = mountForm({ formError: "backend error" })
-    assert.equal(
-      wrapper
-        .find(".validation-message")
-        .at(0)
-        .text(),
-      "backend error"
-    )
-  })
-
   it("should call onUpdate when the input text changes", () => {
     const wrapper = mountForm({ processing: true })
     const event = {

--- a/static/js/components/auth/PasswordResetForm.js
+++ b/static/js/components/auth/PasswordResetForm.js
@@ -11,14 +11,7 @@ type Props = {
 
 export default class PasswordResetForm extends React.Component<Props> {
   render() {
-    const {
-      form,
-      validation,
-      emailApiError,
-      onSubmit,
-      onUpdate,
-      processing
-    } = this.props
+    const { form, validation, onSubmit, onUpdate, processing } = this.props
 
     return (
       <form onSubmit={onSubmit} className="form">
@@ -31,7 +24,6 @@ export default class PasswordResetForm extends React.Component<Props> {
             onChange={onUpdate}
           />
           {validationMessage(validation.email)}
-          {validationMessage(emailApiError)}
         </div>
         <div className="actions row right-aligned">
           <button

--- a/static/js/components/auth/PasswordResetForm_test.js
+++ b/static/js/components/auth/PasswordResetForm_test.js
@@ -63,17 +63,6 @@ describe("PasswordResetForm component", () => {
     )
   })
 
-  it("should show an error message if the API call fails", () => {
-    const wrapper = mountForm({
-      emailApiError: "Email does not exist"
-    })
-
-    assert.equal(
-      wrapper.find(".validation-message").text(),
-      "Email does not exist"
-    )
-  })
-
   it("should call onUpdate when the input text changes", () => {
     const wrapper = mountForm({ processing: true })
     const event = {

--- a/static/js/containers/ImageUploader.js
+++ b/static/js/containers/ImageUploader.js
@@ -15,7 +15,7 @@ import { mergeAndInjectProps } from "../lib/redux_props"
 import { validateImageForm } from "../lib/validation"
 
 import type { ImageForm } from "../flow/discussionTypes"
-import type { WithFormProps } from "../flow/formTypes"
+import type { FormErrors, WithFormProps } from "../flow/formTypes"
 import type { Dispatch } from "redux"
 
 export const makeDialogKey = (name: string) => `DIALOG_IMAGE_UPLOAD_${name}`
@@ -99,6 +99,10 @@ export class ImageUploader extends React.Component<ImageProps> {
   }
 }
 
+const onSubmitFailure = (): FormErrors<*> => ({
+  image: `Error uploading image`
+})
+
 const mapStateToProps = (state, ownProps) => {
   const { name, onUpdate, processing } = ownProps
   const formKey = makeFormKey(name)
@@ -111,14 +115,12 @@ const mapStateToProps = (state, ownProps) => {
     dialogOpen,
     processing,
     onUpdate,
+    onSubmitFailure,
     userName:     ownProps.userName,
     validateForm: validateImageForm,
     form:         getForm(state)
   }
 }
-
-const onSubmitError = formValidate =>
-  formValidate({ image: `Error uploading image` })
 
 const mergeProps = mergeAndInjectProps(
   (
@@ -140,7 +142,6 @@ const mergeProps = mergeAndInjectProps(
       formBeginEdit()
       hideDialog()
     },
-    onSubmitError: () => onSubmitError(formValidate),
     formValidate:  formValidate,
     formBeginEdit: formBeginEdit,
     formEndEdit:   formEndEdit

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -29,7 +29,7 @@ import {
 } from "../../actions/ui"
 
 import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
-import type { WithFormProps } from "../../flow/formTypes"
+import type { FormErrors, WithFormProps } from "../../flow/formTypes"
 
 export const MODERATORS_KEY = "channel:edit:moderators"
 const { getForm, actionCreators } = configureForm(MODERATORS_KEY, newMemberForm)
@@ -144,6 +144,19 @@ export class EditChannelModeratorsPage extends React.Component<Props> {
   }
 }
 
+const loadMembers = (channelName: string) =>
+  actions.channelModerators.get(channelName)
+const loadChannel = (channelName: string) => actions.channels.get(channelName)
+const addModerator = (channel: Channel, email: string) =>
+  actions.channelModerators.post(channel.name, email)
+const addSubscriber = (channel: Channel, username: string) =>
+  actions.channelSubscribers.post(channel.name, username)
+const removeMember = (channel: Channel, username: string) =>
+  actions.channelModerators.delete(channel.name, username)
+const onSubmitFailure = (): FormErrors<*> => ({
+  email: "Error adding new moderator"
+})
+
 const mapStateToProps = (state, ownProps) => {
   const channelName = getChannelName(ownProps)
   const channel = state.channels.data.get(channelName)
@@ -161,22 +174,11 @@ const mapStateToProps = (state, ownProps) => {
     processing,
     memberToRemove,
     dialogOpen,
+    onSubmitFailure,
     validateForm: validateMembersForm,
     form:         form
   }
 }
-
-const loadMembers = (channelName: string) =>
-  actions.channelModerators.get(channelName)
-const loadChannel = (channelName: string) => actions.channels.get(channelName)
-const addModerator = (channel: Channel, email: string) =>
-  actions.channelModerators.post(channel.name, email)
-const addSubscriber = (channel: Channel, username: string) =>
-  actions.channelSubscribers.post(channel.name, username)
-const removeMember = (channel: Channel, username: string) =>
-  actions.channelModerators.delete(channel.name, username)
-const onSubmitError = formValidate =>
-  formValidate({ email: `Error adding new moderator` })
 
 const mergeProps = mergeAndInjectProps(
   (
@@ -186,7 +188,6 @@ const mergeProps = mergeAndInjectProps(
       loadChannel,
       addModerator,
       addSubscriber,
-      formValidate,
       formBeginEdit,
       setSnackbarMessage
     }
@@ -203,8 +204,7 @@ const mergeProps = mergeAndInjectProps(
           newMember.moderator.email
         } as a moderator`
       })
-    },
-    onSubmitError: () => onSubmitError(formValidate)
+    }
   })
 )
 
@@ -217,7 +217,6 @@ export default R.compose(
       addModerator,
       addSubscriber,
       removeMember,
-      onSubmitError,
       setSnackbarMessage,
       setDialogData: (data: any) =>
         setDialogData({ dialogKey: DIALOG_REMOVE_MEMBER, data: data }),

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -15,16 +15,12 @@ import CanonicalLink from "../../components/CanonicalLink"
 import { actions } from "../../actions"
 import { setAuthUserDetail } from "../../actions/ui"
 import { processAuthResponse } from "../../lib/auth"
-import { configureForm } from "../../lib/forms"
+import { configureForm, getAuthResponseFieldErrors } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
 import { REGISTER_URL } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
-import {
-  FLOW_LOGIN,
-  getFormErrorSelector,
-  isProcessing
-} from "../../reducers/auth"
+import { FLOW_LOGIN, isProcessing } from "../../reducers/auth"
 
 import type { Match } from "react-router"
 import type {
@@ -36,21 +32,12 @@ import type { WithFormProps } from "../../flow/formTypes"
 
 type LoginPageProps = {
   match: Match,
-  history: Object,
-  formError: ?string,
-  clearEndpointState: Function
+  history: Object
 } & WithFormProps<EmailForm>
 
 export class LoginPage extends React.Component<LoginPageProps> {
-  componentWillUnmount() {
-    const { formError, clearEndpointState } = this.props
-    if (formError) {
-      clearEndpointState()
-    }
-  }
-
   render() {
-    const { renderForm, formError, match } = this.props
+    const { renderForm, match } = this.props
 
     return (
       <div className="auth-page login-page">
@@ -61,7 +48,7 @@ export class LoginPage extends React.Component<LoginPageProps> {
               <title>{formatTitle("Login")}</title>
               <CanonicalLink match={match} />
             </MetaTags>
-            {renderForm({ formError })}
+            {renderForm()}
             <ExternalLogins />
             <div className="alternate-auth-link">
               Not a member? <Link to={REGISTER_URL}>Sign up</Link>
@@ -78,7 +65,7 @@ const newEmailForm = () => ({ email: "" })
 const onSubmit = ({ email }: EmailForm) =>
   actions.auth.loginEmail(FLOW_LOGIN, email)
 
-const clearEndpointState = actions.auth.clear
+const getSubmitResultErrors = getAuthResponseFieldErrors("email")
 
 const onSubmitResult = R.curry(
   (
@@ -107,14 +94,13 @@ const { getForm, actionCreators } = configureForm(FORM_KEY, newEmailForm)
 const mapStateToProps = state => {
   const form = getForm(state)
   const processing = isProcessing(state)
-  const formError = getFormErrorSelector(state)
 
   return {
     form,
     processing,
     onSubmitResult,
     validateForm,
-    formError
+    getSubmitResultErrors
   }
 }
 
@@ -129,7 +115,6 @@ export default R.compose(
     mapStateToProps,
     {
       onSubmit,
-      clearEndpointState,
       setAuthUserDetail,
       ...actionCreators
     },

--- a/static/js/containers/auth/LoginPasswordPage.js
+++ b/static/js/containers/auth/LoginPasswordPage.js
@@ -12,7 +12,7 @@ import CanonicalLink from "../../components/CanonicalLink"
 
 import { actions } from "../../actions"
 import { processAuthResponse, goToFirstLoginStep } from "../../lib/auth"
-import { configureForm } from "../../lib/forms"
+import { configureForm, getAuthResponseFieldErrors } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
 import { LOGIN_URL } from "../../lib/url"
 import { preventDefaultAndInvoke } from "../../lib/util"
@@ -21,8 +21,7 @@ import { mergeAndInjectProps } from "../../lib/redux_props"
 import {
   getAuthPartialTokenSelector,
   getAuthFlowSelector,
-  isProcessing,
-  getFormErrorSelector
+  isProcessing
 } from "../../reducers/auth"
 import {
   getAuthUiNameSelector,
@@ -39,7 +38,6 @@ type Props = {
   history: Object,
   partialToken: string,
   authFlow: AuthFlow,
-  formError: ?string,
   email: string,
   name: ?string,
   profileImageUrl: ?string
@@ -56,7 +54,6 @@ export class LoginPasswordPage extends React.Component<Props> {
   render() {
     const {
       renderForm,
-      formError,
       email,
       name,
       profileImageUrl,
@@ -86,7 +83,7 @@ export class LoginPasswordPage extends React.Component<Props> {
                 />
               </div>
             </div>
-            {renderForm({ formError })}
+            {renderForm()}
           </Card>
         </div>
       </div>
@@ -105,6 +102,8 @@ const onSubmit = (
   form: PasswordForm
 ) => actions.auth.loginPassword(authFlow, partialToken, form.password)
 
+const getSubmitResultErrors = getAuthResponseFieldErrors("password")
+
 const onSubmitResult = R.curry(processAuthResponse)
 
 export const mergeProps = mergeAndInjectProps(
@@ -119,7 +118,6 @@ const mapStateToProps = state => {
   const processing = isProcessing(state)
   const authFlow = getAuthFlowSelector(state)
   const partialToken = getAuthPartialTokenSelector(state)
-  const formError = getFormErrorSelector(state)
   const name = getAuthUiNameSelector(state)
   const email = getAuthUiEmailSelector(state)
   const profileImageUrl = getAuthUiImgSelector(state)
@@ -129,8 +127,8 @@ const mapStateToProps = state => {
     authFlow,
     processing,
     onSubmitResult,
+    getSubmitResultErrors,
     validateForm,
-    formError,
     email,
     name,
     profileImageUrl

--- a/static/js/containers/auth/LoginPasswordPage_test.js
+++ b/static/js/containers/auth/LoginPasswordPage_test.js
@@ -10,6 +10,7 @@ import ConnectedLoginPasswordPage, {
   LoginPasswordPage,
   FORM_KEY
 } from "./LoginPasswordPage"
+import { shouldIf } from "../../lib/test_utils"
 
 const DEFAULT_STATE = {
   auth: {
@@ -57,19 +58,6 @@ describe("LoginPasswordPage", () => {
 
   afterEach(() => {
     helper.cleanup()
-  })
-
-  it("should render errors", async () => {
-    const { inner } = await renderPage({
-      auth: {
-        data: {
-          errors: ["error"]
-        }
-      }
-    })
-
-    const form = inner.find("AuthPasswordForm")
-    assert.equal(form.props().formError, "error")
   })
 
   //
@@ -126,5 +114,29 @@ describe("LoginPasswordPage", () => {
     const history = helper.browserHistory
     assert.lengthOf(history, 2)
     assert.equal(history.location.pathname, LOGIN_URL)
+  })
+
+  describe("getSubmitResultErrors prop", () => {
+    const errorText = "error text"
+
+    //
+    ;[[[errorText], true], [[], false]].forEach(
+      ([errors, expectErrorObject]) => {
+        it(`${shouldIf(
+          expectErrorObject
+        )} return error object if API response error count == ${String(
+          errors.length
+        )}`, async () => {
+          const { wrapper } = await renderPage()
+          const getSubmitResultErrors = wrapper.prop("getSubmitResultErrors")
+          const submitResultErrors = getSubmitResultErrors({ errors: errors })
+
+          const expectedResult = expectErrorObject
+            ? { password: errorText }
+            : undefined
+          assert.deepEqual(submitResultErrors, expectedResult)
+        })
+      }
+    )
   })
 })

--- a/static/js/containers/auth/PasswordResetPage.js
+++ b/static/js/containers/auth/PasswordResetPage.js
@@ -18,7 +18,7 @@ import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 
 import type { Match } from "react-router"
-import type { WithFormProps } from "../../flow/formTypes"
+import type { FormErrors, WithFormProps } from "../../flow/formTypes"
 import type { EmailForm } from "../../flow/authTypes"
 
 type PasswordResetPageProps = {
@@ -29,7 +29,6 @@ type PasswordResetPageProps = {
 
 export const PasswordResetPage = ({
   renderForm,
-  emailApiError,
   successfullySubmitted,
   match
 }: PasswordResetPageProps) => (
@@ -50,7 +49,7 @@ export const PasswordResetPage = ({
             <CanonicalLink match={match} />
           </MetaTags>
           <h3>Forgot your password?</h3>
-          {renderForm({ emailApiError })}
+          {renderForm()}
           <ExternalLogins />
         </Card>
       )}
@@ -66,6 +65,11 @@ const { getForm, actionCreators } = configureForm(FORM_KEY, passwordResetForm)
 const onSubmit = (form: EmailForm) =>
   actions.passwordReset.postEmail(form.email)
 
+export const onSubmitFailure = (response: Object): FormErrors<*> => {
+  const error = R.prop("email", response)
+  return { email: error || "Error resetting password" }
+}
+
 const mergeProps = mergeAndInjectProps((stateProps, { onSubmit }) => {
   return {
     onSubmit: form => onSubmit(form)
@@ -75,7 +79,6 @@ const mergeProps = mergeAndInjectProps((stateProps, { onSubmit }) => {
 const mapStateToProps = state => {
   const form = getForm(state)
   const passwordReset = state.passwordReset
-  const emailApiError = R.view(R.lensPath(["error", "email"]))(passwordReset)
   const successfullySubmitted =
     passwordReset &&
     passwordReset.loaded &&
@@ -85,8 +88,8 @@ const mapStateToProps = state => {
   return {
     form,
     validateForm,
-    emailApiError,
-    successfullySubmitted
+    successfullySubmitted,
+    onSubmitFailure
   }
 }
 

--- a/static/js/containers/auth/PasswordResetPage_test.js
+++ b/static/js/containers/auth/PasswordResetPage_test.js
@@ -90,17 +90,21 @@ describe("PasswordResetPage", () => {
     )
   })
 
-  it("should pass an error object into the form when the API call fails", async () => {
-    const { inner } = await renderPage({
-      passwordReset: {
-        error: {
-          email: "This email doesn't exist"
-        }
-      }
+  describe("onSubmitFailure prop", () => {
+    [
+      [
+        { email: "error text" },
+        "error text",
+        "reset API response with an email error"
+      ],
+      [{}, "Error resetting password", "empty reset API response"]
+    ].forEach(([submitResponse, expErrorText, responseDesc]) => {
+      it(`should return correct error object when given ${responseDesc}`, async () => {
+        const { wrapper } = await renderPage()
+        const onSubmitFailure = wrapper.prop("onSubmitFailure")
+        const submitFailureResult = onSubmitFailure(submitResponse)
+        assert.deepEqual(submitFailureResult, { email: expErrorText })
+      })
     })
-
-    const form = inner.find("PasswordResetForm")
-    assert.ok(form.exists())
-    assert.equal(form.prop("emailApiError"), "This email doesn't exist")
   })
 })

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -28,7 +28,7 @@ import { mergeAndInjectProps } from "../../lib/redux_props"
 
 import type { Match } from "react-router"
 import type { EmailForm, AuthResponse } from "../../flow/authTypes"
-import type { WithFormProps } from "../../flow/formTypes"
+import type { FormErrors, WithFormProps } from "../../flow/formTypes"
 
 type RegisterPageProps = {
   match: Match,
@@ -67,14 +67,14 @@ const { getForm, actionCreators } = configureForm(FORM_KEY, newEmailForm)
 const onSubmit = (form: EmailForm) =>
   actions.auth.registerEmail(FLOW_REGISTER, form.email, form.recaptcha)
 
-const onSubmitError = formValidate =>
-  formValidate({ recaptcha: `Error validating your submission.` })
+const onSubmitFailure = (): FormErrors<*> => ({
+  recaptcha: `Error validating your submission.`
+})
 
 const mergeProps = mergeAndInjectProps(
-  (stateProps, { setBannerMessage, formValidate }, { history }) => ({
+  (stateProps, { setBannerMessage }, { history }) => ({
     // Used by withForm()
     useRecaptcha:   true,
-    onSubmitError:  () => onSubmitError(formValidate),
     onSubmitResult: (response: AuthResponse) => {
       processAuthResponse(history, response)
       if (response.state === STATE_REGISTER_CONFIRM_SENT && response.email) {
@@ -95,7 +95,8 @@ const mapStateToProps = state => {
   return {
     form,
     validateForm,
-    formError
+    formError,
+    onSubmitFailure
   }
 }
 

--- a/static/js/flow/formTypes.js
+++ b/static/js/flow/formTypes.js
@@ -36,7 +36,8 @@ export type WithFormProps<T> = {
   onUpdate: Object => void,
   onSubmit: T => Promise<*>,
   onSubmitResult: Function,
-  onSubmitError?: Function,
+  getSubmitResultErrors?: ?Object => ?FormErrors<string>,
+  onSubmitFailure?: Object => FormErrors<string>,
   useRecaptcha?: boolean,
   validateForm: FormValue<T> => {value: FormErrors<T>},
   renderForm: Function

--- a/static/js/lib/forms.js
+++ b/static/js/lib/forms.js
@@ -3,7 +3,12 @@ import R from "ramda"
 
 import { actions } from "../actions"
 
-import type { ConfiguredFormProps, NewFormFunc } from "../flow/formTypes"
+import type {
+  ConfiguredFormProps,
+  FormErrors,
+  NewFormFunc
+} from "../flow/formTypes"
+import type { AuthResponse } from "../flow/authTypes"
 
 export const formBeginEditForKey = <T>(
   formKey: string,
@@ -45,3 +50,20 @@ export const configureForm = <T>(
       formValidate:  formValidateForKey(formKey)
     }
   })
+
+/**
+ * Helper function that inspects an auth endpoint response for errors. If errors are found,
+ * it returns an object that can be passed to formValidate so the response error can be shown
+ * as a form validation error.
+ */
+export const getAuthResponseFieldErrors = R.curry(
+  (
+    formFieldToAttachErrors: string,
+    response: ?AuthResponse
+  ): ?FormErrors<*> => {
+    const errors = R.propOr([], "errors", response)
+    if (errors.length > 0) {
+      return { [formFieldToAttachErrors]: errors[0] }
+    }
+  }
+)

--- a/static/js/lib/forms_test.js
+++ b/static/js/lib/forms_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import { configureForm } from "./forms"
+import { configureForm, getAuthResponseFieldErrors } from "./forms"
 import {
   FORM_BEGIN_EDIT,
   FORM_END_EDIT,
@@ -84,6 +84,27 @@ describe("forms lib", () => {
           errors
         },
         type: FORM_VALIDATE
+      })
+    })
+  })
+
+  describe("getAuthResponseFieldErrors", () => {
+    const field = "email"
+    const errorText = "error text"
+
+    //
+    ;[
+      [
+        { errors: [errorText] },
+        { [field]: errorText },
+        "response object with errors"
+      ],
+      [{}, undefined, "response object without errors"],
+      [undefined, undefined, "undefined response object"]
+    ].forEach(([responseObj, expReturnValue, desc]) => {
+      it(`returns correct object when given ${desc}`, () => {
+        const returnValue = getAuthResponseFieldErrors(field, responseObj)
+        assert.deepEqual(returnValue, expReturnValue)
       })
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1129 
Fixes #1130 

#### What's this PR do?
- Changes our form component (HOC) to accept some optional functions that detect HTTP response errors and 'coerce' them to form validation errors
  - Example case: a user enters an unrecognized email in a form, and the HTTP response indicates that the email doesn't exist. You can now define a function that inspects that response and returns an object mapping that error message to the 'email' field of the form
- Updates several components to define these functions
- Removes some behavior that treated HTTP endpoint state as UI state (more on that in the background context section)

#### How should this be manually tested?
Try both of these cases and check to see if the given error shows up like a validation message
- Enter an unrecognized email on the login page (/login), password reset page (/password_reset) and the add moderator/contributor pages (/manage/c/edit/<channel_name>/members/moderators/)
- Enter a valid but incorrect password for a user with email auth

Also try that second case (incorrect password), then click back then forward in your browser. You should no longer see the incorrect password message. You should also be able to enter an email on the first login page with no issues.

#### Where should the reviewer start?
`static/js/hoc/withForm.js` to understand the function props that were changed/added

#### Any background context you want to provide?
The core of the problem being addressed in this PR is that we have been treating HTTP responses as UI state (#1129 has a short thread about this). That presented a few problems for us. If the last request to some endpoint resulted in an error, that really doesn't tell us what we should be showing in the UI. If a form submission results in an error, navigate to a different page, then come back to the same form, the endpoint state will still be the same, but we don't want to continue showing that error any more than we want to show a validation message for a required field that wasn't filled out. Overall, in the context of a form submission, I felt it made the most sense to treat HTTP response errors exactly the same as validation errors.

#### Screenshots (if appropriate)
![ss 2018-09-19 at 12 27 45](https://user-images.githubusercontent.com/14932219/45767166-73e54b80-bc07-11e8-85bc-b1f38da173d1.png)
