### PR TITLE
Shorten menu options

### DIFF
--- a/static/js/components/CommentRemovalForm.js
+++ b/static/js/components/CommentRemovalForm.js
@@ -33,7 +33,7 @@ const CommentRemovalForm = ({
       }-button`}
       onClick={preventDefaultAndInvoke(() => commentAction(comment))}
     >
-      <a href="#">{comment.removed ? "Approve content" : "Remove content"}</a>
+      <a href="#">{comment.removed ? "Approve" : "Remove"}</a>
     </div>
   )
 }

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -201,7 +201,7 @@ export default class CommentTree extends React.Component<Props> {
                     ignoreCommentReports(comment)
                   )}
                 >
-                  <a href="#">Ignore report</a>
+                  <a href="#">Ignore reports</a>
                 </div>
               </li>
             ) : null}

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -385,7 +385,7 @@ describe("CommentTree", () => {
         ...openDropdownMenu(report.comment)
       })
       const ignoreButton = wrapper.find(".ignore-button")
-      assert.equal(ignoreButton.text(), "Ignore report")
+      assert.equal(ignoreButton.text(), "Ignore reports")
       const eventStub = {
         preventDefault: helper.sandbox.stub()
       }

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -91,7 +91,8 @@ export class CompactPostDisplay extends React.Component<Props> {
                   </Link>
                   {post.author_headline ? (
                     <span className="author-headline">
-                      &nbsp;&#8212;&nbsp;{post.author_headline}
+                      &nbsp;&#8212;&nbsp;
+                      {post.author_headline}
                     </span>
                   ) : null}
                 </div>
@@ -174,7 +175,9 @@ export class CompactPostDisplay extends React.Component<Props> {
                 ) : null}
                 {isModerator && ignorePostReports ? (
                   <li>
-                    <a onClick={() => ignorePostReports(post)}>Ignore reports</a>
+                    <a onClick={() => ignorePostReports(post)}>
+                      Ignore reports
+                    </a>
                   </li>
                 ) : null}
                 {!userIsAnonymous() && reportPost ? (

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -169,7 +169,7 @@ export class CompactPostDisplay extends React.Component<Props> {
                 ) : null}
                 {isModerator && removePost ? (
                   <li>
-                    <a onClick={() => removePost(post)}>Remove content</a>
+                    <a onClick={() => removePost(post)}>Remove</a>
                   </li>
                 ) : null}
                 {isModerator && ignorePostReports ? (

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -174,7 +174,7 @@ export class CompactPostDisplay extends React.Component<Props> {
                 ) : null}
                 {isModerator && ignorePostReports ? (
                   <li>
-                    <a onClick={() => ignorePostReports(post)}>Ignore report</a>
+                    <a onClick={() => ignorePostReports(post)}>Ignore reports</a>
                   </li>
                 ) : null}
                 {!userIsAnonymous() && reportPost ? (

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -300,7 +300,7 @@ describe("CompactPostDisplay", () => {
         isModerator: true,
         removePost:  removePostStub
       })
-      const link = wrapper.find({ children: "Remove content" })
+      const link = wrapper.find({ children: "Remove" })
       assert(link.exists())
       link.simulate("click")
       assert.ok(removePostStub.calledWith(post))

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -313,7 +313,7 @@ describe("CompactPostDisplay", () => {
         isModerator:       true,
         ignorePostReports: ignorePostStub
       })
-      const link = wrapper.find({ children: "Ignore report" })
+      const link = wrapper.find({ children: "Ignore reports" })
       assert(link.exists())
       link.simulate("click")
       assert.ok(ignorePostStub.calledWith(post))

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -146,14 +146,14 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
               {isModerator && !post.removed ? (
                 <li className="comment-action-button remove-post">
                   <a onClick={this.removePost.bind(this)} href="#">
-                    Remove content
+                    Remove
                   </a>
                 </li>
               ) : null}
               {isModerator && post.removed ? (
                 <li className="comment-action-button approve-post">
                   <a onClick={this.approvePost.bind(this)} href="#">
-                    Approve content
+                    Approve
                   </a>
                 </li>
               ) : null}

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -50,7 +50,7 @@ export default class UserMenu extends React.Component<Props> {
             </li>
             {SETTINGS.profile_ui_enabled && SETTINGS.username ? (
               <li>
-                <Link to={profileURL(SETTINGS.username)}>View Profile</Link>
+                <Link to={profileURL(SETTINGS.username)}>Profile</Link>
               </li>
             ) : null}
             {SETTINGS.allow_email_auth ? (


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

fixes #1301

#### What's this PR do?

Shortens "Remove Content" and "Approve Content" in the overflow menus of post summary cards and comment cards to "Remove" and "Approve"

#### How should this be manually tested?

1. Channel Listing page: post summary card overflow menu should have item "Remove" instead of "Remove Content"
2. Post Detail page: overflow menu should have item "Remove" instead of "Remove Content"
3. After removing the post, the overflow menu should update with "Approve" instead of "Approve Content"
4. Comment card overflow menu should have item "Remove" instead of "Remove Content"
3. After removing the comment, the overflow menu should update with "Approve" instead of "Approve Content"

#### Where should the reviewer start?

Did tests pass? 
