### PR TITLE
make the button on the image uploader form have type="button"

### DIFF
--- a/static/js/components/ImageUploaderForm.js
+++ b/static/js/components/ImageUploaderForm.js
@@ -125,7 +125,9 @@ export default class ImageUploaderForm<Form> extends React.Component<
       >
         <div className="desktop-upload-message">
           Drag an image here<br />or<br />
-          <button className="outlined">Click to select an image</button>
+          <button type="button" className="outlined">
+            Click to select an image
+          </button>
         </div>
         <div className="mobile-upload-message">Click to select a photo.</div>
       </Dropzone>


### PR DESCRIPTION
#### Pre-Flight checklist


- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

none, something I forgot about when working on #1338 

#### What's this PR do?

just puts `type="button"` on a button in the dialog box, to avoid an issue with default button behavior (see #1322 for details)

#### How should this be manually tested?

look at the image upload thing, and click the button. it should just open the file upload dialog, instead of sending you back to the channel page.