### PR TITLE
Updated login tooltip prompt for anon users

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -14,7 +14,6 @@ import { setPostData } from "../actions/post"
 import { setBannerMessage } from "../actions/ui"
 import {
   isEmptyText,
-  commentLoginText,
   userIsAnonymous,
   preventDefaultAndInvoke
 } from "../lib/util"
@@ -509,12 +508,13 @@ export const ReplyToPostForm: Class<React$Component<*, *>> = connect(
 
       return (
         <div className="reply-post-form">
-          <LoginPopup
-            message={commentLoginText}
-            visible={popupVisible}
-            closePopup={this.onTogglePopup}
-            className="downshift"
-          />
+          {userIsAnonymous() ? (
+            <LoginPopup
+              visible={popupVisible}
+              closePopup={this.onTogglePopup}
+              className="post-reply-popup"
+            />
+          ) : null}
           <CommentFormHelper
             onSubmit={this.onSubmit}
             text={text}

--- a/static/js/components/CommentVoteForm.js
+++ b/static/js/components/CommentVoteForm.js
@@ -2,7 +2,7 @@
 import React from "react"
 
 import LoginPopup from "./LoginPopup"
-import { userIsAnonymous, votingTooltipText } from "../lib/util"
+import { userIsAnonymous } from "../lib/util"
 import type { CommentInTree } from "../flow/discussionTypes"
 
 export type CommentVoteFunc = (comment: CommentInTree) => Promise<*>
@@ -107,11 +107,7 @@ export default class CommentVoteForm extends React.Component<Props, State> {
           />
         </button>
         {userIsAnonymous() ? (
-          <LoginPopup
-            message={votingTooltipText}
-            visible={popupVisible}
-            closePopup={this.onTogglePopup}
-          />
+          <LoginPopup visible={popupVisible} closePopup={this.onTogglePopup} />
         ) : null}
       </div>
     )

--- a/static/js/components/FollowButton.js
+++ b/static/js/components/FollowButton.js
@@ -62,10 +62,9 @@ export default class FollowButton extends React.Component<
         )}
         {userIsAnonymous() ? (
           <LoginPopup
-            message="Sign up or Login to follow"
             visible={popupVisible}
             closePopup={this.onTogglePopup}
-            className="reversed"
+            className="reversed follow-btn-popup"
           />
         ) : null}
       </React.Fragment>

--- a/static/js/components/LoginPopup.js
+++ b/static/js/components/LoginPopup.js
@@ -7,7 +7,6 @@ import Button from "./Button"
 
 type LoginPopupProps = {
   closePopup: Function,
-  message: string,
   visible: boolean,
   className?: string
 }
