### PR TITLE
Show entire message even if on 3 lines

### DIFF
--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -11,7 +11,8 @@
 
   &.mdc-snackbar--active {
     bottom: 10px;
-    padding: 10px;
+    padding-top: 10px;
+    padding-bottom: 10px;
   }
 
   .mdc-snackbar__text {

--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -3,6 +3,7 @@
   background-color: $message-component-bg-color;
   left: 50%;
   border-radius: $std-border-radius;
+  margin: 5px;
 
   @include breakpoint(materialmobile) {
     left: 0;
@@ -10,6 +11,7 @@
 
   &.mdc-snackbar--active {
     bottom: 10px;
+    padding: 10px;
   }
 
   .mdc-snackbar__text {
@@ -17,7 +19,6 @@
     padding: 0;
     min-width: 100%;
     width: 100%;
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1105 

#### What's this PR do?
- Tweaks the snackbar CSS so that messages spanning at least 3 lines are not cut off.

#### How should this be manually tested?
- Make your browser tab moderately narrow.
- Go the 'Moderators' tab for a channel.  Add or remove an email address.  Try adjusting the browser width if the snackbar doesn't span 3 lines.  When it does span 3 lines, the entire message should be visible with some buffer around the edges.

#### Screenshots (if appropriate)
On master branch:

<img width="337" alt="screen shot 2018-09-28 at 3 11 30 pm" src="https://user-images.githubusercontent.com/187676/46229705-801e8680-c334-11e8-9b9e-463d2fea2fb4.png">

On this branch:

<img width="376" alt="screen shot 2018-09-28 at 3 43 34 pm" src="https://user-images.githubusercontent.com/187676/46230020-59148480-c335-11e8-8d97-f2364006162e.png">


