### PR TITLE
Hide useless asteroid warnings when running tests

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -20,7 +20,7 @@ from profiles import api as profile_api
 from profiles.utils import update_full_name
 
 
-def validate_email_auth_request(strategy, backend, user=None, *args, **kwargs):  # pylint: disable=unused-argument
+def validate_email_auth_request(strategy, backend, user=None, **kwargs):  # pylint: disable=unused-argument
     """
     Validates an auth request for email
 
@@ -41,7 +41,7 @@ def validate_email_auth_request(strategy, backend, user=None, *args, **kwargs): 
     return {}
 
 
-def get_username(strategy, backend, user=None, *args, **kwargs):  # pylint: disable=unused-argument
+def get_username(strategy, backend, user=None, **kwargs):  # pylint: disable=unused-argument
     """
     Gets the username for a user
 
@@ -62,7 +62,7 @@ def get_username(strategy, backend, user=None, *args, **kwargs):  # pylint: disa
 
 @partial
 def require_password_and_profile_via_email(
-        strategy, backend, user=None, flow=None, current_partial=None, *args, **kwargs
+        strategy, backend, user=None, flow=None, current_partial=None, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Sets a new user's password and profile
@@ -102,7 +102,7 @@ def require_password_and_profile_via_email(
 
 @partial
 def require_profile_update_user_via_saml(
-        strategy, backend, user=None, is_new=False, *args, **kwargs
+        strategy, backend, user=None, is_new=False, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Sets a new user's password and profile, and updates the user first and last names.
@@ -138,7 +138,7 @@ def require_profile_update_user_via_saml(
 
 @partial
 def validate_password(
-        strategy, backend, user=None, flow=None, current_partial=None, *args, **kwargs
+        strategy, backend, user=None, flow=None, current_partial=None, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Validates a user's password for login

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -19,8 +19,10 @@ from open_discussions.settings import SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME
 from profiles import api as profile_api
 from profiles.utils import update_full_name
 
+# pylint: disable=keyword-arg-before-vararg
 
-def validate_email_auth_request(strategy, backend, user=None, **kwargs):  # pylint: disable=unused-argument
+
+def validate_email_auth_request(strategy, backend, user=None, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Validates an auth request for email
 
@@ -41,7 +43,7 @@ def validate_email_auth_request(strategy, backend, user=None, **kwargs):  # pyli
     return {}
 
 
-def get_username(strategy, backend, user=None, **kwargs):  # pylint: disable=unused-argument
+def get_username(strategy, backend, user=None, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Gets the username for a user
 
@@ -62,7 +64,7 @@ def get_username(strategy, backend, user=None, **kwargs):  # pylint: disable=unu
 
 @partial
 def require_password_and_profile_via_email(
-        strategy, backend, user=None, flow=None, current_partial=None, **kwargs
+        strategy, backend, user=None, flow=None, current_partial=None, *args, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Sets a new user's password and profile
@@ -102,7 +104,7 @@ def require_password_and_profile_via_email(
 
 @partial
 def require_profile_update_user_via_saml(
-        strategy, backend, user=None, is_new=False, **kwargs
+        strategy, backend, user=None, is_new=False, *args, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Sets a new user's password and profile, and updates the user first and last names.
@@ -138,7 +140,7 @@ def require_profile_update_user_via_saml(
 
 @partial
 def validate_password(
-        strategy, backend, user=None, flow=None, current_partial=None, **kwargs
+        strategy, backend, user=None, flow=None, current_partial=None, *args, **kwargs
 ):  # pylint: disable=unused-argument
     """
     Validates a user's password for login

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -669,6 +669,7 @@ def test_add_moderator(mock_client):
     """Test add moderator"""
     client = api.Api(UserFactory.create())
     moderator = UserFactory.create()
+    # pylint: disable=assignment-from-no-return
     redditor = client.add_moderator(moderator.username, 'channel_test_name')
     mock_client.subreddit.return_value.moderator.add.assert_called_once_with(moderator)
     # API function doesn't return the moderator. To do this the view calls _list_moderators

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -900,4 +900,4 @@ class ReportedContentSerializer(serializers.Serializer):
         Returns:
             list of str: list of reasons a post/comment has been reported for
         """
-        return sorted(list({report[0] for report in instance.user_reports + instance.mod_reports}))
+        return sorted({report[0] for report in instance.user_reports + instance.mod_reports})

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -900,4 +900,4 @@ class ReportedContentSerializer(serializers.Serializer):
         Returns:
             list of str: list of reasons a post/comment has been reported for
         """
-        return sorted(list(set([report[0] for report in instance.user_reports + instance.mod_reports])))
+        return sorted(list({report[0] for report in instance.user_reports + instance.mod_reports}))

--- a/open_discussions/settings_test.py
+++ b/open_discussions/settings_test.py
@@ -45,8 +45,8 @@ class TestSettings(TestCase):
         """Verify that we enable and configure S3 with a variable"""
         # Unset, we don't do S3
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_USE_S3': 'False'
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_USE_S3': 'False'
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertNotEqual(
@@ -56,17 +56,17 @@ class TestSettings(TestCase):
 
         with self.assertRaises(ImproperlyConfigured):
             with mock.patch.dict('os.environ', {
-                'OPEN_DISCUSSIONS_USE_S3': 'True',
+                    'OPEN_DISCUSSIONS_USE_S3': 'True',
             }, clear=True):
                 self.reload_settings()
 
         # Verify it all works with it enabled and configured 'properly'
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_USE_S3': 'True',
-            'AWS_ACCESS_KEY_ID': '1',
-            'AWS_SECRET_ACCESS_KEY': '2',
-            'AWS_STORAGE_BUCKET_NAME': '3',
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_USE_S3': 'True',
+                'AWS_ACCESS_KEY_ID': '1',
+                'AWS_SECRET_ACCESS_KEY': '2',
+                'AWS_STORAGE_BUCKET_NAME': '3',
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertEqual(
@@ -78,16 +78,16 @@ class TestSettings(TestCase):
         """Verify that we configure email with environment variable"""
 
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_ADMIN_EMAIL': '',
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_ADMIN_EMAIL': '',
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertFalse(settings_vars.get('ADMINS', False))
 
         test_admin_email = 'cuddle_bunnies@example.com'
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_ADMIN_EMAIL': test_admin_email,
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_ADMIN_EMAIL': test_admin_email,
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertEqual(
@@ -113,8 +113,8 @@ class TestSettings(TestCase):
 
         # Check enabling the setting explicitly
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_DB_DISABLE_SSL': 'True'
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_DB_DISABLE_SSL': 'True'
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertEqual(
@@ -124,8 +124,8 @@ class TestSettings(TestCase):
 
         # Disable it
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'OPEN_DISCUSSIONS_DB_DISABLE_SSL': 'False'
+                **REQUIRED_SETTINGS,
+                'OPEN_DISCUSSIONS_DB_DISABLE_SSL': 'False'
         }, clear=True):
             settings_vars = self.reload_settings()
             self.assertEqual(
@@ -137,9 +137,9 @@ class TestSettings(TestCase):
         """For PR builds we will use the heroku app name instead of the given ELASTICSEARCH_INDEX"""
         index_name = 'heroku_app_name_as_index'
         with mock.patch.dict('os.environ', {
-            **REQUIRED_SETTINGS,
-            'HEROKU_APP_NAME': index_name,
-            'HEROKU_PARENT_APP_NAME': 'some_name',
+                **REQUIRED_SETTINGS,
+                'HEROKU_APP_NAME': index_name,
+                'HEROKU_PARENT_APP_NAME': 'some_name',
         }):
             settings_vars = self.reload_settings()
             assert settings_vars['ELASTICSEARCH_INDEX'] == index_name

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-ignore=migrations,.git
+ignore=migrations,.git,astroid,
 load-plugins = pylint_django
 
 [BASIC]

--- a/pylintrc
+++ b/pylintrc
@@ -20,4 +20,4 @@ ignored-modules=
 	betamax,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return, cyclic-import, duplicate-code, inconsistent-return-statements, keyword-arg-before-vararg, consider-using-set-comprehension, inconsistent-return-statements, raising-format-tuple
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return, cyclic-import, duplicate-code, inconsistent-return-statements,

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-ignore=migrations,.git,astroid,
+ignore=migrations,.git
 load-plugins = pylint_django
 
 [BASIC]
@@ -17,6 +17,7 @@ ignored-classes=
 ignored-modules=
 	six,
 	six.moves,
+	betamax,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return, cyclic-import, duplicate-code, inconsistent-return-statements, keyword-arg-before-vararg, consider-using-set-comprehension, inconsistent-return-statements, raising-format-tuple

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,6 @@ ignored-classes=
 ignored-modules=
 	six,
 	six.moves,
-	betamax,
 
 [MESSAGES CONTROL]
 disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, len-as-condition, no-else-return, cyclic-import, duplicate-code, inconsistent-return-statements,

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -122,7 +122,7 @@ def update_field_values_by_query(query, field_name, field_value):
     """
     conn = get_conn(verify=True)
     for alias in get_active_aliases():
-        es_response = conn.update_by_query(
+        es_response = conn.update_by_query(  # pylint: disable=unexpected-keyword-arg
             index=alias,
             doc_type=GLOBAL_DOC_TYPE,
             conflicts=UPDATE_CONFLICT_SETTING,
@@ -190,7 +190,7 @@ def increment_document_integer_field(doc_id, field_name, incr_amount):
         field_name (str): The name of the field to increment
         incr_amount (int): The amount to increment by
     """
-    _update_document_by_id(
+    _update_document_by_id(  # pylint: disable=redundant-keyword-arg
         doc_id,
         {
             "source": "ctx._source.{} += params.incr_amount".format(field_name),

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -237,7 +237,7 @@ def update_indexed_score(instance, instance_type, vote_action=None):
     elif vote_action in (VoteActions.DOWNVOTE, VoteActions.CLEAR_UPVOTE):
         vote_increment = -1
     else:
-        raise ValueError('Received an invalid vote action value: %s', vote_action)
+        raise ValueError('Received an invalid vote action value: %s' % vote_action)
 
     if instance_type != POST_TYPE:
         return

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-astroid==1.5.3 # fix https://github.com/PyCQA/pylint/issues/1609
+astroid==2.0.4
 bpython
 codecov
 ddt
@@ -7,14 +7,14 @@ ipdb
 nplusone>=0.8.1
 pdbpp
 pip-tools
-pylint==1.7.1
-pylint-django==0.7.2
+pylint==2.1.1
+pylint-django==2.0.2
 pytest
 pytest-cov
 pytest-django
 pytest-pep8
 pytest-mock
-pytest-pylint==0.6.0
+pytest-pylint==0.12.3
 pytest-lazy-fixture
 safety
 semantic-version


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1349

#### What's this PR do?
Prevents asteroid warnings (deprecations, etc) from showing up after running tests locally.

#### How should this be manually tested?
Run `docker-compose run web tox`.  There should not be a huge stream of asteroid warnings afterward.
