### PR TITLE
Replace percent with viewport dimensions

### DIFF
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -13,8 +13,9 @@ export const EmbedlyLoader = (props: Object = {}) => (
     <ContentLoader
       speed={contentLoaderSpeed}
       style={{ width: "100%", height: "300px" }}
-      width="100%"
+      width={1000}
       height={300}
+      preserveAspectRatio="none"
       {...props}
     >
       <rect x="0" y="0" rx="5" ry="5" width="100%" height="200" />

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -39,13 +39,14 @@ const AnimatedEmptyPost = (i: number) => {
           <ContentLoader
             speed={contentLoaderSpeed}
             style={{ width: "100%", height: "137px" }}
-            width="100%"
+            width={1000}
             height={137}
+            preserveAspectRatio="none"
           >
             <rect x="0" y="0" rx="5" ry="5" width="70%" height="20" />
             <rect x="0" y="40" rx="5" ry="5" width="70%" height="16" />
             <rect x="0" y="58" rx="5" ry="5" width="70%" height="16" />
-            <rect x="0" y="113" rx="5" ry="5" width="35" height="24" />
+            <rect x="0" y="113" rx="5" ry="5" width="70" height="24" />
             <rect x="75%" y="0" rx="5" ry="5" width="25%" height="103" />
             <rect x="89%" y="113" rx="5" ry="5" width="11%" height="24" />
           </ContentLoader>
@@ -61,8 +62,9 @@ const PostLoading = () => (
       <ContentLoader
         speed={contentLoaderSpeed}
         style={{ width: "100%", height: "24px" }}
-        width="100%"
+        width={1000}
         height={24}
+        preserveAspectRatio="none"
       >
         <rect x="0" y="0" rx="5" ry="5" width="100%" height="100%" />
       </ContentLoader>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1171 

#### What's this PR do?
Fixes console warning by replacing invalid percent in `viewBox` with a dimension.

#### How should this be manually tested?
Edit `Embedly` in `Embedly.js` to always display `EmbedlyLoader` instead of only displaying it while the content is loading. In `Loading.js` edit the `WithLoading` render method to always render `<LoadingComponent />`.

Check out master and view a post. Resize the browser to various dimensions and note what the loader looks like. Go to the channel page and note that there are 5 post loaders and another small loader at the top. Resize the browser and note what they look like.

Switch to this branch and refresh the page. Resize the browser to various dimensions and make sure that the loaders on the channel page and the one on the post page match what you saw in master. Also note that the console error is not there anymore.

Note that there is a small difference with the small bottom left box in the post loader on the channel page. On master it retains its width but it will shrink and expand on this PR. I can't figure out how to make it work consistently with the viewBox changes since the `ContentLoader` doesn't allow you to leave out the `viewBox` AFAIK.
