### PR TITLE
Add support for the next param for login/register

### DIFF
--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -32,13 +32,14 @@ class SocialAuthState:
     STATE_INVALID_EMAIL = "invalid-email"
 
     def __init__(
-            self, state, *, provider=None, partial=None, flow=None, errors=None
+            self, state, *, provider=None, partial=None, flow=None, errors=None, redirect_url=None
     ):  # pylint: disable=too-many-arguments
         self.state = state
         self.partial = partial
         self.flow = flow
         self.provider = provider
         self.errors = errors or []
+        self.redirect_url = redirect_url
 
 
 def load_drf_strategy(request=None):

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -112,6 +112,7 @@ def login_email_exists(client, email_user):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': any_instance_of(str),
                 'state': SocialAuthState.STATE_LOGIN_PASSWORD,
                 'extra_data': {
@@ -140,6 +141,7 @@ def login_email_mm_only(client, user):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': MicroMastersAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_LOGIN_PROVIDER,
                 'extra_data': {
@@ -174,6 +176,7 @@ def login_email_saml_exists(client, user, settings):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': SAMLAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_LOGIN_PROVIDER,
                 'extra_data': {
@@ -201,6 +204,7 @@ def register_email_exists(client, user, mock_email_send):
                 'errors': ['Password is required to login'],
                 'flow': SocialAuthState.FLOW_REGISTER,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': any_instance_of(str),
                 'state': SocialAuthState.STATE_LOGIN_PASSWORD,
             }
@@ -226,6 +230,7 @@ def login_email_not_exists(client):
                 'errors': ["Couldn't find your MIT OPEN Account"],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_ERROR,
             }
@@ -251,6 +256,7 @@ def register_email_not_exists(client, mock_email_send):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_REGISTER,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_REGISTER_CONFIRM_SENT,
             }
@@ -279,6 +285,7 @@ def register_email_not_exists_with_recaptcha(settings, client, mock_email_send, 
                 'errors': [],
                 'flow': SocialAuthState.FLOW_REGISTER,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_REGISTER_CONFIRM_SENT,
             }
@@ -338,6 +345,7 @@ def login_password_valid(client, user):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_SUCCESS,
             },
@@ -368,6 +376,7 @@ def login_password_user_inactive(client, user):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_INACTIVE,
             }
@@ -394,6 +403,7 @@ def login_password_invalid(client, user):
                 'errors': ['Unable to login with that email and password combination'],
                 'flow': SocialAuthState.FLOW_LOGIN,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': any_instance_of(str),
                 'state': SocialAuthState.STATE_ERROR,
             }
@@ -419,6 +429,7 @@ def redeem_confirmation_code(client, mock_email_send):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_REGISTER,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': any_instance_of(str),
                 'state': SocialAuthState.STATE_REGISTER_DETAILS,
             }
@@ -444,6 +455,7 @@ def register_profile_details(client):
                 'errors': [],
                 'flow': SocialAuthState.FLOW_REGISTER,
                 'provider': EmailAuth.name,
+                'redirect_url': None,
                 'partial_token': None,
                 'state': SocialAuthState.STATE_SUCCESS,
             },
@@ -524,6 +536,7 @@ def test_login_email_error(settings, client, mocker):
         'errors': [],
         'flow': SocialAuthState.FLOW_LOGIN,
         'provider': EmailAuth.name,
+        'redirect_url': None,
         'partial_token': None,
         'state': SocialAuthState.STATE_ERROR,
     }

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -207,6 +207,9 @@ SOCIAL_AUTH_STRATEGY = 'authentication.strategy.OpenDiscussionsStrategy'
 
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = 'login-complete'
 SOCIAL_AUTH_LOGIN_ERROR_URL = 'login'
+SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [
+    urlparse(SITE_BASE_URL).netloc,
+]
 
 # Micromasters backend settings
 SOCIAL_AUTH_MICROMASTERS_LOGIN_URL = get_string('SOCIAL_AUTH_MICROMASTERS_LOGIN_URL', None)

--- a/static/js/containers/auth/AuthRequiredPage.js
+++ b/static/js/containers/auth/AuthRequiredPage.js
@@ -1,5 +1,4 @@
 // @flow
-/* global SETTINGS: false */
 import React from "react"
 import { MetaTags } from "react-meta-tags"
 
