### PR TITLE
Fixed the --name arg to the set_channel_allow_top command

### DIFF
--- a/channels/management/commands/set_channel_allow_top.py
+++ b/channels/management/commands/set_channel_allow_top.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         allow_top = options['allow_top']
 
         if options['name']:
-            channels = channels.filter(name=options['name'])
+            channels = channels.filter(name__in=options['name'])
 
         api_user = User.objects.get(username=settings.INDEXING_API_USERNAME)
         api = Api(api_user)


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a silly mistake in filtering the channels by name in the command. `options['name']` is a list, so we needed `name__in=?`.

#### How should this be manually tested?
Run the command against a single channel name
