### PR TITLE
Third pass of email templates

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -5,6 +5,7 @@ from datetime import (
     datetime,
     timezone,
 )
+from urllib.parse import urlparse
 
 from django.contrib.auth import get_user_model
 from praw.models import Comment, MoreComments
@@ -244,6 +245,7 @@ class BasePostSerializer(RedditObjectSerializer):
     (no deserialization or validation), and does not fetch/serialize Subscription data
     """
     url = WriteableSerializerMethodField(allow_null=True)
+    url_domain = serializers.SerializerMethodField()
     thumbnail = WriteableSerializerMethodField(allow_null=True)
     text = WriteableSerializerMethodField(allow_null=True)
     title = serializers.CharField()
@@ -269,6 +271,10 @@ class BasePostSerializer(RedditObjectSerializer):
     def get_url(self, instance):
         """Returns a url or null depending on if it's a self post"""
         return instance.url if not instance.is_self else None
+
+    def get_url_domain(self, instance):
+        """Returns the url's domain or None"""
+        return urlparse(instance.url).hostname if not instance.is_self else None
 
     def get_thumbnail(self, instance):
         """ Returns a thumbnail url or null"""

--- a/channels/views/reports_test.py
+++ b/channels/views/reports_test.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from channels.api import Api
-from channels.utils import get_reddit_slug
+from channels.views.test_utils import default_post_response_data
 from open_discussions.constants import (
     NOT_AUTHENTICATED_ERROR_TYPE,
     PERMISSION_DENIED_ERROR_TYPE,
@@ -113,28 +113,10 @@ def test_list_reports(staff_client, private_channel_and_contributor, reddit_fact
         "reasons": ["spam"],
     }, {
         "post": {
-            "url": None,
-            "thumbnail": None,
-            "text": post.text,
-            "title": post.title,
-            "upvoted": False,
-            'removed': False,
-            "deleted": False,
-            "subscribed": False,
-            "score": 1,
-            "author_id": user.username,
-            "id": post.id,
-            "slug": get_reddit_slug(post.permalink),
-            "created": post.created,
-            "num_comments": 1,
-            "channel_name": channel.name,
-            "channel_title": channel.title,
-            'author_name': user.profile.name,
-            'author_headline': user.profile.headline,
-            'profile_image': image_uri(user.profile),
-            'edited': False,
-            "stickied": False,
+            **default_post_response_data(channel, post, user),
+            'num_comments': 1,
             'num_reports': 2,
+            'upvoted': False,
         },
         "comment": None,
         "reasons": ["bad", "junk"],

--- a/channels/views/test_utils.py
+++ b/channels/views/test_utils.py
@@ -1,0 +1,48 @@
+"""Utilities for tests"""
+from urllib.parse import urlparse
+
+from channels.utils import get_reddit_slug
+from profiles.utils import image_uri
+
+
+def default_post_response_data(channel, post, user):
+    """
+    Helper function. Returns a dict containing some of the data that we expect from the API given
+    a channel, post, and user.
+    """
+    # For some reason, the default values are different for staff and non-staff users
+    if user.is_staff:
+        user_dependent_defaults = {
+            'upvoted': False,
+            'num_reports': 0
+        }
+    else:
+        user_dependent_defaults = {
+            'upvoted': True,
+            'num_reports': None
+        }
+
+    return {
+        'url': post.url,
+        'url_domain': urlparse(post.url).hostname if post.url else None,
+        'thumbnail': None,
+        'text': post.text,
+        'title': post.title,
+        'removed': False,
+        'deleted': False,
+        'subscribed': False,
+        'score': 1,
+        'author_id': user.username,
+        'id': post.id,
+        'slug': get_reddit_slug(post.permalink),
+        'created': post.created,
+        'num_comments': 0,
+        'channel_name': channel.name,
+        'channel_title': channel.title,
+        "profile_image": image_uri(user.profile),
+        "author_name": user.profile.name,
+        "author_headline": user.profile.headline,
+        'edited': False,
+        "stickied": False,
+        **user_dependent_defaults
+    }

--- a/mail/api.py
+++ b/mail/api.py
@@ -30,6 +30,7 @@ from django.template.loader import render_to_string
 
 from open_discussions import features
 from open_discussions.auth_utils import get_encoded_and_signed_subscription_token
+from sites.api import get_default_site
 
 log = logging.getLogger()
 
@@ -88,6 +89,7 @@ def context_for_user(user, extra_context=None):
         'base_url': settings.SITE_BASE_URL,
         'use_new_branding': features.is_enabled(features.USE_NEW_BRANDING),
         'user': user,
+        'site_name': get_default_site().title,
     }
 
     if extra_context is not None:
@@ -108,6 +110,10 @@ def render_email_templates(template_name, context):
         (str, str, str): tuple of the templates for subject, text_body, html_body
     """
     subject_text = render_to_string('{}/subject.txt'.format(template_name), context).rstrip()
+
+    context.update({
+        'subject': subject_text,
+    })
     html_text = render_to_string('{}/body.html'.format(template_name), context)
 
     # pynliner internally uses bs4, which we can now modify the inlined version into a plaintext version

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -13,7 +13,7 @@ from open_discussions.factories import UserFactory
 
 pytestmark = [
     pytest.mark.django_db,
-    pytest.mark.usefixtures('email_settings'),
+    pytest.mark.usefixtures('email_settings', 'authenticated_site'),
 ]
 
 

--- a/mail/templates/comments/body.html
+++ b/mail/templates/comments/body.html
@@ -1,14 +1,12 @@
 {% extends "email_base.html" %}
 
-{% block title %}Re: [{{ channel.name|safe }}]  post.title|safe %}{% endblock %}
-
 {% block content %}
 <!-- 1 Column Text : BEGIN -->
   <tr>
       <td>
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 20px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px 0;">{{ comment.text }}</p>
                   </td>
               </tr>
@@ -22,9 +20,9 @@
               <tr>
                   <td class="button-td button-td-primary" style="border-radius: 4px; background: #ffffff;">
                        {% if is_comment_reply %}
-                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
+                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
                        {% else %}
-                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
+                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
                        {% endif %}
                   </td>
               </tr>

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
     <meta name="x-apple-disable-message-reformatting">  <!-- Disable auto-scale in iOS 10 Mail entirely -->
-    <title>{% block title %}{% endblock %}</title> <!-- The title tag shows in email notifications, like Android 4.4. -->
+    <title>{{ subject }}</title> <!-- The title tag shows in email notifications, like Android 4.4. -->
 
     <!-- Web Font / @font-face : BEGIN -->
     <!-- NOTE: If web fonts are not required, lines 10 - 27 can be safely removed. -->
@@ -255,15 +255,18 @@
 
             <!-- Clear Spacer : BEGIN -->
               <tr>
-                  <td aria-hidden="true" height="40" style="font-size: 0px; line-height: 0px;text-align:left">
+                  <td aria-hidden="true" height="40" style="font-size: 0px; line-height: 0px;">
                       &nbsp;
                   </td>
               </tr>
             <!-- Clear Spacer : END -->
 
+            <tr>
+              <td style="padding: 0 20px; text-align: left;">--</td>
+            </tr>
+
           </table>
           <!-- Email Body : END -->
-          <span>--</span>
 
           <!-- Email Footer : BEGIN -->
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 680px;">

--- a/mail/templates/frontpage/body.html
+++ b/mail/templates/frontpage/body.html
@@ -2,7 +2,6 @@
 {% load humanize %}
 {% load timeago %}
 
-{% block title %}{{ site_name }} - Recent Popular Posts{% endblock %}
 {% block content %}
 
 <!-- 1 Column Text : BEGIN -->
@@ -11,7 +10,7 @@
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
-                      <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Here are some recent posts you might have missed</h1>
+                      <h1 style="margin: 0 0 10px; font-size: 20px; line-height: 30px; color: #03152d; font-weight: bold;">Top Stories for You</h1>
                   </td>
               </tr>
             </table>
@@ -39,16 +38,17 @@
                         <div style="display:inline-block; margin: 0 -2px; min-width:320px; vertical-align:top;" class="stack-column">
                           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
-                              <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;" class="center-on-narrow">
-                                <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #03152d; font-weight: bold;">
-                                  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #03152d; font-weight: bold;">
-                                    {{ post.title }}
+                              <td dir="ltr" style="font-family: sans-serif; font-size: 12px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;">
+                                <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 14px; line-height: 14px; color: #03152d; font-weight: bold;">
+                                  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 14px; line-height: 22px; color: #03152d; font-weight: bold;">
+                                    {{ post.title }}{% if post.url_domain %} <span style="color:#b0b0b0; font-size: 12px;">({{ post.url_domain }})</span>{% endif %}
                                   </a>
                                 </h2>
                                 <p style="margin: 0 0 10px 0;">{# NOTE: this next line is intentionally long so it renders correctly in plaintext #}
                                   <a href="{{ base_url }}{% url 'profile' username=post.author_id %}" style="color: #212121">{{ post.author_name }}</a>{% if post.author_headline %}<span style="color: #b0b0b0;">&nbsp;&#8212;&nbsp;{{ post.author_headline }}</span>{% endif %}
+                                  <br/>
+                                  <span style="margin: 0 0 10px 0; color: #b0b0b0;">{{ post.created|parse_iso|naturaltime }} in <a href="{{ base_url }}{% url 'channel' channel_name=post.channel_name %}" style="color: #212121">{{ post.channel_title }}</a></span>
                                 </p>
-                                <p style="margin: 0 0 10px 0; color: #b0b0b0;">{{ post.created|parse_iso|naturaltime }}</p>
                               </td>
                             </tr>
                           </table>
@@ -62,12 +62,12 @@
                 </tr>
               {% endfor %}
                 <tr>
-                    <td style="padding: 20px;">
+                    <td style="padding: 5px;">
                         <!-- Button : BEGIN -->
                         <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                             <tr>
                                 <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                                     <a class="button-a button-a-primary" href="{{ base_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
+                                     <a class="button-a button-a-primary" href="{{ base_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
                                 </td>
                             </tr>
                         </table>

--- a/mail/templates/frontpage/subject.txt
+++ b/mail/templates/frontpage/subject.txt
@@ -1,1 +1,1 @@
-{{ posts.0.title|safe }}
+[{{ site_name }}] Top Stories for You

--- a/mail/templates/password_reset/body.html
+++ b/mail/templates/password_reset/body.html
@@ -1,15 +1,13 @@
 {% extends "email_base.html" %}
 
-{% block title %}Reset Password{% endblock %}
-
 {% block content %}
 <!-- 1 Column Text + Button : BEGIN -->
   <tr>
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
-                      <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Reset Your Password</h1>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 14px; line-height: 20px; color: #555555;">
+                      <h1 style="margin: 0 0 10px; font-size: 20px; line-height: 30px; color: #03152d; font-weight: bold;">Reset Your Password</h1>
                       <p style="margin: 0 0 10px;">You're receiving this email because you requested a password reset for your user account at {{ site_name }}.</p>
                       <p style="margin: 0 0 10px;">Please go to the following page and choose a new password:</p>
                   </td>
@@ -20,7 +18,7 @@
                       <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                           <tr>
                               <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                                   <a class="button-a button-a-primary" href="{{ base_url }}{% url 'password-reset-confirm' uid=uid token=token %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Reset Password</a>
+                                   <a class="button-a button-a-primary" href="{{ base_url }}{% url 'password-reset-confirm' uid=uid token=token %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Reset Password</a>
                               </td>
                           </tr>
                       </table>

--- a/mail/templates/verification/body.html
+++ b/mail/templates/verification/body.html
@@ -1,14 +1,12 @@
 {% extends "email_base.html" %}
 
-{% block title %}Verify your email{% endblock %}
-
 {% block content %}
 <!-- 1 Column Text + Button : BEGIN -->
   <tr>
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 14px; line-height: 20px; color: #555555;">
                       <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Verify your email</h1>
                       <p style="margin: 0 0 10px;">Thank you for joining {{ site_name }}. To finish joining, you just need to confirm that we got your email right.</p>
                       <p style="margin: 0 0 10px;">To confirm your email, please click this link:</p>
@@ -20,7 +18,7 @@
                       <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                           <tr>
                               <td class="button-td button-td-primary" style="border-radius: 4px; background: #ffffff;">
-                                   <a class="button-a button-a-primary" href="{{ confirmation_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Verify Your Email</a>
+                                   <a class="button-a button-a-primary" href="{{ confirmation_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Verify Your Email</a>
                               </td>
                           </tr>
                       </table>

--- a/mail/views.py
+++ b/mail/views.py
@@ -80,6 +80,8 @@ class EmailDebuggerView(View):
                         author_headline='Physics Professor',
                         author_id='njksdfg',
                         title="Batman Rules!",
+                        url='http://example.com/batman.jpg',
+                        url_domain='example.com',
                         slug='batman_rules',
                         created="2018-09-19T18:50:32+00:00",
                         channel_name='channel_name',

--- a/notifications/notifiers/comments_test.py
+++ b/notifications/notifiers/comments_test.py
@@ -10,7 +10,10 @@ from notifications.notifiers import comments
 from open_discussions import features
 from open_discussions.test_utils import any_instance_of
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures('authenticated_site'),
+]
 
 
 @pytest.mark.parametrize('is_enabled', [True, False])

--- a/notifications/notifiers/email_test.py
+++ b/notifications/notifiers/email_test.py
@@ -17,7 +17,7 @@ from open_discussions.test_utils import any_instance_of
 
 pytestmark = [
     pytest.mark.django_db,
-    pytest.mark.usefixtures('notifier_settings'),
+    pytest.mark.usefixtures('notifier_settings', 'authenticated_site'),
 ]
 
 

--- a/notifications/notifiers/frontpage_test.py
+++ b/notifications/notifiers/frontpage_test.py
@@ -23,7 +23,7 @@ from open_discussions.test_utils import any_instance_of
 
 pytestmark = [
     pytest.mark.django_db,
-    pytest.mark.usefixtures('notifier_settings'),
+    pytest.mark.usefixtures('notifier_settings', 'authenticated_site'),
 ]
 
 
@@ -129,7 +129,6 @@ def test_send_notification(mocker, user):
     })
 
     send_messages_mock.assert_called_once_with([any_instance_of(EmailMessage)])
-    assert send_messages_mock.call_args[0][0][0].subject == 'post\'s title'
 
 
 def test_send_notification_no_posts(mocker):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1325 

#### What's this PR do?
Updates email templates and fixes a bug where `{{ site_name }}` is not being set in the email context. Also updated quite a few tests to use the default response data stuff @gsidebo wrote to cut down on the amount of code.

#### How should this be manually tested?
Go to `/__emaildebugger__/` and test render the frontpage email and verify it matches the mockup (sans thumbnail images which we're still skipping)

#### Screenshots
![screenshot_2018-10-12 email debugger](https://user-images.githubusercontent.com/28598/46879234-71939d00-ce13-11e8-889a-53e47a97c044.png)

