### PR TITLE
Fixed template context for email confirmation emails

### DIFF
--- a/mail/api.py
+++ b/mail/api.py
@@ -8,7 +8,7 @@ recipients = User.objects.all()[:10]
 
 # generator for recipient emails
 messages = messages_for_recipients([
-    (recipient, context_for_user(user, {
+    (recipient, context_for_user(user=user, extra_context={
         # per-recipient context here
     })) for recipient, user in safe_format_recipients(recipients)
 ], 'sample')
@@ -73,7 +73,7 @@ def can_email_user(user):
     return bool(user.email)
 
 
-def context_for_user(user, extra_context=None):
+def context_for_user(*, user=None, extra_context=None):
     """
     Returns an email context for the given user
 
@@ -86,12 +86,18 @@ def context_for_user(user, extra_context=None):
     """
 
     context = {
-        "anon_token": get_encoded_and_signed_subscription_token(user),
         "base_url": settings.SITE_BASE_URL,
-        "use_new_branding": features.is_enabled(features.USE_NEW_BRANDING),
-        "user": user,
         "site_name": get_default_site().title,
+        "use_new_branding": features.is_enabled(features.USE_NEW_BRANDING),
     }
+
+    if user:
+        context.update(
+            {
+                "user": user,
+                "anon_token": get_encoded_and_signed_subscription_token(user),
+            }
+        )
 
     if extra_context is not None:
         context.update(extra_context)

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -1,7 +1,6 @@
 """API for email verifications"""
 from urllib.parse import quote_plus
 
-from django.conf import settings
 from django.urls import reverse
 
 from mail import api
@@ -33,7 +32,7 @@ def send_verification_email(
                 [
                     (
                         code.email,
-                        {"base_url": settings.SITE_BASE_URL, "confirmation_url": url},
+                        api.context_for_user(extra_context={"confirmation_url": url}),
                     )
                 ],
                 VERIFICATION_TEMPLATE_NAME,

--- a/mail/verification_api_test.py
+++ b/mail/verification_api_test.py
@@ -9,7 +9,7 @@ from social_django.utils import load_backend, load_strategy
 from mail import verification_api
 from open_discussions.test_utils import any_instance_of
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("authenticated_site")]
 
 
 def test_send_verification_email(mocker, rf):

--- a/notifications/notifiers/email.py
+++ b/notifications/notifiers/email.py
@@ -86,7 +86,7 @@ class EmailNotifier(BaseNotifier):
             messages = list(
                 api.messages_for_recipients(
                     [
-                        (recipient, api.context_for_user(user, data))
+                        (recipient, api.context_for_user(user=user, extra_context=data))
                         for recipient, user in api.safe_format_recipients([user])
                     ],
                     self._template_name,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1381

#### What's this PR do?
Adds `context_for_user` to the verification api call so the template gets this common data.