### PR TITLE
Increased comment text size

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -33,6 +33,8 @@ $banner-slide-trans: top 300ms $banner-slide-timing;
 $banner-slide-content-trans: padding-top 300ms $banner-slide-timing;
 $material-icon-size: 24px;
 $channel-banner-height: 105px;
+$author-font-size: 16px;
+$submission-font-size: 16px;
 
 // redesign colors
 $rouge: #a31f34;

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -112,7 +112,7 @@ $replyPaddingLeftPhone: 10px;
         margin: 0;
         color: rgba(0, 0, 0, 0.77);
         line-height: 1.3;
-        font-size: 14px;
+        font-size: $submission-font-size;
         overflow-wrap: break-word;
         word-wrap: break-word;
         word-break: break-word;
@@ -161,15 +161,18 @@ $replyPaddingLeftPhone: 10px;
     }
 
     .author-info {
-      font-size: 14px;
       color: $font-grey;
       margin: 0 0 5px;
+
+      .authored-date {
+        font-size: 14px;
+      }
 
       .author-name {
         display: inline;
         padding-right: 6px;
         font-weight: 500;
-        font-size: 15px;
+        font-size: $author-font-size;
         color: $font-black;
       }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -50,7 +50,7 @@
 
 .comment-detail-card {
   background-color: $bg-blue;
-  font-size: 15px;
+  font-size: $submission-font-size;
 }
 
 .comments-and-menu,
@@ -77,7 +77,7 @@
 .authored-by {
   display: flex;
   flex-direction: column;
-  font-size: 16px;
+  font-size: $author-font-size;
 
   div {
     padding-bottom: 2px;
@@ -150,7 +150,7 @@
 .expanded-post-summary {
   display: flex;
   flex-direction: column;
-  font-size: 15px;
+  font-size: $submission-font-size;
   line-height: 1.3;
 
   .post-upvote-button,
@@ -213,7 +213,7 @@
   .text-content {
     color: rgba(0, 0, 0, 0.77);
     line-height: 1.4;
-    font-size: 15px;
+    font-size: $submission-font-size;
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1241

#### What's this PR do?
Increases comment text size and introduces variables to standardize 

#### How should this be manually tested?
Look at posts and comments in different views, compare to designs like [this](https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5ba4f573f5019c5726109435)

#### Any background context you want to provide?
Even though they are set to the same value right now, I created two different values for the author font size and the post/comment font size in case we want those to be different in the future.

#### Screenshots (if appropriate)
<img width="658" alt="ss 2018-09-24 at 13 45 30" src="https://user-images.githubusercontent.com/14932219/45968872-22baca80-c000-11e8-88d3-9fdc7dbfab82.png">

