### PR TITLE
fix comment share url

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -24,7 +24,7 @@ import {
   getCommentReplyInitialValue
 } from "../components/CommentForms"
 import { makeProfile } from "../lib/profile"
-import { profileURL } from "../lib/url"
+import { profileURL, absolutizeURL } from "../lib/url"
 
 import type {
   GenericComment,
@@ -147,7 +147,7 @@ export default class CommentTree extends React.Component<Props> {
           </div>
           {commentShareOpen ? (
             <SharePopup
-              url={commentPermalink(comment.id)}
+              url={absolutizeURL(commentPermalink(comment.id))}
               closePopup={hideShareMenu}
             />
           ) : null}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -14,7 +14,7 @@ import {
   replyToCommentKey,
   editCommentKey
 } from "./CommentForms"
-import { commentPermalink, profileURL } from "../lib/url"
+import { commentPermalink, profileURL, absolutizeURL } from "../lib/url"
 import Router from "../Router"
 import SharePopup from "./SharePopup"
 
@@ -104,7 +104,7 @@ describe("CommentTree", () => {
     const wrapper = renderCommentTree(openShareMenu(comments[0]))
     assert.ok(wrapper.find(SharePopup).exists())
     const { url } = wrapper.find(SharePopup).props()
-    assert.equal(url, permalinkFunc(comments[0].id))
+    assert.equal(url, absolutizeURL(permalinkFunc(comments[0].id)))
   })
 
   it("should render all replies to a top-level comment", () => {

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -57,11 +57,11 @@ export const embedlyResizeImage = (key: string, url: string, height: number) =>
     url
   )}&height=${height}&grow=false&errorurl=${blankThumbnailUrl()}`
 
+export const absolutizeURL = (url: string) =>
+  new URL(url, window.location.origin).toString()
+
 export const postPermalink = (post: Post): string =>
-  new URL(
-    postDetailURL(post.channel_name, post.id),
-    window.location.origin
-  ).toString()
+  absolutizeURL(postDetailURL(post.channel_name, post.id, post.slug))
 
 // pull the channel name out of location.pathname
 // see here for why this hackish approach was necessary:

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -21,7 +21,8 @@ import {
   postPermalink,
   embedlyThumbnail,
   blankThumbnailUrl,
-  embedlyResizeImage
+  embedlyResizeImage,
+  absolutizeURL
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -211,7 +212,9 @@ describe("url helper functions", () => {
       const post = makePost()
       const url = postPermalink(post)
       assert.ok(url.startsWith(window.location.origin))
-      assert.ok(url.includes(postDetailURL(post.channel_name, post.id)))
+      assert.ok(
+        url.includes(postDetailURL(post.channel_name, post.id, post.slug))
+      )
     })
   })
 
@@ -247,6 +250,14 @@ describe("url helper functions", () => {
         blankThumbnailUrl(),
         `${window.location.origin}/static/images/blank.png`
       )
+    })
+  })
+
+  describe("absolutizeURL", () => {
+    it("should take a relative URL and make it absolute", () => {
+      const url = absolutizeURL("/foo/bar/baz")
+      assert.ok(url.startsWith(window.location.origin))
+      assert.ok(url.includes("/foo/bar/baz"))
     })
   })
 })


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
closes #1216 
#### What's this PR do?

this fixes the comment share url, so that it is an absolute URL and not a relative one.

#### How should this be manually tested?

check that the URL in the comment share popup is an absolute one.