@@ -21,21 +20,25 @@ export class LoginPopupHelper extends React.Component<LoginPopupProps> {
   }
 
   render() {
-    const { message, visible, className } = this.props
+    const { visible, className } = this.props
     return visible ? (
       <div className={`popup login-popup ${className || ""}`}>
         <div className="triangle" />
-        <Button className="close-popup" onClick={this.handleClickOutside}>
-          <span>x</span>
+        <Button className="close-btn" onClick={this.handleClickOutside}>
+          <i className="material-icons">close</i>
         </Button>
-        <div className="popup-title">{message}</div>
+        <h4>Join MIT Open</h4>
+        <div className="popup-text">
+          As a member, you can share your ideas, subscribe, vote, and comment on
+          educational content that matters to you.
+        </div>
         <div className="bottom-row">
           <div className="popup-buttons">
             <Link className="link-button" to="/login">
               Log In
             </Link>
             <Link className="link-button red" to="/signup">
-              Become a member
+              Sign Up
             </Link>
           </div>
         </div>

--- a/static/js/components/LoginPopup_test.js
+++ b/static/js/components/LoginPopup_test.js
@@ -8,16 +8,14 @@ import { LoginPopupHelper } from "./LoginPopup"
 import { configureShallowRenderer } from "../lib/test_utils"
 
 describe("LoginPopup", () => {
-  let closePopupStub, message, visible, sandbox, renderLoginPopupHelper
+  let closePopupStub, visible, sandbox, renderLoginPopupHelper
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     closePopupStub = sandbox.stub()
-    message = "Login to do something"
     visible = true
 
     renderLoginPopupHelper = configureShallowRenderer(LoginPopupHelper, {
-      message,
       visible,
       closePopup: closePopupStub
     })
@@ -31,38 +29,18 @@ describe("LoginPopup", () => {
     const wrapper = renderLoginPopupHelper()
     assert.isFunction(wrapper.instance().handleClickOutside)
     wrapper.instance().handleClickOutside()
-    assert.ok(closePopupStub.called)
-  })
-
-  it("should include the message text", () => {
-    assert.equal(
-      message,
-      renderLoginPopupHelper()
-        .find(".popup-title")
-        .text()
-    )
+    assert.isTrue(closePopupStub.called)
   })
 
   it("should include login and signup buttons", () => {
     const wrapper = renderLoginPopupHelper()
-    assert.equal(
-      wrapper
-        .find(Link)
-        .at(0)
-        .props().to,
-      "/login"
-    )
-    assert.equal(
-      wrapper
-        .find(Link)
-        .at(1)
-        .props().to,
-      "/signup"
-    )
+    const links = wrapper.find(Link)
+    assert.equal(links.at(0).prop("to"), "/login")
+    assert.equal(links.at(1).prop("to"), "/signup")
   })
 
   it("should render null, if visible === false", () => {
     const wrapper = renderLoginPopupHelper({ visible: false })
-    assert.isNotOk(wrapper.find("div").exists())
+    assert.isFalse(wrapper.find("div").exists())
   })
 })

--- a/static/js/components/PostUpvoteButton.js
+++ b/static/js/components/PostUpvoteButton.js
@@ -2,7 +2,7 @@
 import React from "react"
 
 import LoginPopup from "./LoginPopup"
-import { userIsAnonymous, votingTooltipText } from "../lib/util"
+import { userIsAnonymous } from "../lib/util"
 
 import type { Post } from "../flow/discussionTypes"
 
@@ -68,11 +68,7 @@ export default class PostUpvoteButton extends React.Component<Props, State> {
           <span className="votes">{post.score}</span>
         </div>
         {userIsAnonymous() ? (
-          <LoginPopup
-            message={votingTooltipText}
-            visible={popupVisible}
-            closePopup={this.onTogglePopup}
-          />
+          <LoginPopup visible={popupVisible} closePopup={this.onTogglePopup} />
         ) : null}
       </React.Fragment>
     )

--- a/static/js/components/ReplyButton.js
+++ b/static/js/components/ReplyButton.js
@@ -2,7 +2,7 @@
 import React from "react"
 
 import LoginPopup from "./LoginPopup"
-import { commentLoginText, userIsAnonymous } from "../lib/util"
+import { userIsAnonymous } from "../lib/util"
 
 type Props = {
   beginEditing?: Function
@@ -44,9 +44,9 @@ export default class ReplyButton extends React.Component<Props, State> {
         </div>
         {userIsAnonymous() ? (
           <LoginPopup
-            message={commentLoginText}
             visible={popupVisible}
             closePopup={this.onTogglePopup}
+            className="comment-reply-btn-popup"
           />
         ) : null}
       </div>

--- a/static/js/components/SharePopup.js
+++ b/static/js/components/SharePopup.js
@@ -48,7 +48,7 @@ export class SharePopupHelper extends React.Component<SharePopupProps> {
     return (
       <div className="popup share-popup">
         <div className="triangle" />
-        <div className="popup-title">Share a link to this post:</div>
+        <div className="popup-text">Share a link to this post:</div>
         <input ref={this.input} readOnly value={url} />
         <div className="bottom-row">
           {hideSocialButtons ? null : (

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -69,9 +69,6 @@ const getAvatarIndex = (key: string, maxIdx: number) =>
 
 export const userIsAnonymous = () => R.isNil(SETTINGS.username)
 
-export const votingTooltipText = "Sign Up or Login to vote"
-export const commentLoginText = "Sign Up or Login to comment"
-
 export const defaultProfileImageUrl = "/static/images/avatar_default.png"
 export const defaultChannelAvatarUrlPrefix =
   "/static/images/channel_avatars/channel-avatar"

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -35,6 +35,7 @@ $material-icon-size: 24px;
 $channel-banner-height: 105px;
 $author-font-size: 16px;
 $submission-font-size: 16px;
+$tooltip-font-size: 14px;
 
 // Spacing values for items that appear on the left side of the drawer and toolbar
 $icon-padding-left: 19px;

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -7,14 +7,22 @@
   padding: 12px;
   min-width: 250px;
   z-index: 10;
+  font-size: $tooltip-font-size;
 
   .triangle {
     @extend %triangle;
   }
 
-  .popup-title {
+  .popup-text,
+  h4 {
+    width: 90%;
     color: $font-black;
-    margin-bottom: 2px;
+  }
+
+  h4 {
+    padding: 0 0 10px 0;
+    margin: 0;
+    font-size: inherit;
   }
 
   input {
@@ -24,9 +32,9 @@
 
   .bottom-row {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    margin-top: 5px;
+    margin-top: 15px;
 
     .popup-buttons {
       display: flex;
@@ -61,21 +69,22 @@
   right: unset;
   margin-top: 10px;
   min-width: 255px;
+  max-width: 290px;
 
-  &.downshift {
-    margin-top: 50px;
-  }
-
-  .close-popup {
+  .close-btn {
     position: absolute;
     top: 0px;
     right: 0px;
     padding: 5px;
+    margin: 7px 7px 0 0;
     background-color: #fff !important;
     color: #000;
     min-width: unset;
     height: unset;
-    font-size: 12px;
+
+    i {
+      font-size: 16px;
+    }
 
     &:before {
       background-color: $bg-light-grey !important;
@@ -89,16 +98,26 @@
   .link-button {
     background-color: #fff;
     display: block;
-    border-radius: 10px;
+    border-radius: $std-border-radius;
     padding: 5px 15px;
-    border: 1px solid #972c37;
-    color: #972c37;
+    margin: 0 0 0 10px;
+    border: 1px solid $brand-bg;
+    color: $brand-bg;
     text-align: center;
-    margin: 10px 5px 10px;
   }
 
   .red {
-    background-color: #972c37;
+    background-color: $brand-bg;
     color: #fff;
+  }
+
+  // Popup-specific spacing styles
+  // DELETE THESE WHEN #1299 IS COMPLETED
+  &.follow-btn-popup {
+    margin-top: 32px;
+  }
+
+  &.post-reply-popup {
+    margin-top: 50px;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1222 

#### What's this PR do?
Changes the contents and styling of the login tooltip/popup for anonymous users ([example design in Zeplin](https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5baa6eca6d1346b3722eae78))

#### How should this be manually tested?
Go to a post page as an anonymous user. 

#### Any background context you want to provide?
The issue wasn't very clear about which popups should be updated, so I only updated the popups for the cases where users focus on the post reply textarea and where they click the 'Reply' link under a comment. I left the contents for all other popups untouched

#### Screenshots (if appropriate)
![ss 2018-10-02 at 16 04 18](https://user-images.githubusercontent.com/14932219/46374726-64322200-c65f-11e8-99ff-c18b28318ba9.png)
![ss 2018-10-02 at 16 04 05](https://user-images.githubusercontent.com/14932219/46374727-64322200-c65f-11e8-86c5-7d8d0b90ea67.png)
(unchanged)
![ss 2018-10-02 at 16 04 24](https://user-images.githubusercontent.com/14932219/46374724-64322200-c65f-11e8-9484-c4ea0f6ac66f.png)