@@ -7,16 +6,19 @@ import Card from "../../components/Card"
 import CanonicalLink from "../../components/CanonicalLink"
 
 import { formatTitle } from "../../lib/title"
+import { MICROMASTERS_URL, getNextParam } from "../../lib/url"
 
 import type { Match } from "react-router"
 
 type Props = {
+  location: { search: string },
   match?: Match
 }
 
 export default class AuthRequiredPage extends React.Component<Props> {
   render() {
-    const { match } = this.props
+    const { match, location } = this.props
+    const next = getNextParam(location.search)
 
     return (
       <div className="auth-page auth-required-page">
@@ -31,7 +33,7 @@ export default class AuthRequiredPage extends React.Component<Props> {
               To use this site you need to log in with a MicroMasters account.
             </div>
             <div className="login">
-              <a href={SETTINGS.authenticated_site.login_url}>
+              <a href={`${MICROMASTERS_URL}?next=${encodeURIComponent(next)}`}>
                 Log In to MicroMasters
               </a>
             </div>

--- a/static/js/containers/auth/AuthRequiredPage_test.js
+++ b/static/js/containers/auth/AuthRequiredPage_test.js
@@ -5,13 +5,24 @@ import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import AuthRequiredPage from "./AuthRequiredPage"
+import { MICROMASTERS_URL } from "../../lib/url"
 
 describe("AuthRequiredPage", () => {
-  it("uses the external login url", () => {
-    const wrapper = shallow(<AuthRequiredPage />)
+  it("uses the micromasters login url with next param", () => {
+    const wrapper = shallow(<AuthRequiredPage location={{ search: "" }} />)
     assert.equal(
       wrapper.find("a").props().href,
-      SETTINGS.authenticated_site.login_url
+      `${MICROMASTERS_URL}?next=${encodeURIComponent("/")}`
+    )
+  })
+
+  it("uses the micromasters login url with a next param", () => {
+    const next = encodeURIComponent("/secret/url")
+    const search = `?next=${next}&ignore=me`
+    const wrapper = shallow(<AuthRequiredPage location={{ search }} />)
+    assert.equal(
+      wrapper.find("a").props().href,
+      `${MICROMASTERS_URL}?next=${next}`
     )
   })
 })

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux"
 import R from "ramda"
 import { MetaTags } from "react-meta-tags"
 import { Link } from "react-router-dom"
+import qs from "query-string"
 
 import Card from "../../components/Card"
 import AuthEmailForm from "../../components/auth/AuthEmailForm"
@@ -17,12 +18,12 @@ import { setAuthUserDetail } from "../../actions/ui"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm, getAuthResponseFieldErrors } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
-import { REGISTER_URL } from "../../lib/url"
+import { REGISTER_URL, getNextParam } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import { FLOW_LOGIN, isProcessing } from "../../reducers/auth"
 
-import type { Match } from "react-router"
+import type { Location, Match } from "react-router"
 import type {
   AuthResponse,
   EmailDetailAuthResponse,
@@ -31,13 +32,15 @@ import type {
 import type { WithFormProps } from "../../flow/formTypes"
 
 type LoginPageProps = {
+  location: Location,
   match: Match,
-  history: Object
+  history: Object,
+  next: string
 } & WithFormProps<EmailForm>
 
 export class LoginPage extends React.Component<LoginPageProps> {
   render() {
-    const { renderForm, match } = this.props
+    const { renderForm, match, next } = this.props
 
     return (
       <div className="auth-page login-page">
@@ -51,7 +54,10 @@ export class LoginPage extends React.Component<LoginPageProps> {
             {renderForm()}
             <ExternalLogins />
             <div className="alternate-auth-link">
-              Not a member? <Link to={REGISTER_URL}>Sign up</Link>
+              Not a member?{" "}
+              <Link to={`${REGISTER_URL}?${qs.stringify({ next })}`}>
+                Sign up
+              </Link>
             </div>
           </Card>
         </div>
@@ -62,8 +68,8 @@ export class LoginPage extends React.Component<LoginPageProps> {
 
 const newEmailForm = () => ({ email: "" })
 
-const onSubmit = ({ email }: EmailForm) =>
-  actions.auth.loginEmail(FLOW_LOGIN, email)
+const onSubmit = ({ email }: EmailForm, next: string) =>
+  actions.auth.loginEmail(FLOW_LOGIN, email, next)
 
 const getSubmitResultErrors = getAuthResponseFieldErrors("email")
 
@@ -105,9 +111,14 @@ const mapStateToProps = state => {
 }
 
 const mergeProps = mergeAndInjectProps(
-  (stateProps, { setAuthUserDetail }, { history }) => ({
-    onSubmitResult: onSubmitResult(setAuthUserDetail, history)
-  })
+  (stateProps, { setAuthUserDetail, onSubmit }, { history, location }) => {
+    const next = getNextParam(location.search)
+    return {
+      onSubmitResult: onSubmitResult(setAuthUserDetail, history),
+      onSubmit:       form => onSubmit(form, next),
+      next
+    }
+  }
 )
 
 export default R.compose(

--- a/static/js/containers/auth/LoginPage_test.js
+++ b/static/js/containers/auth/LoginPage_test.js
@@ -41,7 +41,8 @@ describe("LoginPage", () => {
     renderPage = helper.configureHOCRenderer(
       ConnectedLoginPage,
       LoginPage,
-      DEFAULT_STATE
+      DEFAULT_STATE,
+      { location: {} }
     )
   })
 
@@ -97,7 +98,7 @@ describe("LoginPage", () => {
     const { inner } = await renderPage()
     const link = inner
       .find("Link")
-      .findWhere(c => c.prop("to") === REGISTER_URL)
+      .findWhere(c => c.prop("to") === `${REGISTER_URL}?next=%2F`)
     assert.ok(link.exists())
   })
 

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux"
 import R from "ramda"
 import { MetaTags } from "react-meta-tags"
 import { Link } from "react-router-dom"
+import qs from "query-string"
 
 import Card from "../../components/Card"
 import ExternalLogins from "../../components/ExternalLogins"
@@ -22,7 +23,7 @@ import {
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
-import { LOGIN_URL } from "../../lib/url"
+import { LOGIN_URL, getNextParam } from "../../lib/url"
 import { validateNewEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 
@@ -33,13 +34,15 @@ import type { FormErrors, WithFormProps } from "../../flow/formTypes"
 type RegisterPageProps = {
   match: Match,
   history: Object,
-  formError: ?string
+  formError: ?string,
+  next: string
 } & WithFormProps<EmailForm>
 
 export const RegisterPage = ({
   renderForm,
   formError,
-  match
+  match,
+  next
 }: RegisterPageProps) => (
   <div className="auth-page register-page">
     <div className="main-content">
@@ -52,7 +55,8 @@ export const RegisterPage = ({
         {renderForm({ formError })}
         <ExternalLogins />
         <div className="alternate-auth-link">
-          Already have an account? <Link to={LOGIN_URL}>Log in</Link>
+          Already have an account?{" "}
+          <Link to={`${LOGIN_URL}?${qs.stringify({ next })}`}>Log in</Link>
         </div>
       </Card>
     </div>
@@ -64,28 +68,33 @@ const newEmailForm = () => ({ email: "" })
 export const FORM_KEY = "register:email"
 const { getForm, actionCreators } = configureForm(FORM_KEY, newEmailForm)
 
-const onSubmit = (form: EmailForm) =>
-  actions.auth.registerEmail(FLOW_REGISTER, form.email, form.recaptcha)
+const onSubmit = (form: EmailForm, next: string) =>
+  actions.auth.registerEmail(FLOW_REGISTER, form.email, next, form.recaptcha)
 
 const onSubmitFailure = (): FormErrors<*> => ({
   recaptcha: `Error validating your submission.`
 })
 
 const mergeProps = mergeAndInjectProps(
-  (stateProps, { setBannerMessage }, { history }) => ({
-    // Used by withForm()
-    useRecaptcha:   true,
-    onSubmitResult: (response: AuthResponse) => {
-      processAuthResponse(history, response)
-      if (response.state === STATE_REGISTER_CONFIRM_SENT && response.email) {
-        setBannerMessage(
-          `We sent an email to <${
-            response.email
-          }>, please validate your address to continue.`
-        )
-      }
+  (stateProps, { setBannerMessage, onSubmit }, { history, location }) => {
+    const next = getNextParam(location.search)
+    return {
+      // Used by withForm()
+      useRecaptcha:   true,
+      onSubmit:       form => onSubmit(form, next),
+      onSubmitResult: (response: AuthResponse) => {
+        processAuthResponse(history, response)
+        if (response.state === STATE_REGISTER_CONFIRM_SENT && response.email) {
+          setBannerMessage(
+            `We sent an email to <${
+              response.email
+            }>, please validate your address to continue.`
+          )
+        }
+      },
+      next
     }
-  })
+  }
 )
 
 const mapStateToProps = state => {

--- a/static/js/containers/auth/RegisterPage_test.js
+++ b/static/js/containers/auth/RegisterPage_test.js
@@ -44,7 +44,8 @@ describe("RegisterPage", () => {
     renderPage = helper.configureHOCRenderer(
       ConnectedRegisterPage,
       RegisterPage,
-      DEFAULT_STATE
+      DEFAULT_STATE,
+      { location: {} }
     )
   })
 
@@ -81,7 +82,9 @@ describe("RegisterPage", () => {
 
   it("should contain a link to the login page", async () => {
     const { inner } = await renderPage()
-    const link = inner.find("Link").findWhere(c => c.prop("to") === LOGIN_URL)
+    const link = inner
+      .find("Link")
+      .findWhere(c => c.prop("to") === `${LOGIN_URL}?next=%2F`)
     assert.ok(link.exists())
   })
 

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -45,7 +45,8 @@ export type AuthResponse = {
   flow:          AuthFlow,
   state:         AuthStates,
   errors:        Array<string>,
-  email?:        string
+  email?:        string,
+  redirect_url:  ?string
 }
 
 export type EmailDetailAuthResponse = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -417,11 +417,12 @@ export function patchChannelBanner(
 
 export const postEmailLogin = (
   flow: AuthFlow,
-  email: string
+  email: string,
+  next: string
 ): Promise<EmailDetailAuthResponse> =>
   fetchJSONWithCSRF("/api/v0/login/email/", {
     method: POST,
-    body:   JSON.stringify({ flow, email })
+    body:   JSON.stringify({ flow, email, next })
   })
 
 export const postPasswordLogin = (
@@ -442,6 +443,7 @@ export const postPasswordLogin = (
 export const postEmailRegister = (
   flow: AuthFlow,
   email: string,
+  next: string,
   recaptcha: ?string,
   partialToken: ?string
 ): Promise<AuthResponse> =>
@@ -449,8 +451,8 @@ export const postEmailRegister = (
     method: POST,
     body:   JSON.stringify(
       partialToken
-        ? { flow, partial_token: partialToken, recaptcha }
-        : { flow, email, recaptcha }
+        ? { flow, partial_token: partialToken, recaptcha, next }
+        : { flow, email, recaptcha, next }
     )
   })
 

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -29,8 +29,9 @@ import type { AuthResponse, EmailDetailAuthResponse } from "../flow/authTypes"
 
 export const processAuthResponse = (
   history: Object,
-  { state }: AuthResponse | EmailDetailAuthResponse
+  response: AuthResponse | EmailDetailAuthResponse
 ) => {
+  const { state } = response
   if (state === STATE_LOGIN_EMAIL) {
     history.push(LOGIN_URL)
   } else if (state === STATE_LOGIN_PASSWORD) {
@@ -45,7 +46,11 @@ export const processAuthResponse = (
     history.push(REGISTER_DETAILS_URL)
   } else if (state === STATE_SUCCESS) {
     // We now have a session, so force a redirect (we want the app to reinitialize)
-    window.location.href = FRONTPAGE_URL
+    if (response.redirect_url) {
+      window.location.href = response.redirect_url
+    } else {
+      window.location.href = FRONTPAGE_URL
+    }
   } else if (state === STATE_INACTIVE) {
     history.push(INACTIVE_USER_URL)
   } else if (state === STATE_LOGIN_PROVIDER) {

--- a/static/js/lib/fetch_auth.js
+++ b/static/js/lib/fetch_auth.js
@@ -6,13 +6,17 @@ import {
   fetchJSONWithCSRF,
   fetchWithCSRF
 } from "redux-hammock/django_csrf_fetch"
+import qs from "query-string"
 
 import { AUTH_REQUIRED_URL, LOGIN_URL } from "./url"
 import { isNotAuthenticatedErrorType } from "../util/rest"
 
 const redirectAndReject = async () => {
   // redirect to the authenticating app
-  window.location = SETTINGS.allow_email_auth ? LOGIN_URL : AUTH_REQUIRED_URL
+  const url = SETTINGS.allow_email_auth ? LOGIN_URL : AUTH_REQUIRED_URL
+  const { pathname, search, hash } = window.location
+  const next = `${pathname}${search}${hash}`
+  window.location = `${url}?${qs.stringify({ next })}`
   return Promise.reject("You were logged out, please login again")
 }
 

--- a/static/js/lib/fetch_auth_test.js
+++ b/static/js/lib/fetch_auth_test.js
@@ -1,6 +1,7 @@
 /* global SETTINGS: false */
 import { assert } from "chai"
 import sinon from "sinon"
+import qs from "query-string"
 import fetchMock from "fetch-mock/src/server"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 
@@ -81,6 +82,8 @@ describe("fetch_auth", function() {
         it(`redirects to ${expectedUrl} if allow_email_auth: ${allowEmailAuth} for error: ${
           error.error_type
         }`, async () => {
+          const next = "/secret/url/?with=params#andhash"
+          window.location = next
           SETTINGS.allow_email_auth = allowEmailAuth
           fetchStub.returns(Promise.reject(error)) // original api call
 
@@ -89,6 +92,7 @@ describe("fetch_auth", function() {
           assert.ok(fetchStub.calledOnce)
           assert.ok(fetchStub.calledWith("/url"))
           assert.equal(window.location.pathname, expectedUrl)
+          assert.equal(qs.parse(window.location.search).next, next)
         })
       })
     })

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -93,6 +93,7 @@ export const REGISTER_DETAILS_URL = "/signup/details/"
 export const INACTIVE_USER_URL = "/account/inactive/"
 
 export const TOUCHSTONE_URL = "/login/saml/?idp=default"
+export const MICROMASTERS_URL = "/login/micromasters/"
 
 export const TERMS_OF_SERVICE_URL = "/terms-and-conditions"
 export const PRIVACY_POLICY_URL = "/privacy-statement"
@@ -102,3 +103,5 @@ export const toQueryString = (params: Object) =>
 
 export const urlHostname = (url: ?string) =>
   url ? new URL(url).hostname.replace(/^www\.(.*\.\w)/i, "$1") : ""
+
+export const getNextParam = (search: string) => qs.parse(search).next || "/"

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -22,7 +22,8 @@ import {
   embedlyThumbnail,
   blankThumbnailUrl,
   embedlyResizeImage,
-  absolutizeURL
+  absolutizeURL,
+  getNextParam
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -258,6 +259,16 @@ describe("url helper functions", () => {
       const url = absolutizeURL("/foo/bar/baz")
       assert.ok(url.startsWith(window.location.origin))
       assert.ok(url.includes("/foo/bar/baz"))
+    })
+  })
+
+  describe("getNextParam", () => {
+    it("should return a default value if no next param", () => {
+      assert.equal(getNextParam(""), "/")
+    })
+    it("should return the next param when present", () => {
+      const next = "/next/url"
+      assert.equal(getNextParam(`?next=${encodeURIComponent(next)}`), next)
     })
   })
 })

--- a/static/js/reducers/auth.js
+++ b/static/js/reducers/auth.js
@@ -41,8 +41,8 @@ export const authEndpoint = {
   initialState: { ...INITIAL_STATE },
   ...deriveVerbFuncs({
     // login functions
-    loginEmail: async (flow: AuthFlow, email: string) => {
-      const response = await api.postEmailLogin(flow, email)
+    loginEmail: async (flow: AuthFlow, email: string, next: string) => {
+      const response = await api.postEmailLogin(flow, email, next)
       return { email, ...response }
     },
     loginPassword: (flow: AuthFlow, partialToken: string, password: string) =>
@@ -51,12 +51,14 @@ export const authEndpoint = {
     registerEmail: async (
       flow: AuthFlow,
       email: string,
+      next: string,
       recaptcha: ?string,
-      partialToken: string
+      partialToken: ?string
     ) => {
       const response = await api.postEmailRegister(
         flow,
         email,
+        next,
         recaptcha,
         partialToken
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #709 

#### What's this PR do?
Adds support in the frontend and backend for redirecting the user back to the `next` url as per normal djanog conventions. PSA already supports this so MM and touchstone logins are already covered. The backend changes support it for email login. PSA stores this all on the session cookie, so this behavior won't work cross-browser/device in the case of registration.

#### How should this be manually tested?
As a logged out user, try to navigate to a private channel and verify you end up there through the login flows.