### PR TITLE
fix spacing for top of channel loading component

### DIFF
--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -113,5 +113,5 @@ export const withLoading = R.curry(
 export const withSpinnerLoading = withLoading(Loading)
 export const withPostLoading = withLoading(PostLoading)
 export const withPostLoadingSidebar = withLoading(
-  withChannelSidebar("channel-page", PostLoading)
+  withChannelSidebar("channel-page channel-loading", PostLoading)
 )

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -1,4 +1,4 @@
-.app .content .main-content.channel-page {
+.app .content .main-content.channel-page:not(.channel-loading) {
   margin-top: 0;
 }
 


### PR DESCRIPTION

#### What are the relevant tickets?

none

#### What's this PR do?

fixes a little style regression. when I made changes to add the channel banner to the top of the channel page I also changed things to set `margin-top: 0;` on the channel page. This had the side-effect of getting ride of the top padding when the loader animation was playing, so it looked like this:

![yuckything](https://user-images.githubusercontent.com/6207644/46758877-f52a7e00-cc9b-11e8-84f2-4385df5b5b00.png)

I meant to scope the `margin-top: 0;` to just when the page had loaded. This PR does just that, so it looks like this:

![yuckythingbetter](https://user-images.githubusercontent.com/6207644/46758945-20ad6880-cc9c-11e8-89fd-ee9f6a4b23b2.png)


#### How should this be manually tested?

reload the channel page, make sure the change described above is there.