### PR TITLE
Added fixes for email template font issues

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -184,6 +184,7 @@ class CustomPasswordResetEmail(DjoserPasswordResetEmail):
         """Adds base_url to the template context"""
         context = super().get_context_data()
         context['base_url'] = settings.SITE_BASE_URL
+        context['use_new_branding'] = features.is_enabled(features.USE_NEW_BRANDING)
         return context
 
 

--- a/mail/templates/comments/body.html
+++ b/mail/templates/comments/body.html
@@ -6,7 +6,7 @@
       <td>
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 20px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px 0;">{{ comment.text }}</p>
                   </td>
               </tr>
@@ -20,9 +20,9 @@
               <tr>
                   <td class="button-td button-td-primary" style="border-radius: 4px; background: #ffffff;">
                        {% if is_comment_reply %}
-                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
+                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post-comment' channel_name=post.channel_name post_id=post.id post_slug=post.slug comment_id=comment.id %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
                        {% else %}
-                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>.
+                         <a class="button-a button-a-primary" href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
                        {% endif %}
                   </td>
               </tr>

--- a/mail/templates/frontpage/body.html
+++ b/mail/templates/frontpage/body.html
@@ -9,78 +9,53 @@
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
-                      <h1 style="margin: 0 0 10px; font-size: 20px; line-height: 30px; color: #03152d; font-weight: bold;">Top Stories for You</h1>
+                  <td style="padding: 5px 20px 0; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                      <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Top Stories for You</h1>
                   </td>
               </tr>
             </table>
           </td>
         </tr>
 <!-- 1 Column Text : END -->
