### PR TITLE
grey out submit button on create post page

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -152,6 +152,7 @@ export default class CreatePostForm extends React.Component<Props> {
     }
 
     const { postType, title } = postForm
+    const readyToSubmit = postType !== null && title !== ""
 
     return (
       <div className="new-post-form">
@@ -195,7 +196,7 @@ export default class CreatePostForm extends React.Component<Props> {
             </button>
             <button
               className={`submit-post ${
-                processing || postType === null ? "disabled" : ""
+                processing || !readyToSubmit ? "disabled" : ""
               }`}
               type="submit"
               disabled={processing}

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -194,7 +194,9 @@ export default class CreatePostForm extends React.Component<Props> {
               Cancel
             </button>
             <button
-              className={`submit-post ${processing ? "disabled" : ""}`}
+              className={`submit-post ${
+                processing || postType === null ? "disabled" : ""
+              }`}
               type="submit"
               disabled={processing}
             >

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -11,6 +11,7 @@ import { makeChannel } from "../factories/channels"
 import { makeArticle } from "../factories/embedly"
 import { newPostForm } from "../lib/posts"
 import { configureShallowRenderer } from "../lib/test_utils"
+import { shouldIf } from "../lib/test_utils"
 
 describe("CreatePostForm", () => {
   let sandbox, isTextTabSelectedStub, isLinkTypeAllowedStub, renderPostForm
@@ -111,6 +112,32 @@ describe("CreatePostForm", () => {
       wrapper.find(".channel-select .validation-message").text(),
       "HEY"
     )
+  })
+
+  //
+  ;[
+    ["", null, true],
+    ["", LINK_TYPE_LINK, true],
+    ["", LINK_TYPE_TEXT, true],
+    ["title", null, true],
+    ["title", LINK_TYPE_LINK, false],
+    ["title", LINK_TYPE_TEXT, false]
+  ].forEach(([title, type, shouldDisable]) => {
+    it(`${shouldIf(
+      shouldDisable
+    )} put .disabled on submit button when title is ${title} and post type is ${type}`, () => {
+      const postForm = { ...newPostForm(), postType: type, title }
+      const wrapper = renderPostForm({
+        postForm
+      })
+      assert.equal(
+        shouldDisable,
+        wrapper
+          .find(".submit-post")
+          .props()
+          .className.includes("disabled")
+      )
+    })
   })
 
   describe("embedly preview link", () => {

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -125,7 +125,9 @@ describe("CreatePostForm", () => {
   ].forEach(([title, type, shouldDisable]) => {
     it(`${shouldIf(
       shouldDisable
-    )} put .disabled on submit button when title is ${title} and post type is ${type}`, () => {
+    )} put .disabled on submit button when title is ${title} and post type is ${String(
+      type
+    )}`, () => {
       const postForm = { ...newPostForm(), postType: type, title }
       const wrapper = renderPostForm({
         postForm

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -12,6 +12,10 @@ a.link-button {
   font-size: 16px;
   text-decoration: none;
   cursor: pointer;
+
+  &.disabled {
+    opacity: 0.4;
+  }
 }
 
 .mdc-button.cancel-button,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #1237 

#### What's this PR do?

This PR just makes it so that, when you're creating a post, the 'submit' button will be greyed out until you enter a title and pick a post type. it doesn't actually disable the button (by passing `disabled={true}`) but instead sets a `.disabled` class on it. we do want the user to be able to click, because unless they've filled anything out they'll see validation errors anyhow.

#### How should this be manually tested?

make sure that the behavior described above (and in the issue) is implemented.