### PR TITLE
add new link style, put it on post-title

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -88,7 +88,7 @@ export class CompactPostDisplay extends React.Component<Props> {
               ) : null}
               <Link
                 to={postDetailURL(post.channel_name, post.id, post.slug)}
-                className="navy"
+                className="navy no-underline"
               >
                 <div className="post-title">
                   <PostTitleAndHostname post={post} />

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -93,6 +93,18 @@ storiesOf("Links and Buttons", module)
       </StoryWrapper>
     )
   })
+  .add("no-underline link", () => {
+    const textContent = textContentKnob()
+    const url = urlKnob()
+
+    return (
+      <StoryWrapper>
+        <a className="no-underline" href={url}>
+          {textContent}
+        </a>
+      </StoryWrapper>
+    )
+  })
   .add("basic button", () => {
     const textContent = textContentKnob()
 

--- a/static/scss/link.scss
+++ b/static/scss/link.scss
@@ -26,3 +26,7 @@ a.navy {
     text-decoration: underline;
   }
 }
+
+a.no-underline:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1367 

#### What's this PR do?

gets rid of the underline on `:hover` for the post title in compact post display.

#### How should this be manually tested?

make sure that the post title on the compact post display doesn't have an on-hover underline going on.
