### PR TITLE
Hid social sharing buttons for private channel comments

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -49,6 +49,7 @@ type Props = {
   loadMoreComments?: LoadMoreCommentsFunc,
   beginEditing?: BeginEditingFunc,
   isModerator: boolean,
+  isPrivateChannel: boolean,
   processing?: boolean,
   deleteComment?: CommentRemoveFunc,
   reportComment?: ReportCommentFunc,
@@ -96,6 +97,7 @@ export default class CommentTree extends React.Component<Props> {
       remove,
       deleteComment,
       beginEditing,
+      isPrivateChannel,
       isModerator,
       reportComment,
       commentPermalink,
@@ -149,6 +151,7 @@ export default class CommentTree extends React.Component<Props> {
             <SharePopup
               url={absolutizeURL(commentPermalink(comment.id))}
               closePopup={hideShareMenu}
+              hideSocialButtons={isPrivateChannel}
             />
           ) : null}
         </div>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -80,6 +80,7 @@ describe("CommentTree", () => {
           toggleFollowComment={toggleFollowCommentStub}
           curriedDropdownMenufunc={dropdownMenuFuncs(helper.sandbox.stub())}
           dropdownMenus={new Set()}
+          isPrivateChannel={true}
           {...props}
         />
       </Router>

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -15,6 +15,7 @@ import SharePopup from "./SharePopup"
 import FollowButton from "./FollowButton"
 import PostUpvoteButton from "./PostUpvoteButton"
 
+import { isPrivate } from "../lib/channels"
 import { formatPostTitle } from "../lib/posts"
 import { userIsAnonymous } from "../lib/util"
 import { editPostKey } from "../components/CommentForms"
@@ -117,7 +118,7 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
               <SharePopup
                 url={postPermalink(post)}
                 closePopup={hidePostShareMenu}
-                hideSocialButtons={channel.channel_type === "private"}
+                hideSocialButtons={isPrivate(channel)}
               />
             ) : null}
           </div>

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -52,6 +52,7 @@ import {
 } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
 import { beginEditing } from "../components/CommentForms"
+import { isPrivate } from "../lib/channels"
 import { formatTitle } from "../lib/title"
 import { channelURL, postDetailURL, commentPermalink } from "../lib/url"
 import { clearPostError } from "../actions/post"
@@ -470,6 +471,7 @@ class PostPage extends React.Component<PostPageProps> {
         {commentsTree.length > 0 ? (
           <CommentTree
             comments={commentsTree}
+            isPrivateChannel={isPrivate(channel)}
             forms={forms}
             upvote={this.upvote}
             downvote={this.downvote}

--- a/static/js/containers/admin/ChannelModerationPage.js
+++ b/static/js/containers/admin/ChannelModerationPage.js
@@ -23,6 +23,7 @@ import { commentPermalink, channelURL } from "../../lib/url"
 import { actions } from "../../actions"
 import { formatTitle } from "../../lib/title"
 import { dropdownMenuFuncs } from "../../lib/ui"
+import { isPrivate } from "../../lib/channels"
 
 import type { Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -75,6 +76,7 @@ export class ChannelModerationPage extends React.Component<Props> {
       removePost,
       approveComment,
       removeComment,
+      channel,
       channelName,
       ignorePostReports,
       ignoreCommentReports,
@@ -108,6 +110,7 @@ export class ChannelModerationPage extends React.Component<Props> {
           key={`${report.comment.id}-${report.comment.post_id}`}
           moderationUI
           isModerator={isModerator}
+          isPrivateChannel={isPrivate(channel)}
           dropdownMenus={dropdownMenus}
           curriedDropdownMenufunc={dropdownMenuFuncs(dispatch)}
         />

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -116,3 +116,6 @@ export const isTextTabSelected = (
 
   return isTextTabSelected
 }
+
+export const isPrivate = (channel: Channel) =>
+  channel.channel_type === CHANNEL_TYPE_PRIVATE

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -14,7 +14,8 @@ import {
   updateLinkType,
   isLinkTypeAllowed,
   isLinkTypeChecked,
-  isTextTabSelected
+  isTextTabSelected,
+  isPrivate
 } from "./channels"
 import { makeChannel } from "../factories/channels"
 
@@ -184,5 +185,19 @@ describe("Channel utils", () => {
         assert.equal(isTextTabSelected(postType, channel), expected)
       })
     })
+  })
+
+  describe("isPrivate", () => {
+    [[CHANNEL_TYPE_PRIVATE, true], [CHANNEL_TYPE_PUBLIC, false]].forEach(
+      ([channelType, expRetVal]) => {
+        it(`should return ${String(
+          expRetVal
+        )} when channel type=${channelType}`, () => {
+          const channel = makeChannel()
+          channel.channel_type = channelType
+          assert.equal(isPrivate(channel), expRetVal)
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1231 

#### What's this PR do?
Hides social sharing buttons for private channel comments (those buttons were already hidden for private channel posts)

#### How should this be manually tested?
Click the 'share' icon under a private channel comment. You should only see the clipboard copying UI
