### PR TITLE
Channel-specific analytics should trigger on direct URL load

### DIFF
--- a/static/js/hoc/withChannelTracker.js
+++ b/static/js/hoc/withChannelTracker.js
@@ -5,6 +5,8 @@ import R from "ramda"
 
 const shouldLoadData = R.complement(
   R.allPass([
+    // if channel name doesn't match
+    R.eqBy(R.path(["channel", "name"])),
     // if URL path doesn't match
     R.eqBy(R.path(["location", "search"]))
   ])

--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -56,11 +56,12 @@ describe("withTracker", () => {
   })
 
   //
-  ;[true, false].forEach(updateChannel => {
+  ;[[true, 4], [false, 2]].forEach(([missingPrevChannel, gaCalls]) => {
     it(`${shouldIf(
-      updateChannel
-    )} call loadGA() on componentDidUpdate`, async () => {
+      missingPrevChannel
+    )} call google analytics on componentDidUpdate`, async () => {
       channel.ga_tracking_id = "UA-FAKE-01"
+      const prevChannel = missingPrevChannel ? null : channel
       window.location = "http://fake/c/path"
       const { wrapper } = await render(
         {},
@@ -68,10 +69,10 @@ describe("withTracker", () => {
       )
       const prevProps = {
         location: window.location,
-        channel:  updateChannel ? null : channel
+        channel:  prevChannel
       }
       wrapper.instance().componentDidUpdate(prevProps)
-      assert.equal(gaGaStub.callCount, updateChannel ? 4 : 2)
+      assert.equal(gaGaStub.callCount, gaCalls)
     })
   })
 })

--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -1,33 +1,40 @@
 import React from "react"
 import ReactGA from "react-ga"
-import sinon from "sinon"
 import { assert } from "chai"
-import { shallow } from "enzyme"
 
 import { makeChannel } from "../factories/channels"
 import { withChannelTracker } from "./withChannelTracker"
-import { TestPage } from "../lib/test_utils"
+import { shouldIf, TestPage } from "../lib/test_utils"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("withTracker", () => {
-  let sandbox, gaGaStub, channel, WrappedPage
-
-  const renderPage = ({ ...props }) => shallow(<WrappedPage {...props} />)
+  let helper, render, gaGaStub, channel, WrappedPage
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    gaGaStub = sandbox.stub(ReactGA, "ga")
+    helper = new IntegrationTestHelper()
+    gaGaStub = helper.sandbox.stub(ReactGA, "ga")
     channel = makeChannel()
+    WrappedPage = withChannelTracker(TestPage)
+    render = helper.configureHOCRenderer(
+      WrappedPage,
+      TestPage,
+      {},
+      {
+        channel:  channel,
+        location: { search: {} }
+      }
+    )
   })
 
   afterEach(() => {
-    sandbox.restore()
+    helper.cleanup()
   })
 
-  it("should call GA create and pageview if channel has a tracking id", () => {
+  it("should call GA create and pageview if channel has a tracking id", async () => {
     channel.ga_tracking_id = "UA-FAKE-01"
     window.location = "http://fake/c/path"
-    WrappedPage = withChannelTracker(TestPage)
-    renderPage({ location: window.location, channel: channel })
+
+    await render({}, { location: window.location, channel: channel })
     assert.ok(
       gaGaStub.calledWith("create", channel.ga_tracking_id, "auto", {
         name: "UA_FAKE_01"
@@ -42,11 +49,30 @@ describe("withTracker", () => {
     )
   })
 
-  it("should not call GA create and pageview if channel does not have a tracking id", () => {
+  it("should not call GA create and pageview if channel does not have a tracking id", async () => {
     channel.ga_tracking_id = null
     window.location = "http://fake/c/path"
-    WrappedPage = withChannelTracker(TestPage)
-    renderPage({ location: window.location, channel: channel })
+    await render({}, { location: window.location, channel: channel })
     assert.ok(gaGaStub.notCalled)
+  })
+
+  //
+  ;[true, false].forEach(updateChannel => {
+    it(`${shouldIf(
+      updateChannel
+    )} call loadGA() on componentDidUpdate`, async () => {
+      channel.ga_tracking_id = "UA-FAKE-01"
+      window.location = "http://fake/c/path"
+      const { wrapper } = await render(
+        {},
+        { location: window.location, channel: channel }
+      )
+      const prevProps = {
+        location: window.location,
+        channel:  updateChannel ? null : channel
+      }
+      wrapper.instance().componentDidUpdate(prevProps)
+      assert.equal(gaGaStub.callCount, updateChannel ? 4 : 2)
+    })
   })
 })

--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -1,4 +1,3 @@
-import React from "react"
 import ReactGA from "react-ga"
 import { assert } from "chai"
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1306

#### What's this PR do?
Triggers a channel-specific pageview to Google Analytics when a channel/post URL is loaded without navigating to it from within the app.

#### How should this be manually tested?
- Set `GA_TRACKING_ID` to any value in your `.env` file.
- In django admin, enter a fake google analytics tracking id for a channel (different from above).
- Manually enter the URL for that channel, and a URL for any post in that channel, into a browser tab, with network console open.  For each URL, two `collect` calls to Google Analytics should be made, one of which should be for the above tracking id, the other for the main tracking id.
- Navigate to Home, then navigate back to the channel, and then a post in that channel.  Two calls should be made for each of that channel's URLs.
