### PR TITLE
add channel header to channel page

### DIFF
--- a/static/js/components/ChannelSidebar.js
+++ b/static/js/components/ChannelSidebar.js
@@ -10,7 +10,7 @@ import { editChannelBasicURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type ChannelSidebarProps = {
-  channel: Channel,
+  channel: ?Channel,
   isModerator: boolean
 }
 

--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -46,10 +46,14 @@ type CellWidth =
   | typeof twelve
 
 type CellProps = {
-  children: React$Element<*>,
-  width: CellWidth
+  children: any,
+  width: CellWidth,
+  className?: string
 }
 
-export const Cell = ({ children, width }: CellProps) => (
-  <div className={`mdc-layout-grid__cell--span-${width}`}>{children}</div>
+const cellClassName = (width, className) =>
+  `mdc-layout-grid__cell--span-${width} ${className || ""}`.trim()
+
+export const Cell = ({ children, width, className }: CellProps) => (
+  <div className={cellClassName(width, className)}>{children}</div>
 )

--- a/static/js/components/Grid_test.js
+++ b/static/js/components/Grid_test.js
@@ -32,4 +32,22 @@ describe("Grid components", () => {
       assert.ok(wrapper.find(".child").exists())
     })
   })
+
+  it("should allow passing a className to Grid", () => {
+    const wrapper = shallow(
+      <Grid width={2} className="foobar">
+        <div />
+      </Grid>
+    )
+    assert.ok(wrapper.find(".foobar"))
+  })
+
+  it("should allow passing a className to Cell", () => {
+    const wrapper = shallow(
+      <Cell width={2} className="foobar">
+        <div />
+      </Cell>
+    )
+    assert.ok(wrapper.find(".foobar"))
+  })
 })

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -6,6 +6,7 @@ import ContentLoader from "react-content-loader"
 import { NotFound, NotAuthorized } from "../components/ErrorPages"
 import Card from "./Card"
 import { contentLoaderSpeed } from "../lib/constants"
+import withChannelSidebar from "../hoc/withChannelSidebar"
 
 type LoadingProps = {
   loaded: boolean,
@@ -109,3 +110,6 @@ export const withLoading = R.curry(
 
 export const withSpinnerLoading = withLoading(Loading)
 export const withPostLoading = withLoading(PostLoading)
+export const withPostLoadingSidebar = withLoading(
+  withChannelSidebar("channel-page", PostLoading)
+)

--- a/static/js/components/admin/EditChannelAppearanceForm.js
+++ b/static/js/components/admin/EditChannelAppearanceForm.js
@@ -50,7 +50,7 @@ export default class EditChannelAppearanceForm extends React.Component<Props> {
                 form.avatar.edit &&
                 URL.createObjectURL(form.avatar.edit)
               }
-              imageSize="medium"
+              imageSize="large"
             />
             <div className="title-container">
               <input

--- a/static/js/containers/ChannelAvatar.js
+++ b/static/js/containers/ChannelAvatar.js
@@ -18,8 +18,12 @@ import type { Channel } from "../flow/discussionTypes"
 
 export const CHANNEL_AVATAR_SMALL: "small" = "small"
 export const CHANNEL_AVATAR_MEDIUM: "medium" = "medium"
+export const CHANNEL_AVATAR_LARGE: "large" = "large"
 
-type ImageSize = typeof CHANNEL_AVATAR_SMALL | typeof CHANNEL_AVATAR_MEDIUM
+type ImageSize =
+  | typeof CHANNEL_AVATAR_SMALL
+  | typeof CHANNEL_AVATAR_MEDIUM
+  | typeof CHANNEL_AVATAR_LARGE
 
 type Props = {
   imageSize: ImageSize,

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -7,8 +7,7 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
 import CanonicalLink from "../components/CanonicalLink"
-import { withPostLoading } from "../components/Loading"
-import withChannelSidebar from "../hoc/withChannelSidebar"
+import { withPostLoadingSidebar } from "../components/Loading"
 import { PostSortPicker } from "../components/SortPicker"
 import {
   withPostModeration,
@@ -17,6 +16,13 @@ import {
 import withPostList from "../hoc/withPostList"
 import IntraPageNav from "../components/IntraPageNav"
 import { withChannelTracker } from "../hoc/withChannelTracker"
+import ChannelSidebar from "../components/ChannelSidebar"
+import Sidebar from "../components/Sidebar"
+import { Grid, Cell } from "../components/Grid"
+import ChannelBanner from "../containers/ChannelBanner"
+import ChannelAvatar, {
+  CHANNEL_AVATAR_MEDIUM
+} from "../containers/ChannelAvatar"
 
 import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
@@ -118,25 +124,48 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
       return null
     } else {
       return (
-        <React.Fragment>
-          <MetaTags>
-            <title>{formatTitle(channel.title)}</title>
-            <CanonicalLink match={match} />
-          </MetaTags>
-          <IntraPageNav>
-            <a href="#" className="active">
-              Posts
-            </a>
-          </IntraPageNav>
-          <div className="post-list-title">
-            <div>All</div>
-            <PostSortPicker
-              updateSortParam={updatePostSortParam(this.props)}
-              value={qs.parse(search).sort || POSTS_SORT_HOT}
-            />
-          </div>
-          {renderPosts()}
-        </React.Fragment>
+        <div className="channel-page-wrapper">
+          <ChannelBanner editable={false} channel={channel} />
+          <Grid className={`main-content two-column channel-page`}>
+            <Cell className="avatar-headline-row" width={12}>
+              <ChannelAvatar
+                editable={false}
+                channel={channel}
+                imageSize={CHANNEL_AVATAR_MEDIUM}
+              />
+              <div className="title-and-headline">
+                <div className="title">{channel.title}</div>
+                {channel.public_description ? (
+                  <div className="headline">{channel.public_description}</div>
+                ) : null}
+              </div>
+            </Cell>
+            <Cell width={8}>
+              <MetaTags>
+                <title>{formatTitle(channel.title)}</title>
+                <CanonicalLink match={match} />
+              </MetaTags>
+              <IntraPageNav>
+                <a href="#" className="active">
+                  Posts
+                </a>
+              </IntraPageNav>
+              <div className="post-list-title">
+                <div>All</div>
+                <PostSortPicker
+                  updateSortParam={updatePostSortParam(this.props)}
+                  value={qs.parse(search).sort || POSTS_SORT_HOT}
+                />
+              </div>
+              {renderPosts()}
+            </Cell>
+            <Cell width={4}>
+              <Sidebar className="sidebar-right">
+                <ChannelSidebar {...this.props} />
+              </Sidebar>
+            </Cell>
+          </Grid>
+        </div>
       )
     }
   }
@@ -207,8 +236,7 @@ export default R.compose(
     mapDispatchToProps
   ),
   withPostModeration,
-  withChannelSidebar("channel-page"),
   withChannelTracker,
   withPostList,
-  withPostLoading
+  withPostLoadingSidebar
 )(ChannelPage)

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -187,7 +187,7 @@ describe("ChannelPage", () => {
         }
       }
     )
-    assert.lengthOf(inner.find("PostLoading"), 1)
+    assert.lengthOf(inner.find("WithChannelSidebar"), 1)
   })
 
   it("should clear the error if present on load", async () => {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -32,6 +32,7 @@ $banner-slide-timing: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 $banner-slide-trans: top 300ms $banner-slide-timing;
 $banner-slide-content-trans: padding-top 300ms $banner-slide-timing;
 $material-icon-size: 24px;
+$channel-banner-height: 105px;
 
 // redesign colors
 $rouge: #a31f34;

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -129,16 +129,3 @@
     margin-left: 20px;
   }
 }
