### PR TITLE
Show post type buttons after switching channels if empty

### DIFF
--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -20,7 +20,7 @@ import { newPostForm } from "../lib/posts"
 import { postDetailURL } from "../lib/url"
 import { getChannelName } from "../lib/util"
 import { formatTitle } from "../lib/title"
-import { validatePostCreateForm } from "../lib/validation"
+import { emptyOrNil, validatePostCreateForm } from "../lib/validation"
 import { ensureTwitterEmbedJS, handleTwitterWidgets } from "../lib/embed"
 import { anyErrorExcept404 } from "../util/rest"
 
@@ -87,20 +87,24 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
     // we may need to change out the postType under certain conditions
     // if the user switches channels and the new channel isn't LINK_TYPE_ANY,
     // and the current postType is null or a postType which is incompatible with the
-    // new channel, we want to set the postType to be the link_type for the channel
+    // new channel, we want to set the postType to be the link_type for the channel.
+    // If the new channel is LINK_TYPE_ANY and both text and url values are empty,
+    // we want to set the postType to null to display the post type options.
     if (
       postForm &&
       channel &&
       ((prevProps.channel && prevProps.channel.name !== channel.name) ||
         !prevProps.channel) &&
-      channel.link_type !== LINK_TYPE_ANY &&
+      (channel.link_type !== LINK_TYPE_ANY ||
+        emptyOrNil(postForm.value.text + postForm.value.url)) &&
       channel.link_type !== postForm.value.postType
     ) {
       dispatch(
         actions.forms.formUpdate({
           ...CREATE_POST_PAYLOAD,
           value: {
-            postType:  channel.link_type,
+            postType:
+              channel.link_type === LINK_TYPE_ANY ? null : channel.link_type,
             url:       "",
             text:      "",
             thumbnail: null

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -83,8 +83,11 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
 
   shouldTriggerUpdate() {
     const { postForm } = this.props
-    return (emptyOrNil(postForm.value.text + postForm.value.url) &&
-          !emptyOrNil(postForm.value.postType))
+    return (
+      postForm &&
+      emptyOrNil(postForm.value.text + postForm.value.url) &&
+      !emptyOrNil(postForm.value.postType)
+    )
   }
 
   componentDidUpdate(prevProps: CreatePostPageProps) {

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -85,7 +85,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
     const { postForm } = this.props
     return (
       postForm &&
-      emptyOrNil(postForm.value.text + postForm.value.url) &&
+      R.all(emptyOrNil, [postForm.value.text, postForm.value.url]) &&
       !emptyOrNil(postForm.value.postType)
     )
   }

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -96,7 +96,8 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       ((prevProps.channel && prevProps.channel.name !== channel.name) ||
         !prevProps.channel) &&
       (channel.link_type !== LINK_TYPE_ANY ||
-        emptyOrNil(postForm.value.text + postForm.value.url)) &&
+        (emptyOrNil(postForm.value.text + postForm.value.url) &&
+          !emptyOrNil(postForm.value.postType))) &&
       channel.link_type !== postForm.value.postType
     ) {
       dispatch(

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -81,6 +81,12 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
     ensureTwitterEmbedJS()
   }
 
+  shouldTriggerUpdate() {
+    const { postForm } = this.props
+    return (emptyOrNil(postForm.value.text + postForm.value.url) &&
+          !emptyOrNil(postForm.value.postType))
+  }
+
   componentDidUpdate(prevProps: CreatePostPageProps) {
     const { channel, dispatch, postForm } = this.props
 
@@ -95,9 +101,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       channel &&
       ((prevProps.channel && prevProps.channel.name !== channel.name) ||
         !prevProps.channel) &&
-      (channel.link_type !== LINK_TYPE_ANY ||
-        (emptyOrNil(postForm.value.text + postForm.value.url) &&
-          !emptyOrNil(postForm.value.postType))) &&
+      (channel.link_type !== LINK_TYPE_ANY || this.shouldTriggerUpdate()) &&
       channel.link_type !== postForm.value.postType
     ) {
       dispatch(

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -414,83 +414,61 @@ describe("CreatePostPage", () => {
   describe("componentDidUpdate logic", () => {
     [
       // starting with ANY
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_LINK, true, true],
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, null, false, true],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_LINK, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_TEXT, true, true],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, null, false, true],
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, null, false, false],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_LINK, true],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_TEXT, false],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, null, true],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_LINK, false],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_TEXT, true],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, null, true],
       // starting with LINK
-      [LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_LINK, true, true],
-      [LINK_TYPE_LINK, LINK_TYPE_TEXT, null, false, true],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, false, true],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, null, false, false],
+      [LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_LINK, true],
+      [LINK_TYPE_LINK, LINK_TYPE_TEXT, null, true],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, null, false],
       // starting with TEXT
