### PR TITLE
fix post form validation for URL validity

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -119,7 +119,7 @@ export default class CreatePostForm extends React.Component<Props> {
           this.renderEmbed()
         ) : (
           <input
-            type="url"
+            type="text"
             placeholder="Paste a link to something related to the title..."
             name="url"
             value={url}
@@ -188,6 +188,7 @@ export default class CreatePostForm extends React.Component<Props> {
           <div className="actions row">
             <button
               className="cancel"
+              type="button"
               onClick={goBackAndHandleEvent(history)}
               disabled={processing}
             >

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -2,6 +2,7 @@
 /* global SETTINGS:false */
 import React from "react"
 import R from "ramda"
+import isURL from "validator/lib/isURL"
 
 import { S } from "./sanctuary"
 import { LINK_TYPE_LINK } from "../lib/channels"
@@ -53,16 +54,24 @@ export const validNotMIT = R.compose(
 )
 
 // POST CREATE VALIDATION
-export const postUrlOrTextPresent = (postForm: { value: PostForm }) => {
+export const postURLValidation = (postForm: { value: PostForm }) => {
   if (R.isEmpty(postForm)) {
     return S.Nothing
   }
 
   const post = postForm.value
-  if (post.postType === LINK_TYPE_LINK && emptyOrNil(post.url)) {
-    return S.Just(
-      R.set(R.lensPath(["value", "url"]), "Post url cannot be empty")
-    )
+  if (post.postType === LINK_TYPE_LINK) {
+    if (emptyOrNil(post.url)) {
+      return S.Just(
+        R.set(R.lensPath(["value", "url"]), "Post url cannot be empty")
+      )
+    }
+
+    if (!isURL(post.url)) {
+      return S.Just(
+        R.set(R.lensPath(["value", "url"]), "Post url must be a valid url")
+      )
+    }
   }
 
   return S.Nothing
@@ -78,7 +87,7 @@ export const validatePostCreateForm = validate([
     "Title length is limited to 300 characters"
   ),
   validation(emptyOrNil, R.lensPath(["value", "title"]), "Title is required"),
-  postUrlOrTextPresent
+  postURLValidation
 ])
 
 export const validateProfileForm = validate([

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -130,6 +130,17 @@ describe("validation library", () => {
       })
     })
 
+    it("should complain about an invalid url on a url post", () => {
+      const post = {
+        value: { postType: LINK_TYPE_LINK, title: "potato", url: "potato" }
+      }
+      assert.deepEqual(validatePostCreateForm(post), {
+        value: {
+          url: "Post url must be a valid url"
+        }
+      })
+    })
+
     it("should complain about too long of a title", () => {
       const post = {
         value: {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1366 

#### What's this PR do?
fixes two issues:

- Adds URL validation to check that a URL is valid to the post create form. We already use the same library to validate URLs before we submit the URL to embedly.
- adds `type="button"` to the 'cancel' button on the create post form. not having this was creating a strange issue, where hitting 'enter' in the 'url' field would trigger the `onClick` handler on this button, so you would go back to the previous page. Adding `type="button"` fixes this.

#### How should this be manually tested?

Go to the 'create post' page, and try adding a link post. If you type in an invalid url, like `ffff`, and try to click the 'Post' button, you should see an error like in the screenshot below. If you add a valid URL you should be able to go ahead and make the post.

Also, try to reproduce the error described above with the 'enter' key (also explained on the linked issue) on `master`. then confirm that this PR fixes it.

#### Screenshots (if appropriate)

a screenshot showing the 'valid url' error:

![valid_url_message](https://user-images.githubusercontent.com/6207644/47024685-31445f80-d130-11e8-847c-d2c4b4bc2093.png)

![valid_url_messagemob](https://user-images.githubusercontent.com/6207644/47026301-24753b00-d133-11e8-8492-a16e029495ec.png)
