### PR TITLE
Fix registration for MM-only accounts

### DIFF
--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -42,6 +42,7 @@ class SocialAuthState:
         flow=None,
         errors=None,
         redirect_url=None,
+        profile=None,
     ):  # pylint: disable=too-many-arguments
         self.state = state
         self.partial = partial
@@ -49,6 +50,7 @@ class SocialAuthState:
         self.provider = provider
         self.errors = errors or []
         self.redirect_url = redirect_url
+        self.profile = profile
 
 
 def load_drf_strategy(request=None):

--- a/cassettes/authentication.views_test.test_login_register_flows[register_mm_exists].json
+++ b/cassettes/authentication.views_test.test_login_register_flows[register_mm_exists].json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-16T14:51:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CSYNQKWWKQ9GN2YM76NE8AAG"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI2stA1LXItMSguLQwp0y2NMsoyKHROiSzwNQ739UpX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZG7l6pMcXFFt66prnhJi75bmElJQG+1V4FSaD9KSklmUmp8ZnpoAMhnCUagFU1JUpuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 16 Oct 2018 14:51:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=hk80dRc0mCJxc30ciN; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 15-Oct-2020 14:51:04 GMT",
+            "loidcreated=2018-10-16T14%3A51%3A03.945Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 15-Oct-2020 14:51:04 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CSYNQKWWKQ9GN2YM76NE8AAG"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/factory_data/authentication.views_test.test_login_register_flows[register_mm_exists].json
+++ b/factory_data/authentication.views_test.test_login_register_flows[register_mm_exists].json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "contributor": {
+      "username": "01CSYNQKWWKQ9GN2YM76NE8AAG"
+    }
+  }
+}

--- a/static/js/containers/auth/LoginPage.js
+++ b/static/js/containers/auth/LoginPage.js
@@ -24,11 +24,7 @@ import { mergeAndInjectProps } from "../../lib/redux_props"
 import { FLOW_LOGIN, isProcessing } from "../../reducers/auth"
 
 import type { Location, Match } from "react-router"
-import type {
-  AuthResponse,
-  EmailDetailAuthResponse,
-  EmailForm
-} from "../../flow/authTypes"
+import type { AuthResponse, EmailForm } from "../../flow/authTypes"
 import type { WithFormProps } from "../../flow/formTypes"
 
 type LoginPageProps = {
@@ -74,11 +70,7 @@ const onSubmit = ({ email }: EmailForm, next: string) =>
 const getSubmitResultErrors = getAuthResponseFieldErrors("email")
 
 const onSubmitResult = R.curry(
-  (
-    setAuthUserDetail: Function,
-    history: Object,
-    response: AuthResponse | EmailDetailAuthResponse
-  ) => {
+  (setAuthUserDetail: Function, history: Object, response: AuthResponse) => {
     // The auth endpoint returns some information about the user in a property called "extra_data".
     // We want to keep that data around for UI purposes, so we dispatch an action here to set it in the state.
     // NOTE:
@@ -87,7 +79,7 @@ const onSubmitResult = R.curry(
     // We may find situations where we need to clear that state programatically to avoid unintended
     // UI consequences. In that case it would probably be best to wrap all of the auth flow components
     // in a special <Route> that handles the lifecycle of that auth user detail state.
-    const authUserDetail = R.propOr({}, "extra_data")(response)
+    const authUserDetail = response.extra_data
     authUserDetail.email = response.email
     setAuthUserDetail(authUserDetail)
     return processAuthResponse(history, response)

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -46,12 +46,10 @@ export type AuthResponse = {
   state:         AuthStates,
   errors:        Array<string>,
   email?:        string,
-  redirect_url:  ?string
-}
-
-export type EmailDetailAuthResponse = {
-  extra_data?: {
-    name: string,
-    profile_image_small: string
+  redirect_url:  ?string,
+  extra_data: {
+    name?: string,
+    profile_image_small?: string,
+    email?: string
   }
-} & AuthResponse
+}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -15,11 +15,7 @@ import {
 import { toQueryString } from "../lib/url"
 import { getPaginationSortParams } from "../lib/posts"
 
-import type {
-  AuthResponse,
-  EmailDetailAuthResponse,
-  AuthFlow
-} from "../flow/authTypes"
+import type { AuthResponse, AuthFlow } from "../flow/authTypes"
 import type {
   Channel,
   ChannelContributors,
@@ -419,7 +415,7 @@ export const postEmailLogin = (
   flow: AuthFlow,
   email: string,
   next: string
-): Promise<EmailDetailAuthResponse> =>
+): Promise<AuthResponse> =>
   fetchJSONWithCSRF("/api/v0/login/email/", {
     method: POST,
     body:   JSON.stringify({ flow, email, next })

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -25,11 +25,11 @@ import {
   STATE_INACTIVE
 } from "../reducers/auth"
 
-import type { AuthResponse, EmailDetailAuthResponse } from "../flow/authTypes"
+import type { AuthResponse } from "../flow/authTypes"
 
 export const processAuthResponse = (
   history: Object,
-  response: AuthResponse | EmailDetailAuthResponse
+  response: AuthResponse
 ) => {
   const { state } = response
   if (state === STATE_LOGIN_EMAIL) {

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -40,7 +40,8 @@ const DEFAULT_ARGS = {
   partial_token: null,
   flow:          FLOW_REGISTER,
   errors:        [],
-  redirect_url:  null
+  redirect_url:  null,
+  extra_data:    {}
 }
 
 describe("auth lib", () => {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1364 

#### What's this PR do?
Fixes the register API so it doesn't error and instead causes the UI to prompt the user to login with MM.

Also refactored the `extra_data` code so it is a little cleaner and standard across all responses and in the frontend.

#### How should this be manually tested?
Try to register with an email for an account that already exists and only has a MM social auth. You should see no error and instead be prompted to login with MM.