### PR TITLE
Replace underscores with dashes in post slugs

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -278,8 +278,8 @@ class BasePostSerializer(RedditObjectSerializer):
         return None
 
     def get_slug(self, instance):
-        """Returns the post slug from reddit and replaces '_' with '-'"""
-        return get_reddit_slug(instance.permalink).replace('_', '-')
+        """Returns the post slug"""
+        return get_reddit_slug(instance.permalink)
 
     def get_author_name(self, instance):
         """get the authors name"""

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -278,8 +278,8 @@ class BasePostSerializer(RedditObjectSerializer):
         return None
 
     def get_slug(self, instance):
-        """Returns the post slug"""
-        return get_reddit_slug(instance.permalink)
+        """Returns the post slug from reddit and replaces '_' with '-'"""
+        return get_reddit_slug(instance.permalink).replace('_', '-')
 
     def get_author_name(self, instance):
         """get the authors name"""

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -241,7 +241,7 @@ def get_kind_mapping():
 
 def get_reddit_slug(permalink):
     """
-    Get the reddit slug from a submission permalink
+    Get the reddit slug from a submission permalink, with '_' replaced by '-'
 
     Args:
         permalink (str): reddit submission permalink
@@ -249,7 +249,7 @@ def get_reddit_slug(permalink):
     Returns:
         str: the reddit slug for a submission
     """
-    return list(filter(None, permalink.split('/')))[-1]
+    return list(filter(None, permalink.split('/')))[-1].replace('_', '-')
 
 
 @transaction.atomic

