### PR TITLE
fix author line display on post card

### DIFF
--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -190,12 +190,17 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
                   imageSize={PROFILE_IMAGE_MICRO}
                 />
                 <span className="author-name">{post.author_name}</span>
-                {post.author_headline ? (
-                  <span className="author-headline">
-                    &nbsp;&#8212;&nbsp;{post.author_headline}
-                  </span>
-                ) : null}
               </Link>
+              {post.author_headline ? (
+                <React.Fragment>
+                  <span className="author-headline separator">
+                    &nbsp;&#8212;&nbsp;
+                  </span>
+                  <span className="author-headline">
+                    {post.author_headline}
+                  </span>
+                </React.Fragment>
+              ) : null}
             </div>
             <div className="right date">{formattedDate}</div>
           </div>

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -114,7 +114,7 @@ describe("ExpandedPostDisplay", () => {
       )} display headline span when text=${String(headlineText)}`, () => {
         post.author_headline = headlineText
         const wrapper = renderPostDisplay({ post })
-        const headlineSpan = wrapper.find(".author-headline")
+        const headlineSpan = wrapper.find(".author-headline").at(1)
         assert.equal(headlineSpan.exists(), expElementExists)
         if (expElementExists && headlineText) {
           assert(headlineSpan.text().includes(headlineText))

--- a/static/scss/_breakpoints.scss
+++ b/static/scss/_breakpoints.scss
@@ -7,6 +7,10 @@
     @media (min-width: 1000px) {
       @content;
     }
+  } @else if $name == extrawide {
+    @media (min-width: 1150px) {
+      @content;
+    }
   } @else if $name == mobile {
     @media (max-width: 800px) {
       @content;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -167,20 +167,59 @@
   }
 
   .authored-by {
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: row;
-    margin: 20px 0;
+    line-height: 1;
+    align-items: flex-start;
+    flex-direction: column;
+    margin: 10px 0;
 
     .profile-image-container {
       padding: 0 10px 0 0;
     }
 
+    .date,
+    .author-headline {
+      margin-left: 35px;
+    }
+
+    .separator {
+      display: none;
+    }
+
     .left {
+      flex-direction: column;
+      align-items: flex-start;
+
       a {
         display: flex;
         align-items: center;
       }
+    }
+
+    @include breakpoint(extrawide) {
+      justify-content: space-between;
+      flex-direction: row;
+      align-items: center;
+      margin: 20px 0;
+      line-height: initial;
+
+      .date,
+      .author-headline {
+        margin-left: 0;
+      }
+
+      .separator {
+        display: initial;
+      }
+
+      .left {
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+      }
+    }
+
+    @include breakpoint(phone) {
+      font-size: 13px;
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1255 

#### What's this PR do?

Fixes the display of the author name, profile image, headline, and date on the post page, specifically to avoid the case where longer headlines could cause the date, headline, and author name to wrap in an ugly way on narrower screen widths.

#### How should this be manually tested?

Give yourself a good long headline and / or name, and make sure that things look alright on all screenwidths.

Note that because of the squeezing of the main page content by the nav drawer on desktop widths I had to use the 'mobile' display for screen widths up to 1150px. Otherwise there's a sort of twilight zone between where we switch over to the desktop nav and the point where the screen gets wide enough for things not to run into each other in the 'desktop' configuration (around 1150px).