-
-.banner-container {
-  .banner-image {
-    width: 100%;
-    display: block;
-  }
-
-  .upload-banner {
-    margin-top: 20px;
-    display: block;
-    text-align: right;
-  }
-}

--- a/static/scss/channel-banner.scss
+++ b/static/scss/channel-banner.scss
@@ -1,0 +1,14 @@
+.banner-container {
+  .banner-image {
+    width: 100%;
+    display: block;
+    height: $channel-banner-height;
+    object-fit: cover;
+  }
+
+  .upload-banner {
+    margin-top: 20px;
+    display: block;
+    text-align: right;
+  }
+}

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -1,3 +1,40 @@
+.channel-page-wrapper {
+  position: relative;
+}
+
+.avatar-headline-row {
+  position: absolute;
+  top: 0;
+  height: $channel-banner-height;
+  display: flex;
+  align-items: center;
+
+  .avatar-image,
+  .avatar-initials {
+    border-radius: 4px;
+  }
+
+  .avatar {
+    margin-right: 22px;
+  }
+
+  .title-and-headline {
+    display: flex;
+    flex-direction: column;
+    color: white;
+    height: 57px;
+
+    .title {
+      font-size: 22px;
+      font-weight: bold;
+    }
+
+    .headline {
+      font-size: 16px;
+    }
+  }
+}
+
 .channel-about {
   position: relative;
   max-width: 400px;
@@ -29,7 +66,8 @@
   }
 }
 
-$avatar-dimension-medium: 90px;
+$avatar-dimension-large: 90px;
+$avatar-dimension-medium: 57px;
 $avatar-dimension-small: 22px;
 
 .avatar-container {
@@ -78,6 +116,19 @@ $avatar-dimension-small: 22px;
 
     .avatar-initials {
       font-size: $avatar-dimension-medium / 4;
+    }
+  }
+
+  &.large-size {
+    img,
+    .avatar,
+    .avatar-initials {
+      width: $avatar-dimension-large;
+      height: $avatar-dimension-large;
+    }
+
+    .avatar-initials {
+      font-size: $avatar-dimension-large / 4;
     }
   }
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -50,6 +50,7 @@
 @import "add-link-menu";
 @import "close-button";
 @import "intra-page-nav";
+@import "channel-banner";
 
 body {
   font-family: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/loader.scss
+++ b/static/scss/loader.scss
@@ -18,3 +18,7 @@
 .loading.infinite {
   height: 100px;
 }
+
+.loaded {
+  width: 100%;
+}

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -96,6 +96,7 @@ $profile-image-small-size: 45px;
 .photo-dropzone {
   font-size: 20px;
   font-weight: 400;
+  cursor: pointer;
 
   .desktop-upload-message,
   .mobile-upload-message {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #989 

#### What's this PR do?

this adds the channel avatar and the banner to the channel page. it also shows the channel title and the headline up there (the headline only if it's been set).

#### How should this be manually tested?

make sure that the things described above show up. it should look ok and so on. everything should work decently well on mobile as well.

here's what it looks like with the gradient:

![channel-header](https://user-images.githubusercontent.com/6207644/45841996-6c966e80-bce9-11e8-912d-b83c412614d7.png)

here's with an image:

![channel-headewimager](https://user-images.githubusercontent.com/6207644/45842007-78823080-bce9-11e8-9974-6b4083708c13.png)

one possible concern is that certain images will make the headline and channel title text pretty hard to read (as the one above does, for instance).