--- a/channels/utils_test.py
+++ b/channels/utils_test.py
@@ -192,8 +192,8 @@ def test_translate_praw_exceptions(raised_exception, is_anonymous, expected_exce
 
 
 @pytest.mark.parametrize("permalink,slug", [
-    ["/r/1511374327_magnam/comments/ea/text_post/", "text_post"],
-    ["/r/1511371168_mollitia/comments/e6/url_post", "url_post"],
+    ["/r/1511374327_magnam/comments/ea/text_post/", "text-post"],
+    ["/r/1511371168_mollitia/comments/e6/url_post", "url-post"],
 ])
 def test_get_reddit_slug(permalink, slug):
     """Test that the correct slug is retrieved from a permalink"""

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -93,7 +93,7 @@ def test_create_url_post_existing_meta(client, private_channel_and_contributor, 
         'created': '2018-08-24T18:02:48+00:00',
         'upvoted': True,
         'id': '14',
-        'slug': 'url_title',
+        'slug': 'url-title',
         'num_comments': 0,
         'removed': False,
         'deleted': False,
@@ -175,7 +175,7 @@ def test_create_text_post(client, private_channel_and_contributor):
         'deleted': False,
         'subscribed': True,
         'id': '17',
-        'slug': 'parameterized_testing',
+        'slug': 'parameterized-testing',
         'num_comments': 0,
         'score': 1,
         'channel_name': channel.name,
@@ -272,7 +272,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         user.profile.image_small = '/just/a/great/image.png.jpg.gif'
     user.profile.save()
 
-    post = reddit_factories.text_post('my geat post', user, channel=channel)
+    post = reddit_factories.text_post('my great post', user, channel=channel)
     url = reverse('post-detail', kwargs={'post_id': post.id})
     client.force_login(user)
     resp = client.get(url)
@@ -290,7 +290,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': get_reddit_slug(post.permalink),
+        'slug': 'my-great-post',
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -309,7 +309,7 @@ def test_get_post_no_profile(client, private_channel_and_contributor, reddit_fac
     channel, user = private_channel_and_contributor
     user.profile.delete()
 
-    post = reddit_factories.text_post('my geat post', user, channel=channel)
+    post = reddit_factories.text_post('my great post', user, channel=channel)
     url = reverse('post-detail', kwargs={'post_id': post.id})
     client.force_login(user)
     resp = client.get(url)
@@ -327,7 +327,7 @@ def test_get_post_no_profile(client, private_channel_and_contributor, reddit_fac
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': get_reddit_slug(post.permalink),
+        'slug': 'my-great-post',
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -378,7 +378,7 @@ def test_get_post_stickied(client, private_channel_and_contributor, reddit_facto
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': get_reddit_slug(post.permalink),
+        'slug': 'just-a-post',
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -709,7 +709,7 @@ def test_list_posts_anonymous(client, public_channel, reddit_factories, settings
                 'created': post.created,
                 'edited': False,
                 'id': post.id,
-                'slug': get_reddit_slug(post.permalink),
+                'slug': get_reddit_slug(post.permalink).replace('_', '-'),
                 'num_comments': 0,
                 'num_reports': None,
                 'profile_image': image_uri(user.profile),

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -272,7 +272,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         user.profile.image_small = '/just/a/great/image.png.jpg.gif'
     user.profile.save()
 
-    post = reddit_factories.text_post('my great post', user, channel=channel)
+    post = reddit_factories.text_post('my geat post', user, channel=channel)
     url = reverse('post-detail', kwargs={'post_id': post.id})
     client.force_login(user)
     resp = client.get(url)
@@ -290,7 +290,7 @@ def test_get_post(client, private_channel_and_contributor, reddit_factories, mis
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': 'my-great-post',
+        'slug': get_reddit_slug(post.permalink),
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -309,7 +309,7 @@ def test_get_post_no_profile(client, private_channel_and_contributor, reddit_fac
     channel, user = private_channel_and_contributor
     user.profile.delete()
 
-    post = reddit_factories.text_post('my great post', user, channel=channel)
+    post = reddit_factories.text_post('my geat post', user, channel=channel)
     url = reverse('post-detail', kwargs={'post_id': post.id})
     client.force_login(user)
     resp = client.get(url)
@@ -327,7 +327,7 @@ def test_get_post_no_profile(client, private_channel_and_contributor, reddit_fac
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': 'my-great-post',
+        'slug': get_reddit_slug(post.permalink),
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -378,7 +378,7 @@ def test_get_post_stickied(client, private_channel_and_contributor, reddit_facto
         "score": 1,
         "author_id": user.username,
         "id": post.id,
-        'slug': 'just-a-post',
+        'slug': get_reddit_slug(post.permalink),
         "created": post.created,
         "num_comments": 0,
         "channel_name": channel.name,
@@ -709,7 +709,7 @@ def test_list_posts_anonymous(client, public_channel, reddit_factories, settings
                 'created': post.created,
                 'edited': False,
                 'id': post.id,
-                'slug': 'link-post',
+                'slug': get_reddit_slug(post.permalink),
                 'num_comments': 0,
                 'num_reports': None,
                 'profile_image': image_uri(user.profile),

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -709,7 +709,7 @@ def test_list_posts_anonymous(client, public_channel, reddit_factories, settings
                 'created': post.created,
                 'edited': False,
                 'id': post.id,
-                'slug': get_reddit_slug(post.permalink).replace('_', '-'),
+                'slug': 'link-post',
                 'num_comments': 0,
                 'num_reports': None,
                 'profile_image': image_uri(user.profile),

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -38,12 +38,12 @@ urlpatterns = [
     url(r'^content_policy/$', index),
     url(  # so that we can use reverse() to link to this
         r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/'
-        r'(?P<post_slug>[A-Za-z0-9_]+)/comment/(?P<comment_id>[A-Za-z0-9_]+)/$',
+        r'(?P<post_slug>[A-Za-z0-9_\-]+)/comment/(?P<comment_id>[A-Za-z0-9_]+)/$',
         index,
         name='channel-post-comment',
     ),
     url(  # so that we can use reverse() to link to this
-        r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>[A-Za-z0-9_]+)/$',
+        r'^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>[A-Za-z0-9_\-]+)/$',
         index,
         name='channel-post',
     ),

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -69,7 +69,7 @@ import { dropdownMenuFuncs } from "../lib/ui"
 import { getOwnProfile } from "../lib/redux_selectors"
 
 import type { Dispatch } from "redux"
-import type { Match, Location } from "react-router"
+import type { Location } from "react-router"
 import type { FormsState } from "../flow/formTypes"
 import type {
   Channel,
@@ -81,7 +81,6 @@ import type {
 } from "../flow/discussionTypes"
 
 type PostPageProps = {
-  match: Match,
   dispatch: Dispatch<any>,
   post: Post,
   channel: Channel,
@@ -354,7 +353,6 @@ class PostPage extends React.Component<PostPageProps> {
   render() {
     const {
       dispatch,
-      match,
       post,
       channel,
       commentsTree,
@@ -390,7 +388,13 @@ class PostPage extends React.Component<PostPageProps> {
       <div>
         <MetaTags>
           <title>{formatTitle(post.title)}</title>
-          <CanonicalLink match={match} />
+          <CanonicalLink
+            relativeUrl={
+              commentID
+                ? commentPermalink(channel.name, post.id, post.slug, commentID)
+                : postDetailURL(channel.name, post.id, post.slug)
+            }
+          />
           <meta name="description" content={truncate(post.text, 300)} />
         </MetaTags>
         <Dialog

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -39,7 +39,7 @@ import { VALID_COMMENT_SORT_TYPES } from "../lib/sorting"
 import { makeArticle, makeTweet } from "../factories/embedly"
 import * as utilFuncs from "../lib/util"
 import * as embedUtil from "../lib/embed"
-import { truncate } from "../lib/util"
+import { removeTrailingSlash, truncate } from "../lib/util"
 import { NOT_AUTHORIZED_ERROR_TYPE } from "../util/rest"
 
 describe("PostPage", function() {
@@ -117,6 +117,31 @@ describe("PostPage", function() {
     assert.equal(
       document.head.querySelector("[name=description]").content,
       truncate(post.text, 300)
+    )
+  })
+
+  it("should set the document meta canonical link to the post detail url", async () => {
+    await renderPage()
+    assert.equal(
+      document.head.querySelector("[rel=canonical]").href,
+      removeTrailingSlash(
+        `http://fake.open.url${postDetailURL(channel.name, post.id, post.slug)}`
+      )
+    )
+  })
+
+  it("should set the document meta canonical link to the comment permalink", async () => {
+    const commentLink = commentPermalink(
+      channel.name,
+      post.id,
+      post.slug,
+      comments[0].id
+    )
+    const [wrapper] = await renderComponent(commentLink, basicPostPageActions)
+    wrapper.update()
+    assert.equal(
+      document.head.querySelector("[rel=canonical]").href,
+      removeTrailingSlash(`http://fake.open.url${commentLink}`)
     )
   })
 

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -46,7 +46,7 @@ describe("url helper functions", () => {
     it(`should return a good post URL including slug`, () => {
       assert.equal(
         postDetailURL("foobar", "23434j3j3", "post_slug"),
-        "/c/foobar/23434j3j3/post_slug"
+        "/c/foobar/23434j3j3/post-slug"
       )
     })
   })
@@ -144,8 +144,8 @@ describe("url helper functions", () => {
   describe("commentPermalink with post slug", () => {
     it("should return a comment permalink with post slug", () => {
       assert.equal(
-        "/c/channel_name/post_id/post_slug/comment/comment_id/",
-        commentPermalink("channel_name", "post_id", "post_slug", "comment_id")
+        "/c/channel_name/post_id/post-slug/comment/comment_id/",
+        commentPermalink("channel_name", "post_id", "post-slug", "comment_id")
       )
     })
   })

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -45,7 +45,7 @@ describe("url helper functions", () => {
   describe("postDetailURLWithSlug", () => {
     it(`should return a good post URL including slug`, () => {
       assert.equal(
-        postDetailURL("foobar", "23434j3j3", "post_slug"),
+        postDetailURL("foobar", "23434j3j3", "post-slug"),
         "/c/foobar/23434j3j3/post-slug"
       )
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1278 

#### What's this PR do?
- Modifies `channels.utils.get_reddit_slug ` to replace underscores in the slug with dashes 

#### How should this be manually tested?
Click on links posts that have spaces in their titles, and links to comments for those posts.  The post slug in each URL should have dashes but no underscores.
