### PR TITLE
fix display of auth cards at all screen widths

### DIFF
--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -1,27 +1,25 @@
+.content .auth-page .main-content {
+  max-width: 470px;
+}
+
 @include breakpoint(desktop) {
   .content .auth-page .main-content {
     margin-top: 70px !important;
-    max-width: 470px;
-  }
-
-  .auth-page {
-    form,
-    .card-contents {
-      width: 350px;
-    }
   }
 }
 
 .auth-page {
   @include breakpoint(mobile) {
     width: 95%;
-    margin: auto;
 
-    form,
-    .actions,
+    .main-content,
     .card-contents {
-      width: 100%;
+      margin: auto;
     }
+  }
+
+  form {
+    width: 100%;
   }
 
   .form-header {
@@ -33,8 +31,22 @@
     color: $font-grey;
   }
 
-  .link-button {
+  .link-button,
+  button[type="submit"] {
     margin-right: 0;
+  }
+
+  button {
+    width: 100%;
+
+    &[type="submit"] {
+      width: 35%;
+    }
+
+    &.submit-password-reset {
+      width: 50%;
+      padding: 9px 19px;
+    }
   }
 
   .touchstone-text-logo {
@@ -66,25 +78,14 @@
   }
 
   .card-contents {
+    max-width: 350px;
     display: flex;
     flex-direction: column;
     align-items: center;
 
     @include breakpoint(desktop) {
       padding: 60px;
-    }
-  }
-
-  button {
-    width: 100%;
-
-    &[type="submit"] {
-      width: 35%;
-    }
-
-    &.submit-password-reset {
-      width: 50%;
-      padding: 9px 19px;
+      width: 350px;
     }
   }
 


### PR DESCRIPTION

#### What are the relevant tickets?

closes #1267 

#### What's this PR do?

fixes the display for the auth cards at all page widths

#### How should this be manually tested?

Look at various auth pages and make sure that the display bug shown in the attached issue doesn't crop up anywhere. make sure you're testing in the chrome device simulator or a mobile device emulator.