-      [LINK_TYPE_TEXT, LINK_TYPE_TEXT, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_TEXT, true, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_LINK, null, false, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, null, false, false]
-    ].forEach(
-      ([fromLinkType, toLinkType, formValue, hasUrlOrText, shouldDispatch]) => {
-        it(`${shouldIf(
-          shouldDispatch
-        )} dispatch FORM_UPDATE if the postType is ${String(
-          formValue
-        )} when it goes from ${String(
-          fromLinkType
-        )} to ${toLinkType} and user has ${
-          hasUrlOrText ? "" : "not "
-        }entered a value`, () => {
-          const dispatch = helper.sandbox.stub()
-          currentChannel.link_type = fromLinkType
-          const nextChannel = channels[1]
-          nextChannel.link_type = toLinkType
-          const page = new InnerCreatePostPage()
-          const url =
-            hasUrlOrText && formValue === LINK_TYPE_LINK ? "http://foo.edu" : ""
-          const text =
-            hasUrlOrText && formValue === LINK_TYPE_TEXT ? "test text" : ""
-          const props: any = {
-            dispatch: dispatch,
-            channel:  nextChannel,
-            postForm: {
-              value: {
-                postType: formValue,
-                url,
-                text
-              }
+      [LINK_TYPE_TEXT, LINK_TYPE_TEXT, LINK_TYPE_TEXT, false],
+      [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_TEXT, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_LINK, null, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, null, false]
+    ].forEach(([fromLinkType, toLinkType, formValue, shouldDispatch]) => {
+      it(`${
+        shouldDispatch ? "dispatches" : "doesn't dispatch"
+      } FORM_UPDATE if the postType is ${String(
+        formValue
+      )} when it goes from ${String(fromLinkType)} to ${toLinkType}`, () => {
+        const dispatch = helper.sandbox.stub()
+        currentChannel.link_type = fromLinkType
+        const nextChannel = channels[1]
+        nextChannel.link_type = toLinkType
+        const page = new InnerCreatePostPage()
+        const props: any = {
+          dispatch: dispatch,
+          channel:  nextChannel,
+          postForm: {
+            value: {
+              postType: formValue
             }
           }
-          page.props = props
-          const prevProps = {
-            channel: currentChannel
-          }
+        }
+        page.props = props
+        const prevProps = {
+          channel: currentChannel
+        }
 
-          // $FlowFixMe
-          page.componentDidUpdate(prevProps)
-          if (shouldDispatch) {
-            assert.equal(dispatch.callCount, 1)
-            assert.deepEqual(dispatch.args[0][0].payload.value, {
-              postType:
-                toLinkType === LINK_TYPE_ANY && !hasUrlOrText
-                  ? null
-                  : toLinkType,
-              url:       "",
-              text:      "",
-              thumbnail: null
-            })
-          } else {
-            assert.equal(dispatch.callCount, 0)
-          }
-        })
-      }
-    )
+        // $FlowFixMe
+        page.componentDidUpdate(prevProps)
+        if (shouldDispatch) {
+          assert.equal(dispatch.callCount, 1)
+          assert.deepEqual(dispatch.args[0][0].payload.value, {
+            postType:  toLinkType,
+            url:       "",
+            text:      "",
+            thumbnail: null
+          })
+        } else {
+          assert.equal(dispatch.callCount, 0)
+        }
+      })
+    })
 
     //
     ;[
@@ -529,5 +507,70 @@ describe("CreatePostPage", () => {
         }
       })
     })
