### PR TITLE
fix appearance of quoted text in posts

### DIFF
--- a/static/js/components/Markdown.js
+++ b/static/js/components/Markdown.js
@@ -20,6 +20,7 @@ export const Markdown = (props: MarkdownProps) => (
   <ReactMarkdown
     disallowedTypes={["image"]}
     escapeHtml
+    className="markdown"
     renderers={{
       linkReference: reference =>
         reference.href ? (

--- a/static/js/components/Markdown_test.js
+++ b/static/js/components/Markdown_test.js
@@ -40,6 +40,7 @@ describe("Markdown", () => {
 
   it("should render markdown", () => {
     const wrapper = renderMD("# MARKDOWN\n\nyeah markdown")
+    assert.equal(wrapper.find("ReactMarkdown").props().className, "markdown")
     assert.equal(wrapper.find("h1").text(), "MARKDOWN")
     assert.equal(wrapper.text(), "MARKDOWNyeah markdown")
   })

--- a/static/scss/editor.scss
+++ b/static/scss/editor.scss
@@ -19,6 +19,10 @@
         outline: none;
       }
     }
+
+    blockquote {
+      @extend %blockquote;
+    }
   }
 
   .menu-bar {

--- a/static/scss/extensions.scss
+++ b/static/scss/extensions.scss
@@ -6,3 +6,10 @@
   background: white;
   transform: rotate(45deg);
 }
+
+%blockquote {
+  border-left: 2px solid $navy;
+  padding: 0 40px;
+  margin: 16px 0;
+  font-style: italic;
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -13,7 +13,7 @@
 @import "node_modules/prosemirror-view/style/prosemirror";
 @import "breakpoints";
 @import "variables";
-@import "triangle";
+@import "extensions";
 @import "card";
 @import "basic";
 @import "breadcrumbs";
@@ -51,6 +51,7 @@
 @import "close-button";
 @import "intra-page-nav";
 @import "channel-banner";
+@import "markdown";
 
 body {
   font-family: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/markdown.scss
+++ b/static/scss/markdown.scss
@@ -1,0 +1,5 @@
+.markdown {
+  blockquote {
+    @extend %blockquote;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1208 

#### What's this PR do?

this fixes the styling for blockquotes in posts, both when display and when editing.

#### How should this be manually tested?

Make a new post, or edit an existing post, which includes a blockquote. It should look like what's shown here: https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5ba4f573f5019c5726109435

it should look the same in the editor component and when it's being displayed.