### PR TITLE
Refactored form update logic on post creation page

### DIFF
--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -425,17 +425,13 @@ describe("CreatePostPage", () => {
       [LINK_TYPE_ANY, LINK_TYPE_ANY, null, false, false],
       // starting with LINK
       [LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_LINK, true, true],
-      [LINK_TYPE_LINK, LINK_TYPE_TEXT, null, false, true],
       [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, true, false],
       [LINK_TYPE_LINK, LINK_TYPE_ANY, LINK_TYPE_LINK, false, true],
-      [LINK_TYPE_LINK, LINK_TYPE_ANY, null, false, false],
       // starting with TEXT
       [LINK_TYPE_TEXT, LINK_TYPE_TEXT, LINK_TYPE_TEXT, true, false],
       [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_TEXT, true, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_LINK, null, false, true],
       [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, true, false],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true],
-      [LINK_TYPE_TEXT, LINK_TYPE_ANY, null, false, false]
+      [LINK_TYPE_TEXT, LINK_TYPE_ANY, LINK_TYPE_TEXT, false, true]
     ].forEach(
       ([
         fromChannelType,
@@ -502,9 +498,9 @@ describe("CreatePostPage", () => {
       [LINK_TYPE_LINK, true],
       [LINK_TYPE_TEXT, true]
     ].forEach(([linkType, shouldDispatch]) => {
-      it(`${
-        shouldDispatch ? "should" : "shouldn't"
-      } FORM_UPDATE when coming from no channel to a channel with ${linkType}`, () => {
+      it(`${shouldIf(
+        shouldDispatch
+      )} update form when coming from no channel to a channel with link type '${linkType}'`, () => {
         const dispatch = helper.sandbox.stub()
         currentChannel.link_type = linkType
         const page = new InnerCreatePostPage()

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -128,3 +128,6 @@ export const removeTrailingSlash = (str: string) =>
   str.length > 0 && str[str.length - 1] === "/"
     ? str.substr(0, str.length - 1)
     : str
+
+export const emptyOrNil = R.either(R.isEmpty, R.isNil)
+export const allEmptyOrNil = R.all(emptyOrNil)

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -5,6 +5,7 @@ import R from "ramda"
 
 import { S } from "./sanctuary"
 import { LINK_TYPE_LINK } from "../lib/channels"
+import { emptyOrNil } from "../lib/util"
 
 import type { PostForm } from "../flow/discussionTypes"
 
@@ -40,8 +41,6 @@ export const validate = R.curry((validations, toValidate) =>
     validations
   )(toValidate)
 )
-
-export const emptyOrNil = R.either(R.isEmpty, R.isNil)
 
 export const validEmail = R.compose(
   R.test(/^\S+@\S+\.\S+$/), // matches any email that matches the format local@domain.tld


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1264 

#### What's this PR do?
Refactors some potentially confusing logic around updating the post creation form when the selected channel changes

#### How should this be manually tested?
Click through channels of different types while looking at the post creation page. Make sure the form updates as expected

#### Any background context you want to provide?
- I already wrote most of the code for this in a previous PR review, so it was easy enough to put together this PR
- The test parameters I deleted in `static/js/containers/CreatePostPage_test.js` were impossible scenarios
