### PR TITLE
fix styling of intro card on mobile

### DIFF
--- a/static/scss/home-page.scss
+++ b/static/scss/home-page.scss
@@ -12,6 +12,11 @@
     img {
       width: 67px;
       height: 67px;
+
+      @include breakpoint(phone) {
+        width: 45px;
+        height: 45px;
+      }
     }
   }
 
@@ -31,11 +36,20 @@
       min-width: 240px;
       flex-basis: 240px;
 
+      @include breakpoint(phone) {
+        min-width: 0;
+        padding: 0;
+      }
+
       h3 {
         margin: 0;
         padding: 0 0 8px 0;
         font-size: 24px;
         line-height: 24px;
+
+        @include breakpoint(phone) {
+          font-size: 20px;
+        }
       }
 
       p {
@@ -43,6 +57,10 @@
         padding: 0;
         font-size: 16px;
         color: $font-grey;
+
+        @include breakpoint(phone) {
+          font-size: 14px;
+        }
       }
     }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review
  - [x] Add screenshots to the PR description for any changes that affect layout or styling
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1359 

#### What's this PR do?

adds some phone-specific styling for the welcome card, so it doesn't get cut off on narrow widths.

#### How should this be manually tested?

Use chrome or something that can simulate the width of an iphone 5 / 5s / SE and make sure that the welcome card looks alright.

The iphone 5 screen is 320px wide. I looked on our google analytics, and looking through the top 40 screen sizes (by number of users) we've seen that is the narrowest screen width, so I don't think we need to worry about anything smaller than 320px.

#### Screenshots (if appropriate)

![welcomecard_spacing](https://user-images.githubusercontent.com/6207644/46972092-b7f33100-d08b-11e8-9e7b-6ce0330e565b.png)