### PR TITLE
Fixed login button width for narrow widths

### DIFF
--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -61,6 +61,11 @@ $link-padding: 11px 20px 11px $icon-padding-left;
       margin: 0 30px 0 0;
       padding: 4px 50px;
       white-space: nowrap;
+
+      @include breakpoint(materialmobile) {
+        padding-left: 15px;
+        padding-right: 15px;
+      }
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
No issue - fixes a minor style issue introduced by #1219 

#### What's this PR do?
Fixes login button width for narrow widths

#### How should this be manually tested?
Look at the top nav on a logged-out page in mobile view

#### Screenshots (if appropriate)
<img width="215" alt="ss 2018-09-21 at 10 01 48" src="https://user-images.githubusercontent.com/14932219/45885934-ba60b480-bd85-11e8-86d0-55fb0d3e2172.png">