-<!-- Thumbnail Right, Text Left : BEGIN -->
-    <tr>
-        <!-- dir=rtl is where the magic happens. This can be changed to dir=ltr to swap the alignment on wide while maintaining stack order on narrow. -->
-        <td dir="rtl" height="100%" valign="top" width="100%" style="padding: 10px 0; background-color: #ffffff;">
-            <!--[if mso]>
-            <table align="center" role="presentation" border="0" cellspacing="0" cellpadding="0" width="660" style="width: 660px;">
+
+{% for post in posts %}
+<!-- 1 Column Text + Button : BEGIN -->
+<tr>
+   <td style="background-color: #ffffff;">
+       <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+           <tr>
+               <td style="padding: 10px 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+
+
+                   <h2 style="margin: 0 0 10px; font-family: sans-serif; font-size: 25px; line-height: 25px; color: #03152d; font-weight: bold;">
+                     <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #03152d; font-weight: bold;">
+                       {{ post.title }} {% if post.url_domain %}<span style="color:#b0b0b0; font-size: 12px;">({{ post.url_domain }})</span>{% endif %}
+                     </a>
+                   </h2>
+                   <p style="margin: 0 0 10px;">{# NOTE: this next line is intentionally long so it renders correctly in plaintext #}
+                     <a href="{{ base_url }}{% url 'profile' username=post.author_id %}" style="color: #212121">{{ post.author_name }}</a>{% if post.author_headline %}<span style="color: #b0b0b0;">&nbsp;&#8212;&nbsp;{{ post.author_headline }}</span>{% endif %}
+                     <br/>
+                     <span style="margin: 0 0 10px; color: #b0b0b0;">{{ post.created|parse_iso|naturaltime }}</span> in <a href="{{ base_url }}{% url 'channel' channel_name=post.channel_name %}" style="color: #212121">{{ post.channel_title }}</a>
+                   </p>
+               </td>
+           </tr>
+       </table>
+   </td>
+</tr>
+<!-- 1 Column Text + Button : END -->
+
+{% endfor %}
+<tr>
+    <td style="padding: 10px 20px;">
+        <!-- Button : BEGIN -->
+        <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
             <tr>
-            <td valign="top" width="660">
-            <![endif]-->
-            <table align="center" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:660px;">
-              {% for post in posts %}
-                <tr>
-                    <td align="center" valign="top" style="font-size:0; padding: 10px 0;">
-                        <!--[if mso]>
-                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="660" style="width: 660px;">
-                        <tr>
-                        <td valign="top" width="660" style="width: 660px;">
-                        <![endif]-->
-                        <div style="display:inline-block; margin: 0 -2px; min-width:320px; vertical-align:top;" class="stack-column">
-                          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                            <tr>
-                              <td dir="ltr" style="font-family: sans-serif; font-size: 12px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;">
-                                <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 14px; line-height: 14px; color: #03152d; font-weight: bold;">
-                                  <a href="{{ base_url }}{% url 'channel-post' channel_name=post.channel_name post_id=post.id post_slug=post.slug %}" style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 14px; line-height: 22px; color: #03152d; font-weight: bold;">
-                                    {{ post.title }}{% if post.url_domain %} <span style="color:#b0b0b0; font-size: 12px;">({{ post.url_domain }})</span>{% endif %}
-                                  </a>
-                                </h2>
-                                <p style="margin: 0 0 10px 0;">{# NOTE: this next line is intentionally long so it renders correctly in plaintext #}
-                                  <a href="{{ base_url }}{% url 'profile' username=post.author_id %}" style="color: #212121">{{ post.author_name }}</a>{% if post.author_headline %}<span style="color: #b0b0b0;">&nbsp;&#8212;&nbsp;{{ post.author_headline }}</span>{% endif %}
-                                  <br/>
-                                  <span style="margin: 0 0 10px 0; color: #b0b0b0;">{{ post.created|parse_iso|naturaltime }} in <a href="{{ base_url }}{% url 'channel' channel_name=post.channel_name %}" style="color: #212121">{{ post.channel_title }}</a></span>
-                                </p>
-                              </td>
-                            </tr>
-                          </table>
-                        </div>
-                        <!--[if mso]>
-                        </td>
-                        </tr>
-                        </table>
-                        <![endif]-->
-                    </td>
-                </tr>
-              {% endfor %}
-                <tr>
-                    <td style="padding: 5px;">
-                        <!-- Button : BEGIN -->
-                        <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
-                            <tr>
-                                <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                                     <a class="button-a button-a-primary" href="{{ base_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
-                                </td>
-                            </tr>
-                        </table>
-                        <!-- Button : END -->
-                    </td>
-                </tr>
-            </table>
-            <!--[if mso]>
-            </td>
+                <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
+                     <a class="button-a button-a-primary" href="{{ base_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
+                </td>
             </tr>
-            </table>
-            <![endif]-->
-        </td>
-    </tr>
-<!-- Thumbnail Right, Text Left : END -->
+        </table>
+        <!-- Button : END -->
+    </td>
+</tr>
 {% endblock %}

--- a/mail/templates/password_reset/body.html
+++ b/mail/templates/password_reset/body.html
@@ -6,8 +6,8 @@
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 14px; line-height: 20px; color: #555555;">
-                      <h1 style="margin: 0 0 10px; font-size: 20px; line-height: 30px; color: #03152d; font-weight: bold;">Reset Your Password</h1>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                      <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Reset Your Password</h1>
                       <p style="margin: 0 0 10px;">You're receiving this email because you requested a password reset for your user account at {{ site_name }}.</p>
                       <p style="margin: 0 0 10px;">Please go to the following page and choose a new password:</p>
                   </td>
@@ -18,7 +18,7 @@
                       <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                           <tr>
                               <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                                   <a class="button-a button-a-primary" href="{{ base_url }}{% url 'password-reset-confirm' uid=uid token=token %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Reset Password</a>
+                                   <a class="button-a button-a-primary" href="{{ base_url }}{% url 'password-reset-confirm' uid=uid token=token %}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Reset Password</a>
                               </td>
                           </tr>
                       </table>

--- a/mail/templates/verification/body.html
+++ b/mail/templates/verification/body.html
@@ -6,7 +6,7 @@
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 14px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Verify your email</h1>
                       <p style="margin: 0 0 10px;">Thank you for joining {{ site_name }}. To finish joining, you just need to confirm that we got your email right.</p>
                       <p style="margin: 0 0 10px;">To confirm your email, please click this link:</p>
@@ -18,7 +18,7 @@
                       <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                           <tr>
                               <td class="button-td button-td-primary" style="border-radius: 4px; background: #ffffff;">
-                                   <a class="button-a button-a-primary" href="{{ confirmation_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 14px; line-height: 14px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Verify Your Email</a>
+                                   <a class="button-a button-a-primary" href="{{ confirmation_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 28px; color: #a31f34; display: block; border-radius: 4px;">Verify Your Email</a>
                               </td>
                           </tr>
                       </table>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review
  - [x] Add screenshots to the PR description for any changes that affect layout or styling
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1361
Fixes #1360

#### What's this PR do?
Fixes some font sizing issues that crop up in OSX and friends.
Also adds `use_new_branding` to the context for password reset to fix #1360

#### How should this be manually tested?
Test the frontpage email in the debugger and verify it looks ok

#### Screenshots (if appropriate)
![screenshot_2018-10-15 email debugger](https://user-images.githubusercontent.com/28598/46969398-ebca5880-d083-11e8-96c4-a4c1fc077fd8.png)

@pdpinch @Ferdi, this is the PR for the test email I sent both you