### PR TITLE
Remove "Show thread" from comment dropdown 

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -115,6 +115,7 @@ export default class CommentTree extends React.Component<Props> {
     } = curriedDropdownMenufunc(commentShareKey(comment))
     const commentMenuOpen = dropdownMenus.has(commentDropdownKey(comment))
     const commentShareOpen = dropdownMenus.has(commentShareKey(comment))
+
     return (
       <div className="row comment-actions">
         {upvote && downvote ? (
@@ -151,11 +152,11 @@ export default class CommentTree extends React.Component<Props> {
             />
           ) : null}
         </div>
-        { !userIsAnonymous() ? (
+        {!userIsAnonymous() ? (
           <i className="material-icons more_vert" onClick={showDropdown}>
             more_vert
-          </i>) : null
-        }
+          </i>
+        ) : null}
         <ReportCount count={comment.num_reports} />
         {commentMenuOpen ? (
           <DropdownMenu

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -115,7 +115,6 @@ export default class CommentTree extends React.Component<Props> {
     } = curriedDropdownMenufunc(commentShareKey(comment))
     const commentMenuOpen = dropdownMenus.has(commentDropdownKey(comment))
     const commentShareOpen = dropdownMenus.has(commentShareKey(comment))
-
     return (
       <div className="row comment-actions">
         {upvote && downvote ? (
@@ -152,9 +151,11 @@ export default class CommentTree extends React.Component<Props> {
             />
           ) : null}
         </div>
-        <i className="material-icons more_vert" onClick={showDropdown}>
-          more_vert
-        </i>
+        { !userIsAnonymous() ? (
+          <i className="material-icons more_vert" onClick={showDropdown}>
+            more_vert
+          </i>) : null
+        }
         <ReportCount count={comment.num_reports} />
         {commentMenuOpen ? (
           <DropdownMenu
@@ -200,9 +201,6 @@ export default class CommentTree extends React.Component<Props> {
                 </div>
               </li>
             ) : null}
-            <li className="comment-action-button permalink-button">
-              <Link to={commentPermalink(comment.id)}>Show this thread</Link>
-            </li>
             <li>
               <CommentRemovalForm
                 comment={comment}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -25,6 +25,7 @@ import { createCommentTree } from "../reducers/comments"
 import { makeCommentReport } from "../factories/reports"
 import * as utilFuncs from "../lib/util"
 import { dropdownMenuFuncs } from "../lib/ui"
+import {shouldIf} from "../lib/test_utils";
 
 describe("CommentTree", () => {
   let comments,
@@ -180,6 +181,15 @@ describe("CommentTree", () => {
     )
   })
 
+  //
+  ;['testuser', null].forEach((username) => {
+    it(`${shouldIf(username !== null)} include a showMenu icon`, () => {
+      SETTINGS.username = username
+      const wrapper = renderCommentTree()
+      assert.equal(wrapper.find('.more_vert').exists(), username !== null)
+    })
+  })
+
   it('should include a "report" button', () => {
     const wrapper = renderCommentTree(openDropdownMenu(comments[0]))
     wrapper
@@ -260,20 +270,6 @@ describe("CommentTree", () => {
       renderCommentTree()
         .find(".delete-button")
         .exists()
-    )
-  })
-
-  it("should include a permalink", () => {
-    const button = renderCommentTree(openDropdownMenu(comments[0])).find(
-      ".permalink-button"
-    )
-    assert(button.exists())
-    assert.equal(
-      button
-        .find(Link)
-        .at(0)
-        .props().to,
-      permalinkFunc(comments[0].id)
     )
   })
 

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -4,7 +4,6 @@ import sinon from "sinon"
 import R from "ramda"
 import { assert } from "chai"
 import { mount } from "enzyme"
-import { Link } from "react-router-dom"
 import ReactMarkdown from "react-markdown"
 
 import Card from "../components/Card"
@@ -25,7 +24,7 @@ import { createCommentTree } from "../reducers/comments"
 import { makeCommentReport } from "../factories/reports"
 import * as utilFuncs from "../lib/util"
 import { dropdownMenuFuncs } from "../lib/ui"
-import {shouldIf} from "../lib/test_utils";
+import { shouldIf } from "../lib/test_utils"
 
 describe("CommentTree", () => {
   let comments,
@@ -182,11 +181,11 @@ describe("CommentTree", () => {
   })
 
   //
-  ;['testuser', null].forEach((username) => {
+  ;["testuser", null].forEach(username => {
     it(`${shouldIf(username !== null)} include a showMenu icon`, () => {
       SETTINGS.username = username
       const wrapper = renderCommentTree()
-      assert.equal(wrapper.find('.more_vert').exists(), username !== null)
+      assert.equal(wrapper.find(".more_vert").exists(), username !== null)
     })
   })
 


### PR DESCRIPTION
~Blocked: Should not be merged until after #1234 is merged.~

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1224

#### What's this PR do?
- Removes the "show thread" option from the comment dropdown menu
- Hides the icon for displaying the dropdown if user is anonymous (because there's nothing to select)

#### How should this be manually tested?
- While logged in, click the icon to open the dropdown menu for a comment. "Show this thread" should not be one of the options.
- While anonymous, the icon for the comment dropdown menu should not be visible.
