### PR TITLE
Show LoginPopup in comment textarea via focus/change events

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -72,7 +72,8 @@ const getPostReplyInitialValue = (parent: Post) => ({
   text:    ""
 })
 
-const userConditionalFunction = (
+const userOrAnonymousFunction = (
+  //Return one of two functions depending on whether the user is logged in or anonymous.
   userFunc: ?Function,
   anonymousFunc: ?Function
 ) =>
@@ -107,7 +108,7 @@ const CommentFormHelper = ({
 }: CommentFormProps) => (
   <div className="reply-form">
     <form
-      onSubmit={userConditionalFunction(onSubmit, onTogglePopup)}
+      onSubmit={userOrAnonymousFunction(onSubmit, onTogglePopup)}
       className="form"
       onKeyDown={e => {
         if (e.key === "Enter" && e.ctrlKey && !disabled && !isEmptyText(text)) {
@@ -136,9 +137,9 @@ const CommentFormHelper = ({
             placeholder="Write a reply here..."
             value={text || ""}
             onChange={
-              disabled ? userConditionalFunction(null, onTogglePopup) : onUpdate
+              disabled ? userOrAnonymousFunction(null, onTogglePopup) : onUpdate
             }
-            onFocus={userConditionalFunction(null, onTogglePopup)}
+            onFocus={userOrAnonymousFunction(null, onTogglePopup)}
             autoFocus={autoFocus}
           />
         )}

--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -72,6 +72,14 @@ const getPostReplyInitialValue = (parent: Post) => ({
   text:    ""
 })
 
+const userConditionalFunction = (
+  userFunc: ?Function,
+  anonymousFunc: ?Function
+) =>
+  userIsAnonymous() && anonymousFunc
+    ? preventDefaultAndInvoke(anonymousFunc)
+    : userFunc
+
 type CommentFormProps = {
   onSubmit: (e: Event) => Promise<*>,
   text: string,
@@ -99,12 +107,7 @@ const CommentFormHelper = ({
 }: CommentFormProps) => (
   <div className="reply-form">
     <form
-      onSubmit={
-        userIsAnonymous() && onTogglePopup
-          ? // $FlowFixMe - the above ensures onTogglePopup is defined
-          preventDefaultAndInvoke(onTogglePopup)
-          : onSubmit
-      }
+      onSubmit={userConditionalFunction(onSubmit, onTogglePopup)}
       className="form"
       onKeyDown={e => {
         if (e.key === "Enter" && e.ctrlKey && !disabled && !isEmptyText(text)) {
@@ -132,13 +135,10 @@ const CommentFormHelper = ({
             className="input"
             placeholder="Write a reply here..."
             value={text || ""}
-            onChange={disabled ? null : onUpdate}
-            onClick={
-              userIsAnonymous() && onTogglePopup
-                ? // $FlowFixMe: the above
-                preventDefaultAndInvoke(onTogglePopup)
-                : null
+            onChange={
+              disabled ? userConditionalFunction(null, onTogglePopup) : onUpdate
             }
+            onFocus={userConditionalFunction(null, onTogglePopup)}
             autoFocus={autoFocus}
           />
         )}

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -1,3 +1,4 @@
+/* global SETTINGS:false */
 import React from "react"
 import R from "ramda"
 import { Provider } from "react-redux"
@@ -22,7 +23,6 @@ import Router from "../Router"
 import LoginPopup from "./LoginPopup"
 
 import * as forms from "../actions/forms"
-import * as utilFuncs from "../lib/util"
 import { actions } from "../actions"
 import { CLEAR_COMMENT_ERROR } from "../actions/comment"
 import { SET_POST_DATA, setPostData } from "../actions/post"
@@ -158,12 +158,15 @@ describe("CommentForms", () => {
       })
     })
 
-    it("should be enabled but display a login popup on click if user is anonymous", async () => {
-      helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
-      wrapper = renderPostForm()
-      assert.isFalse(wrapper.find("button").props().disabled)
-      wrapper.find("textarea").simulate("click")
-      assert.isTrue(wrapper.find(LoginPopup).props().visible)
+    //
+    ;["change", "focus"].forEach(event => {
+      it(`should be enabled but display a login popup on ${event} if user is anonymous`, async () => {
+        SETTINGS.username = null
+        wrapper = renderPostForm()
+        assert.isFalse(wrapper.find("button").props().disabled)
+        wrapper.find("textarea").simulate(event)
+        assert.isTrue(wrapper.find(LoginPopup).props().visible)
+      })
     })
 
     it("should submit the form", async () => {

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -87,6 +87,7 @@
   }
 
   .link-button {
+    background-color: #fff;
     display: block;
     border-radius: 10px;
     padding: 5px 15px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1182
Fixes #1228

#### What's this PR do?
- Shows the LoginPopup in the comment textarea via onChange and onFocus events instead of onClick.
- Fixes CSS for the LoginPopup login button

#### How should this be manually tested?
- Go to a public post detail page as an anonymous user
- Use the tab key to navigate to the comment form.  The LoginPopup should appear you tab into it.
- Close the popup, then click inside the textarea.  The popup should appear again.