### PR TITLE
Post detail page: improve wrapping of long URLs

### DIFF
--- a/static/scss/markdown.scss
+++ b/static/scss/markdown.scss
@@ -2,4 +2,8 @@
   blockquote {
     @extend %blockquote;
   }
+
+  a {
+    word-break: break-word;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
Fixes #1319 

#### What's this PR do?
Includes `word-break: break-word` on styling for links inside elements with the `markdown` style class.

#### How should this be manually tested?
Create a text post and insert a very long URL.  The URL should be wrapped inside the card, and not extend in a single line beyond it.

#### Screenshots (if appropriate)
<img width="752" alt="screen shot 2018-10-18 at 3 41 01 pm" src="https://user-images.githubusercontent.com/187676/47179541-567dcd00-d2ec-11e8-8dc1-d39ecf6d4857.png">

<img width="752" alt="screen shot 2018-10-18 at 3 41 23 pm" src="https://user-images.githubusercontent.com/187676/47179548-5a115400-d2ec-11e8-98d5-9c56df594607.png">

<img width="395" alt="screen shot 2018-10-18 at 3 45 55 pm" src="https://user-images.githubusercontent.com/187676/47179784-f9cee200-d2ec-11e8-89cd-9cd33b3da2f3.png">
