### PR TITLE
Fixed styling for incomplete profile indicator

### DIFF
--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -28,16 +28,6 @@ $profile-image-small-size: 45px;
   font-size: 36px;
 }
 
-.profile-incomplete {
-  height: 10px;
-  width: 10px;
-  background-color: red;
-  border-radius: 50%;
-  position: relative;
-  left: 3px;
-  top: -10px;
-}
-
 .profile-image-container,
 .avatar-container {
   display: flex;

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -9,4 +9,14 @@
     top: 28px;
     right: -6px;
   }
+
+  .profile-incomplete {
+    height: 10px;
+    width: 10px;
+    background-color: red;
+    border-radius: 50%;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1238

#### What's this PR do?
Fixes styling for incomplete profile indicator so that it no longer pushes up the profile image

#### How should this be manually tested?
Check the profile image with a user that has an incomplete profile (or just edit the `static/js/components/UserMenu.js` code to always show the icon)

#### Screenshots (if appropriate)
![ss 2018-09-27 at 16 22 42](https://user-images.githubusercontent.com/14932219/46172490-944d7f80-c271-11e8-9527-ac3dd5377eda.png)
Dotted border added as a visual aid – compare with screenshots in the issue

