### PR TITLE
move the channel edit button to channel banner

### DIFF
--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -3,7 +3,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 import ChannelAvatar from "../containers/ChannelAvatar"
-import { channelURL, editChannelBasicURL } from "../lib/url"
+import { channelURL } from "../lib/url"
 import type { Channel } from "../flow/discussionTypes"
 
 type Props = {
@@ -27,14 +27,6 @@ export default class SubscriptionsList extends React.Component<Props> {
           <ChannelAvatar channel={channel} imageSize="small" />
           <span className="title">{channel.title}</span>
         </Link>
-        {channel.user_is_moderator ? (
-          <Link
-            to={editChannelBasicURL(channel.name)}
-            className="settings-link"
-          >
-            Edit
-          </Link>
-        ) : null}
       </div>
     )
   }

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -3,7 +3,7 @@ import { assert } from "chai"
 
 import SubscriptionsList from "./SubscriptionsList"
 
-import { channelURL, editChannelBasicURL } from "../lib/url"
+import { channelURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 import { configureShallowRenderer } from "../lib/test_utils"
 
@@ -54,20 +54,6 @@ describe("SubscriptionsList", function() {
         notMyChannels[index]
       )
     })
-  })
-
-  it("should show settings links for channels you are moderator of", () => {
-    const wrapper = renderSubscriptionsList()
-
-    assert.equal(
-      wrapper.find(".my-channels .settings-link").length,
-      myChannels.length
-    )
-    wrapper.find(".my-channels .settings-link").forEach((link, index) => {
-      assert.equal(link.props().to, editChannelBasicURL(myChannels[index].name))
-    })
-
-    assert.equal(wrapper.find(".channels .settings-link").length, 0)
   })
 
   it("should highlight the current channel", () => {

--- a/static/js/containers/ChannelBanner.js
+++ b/static/js/containers/ChannelBanner.js
@@ -46,6 +46,7 @@ class ChannelBanner extends React.Component<Props> {
             alt={`Channel banner for ${channel.name}`}
             className={`banner-image`}
           />
+          <div className="gradient" />
           {editable ? (
             <React.Fragment>
               <ImageUploader

--- a/static/js/containers/ChannelBanner_test.js
+++ b/static/js/containers/ChannelBanner_test.js
@@ -29,6 +29,8 @@ describe("ChannelBanner", () => {
   afterEach(() => {
     helper.cleanup()
   })
+
+  //
   ;[true, false].forEach(hasBanner => {
     it("renders an image", async () => {
       channel.banner = hasBanner ? "channel" : null
@@ -38,12 +40,15 @@ describe("ChannelBanner", () => {
         inner.find("img").props().alt,
         `Channel banner for ${channel.name}`
       )
+      assert.ok(inner.find(".gradient").exists())
       assert.equal(
         inner.find("img").props().src,
         hasBanner ? channel.banner : defaultChannelBannerUrl
       )
     })
   })
+
+  //
   ;[true, false].forEach(editable => {
     it(`${
       editable ? "renders" : "doesn't render"
@@ -66,6 +71,8 @@ describe("ChannelBanner", () => {
         assert.equal(imageUploader.props().isAdd, !hasBanner)
       })
     })
+
+    //
     ;[true, false].forEach(hasFormImageUrl => {
       it(`${
         hasFormImageUrl ? "provides" : "doesn't provide"
@@ -83,6 +90,8 @@ describe("ChannelBanner", () => {
       })
     })
   })
+
+  //
   ;["name", "onUpdate"].forEach(field => {
     it(`passes in ${field}`, async () => {
       const value = field

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -5,6 +5,7 @@ import R from "ramda"
 import qs from "query-string"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
+import { Link } from "react-router-dom"
 
 import CanonicalLink from "../components/CanonicalLink"
 import { withPostLoadingSidebar } from "../components/Loading"
@@ -35,6 +36,7 @@ import { formatTitle } from "../lib/title"
 import { clearChannelError } from "../actions/channel"
 import { evictPostsForChannel } from "../actions/posts_for_channel"
 import { updatePostSortParam, POSTS_SORT_HOT } from "../lib/sorting"
+import { editChannelBasicURL } from "../lib/url"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -117,7 +119,8 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
       subscribedChannels,
       posts,
       location: { search },
-      renderPosts
+      renderPosts,
+      isModerator
     } = this.props
 
     if (!channel || !subscribedChannels || !posts) {
@@ -128,15 +131,27 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
           <ChannelBanner editable={false} channel={channel} />
           <Grid className={`main-content two-column channel-page`}>
             <Cell className="avatar-headline-row" width={12}>
-              <ChannelAvatar
-                editable={false}
-                channel={channel}
-                imageSize={CHANNEL_AVATAR_MEDIUM}
-              />
-              <div className="title-and-headline">
-                <div className="title">{channel.title}</div>
-                {channel.public_description ? (
-                  <div className="headline">{channel.public_description}</div>
+              <div className="left">
+                <ChannelAvatar
+                  editable={false}
+                  channel={channel}
+                  imageSize={CHANNEL_AVATAR_MEDIUM}
+                />
+                <div className="title-and-headline">
+                  <div className="title">{channel.title}</div>
+                  {channel.public_description ? (
+                    <div className="headline">{channel.public_description}</div>
+                  ) : null}
+                </div>
+              </div>
+              <div className="right">
+                {isModerator ? (
+                  <Link
+                    to={editChannelBasicURL(channel.name)}
+                    className="edit-button"
+                  >
+                    <i className="material-icons settings">settings</i>
+                  </Link>
                 ) : null}
               </div>
             </Cell>

--- a/static/scss/channel-banner.scss
+++ b/static/scss/channel-banner.scss
@@ -3,11 +3,25 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    position: relative;
 
-    .banner-image {
+    .gradient {
+      background-image: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0),
+        rgba(0, 0, 0, 0.5)
+      );
+      position: absolute;
+    }
+
+    .banner-image,
+    .gradient {
       width: 100%;
       display: block;
       height: $channel-banner-height;
+    }
+
+    .banner-image {
       object-fit: cover;
     }
 

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -1,13 +1,27 @@
+.app .content .main-content.channel-page {
+  margin-top: 0;
+}
+
 .channel-page-wrapper {
   position: relative;
+
+  .banner-container {
+    position: absolute;
+    width: 100%;
+    z-index: -1;
+  }
 }
 
 .avatar-headline-row {
-  position: absolute;
-  top: 0;
   height: $channel-banner-height;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+
+  .left {
+    display: flex;
+    align-items: center;
+  }
 
   .avatar-image,
   .avatar-initials {
@@ -32,6 +46,10 @@
     .headline {
       font-size: 16px;
     }
+  }
+
+  .edit-button {
+    color: white;
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1271 
closes #1291 

#### What's this PR do?

This moves the edit icon up to the channel banner on the channel page, and removes it from the nav sidebar.

To get this to work I had to fiddle with the styling of the channel banner and the stuff that goes above it a little bit - I think it's cleaner now, in any case.

#### How should this be manually tested?

If you are looking at a channel you should see an edit icon up top, provided you're a moderator. If you're not, you shouldn't see it. The layout should also do alright with resizing the screen horizontally - the stuff in the channel banner up top should always be justified to the same width as the post list and everything else on the page.

desktop:

![editbutton](https://user-images.githubusercontent.com/6207644/46494919-1265d500-c7e2-11e8-82ef-0f120bc89962.png)

mobile:

![editbuttonmob](https://user-images.githubusercontent.com/6207644/46494931-185bb600-c7e2-11e8-8487-85123ea55885.png)
