### PR TITLE
Added login popup/tooltip to drawer compose button

### DIFF
--- a/static/js/components/LoginPopup.js
+++ b/static/js/components/LoginPopup.js
@@ -20,7 +20,7 @@ export class LoginPopupHelper extends React.Component<LoginPopupProps> {
   }
 
   render() {
-    const { visible, className } = this.props
+    const { visible, className, closePopup } = this.props
     return visible ? (
       <div className={`popup login-popup ${className || ""}`}>
         <div className="triangle" />
@@ -34,10 +34,10 @@ export class LoginPopupHelper extends React.Component<LoginPopupProps> {
         </div>
         <div className="bottom-row">
           <div className="popup-buttons">
-            <Link className="link-button" to="/login">
+            <Link className="link-button" to="/login" onClick={closePopup}>
               Log In
             </Link>
-            <Link className="link-button red" to="/signup">
+            <Link className="link-button red" to="/signup" onClick={closePopup}>
               Sign Up
             </Link>
           </div>

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -1,65 +1,110 @@
 // @flow
 import React from "react"
-import R from "ramda"
 import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
+import LoginPopup from "./LoginPopup"
 
-import { userCanPost } from "../lib/channels"
-import {
-  newPostURL,
-  getChannelNameFromPathname,
-  FRONTPAGE_URL
-} from "../lib/url"
-import { userIsAnonymous } from "../lib/util"
+import { getChannelNameFromPathname, FRONTPAGE_URL } from "../lib/url"
+import { preventDefaultAndInvoke, userIsAnonymous } from "../lib/util"
 
 import type { Channel } from "../flow/discussionTypes"
 
 type NavigationProps = {
-  channels: Map<string, Channel>,
   pathname: string,
-  subscribedChannels: Array<Channel>
+  subscribedChannels: Array<Channel>,
+  showComposeLink: boolean,
+  composeHref: ?string,
+  useLoginPopup: boolean
 }
 
-const Navigation = (props: NavigationProps) => {
-  const { channels, subscribedChannels, pathname } = props
+type State = {
+  popupVisible: boolean
+}
 
-  const channelName = getChannelNameFromPathname(pathname)
+class Navigation extends React.Component<NavigationProps, State> {
+  constructor() {
+    super()
+    this.state = {
+      popupVisible: false
+    }
+  }
 
-  const currentChannel = channels.get(channelName)
-  const showPostButton =
-    !userIsAnonymous() &&
-    (currentChannel
-      ? userCanPost(currentChannel)
-      : R.any(userCanPost, [...channels.values()]))
+  onTogglePopup = async () => {
+    const { popupVisible } = this.state
+    this.setState({
+      popupVisible: !popupVisible
+    })
+  }
 
-  const homeClassName =
-    pathname === "/" ? "location current-location" : "location"
+  render() {
+    const {
+      subscribedChannels,
+      pathname,
+      showComposeLink,
+      composeHref,
+      useLoginPopup
+    } = this.props
 
-  return (
-    <div className="navigation">
-      <div className="location-list">
-        <div className={homeClassName}>
-          <Link className="home-link" to={FRONTPAGE_URL}>
-            <i className="material-icons home">home</i>
-            <span className="title">Home</span>
+    const channelName = getChannelNameFromPathname(pathname)
+    const homeClassName =
+      pathname === "/" ? "location current-location" : "location"
+
+    let composeBtn
+    if (showComposeLink) {
+      const composeBtnContents = (
+        <React.Fragment>
+          <i className="material-icons add">add</i>
+          <span className="title">Compose</span>
+        </React.Fragment>
+      )
+
+      if (useLoginPopup) {
+        composeBtn = (
+          <a
+            href="#"
+            onClick={preventDefaultAndInvoke(this.onTogglePopup)}
+            className="new-post-link"
+          >
+            {composeBtnContents}
+          </a>
+        )
+      } else if (composeHref) {
+        composeBtn = (
+          <Link to={composeHref} className="new-post-link">
+            {composeBtnContents}
           </Link>
+        )
+      }
+    }
+
+    return (
+      <div className="navigation">
+        <div className="location-list">
+          <div className={homeClassName}>
+            <Link className="home-link" to={FRONTPAGE_URL}>
+              <i className="material-icons home">home</i>
+              <span className="title">Home</span>
+            </Link>
+          </div>
         </div>
+        {composeBtn ? (
+          <div className="new-post-link-container">{composeBtn}</div>
+        ) : null}
+        {userIsAnonymous() ? (
+          <LoginPopup
+            visible={this.state.popupVisible}
+            closePopup={this.onTogglePopup}
+            className="compose-popup"
+          />
+        ) : null}
+        <SubscriptionsList
+          currentChannel={channelName}
+          subscribedChannels={subscribedChannels}
+        />
       </div>
-      {showPostButton ? (
-        <div className="new-post-link-container">
-          <Link className="new-post-link" to={newPostURL(channelName)}>
-            <i className="material-icons add">add</i>
-            <span className="title">Compose</span>
-          </Link>
-        </div>
-      ) : null}
-      <SubscriptionsList
-        currentChannel={channelName}
-        subscribedChannels={subscribedChannels}
-      />
-    </div>
-  )
+    )
+  }
 }
 
 export default Navigation

--- a/static/js/components/Navigation_test.js
+++ b/static/js/components/Navigation_test.js
@@ -1,16 +1,15 @@
 // @flow
 import { assert } from "chai"
-import { Link } from "react-router-dom"
 import sinon from "sinon"
 
 import Navigation from "./Navigation"
 import SubscriptionsList from "./SubscriptionsList"
 
 import * as channels from "../lib/channels"
-import { newPostURL, FRONTPAGE_URL, channelURL } from "../lib/url"
-import { makeChannelList } from "../factories/channels"
 import * as util from "../lib/util"
-import { configureShallowRenderer } from "../lib/test_utils"
+import { channelURL } from "../lib/url"
+import { configureShallowRenderer, shouldIf } from "../lib/test_utils"
+import { makeChannelList } from "../factories/channels"
 
 describe("Navigation", () => {
   let sandbox,
@@ -28,10 +27,7 @@ describe("Navigation", () => {
     const subscribedChannels = makeChannelList(10)
     defaultProps = {
       pathname:           "/",
-      subscribedChannels: subscribedChannels,
-      channels:           new Map(
-        subscribedChannels.map(channel => [channel.name, channel])
-      )
+      subscribedChannels: subscribedChannels
     }
     renderComponent = configureShallowRenderer(Navigation, defaultProps)
   })
@@ -40,88 +36,60 @@ describe("Navigation", () => {
     sandbox.restore()
   })
 
-  describe("create post link", () => {
-    it("should not have channel name if channelName is not in URL", () => {
-      const wrapper = renderComponent()
-      assert.lengthOf(wrapper.find(Link), 2)
-      const link = wrapper.find(".new-post-link")
-      assert.equal(link.props().to, "/create_post/")
-      assert.equal(
-        link
-          .children()
-          .at(1)
-          .text(),
-        "Compose"
-      )
-    })
+  describe("compose link", () => {
+    const postLinkSel = ".new-post-link"
 
-    it("should highlight the home link if, well, home", () => {
-      const wrapper = renderComponent()
-      assert.ok(
-        wrapper
-          .find(".location.current-location")
-          .find(".home-link")
-          .exists()
-      )
-    })
-
-    it("shouldn't highlight the homelink if not home!", () => {
+    it("should not be shown if the showComposeLink=false", () => {
       const wrapper = renderComponent({
-        pathname: "/hfodfo/asdfasdfasdf"
+        showComposeLink: false
       })
-      assert.isNotOk(
-        wrapper
-          .find(".location.current-location")
-          .find(".home-link")
-          .exists()
-      )
+      assert.isFalse(wrapper.find(postLinkSel).exists())
     })
 
-    it("create post link should have channel name if channelName is in URL", () => {
-      const wrapper = renderComponent({
-        pathname: channelURL("foobar")
-      })
-      const link = wrapper.find(".new-post-link")
-      assert.equal(link.props().to, newPostURL("foobar"))
-      assert.equal(
-        link
-          .children()
-          .at(1)
-          .text(),
-        "Compose"
-      )
-    })
-
-    it("should not show the create post link if an anonymous user", () => {
+    it("should show a tooltip when clicked if useLoginPopup=true", async () => {
       userIsAnonymousStub.returns(true)
-      const wrapper = renderComponent()
-      assert.isNotOk(wrapper.find(".mdc-button").exists())
-    })
-
-    it("should not show the create post link if the user can't post in the channel", () => {
-      userCanPostStub.returns(false)
-      const channel = defaultProps.subscribedChannels[3]
       const wrapper = renderComponent({
-        pathname: channelURL(channel.name)
+        showComposeLink: true,
+        useLoginPopup:   true
       })
-      assert.isNotOk(wrapper.find(".mdc-button").exists())
-      assert.equal(userCanPostStub.callCount, 1)
-      sinon.assert.calledWith(userCanPostStub, channel)
+      const newPostLink = wrapper.find(postLinkSel)
+      assert.equal(newPostLink.prop("href"), "#")
+      assert.isFalse(wrapper.state("popupVisible"))
+      await newPostLink.simulate("click", null)
+      assert.isTrue(wrapper.state("popupVisible"))
     })
 
-    it("should not show the create post link if the user can't post in any channel", () => {
-      userCanPostStub.returns(false)
-      const wrapper = renderComponent()
-      assert.isNotOk(wrapper.find(".mdc-button").exists())
-      assert.equal(
-        userCanPostStub.callCount,
-        defaultProps.subscribedChannels.length
-      )
-      defaultProps.subscribedChannels.forEach(channel => {
-        sinon.assert.calledWith(userCanPostStub, channel)
+    it("should link to a page indicated by the composeHref prop", () => {
+      const composeHref = "/path/to/compose"
+      const wrapper = renderComponent({
+        showComposeLink: true,
+        useLoginPopup:   false,
+        composeHref:     composeHref
       })
+      const newPostLink = wrapper.find(postLinkSel)
+      assert.equal(newPostLink.prop("to"), composeHref)
     })
   })
+
+  //
+  ;[[null, true], ["/not/home", false]].forEach(
+    ([pathnameProp, expHighlighted]) => {
+      it(`${shouldIf(expHighlighted)} highlight the home link if path=${String(
+        pathnameProp
+      )}`, () => {
+        const wrapper = renderComponent(
+          pathnameProp ? { pathname: pathnameProp } : {}
+        )
+        assert.equal(
+          wrapper
+            .find(".location.current-location")
+            .find(".home-link")
+            .exists(),
+          expHighlighted
+        )
+      })
+    }
+  )
 
   it("should show a SubscriptionsList", () => {
     const channels = makeChannelList(10)
@@ -142,17 +110,5 @@ describe("Navigation", () => {
       wrapper.find(SubscriptionsList).props().currentChannel,
       "foobar"
     )
-  })
-
-  it("should have to link to home", () => {
-    const wrapper = renderComponent().find(".home-link")
-    assert.equal(wrapper.find(".title").text(), "Home")
-    assert.equal(wrapper.props().to, FRONTPAGE_URL)
-  })
-
-  it("should hide the link to settings, if the user is anonymous", () => {
-    userIsAnonymousStub.returns(true)
-    const wrapper = renderComponent()
-    assert.isNotOk(wrapper.find(".settings-link").exists())
   })
 })

--- a/static/js/factories/util.js
+++ b/static/js/factories/util.js
@@ -2,7 +2,7 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
-import type { Match } from "react-router"
+import type { Match, Location } from "react-router"
 
 export const arrayN = (min: number, max: number) =>
   R.range(0, casual.integer(min, max))
@@ -25,4 +25,10 @@ export const makeMatch = (url: string): Match => ({
   isExact: true,
   params:  {},
   path:    ""
+})
+
+export const makeLocation = (pathname: string): Location => ({
+  pathname: pathname,
+  search:   "",
+  hash:     ""
 })

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -54,6 +54,7 @@ $footer-height: 132px;
     margin-top: 61px;
 
     .new-post-link {
+      background-color: #ffffff;
       color: $red-link-color;
       display: inline-flex;
       align-items: center;
@@ -63,23 +64,6 @@ $footer-height: 132px;
       border-radius: 30px;
       height: 26px;
     }
-  }
-
-  .mdc-button {
-    width: 87%;
-    height: 43px;
-    line-height: 43px;
-    font-size: 15px;
-    text-transform: none;
-    font-weight: 500;
-    padding: 0 5px;
-    box-shadow: none;
-    margin-left: 14px;
-  }
-
-  .mdc-button:hover {
-    box-shadow: 2px 3px 5px 0px rgba(0, 0, 0, 0.2);
-    transition: none;
   }
 
   .current-location {

--- a/static/scss/popup.scss
+++ b/static/scss/popup.scss
@@ -124,4 +124,12 @@
   &.post-upvote-popup {
     margin-top: 97px;
   }
+
+  &.compose-popup {
+    top: 150px;
+
+    .triangle {
+      left: 80px;
+    }
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1227 

#### What's this PR do?
Adds the compose button back into the drawer for anonymous users and shows the signup prompt when it's clicked

#### How should this be manually tested?
Click the "Compose" button as an anonymous user

#### Screenshots (if appropriate)
![ss 2018-10-04 at 17 02 35](https://user-images.githubusercontent.com/14932219/46503274-5c59b580-c7f8-11e8-820f-4765fef143dc.png)