+
+    //
+    ;[
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, null, false, false],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, false, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true]
+    ].forEach(
+      ([fromChannelType, toChannelType, formValue, hasUrlOrText, shouldDispatch]) => {
+        it(`${shouldIf(
+          shouldDispatch
+        )} dispatch FORM_UPDATE if the postType is ${String(
+          formValue
+        )} when it goes from ${String(
+          fromChannelType
+        )} to ${toChannelType} and user has ${
+          hasUrlOrText ? "" : "not "
+        }entered a value`, () => {
+          const dispatch = helper.sandbox.stub()
+          currentChannel.link_type = fromChannelType
+          const nextChannel = channels[1]
+          nextChannel.link_type = toChannelType
+          const page = new InnerCreatePostPage()
+          const url =
+            hasUrlOrText && formValue === LINK_TYPE_LINK ? "http://foo.edu" : ""
+          const text =
+            hasUrlOrText && formValue === LINK_TYPE_TEXT ? "test text" : ""
+          const props: any = {
+            dispatch: dispatch,
+            channel:  nextChannel,
+            postForm: {
+              value: {
+                postType: formValue,
+                url,
+                text
+              }
+            }
+          }
+          page.props = props
+          const prevProps = {
+            channel: currentChannel
+          }
+
+          // $FlowFixMe
+          page.componentDidUpdate(prevProps)
+          if (shouldDispatch) {
+            assert.equal(dispatch.callCount, 1)
+            assert.deepEqual(dispatch.args[0][0].payload.value, {
+              postType:
+                toChannelType === LINK_TYPE_ANY && !hasUrlOrText
+                  ? null
+                  : toChannelType,
+              url:       "",
+              text:      "",
+              thumbnail: null
+            })
+          } else {
+            assert.equal(dispatch.callCount, 0)
+          }
+        })
+      }
+    )
   })
 })

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -518,7 +518,13 @@ describe("CreatePostPage", () => {
       [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
       [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true]
     ].forEach(
-      ([fromChannelType, toChannelType, formValue, hasUrlOrText, shouldDispatch]) => {
+      ([
+        fromChannelType,
+        toChannelType,
+        formValue,
+        hasUrlOrText,
+        shouldDispatch
+      ]) => {
         it(`${shouldIf(
           shouldDispatch
         )} dispatch FORM_UPDATE if the postType is ${String(

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -414,61 +414,87 @@ describe("CreatePostPage", () => {
   describe("componentDidUpdate logic", () => {
     [
       // starting with ANY
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_LINK, true],
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_TEXT, false],
-      [LINK_TYPE_ANY, LINK_TYPE_TEXT, null, true],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_LINK, false],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_TEXT, true],
-      [LINK_TYPE_ANY, LINK_TYPE_LINK, null, true],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_LINK, true, true],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_TEXT, null, false, true],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_LINK, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, LINK_TYPE_TEXT, true, true],
+      [LINK_TYPE_ANY, LINK_TYPE_LINK, null, false, true],
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_ANY, LINK_TYPE_ANY, null, false, false],
       // starting with LINK
-      [LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_LINK, true],
-      [LINK_TYPE_LINK, LINK_TYPE_TEXT, null, true],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, null, false],
+      [LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_LINK, true, true],
+      [LINK_TYPE_LINK, LINK_TYPE_TEXT, null, false, true],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, false, true],
+      [LINK_TYPE_LINK, LINK_TYPE_ANY, null, false, false],
       // starting with TEXT
-      [LINK_TYPE_TEXT, LINK_TYPE_TEXT, LINK_TYPE_TEXT, false],
-      [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_TEXT, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_LINK, null, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, null, false]
-    ].forEach(([fromLinkType, toLinkType, formValue, shouldDispatch]) => {
-      it(`${
-        shouldDispatch ? "dispatches" : "doesn't dispatch"
-      } FORM_UPDATE if the postType is ${String(
-        formValue
-      )} when it goes from ${String(fromLinkType)} to ${toLinkType}`, () => {
-        const dispatch = helper.sandbox.stub()
-        currentChannel.link_type = fromLinkType
-        const nextChannel = channels[1]
-        nextChannel.link_type = toLinkType
-        const page = new InnerCreatePostPage()
-        const props: any = {
-          dispatch: dispatch,
-          channel:  nextChannel,
-          postForm: {
-            value: {
-              postType: formValue
+      [LINK_TYPE_TEXT, LINK_TYPE_TEXT, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_TEXT, true, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_LINK, null, false, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true],
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, null, false, false]
+    ].forEach(
+      ([
+        fromChannelType,
+        toChannelType,
+        postType,
+        hasInput,
+        shouldDispatch
+      ]) => {
+        it(`${shouldIf(
+          shouldDispatch
+        )} reset form if channel type changes from ${String(
+          fromChannelType
+        )} to ${toChannelType}, postType=${String(postType)}, user input is ${
+          hasInput ? "not " : ""
+        }empty`, () => {
+          const dispatch = helper.sandbox.stub()
+          currentChannel.link_type = fromChannelType
+          const nextChannel = channels[1]
+          nextChannel.link_type = toChannelType
+          const page = new InnerCreatePostPage()
+          const url =
+            hasInput && postType === LINK_TYPE_LINK ? "http://foo.edu" : ""
+          const text =
+            hasInput && postType === LINK_TYPE_TEXT ? "test text" : ""
+          const props: any = {
+            dispatch: dispatch,
+            channel:  nextChannel,
+            postForm: {
+              value: {
+                postType: postType,
+                url,
+                text
+              }
             }
           }
-        }
-        page.props = props
-        const prevProps = {
-          channel: currentChannel
-        }
+          page.props = props
+          const prevProps = {
+            channel: currentChannel
+          }
 
-        // $FlowFixMe
-        page.componentDidUpdate(prevProps)
-        if (shouldDispatch) {
-          assert.equal(dispatch.callCount, 1)
-          assert.deepEqual(dispatch.args[0][0].payload.value, {
-            postType:  toLinkType,
-            url:       "",
-            text:      "",
-            thumbnail: null
-          })
-        } else {
-          assert.equal(dispatch.callCount, 0)
-        }
-      })
-    })
+          // $FlowFixMe
+          page.componentDidUpdate(prevProps)
+          if (shouldDispatch) {
+            assert.equal(dispatch.callCount, 1)
+            assert.deepEqual(dispatch.args[0][0].payload.value, {
+              postType:
+                toChannelType === LINK_TYPE_ANY && !hasInput
+                  ? null
+                  : toChannelType,
+              url:       "",
+              text:      "",
+              thumbnail: null
+            })
+          } else {
+            assert.equal(dispatch.callCount, 0)
+          }
+        })
+      }
+    )
 
     //
     ;[
@@ -507,76 +533,5 @@ describe("CreatePostPage", () => {
         }
       })
     })
-
-    //
-    ;[
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_ANY, LINK_TYPE_ANY, null, false, false],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, false, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true]
-    ].forEach(
-      ([
-        fromChannelType,
-        toChannelType,
-        formValue,
-        hasUrlOrText,
-        shouldDispatch
-      ]) => {
-        it(`${shouldIf(
-          shouldDispatch
-        )} dispatch FORM_UPDATE if the postType is ${String(
-          formValue
-        )} when it goes from ${String(
-          fromChannelType
-        )} to ${toChannelType} and user has ${
-          hasUrlOrText ? "" : "not "
-        }entered a value`, () => {
-          const dispatch = helper.sandbox.stub()
-          currentChannel.link_type = fromChannelType
-          const nextChannel = channels[1]
-          nextChannel.link_type = toChannelType
-          const page = new InnerCreatePostPage()
-          const url =
-            hasUrlOrText && formValue === LINK_TYPE_LINK ? "http://foo.edu" : ""
-          const text =
-            hasUrlOrText && formValue === LINK_TYPE_TEXT ? "test text" : ""
-          const props: any = {
-            dispatch: dispatch,
-            channel:  nextChannel,
-            postForm: {
-              value: {
-                postType: formValue,
-                url,
-                text
-              }
-            }
-          }
-          page.props = props
-          const prevProps = {
-            channel: currentChannel
-          }
-
-          // $FlowFixMe
-          page.componentDidUpdate(prevProps)
-          if (shouldDispatch) {
-            assert.equal(dispatch.callCount, 1)
-            assert.deepEqual(dispatch.args[0][0].payload.value, {
-              postType:
-                toChannelType === LINK_TYPE_ANY && !hasUrlOrText
-                  ? null
-                  : toChannelType,
-              url:       "",
-              text:      "",
-              thumbnail: null
-            })
-          } else {
-            assert.equal(dispatch.callCount, 0)
-          }
-        })
-      }
-    )
   })
 })

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -41,7 +41,7 @@ export const validate = R.curry((validations, toValidate) =>
   )(toValidate)
 )
 
-const emptyOrNil = R.either(R.isEmpty, R.isNil)
+export const emptyOrNil = R.either(R.isEmpty, R.isNil)
 
 export const validEmail = R.compose(
   R.test(/^\S+@\S+\.\S+$/), // matches any email that matches the format local@domain.tld


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1215 

#### What's this PR do?
Alters the `CreatePostPage.componentDidUpdate` logic so that if the new post form is switched to a channel that accepts both text and link posts, and both the text and url form values are null, those input fields will be hidden if visible and the post type buttons will be displayed instead.

#### How should this be manually tested?
- Create a few channels, one that accepts any post types, one that accepts only link posts, one that accepts only text posts.
- From the home page, click 'Compose' to create a new post. Select the links-only channel.  The URL field should appear. Don't put anything in it, and switch to the 'any' channel.  The URL field should disappear and you should see the post type buttons.
- Select the link post type.  Don't put anything in the URL field.  Switch to the links-only channel.  The URL field should still be visible.
- Enter a value in the URL field.  Either before or after embedly shows a screenshot, change back to the 'any' channel.  The URL field or embedly screenshot should still display.
- Change to the text-only channel.  The URL field or embedly screenshot should be replaced with a textarea.

#### Where should the reviewer start?
`CreatePostPage.componentDidUpdate`
