### PR TITLE
fix styling for channel members tab

### DIFF
--- a/static/js/components/Dialog.js
+++ b/static/js/components/Dialog.js
@@ -18,7 +18,7 @@ type Props = {
   title: string,
   submitText: string,
   id?: string,
-  children: any
+  children?: any
 }
 
 const OurDialog = ({

--- a/static/js/components/admin/EditChannelMembersForm.js
+++ b/static/js/components/admin/EditChannelMembersForm.js
@@ -10,33 +10,29 @@ type Props = {
   memberTypeDescription: string
 } & FormProps<AddMemberForm>
 
-export default class EditChannelMembersForm extends React.Component<Props> {
-  render() {
-    const {
-      processing,
-      validation,
-      form,
-      onUpdate,
-      onSubmit,
-      memberTypeDescription
-    } = this.props
+const EditChannelMembersForm = ({
+  processing,
+  validation,
+  form,
+  onUpdate,
+  onSubmit,
+  memberTypeDescription
+}: Props) => (
+  <div className="members">
+    <form className="add-member-form" onSubmit={onSubmit}>
+      <input
+        type="text"
+        onChange={onUpdate}
+        name="email"
+        placeholder={`The email of the ${memberTypeDescription} you want to add`}
+        value={form.email}
+      />{" "}
+      <button type="submit" className="outlined" disabled={processing}>
+        Submit
+      </button>
+    </form>
+    {validationMessage(validation.email)}
+  </div>
+)
 
-    return (
-      <div className="members">
-        <form className="add-member-form" onSubmit={onSubmit}>
-          <input
-            type="textbox"
-            onChange={onUpdate}
-            name="email"
-            placeholder={`The email of the ${memberTypeDescription} you want to add`}
-            value={form.email}
-          />{" "}
-          <button type="submit" disabled={processing}>
-            Submit
-          </button>
-        </form>
-        {validationMessage(validation.email)}
-      </div>
-    )
-  }
-}
+export default EditChannelMembersForm

--- a/static/js/components/admin/MembersList.js
+++ b/static/js/components/admin/MembersList.js
@@ -3,11 +3,12 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
+import Dialog from "../Dialog"
+
 import { profileURL } from "../../lib/url"
 import { MISSING_TEXT } from "../../lib/channels"
 
 import type { Channel, Member } from "../../flow/discussionTypes"
-import { Dialog } from "@mitodl/mdl-react-components"
 
 type Props = {
   channel: Channel,
@@ -23,11 +24,7 @@ type Props = {
 }
 
 export default class MembersList extends React.Component<Props> {
-  removeMember = (event: Event) => {
-    if (event.type !== "MDCDialog:accept") {
-      // filter out click event to avoid double execution
-      return
-    }
+  removeMember = () => {
     const { removeMember, channel, memberToRemove } = this.props
     if (!memberToRemove) {
       throw new Error("Expected memberToRemove to be set")
@@ -55,7 +52,7 @@ export default class MembersList extends React.Component<Props> {
     } = this.props
 
     return (
-      <React.Fragment>
+      <div className="members-list">
         <table>
           <tbody>
             {members.map((member, index) => (
@@ -71,7 +68,7 @@ export default class MembersList extends React.Component<Props> {
                     {editable ? (
                       <td>
                         <a
-                          className="remove"
+                          className="remove grey-surround"
                           onClick={() => this.showRemoveDialog(member)}
                         >
                           Leave
@@ -84,7 +81,7 @@ export default class MembersList extends React.Component<Props> {
                     <td>
                       {member.full_name ? (
                         <Link
-                          className="name"
+                          className="restyled name"
                           to={profileURL(usernameGetter(member))}
                         >
                           {member.full_name}
@@ -104,7 +101,7 @@ export default class MembersList extends React.Component<Props> {
                           <span className="cant_remove">Can't remove</span>
                         ) : (
                           <a
-                            className="remove"
+                            className="remove grey-surround"
                             onClick={() => this.showRemoveDialog(member)}
                           >
                             Remove
@@ -130,7 +127,7 @@ export default class MembersList extends React.Component<Props> {
               : memberToRemove.full_name)) ||
             "member"}?`}
         />
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/static/js/containers/admin/EditChannelContributorsPage.js
+++ b/static/js/containers/admin/EditChannelContributorsPage.js
@@ -1,20 +1,14 @@
 // @flow
-import React from "react"
 import R from "ramda"
-import { MetaTags } from "react-meta-tags"
 import { connect } from "react-redux"
 
-import Card from "../../components/Card"
 import EditChannelMembersForm from "../../components/admin/EditChannelMembersForm"
-import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
-import MembersNavbar from "../../components/admin/MembersNavbar"
-import MembersList from "../../components/admin/MembersList"
 import withForm from "../../hoc/withForm"
 import withSingleColumn from "../../hoc/withSingleColumn"
+import editChannelMembershipPage from "./EditChannelMembershipPage"
 
 import { newMemberForm } from "../../lib/channels"
 import { configureForm } from "../../lib/forms"
-import { formatTitle } from "../../lib/title"
 import { actions } from "../../actions"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import { getChannelName } from "../../lib/util"
@@ -27,136 +21,27 @@ import {
   DIALOG_REMOVE_MEMBER
 } from "../../actions/ui"
 
-import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
-import type { FormErrors, WithFormProps } from "../../flow/formTypes"
-import { channelURL } from "../../lib/url"
+import type { FormErrors } from "../../flow/formTypes"
 
 export const CONTRIBUTORS_KEY = "channel:edit:contributors"
+
 const { getForm, actionCreators } = configureForm(
   CONTRIBUTORS_KEY,
   newMemberForm
 )
 
-const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 const usernameGetter = R.prop("contributor_name")
 
-type Props = {
-  channel: Channel,
-  loadChannel: () => Promise<Channel>,
-  loadMembers: () => Promise<*>,
-  members: Array<Member>,
-  removeMember: (channel: Channel, email: string) => Promise<*>,
-  memberToRemove: ?Member,
-  dialogOpen: boolean,
-  setDialogVisibility: (visibility: boolean) => void,
-  setDialogData: (data: any) => void,
-  history: Object,
-  setSnackbarMessage: (obj: Object) => void
-} & WithFormProps<AddMemberForm>
-
-export class EditChannelContributorsPage extends React.Component<Props> {
-  componentDidMount() {
-    this.loadData()
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (shouldLoadData(prevProps, this.props)) {
-      this.loadData()
-    }
-  }
-
-  loadData = async () => {
-    const { channel, loadMembers, members } = this.props
-
-    if (!members) {
-      loadMembers()
-    }
-    if (!channel) {
-      this.validateModerator()
-    }
-  }
-
-  validateModerator = async () => {
-    const { loadChannel, history } = this.props
-
-    const channel = await loadChannel()
-    if (!channel.user_is_moderator) {
-      history.push(channelURL(channel.name))
-    }
-  }
-
-  removeMember = async (channel: Channel, member: Member) => {
-    const { removeMember, setSnackbarMessage } = this.props
-    await removeMember(channel, usernameGetter(member))
-    setSnackbarMessage({
-      message: `Successfully removed ${String(member.email)} as a contributor`
-    })
-  }
-
-  render() {
-    const {
-      renderForm,
-      form,
-      channel,
-      members,
-      memberToRemove,
-      dialogOpen,
-      setDialogData,
-      setDialogVisibility
-    } = this.props
-
-    if (!channel || !members || !form) {
-      return null
-    }
-
-    const editable = !channel.membership_is_managed
-
-    return (
-      <React.Fragment>
-        <MetaTags>
-          <title>{formatTitle("Edit Channel")}</title>
-        </MetaTags>
-        <EditChannelNavbar channelName={channel.name} />
-        <Card>
-          <MembersNavbar channel={channel} />
-          {!editable ? (
-            <div className="membership-notice">
-              Membership is managed via MicroMasters
-            </div>
-          ) : (
-            renderForm({
-              memberTypeDescription: "contributor"
-            })
-          )}
-          <MembersList
-            channel={channel}
-            removeMember={this.removeMember}
-            editable={editable}
-            members={members}
-            usernameGetter={usernameGetter}
-            memberTypeDescription="contributor"
-            memberToRemove={memberToRemove}
-            dialogOpen={dialogOpen}
-            setDialogData={setDialogData}
-            setDialogVisibility={setDialogVisibility}
-          />
-        </Card>
-      </React.Fragment>
-    )
-  }
-}
-
-const loadMembers = (channelName: string) =>
-  actions.channelContributors.get(channelName)
-const loadChannel = (channelName: string) => actions.channels.get(channelName)
-const addMember = (channel: Channel, email: string) =>
-  actions.channelContributors.post(channel.name, email)
-const removeMember = (channel: Channel, username: string) =>
-  actions.channelContributors.delete(channel.name, username)
 const onSubmitFailure = (): FormErrors<*> => ({
   email: "Error adding new contributor"
 })
-const onSubmit = (channel, { email }) => addMember(channel, email)
+
+export const EditChannelContributorsPage = editChannelMembershipPage(
+  "contributor",
+  "EditChannelContributorsPage",
+  usernameGetter,
+  false
+)
 
 const mapStateToProps = (state, ownProps) => {
   const channelName = getChannelName(ownProps)
@@ -184,13 +69,13 @@ const mapStateToProps = (state, ownProps) => {
 const mergeProps = mergeAndInjectProps(
   (
     { channelName, channel },
-    { loadMembers, loadChannel, onSubmit, formBeginEdit, setSnackbarMessage }
+    { loadMembers, loadChannel, addMember, formBeginEdit, setSnackbarMessage }
   ) => ({
     loadMembers:    () => loadMembers(channelName),
     loadChannel:    () => loadChannel(channelName),
     onSubmitResult: formBeginEdit,
     onSubmit:       async form => {
-      const newMember = await onSubmit(channel, form)
+      const newMember = await addMember(channel.name, form.email)
       setSnackbarMessage({
         message: `Successfully added ${
           newMember.contributor.email
@@ -204,11 +89,10 @@ export default R.compose(
   connect(
     mapStateToProps,
     {
-      loadMembers,
-      loadChannel,
-      addMember,
-      removeMember,
-      onSubmit,
+      loadMembers:   actions.channelContributors.get,
+      loadChannel:   actions.channels.get,
+      addMember:     actions.channelContributors.post,
+      removeMember:  actions.channelContributors.delete,
       setSnackbarMessage,
       setDialogData: (data: any) =>
         setDialogData({ dialogKey: DIALOG_REMOVE_MEMBER, data: data }),

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -255,7 +255,7 @@ describe("EditChannelContributorsPage", () => {
 
     const actions = store.getActions()
 
-    assert.deepEqual(actions[actions.length - 1], {
+    assert.deepEqual(actions[actions.length - 2], {
       type:    SET_SNACKBAR_MESSAGE,
       payload: {
         message: `Successfully removed ${String(
@@ -263,7 +263,13 @@ describe("EditChannelContributorsPage", () => {
         )} as a contributor`
       }
     })
+    assert.deepEqual(actions[actions.length - 1], {
+      type:    HIDE_DIALOG,
+      payload: DIALOG_REMOVE_MEMBER
+    })
   })
+
+  //
   ;[true, false].forEach(hasDialog => {
     it(`passes a dialog value of ${String(hasDialog)}`, async () => {
       const { inner } = await render({

--- a/static/js/containers/admin/EditChannelMembershipPage.js
+++ b/static/js/containers/admin/EditChannelMembershipPage.js
@@ -1,0 +1,148 @@
+// @flow
+import React from "react"
+import R from "ramda"
+import { MetaTags } from "react-meta-tags"
+
+import Card from "../../components/Card"
+import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
+import MembersNavbar from "../../components/admin/MembersNavbar"
+import MembersList from "../../components/admin/MembersList"
+
+import { formatTitle } from "../../lib/title"
+import { channelURL } from "../../lib/url"
+
+import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
+import type { WithFormProps } from "../../flow/formTypes"
+
+const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
+
+type Props = {
+  channel: Channel,
+  loadChannel: () => Promise<Channel>,
+  loadMembers: () => Promise<*>,
+  members: Array<Member>,
+  removeMember: (channelName: string, email: string) => Promise<*>,
+  memberToRemove: ?Member,
+  dialogOpen: boolean,
+  setDialogVisibility: (visibility: boolean) => void,
+  setDialogData: (data: any) => void,
+  history: Object,
+  setSnackbarMessage: (obj: Object) => void
+} & WithFormProps<AddMemberForm>
+
+const editChannelMembershipPage = (
+  memberTypeDescription: string,
+  displayName: string,
+  usernameGetter: Function,
+  redirectAfterSelfRemoval: boolean
+) => {
+  class EditChannelMembershipPage extends React.Component<Props> {
+    componentDidMount() {
+      this.loadData()
+    }
+
+    componentDidUpdate(prevProps: Props) {
+      if (shouldLoadData(prevProps, this.props)) {
+        this.loadData()
+      }
+    }
+
+    loadData = async () => {
+      const { channel, loadMembers, members } = this.props
+
+      if (!members) {
+        loadMembers()
+      }
+      if (!channel) {
+        this.validateModerator()
+      }
+    }
+
+    validateModerator = async () => {
+      const { loadChannel, history } = this.props
+
+      const channel = await loadChannel()
+      if (!channel.user_is_moderator) {
+        history.push(channelURL(channel.name))
+      }
+    }
+
+    removeMember = async (channel: Channel, member: Member) => {
+      const {
+        removeMember,
+        setSnackbarMessage,
+        setDialogVisibility
+      } = this.props
+      await removeMember(channel.name, usernameGetter(member))
+
+      if (redirectAfterSelfRemoval) {
+        this.validateModerator()
+      }
+
+      setSnackbarMessage({
+        message: `Successfully removed ${String(
+          member.email
+        )} as a ${memberTypeDescription}`
+      })
+      setDialogVisibility(false)
+    }
+
+    render() {
+      const {
+        renderForm,
+        form,
+        channel,
+        members,
+        memberToRemove,
+        dialogOpen,
+        setDialogData,
+        setDialogVisibility
+      } = this.props
+
+      if (!channel || !members || !form) {
+        return null
+      }
+
+      const editable = !channel.membership_is_managed
+
+      return (
+        <React.Fragment>
+          <MetaTags>
+            <title>{formatTitle("Edit Channel")}</title>
+          </MetaTags>
+          <EditChannelNavbar channelName={channel.name} />
+          <Card className="members">
+            <MembersNavbar channel={channel} />
+            {!editable ? (
+              <div className="membership-notice">
+                Membership is managed via MicroMasters
+              </div>
+            ) : (
+              renderForm({
+                memberTypeDescription
+              })
+            )}
+            <MembersList
+              channel={channel}
+              removeMember={this.removeMember}
+              editable={editable}
+              members={members}
+              usernameGetter={usernameGetter}
+              memberTypeDescription={memberTypeDescription}
+              memberToRemove={memberToRemove}
+              dialogOpen={dialogOpen}
+              setDialogData={setDialogData}
+              setDialogVisibility={setDialogVisibility}
+            />
+          </Card>
+        </React.Fragment>
+      )
+    }
+  }
+
+  EditChannelMembershipPage.displayName = displayName
+
+  return EditChannelMembershipPage
+}
+
+export default editChannelMembershipPage

--- a/static/js/containers/admin/EditChannelModeratorsPage.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage.js
@@ -1,23 +1,16 @@
 // @flow
-import React from "react"
 import R from "ramda"
-import { MetaTags } from "react-meta-tags"
 import { connect } from "react-redux"
 
-import Card from "../../components/Card"
 import EditChannelMembersForm from "../../components/admin/EditChannelMembersForm"
-import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
-import MembersNavbar from "../../components/admin/MembersNavbar"
-import MembersList from "../../components/admin/MembersList"
 import withForm from "../../hoc/withForm"
 import withSingleColumn from "../../hoc/withSingleColumn"
+import editChannelMembershipPage from "./EditChannelMembershipPage"
 
 import { newMemberForm } from "../../lib/channels"
 import { configureForm } from "../../lib/forms"
-import { formatTitle } from "../../lib/title"
 import { actions } from "../../actions"
 import { mergeAndInjectProps } from "../../lib/redux_props"
-import { channelURL } from "../../lib/url"
 import { getChannelName } from "../../lib/util"
 import { validateMembersForm } from "../../lib/validation"
 import {
@@ -28,134 +21,23 @@ import {
   DIALOG_REMOVE_MEMBER
 } from "../../actions/ui"
 
-import type { AddMemberForm, Channel, Member } from "../../flow/discussionTypes"
-import type { FormErrors, WithFormProps } from "../../flow/formTypes"
+import type { FormErrors } from "../../flow/formTypes"
 
 export const MODERATORS_KEY = "channel:edit:moderators"
 const { getForm, actionCreators } = configureForm(MODERATORS_KEY, newMemberForm)
 
-const shouldLoadData = R.complement(R.allPass([R.eqProps("channelName")]))
 const usernameGetter = R.prop("moderator_name")
 
-type Props = {
-  channel: Channel,
-  loadChannel: () => Promise<Channel>,
-  loadMembers: () => Promise<*>,
-  members: Array<Member>,
-  removeMember: (channel: Channel, email: string) => Promise<*>,
-  memberToRemove: ?Member,
-  dialogOpen: boolean,
-  setDialogVisibility: (visibility: boolean) => void,
-  setDialogData: (data: any) => void,
-  history: Object,
-  setSnackbarMessage: (obj: Object) => void
-} & WithFormProps<AddMemberForm>
-
-export class EditChannelModeratorsPage extends React.Component<Props> {
-  componentDidMount() {
-    this.loadData()
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (shouldLoadData(prevProps, this.props)) {
-      this.loadData()
-    }
-  }
-
-  loadData = async () => {
-    const { channel, loadMembers, members } = this.props
-
-    if (!members) {
-      loadMembers()
-    }
-    if (!channel) {
-      this.validateModerator()
-    }
-  }
-
-  validateModerator = async () => {
-    const { loadChannel, history } = this.props
-
-    const channel = await loadChannel()
-    if (!channel.user_is_moderator) {
-      history.push(channelURL(channel.name))
-    }
-  }
-
-  removeMember = async (channel: Channel, member: Member) => {
-    const { removeMember, setSnackbarMessage } = this.props
-    await removeMember(channel, usernameGetter(member))
-    this.validateModerator()
-    setSnackbarMessage({
-      message: `Successfully removed ${String(member.email)} as a moderator`
-    })
-  }
-
-  render() {
-    const {
-      renderForm,
-      form,
-      channel,
-      members,
-      memberToRemove,
-      dialogOpen,
-      setDialogData,
-      setDialogVisibility
-    } = this.props
-
-    if (!channel || !members || !form) {
-      return null
-    }
-
-    const editable = !channel.membership_is_managed
-
-    return (
-      <React.Fragment>
-        <MetaTags>
-          <title>{formatTitle("Edit Channel")}</title>
-        </MetaTags>
-        <EditChannelNavbar channelName={channel.name} />
-        <Card>
-          <MembersNavbar channel={channel} />
-          {!editable ? (
-            <div className="membership-notice">
-              Membership is managed via MicroMasters
-            </div>
-          ) : (
-            renderForm({
-              memberTypeDescription: "moderator"
-            })
-          )}
-          <MembersList
-            channel={channel}
-            removeMember={this.removeMember}
-            editable={editable}
-            members={members}
-            usernameGetter={usernameGetter}
-            memberTypeDescription="moderator"
-            memberToRemove={memberToRemove}
-            dialogOpen={dialogOpen}
-            setDialogData={setDialogData}
-            setDialogVisibility={setDialogVisibility}
-          />
-        </Card>
-      </React.Fragment>
-    )
-  }
-}
-
-const loadMembers = (channelName: string) =>
-  actions.channelModerators.get(channelName)
-const loadChannel = (channelName: string) => actions.channels.get(channelName)
-const addModerator = (channel: Channel, email: string) =>
-  actions.channelModerators.post(channel.name, email)
-const addSubscriber = (channel: Channel, username: string) =>
-  actions.channelSubscribers.post(channel.name, username)
-const removeMember = (channel: Channel, username: string) =>
-  actions.channelModerators.delete(channel.name, username)
 const onSubmitFailure = (): FormErrors<*> => ({
   email: "Error adding new moderator"
 })
+
+export const EditChannelModeratorsPage = editChannelMembershipPage(
+  "moderator",
+  "EditChannelModeratorsPage",
+  usernameGetter,
+  true
+)
 
 const mapStateToProps = (state, ownProps) => {
   const channelName = getChannelName(ownProps)
@@ -196,8 +78,8 @@ const mergeProps = mergeAndInjectProps(
     loadChannel:    () => loadChannel(channelName),
     onSubmitResult: formBeginEdit,
     onSubmit:       async form => {
-      const newMember = await addModerator(channel, form.email)
-      await addSubscriber(channel, newMember.moderator.moderator_name)
+      const newMember = await addModerator(channel.name, form.email)
+      await addSubscriber(channel.name, newMember.moderator.moderator_name)
 
       setSnackbarMessage({
         message: `Successfully added ${
@@ -207,16 +89,15 @@ const mergeProps = mergeAndInjectProps(
     }
   })
 )
-
 export default R.compose(
   connect(
     mapStateToProps,
     {
-      loadMembers,
-      loadChannel,
-      addModerator,
-      addSubscriber,
-      removeMember,
+      loadMembers:   actions.channelModerators.get,
+      loadChannel:   actions.channels.get,
+      addModerator:  actions.channelModerators.post,
+      addSubscriber: actions.channelSubscribers.post,
+      removeMember:  actions.channelModerators.delete,
       setSnackbarMessage,
       setDialogData: (data: any) =>
         setDialogData({ dialogKey: DIALOG_REMOVE_MEMBER, data: data }),

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -317,7 +317,7 @@ describe("EditChannelModeratorsPage", () => {
 
       const actions = store.getActions()
 
-      assert.deepEqual(actions[actions.length - 2], {
+      assert.deepEqual(actions[actions.length - 3], {
         type:    SET_SNACKBAR_MESSAGE,
         payload: {
           message: `Successfully removed ${String(
@@ -325,8 +325,15 @@ describe("EditChannelModeratorsPage", () => {
           )} as a moderator`
         }
       })
+
+      assert.deepEqual(actions[actions.length - 2], {
+        type:    HIDE_DIALOG,
+        payload: DIALOG_REMOVE_MEMBER
+      })
     })
   })
+
+  //
   ;[true, false].forEach(hasDialog => {
     it(`passes a dialog value of ${String(hasDialog)}`, async () => {
       const { inner } = await render({

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -58,25 +58,43 @@
     }
   }
 
-  table {
-    width: 100%;
+  .members-list {
+    font-weight: bold;
 
-    .three-cols {
-      td {
-        width: 3 * (100%/8);
+    .email {
+      color: $font-grey-light;
+      font-weight: normal;
+    }
 
-        &:last-child {
-          width: 2 * (100%/8);
+    .remove {
+      font-size: 16px;
+      display: inline-block;
+      margin: 0 5px;
+      width: 100px;
+      padding: 2px 10px;
+    }
+
+    table {
+      width: 100%;
+      border-spacing: 12px;
+
+      .three-cols {
+        td {
+          width: 3 * 100% / 8;
+
+          &:last-child {
+            width: 2 * 100% / 8;
+          }
         }
       }
-    }
 
-    .two-cols {
-      width: 50%;
-    }
+      .two-cols {
+        width: 50%;
+      }
 
-    td:last-child {
-      text-align: right;
+      td:last-child {
+        text-align: center;
+      }
     }
   }
 
@@ -97,11 +115,15 @@
     }
   }
 
+  .members {
+    color: $navy;
+  }
+
   .add-member-form {
     display: flex;
     flex-direction: row;
     align-items: center;
-
+    color: $navy;
     margin-bottom: 20px;
 
     button[type="submit"] {
@@ -109,12 +131,9 @@
     }
   }
 
-  .remove {
-    cursor: pointer;
-  }
-
   .cant_remove {
-    color: grey;
+    color: $font-grey-light;
+    font-weight: normal;
   }
 
   .membership-notice {
@@ -125,10 +144,6 @@
   input[name="email"] {
     width: 100%;
     margin-right: 10px;
-  }
-
-  a {
-    cursor: pointer;
   }
 }
 

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -17,6 +17,7 @@ a.link-button {
 .mdc-button.cancel-button,
 button.cancel,
 a.link-button.cancel,
+button.outlined,
 a.link-button.outlined {
   background-color: inherit;
   border: 1px solid $rouge;

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -70,9 +70,9 @@ input[type="password"] {
   }
 }
 
-textarea {
+textarea,
+input[type="text"] {
   width: 100%;
-  height: 110px;
   padding: 12px 10px;
   box-sizing: border-box;
   border-radius: $std-border-radius;
@@ -85,6 +85,10 @@ textarea {
   &.no-height {
     height: auto;
   }
+}
+
+textarea {
+  height: 110px;
 }
 
 label {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -52,6 +52,7 @@
 @import "intra-page-nav";
 @import "channel-banner";
 @import "markdown";
+@import "link";
 
 body {
   font-family: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/link.scss
+++ b/static/scss/link.scss
@@ -1,0 +1,16 @@
+a {
+  cursor: pointer;
+}
+
+a.restyled {
+  color: $navy;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:visited {
+    color: $navy;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1246 

#### What's this PR do?

this just fixes some styling issues (see the list on the attached issue) for the channel members page. while I was in there I did some refactoring to remove duplicated and / or unnecessary code.


#### How should this be manually tested?

make sure that the channel moderators pages look good, and that all functionality is retained (i.e. you should be able to add and remove moderators and contributors, the dialogs should all work, etc). Things should implement the changes listed on the issue as well.

here's a basic screenshot:

![members](https://user-images.githubusercontent.com/6207644/46422354-2c2feb00-c702-11e8-8ba5-ae279fddeff7.png)
