### PR TITLE
fix issue with over-eager linebreaks

### DIFF
--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -58,7 +58,7 @@ $link-padding: 11px 20px 11px 19px;
   .title {
     margin-left: $text-padding-left;
     font-size: 18px;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .new-post-link-container {


### PR DESCRIPTION


#### What are the relevant tickets?

we took one approach to this in #1153, this changes out for another

#### What's this PR do?

changes the line breaking behavior of the titles in the navigation drawer, just so that lines with long words aren't broken in the middle of the word (as often).

#### How should this be manually tested?

Make some longer channel names, with long words in them, and make sure that things aren't all wacky.