### PR TITLE
Convert "days ago" text to post/comment link

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -230,7 +230,7 @@ export default class CommentTree extends React.Component<Props> {
   }
 
   renderComment = (depth: number, comment: CommentInTree) => {
-    const { forms, processing } = this.props
+    const { forms, processing, commentPermalink } = this.props
     const editFormKey = editCommentKey(comment)
     // ramda can't determine arity here so use curryN
     const renderGenericComment = R.curryN(2, this.renderGenericComment)(
@@ -260,9 +260,11 @@ export default class CommentTree extends React.Component<Props> {
               <Link to={profileURL(comment.author_id)}>
                 <span className="author-name">{comment.author_name}</span>
               </Link>
-              <span className="authored-date">
-                {moment(comment.created).fromNow()}
-              </span>
+              <Link to={commentPermalink(comment.id)}>
+                <span className="authored-date">
+                  {moment(comment.created).fromNow()}
+                </span>
+              </Link>
               <span className="removed-note">
                 {comment.removed ? (
                   <span>[comment removed by moderator]</span>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -294,6 +294,7 @@ describe("CommentTree", () => {
       .find(".author-info")
       .at(0)
       .find("Link")
+      .at(0)
     assert.equal(link.text(), comments[0].author_name)
     assert.equal(link.props().to, profileURL(comments[0].author_id))
     const secondLink = wrapper
@@ -303,6 +304,17 @@ describe("CommentTree", () => {
       .at(0)
     assert.equal(secondLink.props().to, profileURL(comments[0].author_id))
     assert(secondLink.find("ProfileImage").exists())
+  })
+
+  it("should link to the comment URL", () => {
+    const wrapper = renderCommentTree()
+    const link = wrapper
+      .find(".author-info")
+      .at(0)
+      .find("Link")
+      .at(1)
+      .props()
+    assert.equal(link.to, permalinkFunc(comments[0].id))
   })
 
   it("should limit replies to the max comment depth", () => {

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -96,7 +96,11 @@ export class CompactPostDisplay extends React.Component<Props> {
                   ) : null}
                 </div>
                 <div className="date">
-                  {formattedDate}
+                  <Link
+                    to={postDetailURL(post.channel_name, post.id, post.slug)}
+                  >
+                    <span>{formattedDate}</span>
+                  </Link>
                   {this.showChannelLink()}
                 </div>
               </div>

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -92,8 +92,23 @@ describe("CompactPostDisplay", () => {
     const link = renderPostDisplay({ post })
       .find(".authored-by")
       .find("Link")
+      .at(0)
     assert.equal(link.text(), post.author_name)
     assert.equal(link.props().to, profileURL(post.author_id))
+  })
+
+  it("should link to the post detail page via post date", () => {
+    const wrapper = renderPostDisplay({ post })
+    const linkProps = wrapper
+      .find(".date")
+      .at(0)
+      .find(Link)
+      .at(0)
+      .props()
+    assert.equal(
+      linkProps.to,
+      postDetailURL(post.channel_name, post.id, post.slug)
+    )
   })
 
   it("should link to the subreddit, if told to", () => {
@@ -101,7 +116,9 @@ describe("CompactPostDisplay", () => {
     const wrapper = renderPostDisplay({ post, showChannelLink: true })
     const linkProps = wrapper
       .find(".date")
+      .at(0)
       .find(Link)
+      .at(1)
       .props()
     assert.equal(linkProps.to, channelURL("channel_name"))
     assert.equal(linkProps.children, post.channel_title)
@@ -112,7 +129,7 @@ describe("CompactPostDisplay", () => {
     const wrapper = renderPostDisplay({ post })
     const { href, target } = wrapper
       .find("a")
-      .at(2)
+      .at(3)
       .props()
     assert.equal(href, post.url)
     assert.equal(target, "_blank")

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -177,7 +177,7 @@ $replyPaddingLeftPhone: 10px;
       }
 
       .authored-date {
-        color: #b0b0b0;
+        color: $navy;
       }
 
       .removed-note {

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -176,6 +176,10 @@ $replyPaddingLeftPhone: 10px;
         color: $font-black;
       }
 
+      .authored-date {
+        color: #b0b0b0;
+      }
+
       .removed-note {
         font-style: italic;
         color: $font-black;

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -166,6 +166,7 @@ $replyPaddingLeftPhone: 10px;
 
       .authored-date {
         font-size: 14px;
+        color: $navy;
       }
 
       .author-name {
@@ -174,10 +175,6 @@ $replyPaddingLeftPhone: 10px;
         font-weight: 500;
         font-size: $author-font-size;
         color: $font-black;
-      }
-
-      .authored-date {
-        color: $navy;
       }
 
       .removed-note {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -95,7 +95,7 @@
     color: $font-grey-light;
 
     a {
-      color: $font-grey-light;
+      color: $navy;
     }
   }
 }

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -93,6 +93,10 @@
 
   .date {
     color: $font-grey-light;
+
+    a {
+      color: $font-grey-light;
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1225 

#### What's this PR do?
Converts the "X days ago" text on comment cards and compact post cards to links that should bring that user to the post detail page (and particular comment).

#### How should this be manually tested?
- Go to a channel page.  The "X days ago" text for each post should look the same as before (gray color).  Clicking on it should bring you to the post detail page.
- Click on the "X days ago" text next to a comment.  It should load the post detail page with that comment/thread only showing.
