### PR TITLE
## Reports instead of Reported ## times

### DIFF
--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -359,7 +359,7 @@ describe("CommentTree", () => {
         ...openDropdownMenu(report.comment)
       })
       assert.ok(wrapper.find(".report-count").exists())
-      assert.equal(wrapper.find(".report-count").text(), "Reported 2 times")
+      assert.equal(wrapper.find(".report-count").text(), "2 Reports")
     })
 
     it("should not render a report count, if comment has no report data", () => {

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -267,7 +267,7 @@ describe("CompactPostDisplay", () => {
       const count = wrapper.find(".report-count")
       assert.ok(count.exists())
       // $FlowFixMe: thinks this doesn't exist
-      assert.equal(count.text(), `Reported ${post.num_reports} times`)
+      assert.equal(count.text(), `${post.num_reports} Report(s)`)
     })
 
     it("should not render a report count, if post has no report data", () => {

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -267,7 +267,7 @@ describe("CompactPostDisplay", () => {
       const count = wrapper.find(".report-count")
       assert.ok(count.exists())
       // $FlowFixMe: thinks this doesn't exist
-      assert.equal(count.text(), `${post.num_reports} Report(s)`)
+      assert.equal(count.text(), `${post.num_reports} Reports`)
     })
 
     it("should not render a report count, if post has no report data", () => {

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -364,7 +364,7 @@ describe("ExpandedPostDisplay", () => {
     const count = wrapper.find(".report-count")
     assert.ok(count.exists())
     // $FlowFixMe: thinks this doesn't exist
-    assert.equal(count.text(), `Reported ${post.num_reports} times`)
+    assert.equal(count.text(), `${post.num_reports} Reports`)
   })
 
   it("should not render a report count, if post has no report data", () => {

--- a/static/js/components/ReportCount.js
+++ b/static/js/components/ReportCount.js
@@ -14,7 +14,7 @@ export default class ReportCount extends React.Component<Props> {
 
     return (
       <div className="report-count">
-        Reported {count} {count === 1 ? "time" : "times"}
+        {count} {count === 1 ? "Report" : "Reports"}
       </div>
     )
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- no migrations
- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested
- no settings changes

#### What are the relevant tickets?

Fixes #

#### What's this PR do?

Changes the text "Reported 2 times" to "2 Reports" 

#### How should this be manually tested?

1. Report a post
2. As a moderator, view the post summary card for the reported post. 
3. The text should read "1 Report" 
4. As another user, report the post again. 
5. The text should read "2 Reports" 

1. Report a comment
2. As a moderator, view the reported comment
3. The text should read "1 Report"

You can also view this on the reports tab of the channel settings. 

#### Screenshots (if appropriate)

I'll add one if I can get the review build to work. 


