### PR TITLE
Fix placement of reported comment dropdown

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -156,77 +156,79 @@ export default class CommentTree extends React.Component<Props> {
           ) : null}
         </div>
         {!userIsAnonymous() ? (
-          <i className="material-icons more_vert" onClick={showDropdown}>
-            more_vert
-          </i>
+          <div>
+            <i className="material-icons more_vert" onClick={showDropdown}>
+              more_vert
+            </i>
+            {commentMenuOpen ? (
+              <DropdownMenu
+                closeMenu={hideDropdown}
+                className="post-comment-dropdown"
+              >
+                {userIsAnonymous() ? null : this.renderFollowButton(comment)}
+                {SETTINGS.username === comment.author_id && !moderationUI ? (
+                  <li>
+                    <div
+                      className="comment-action-button edit-button"
+                      onClick={e => {
+                        if (beginEditing) {
+                          beginEditing(editFormKey, comment, e)
+                        }
+                      }}
+                    >
+                      <a href="#">Edit</a>
+                    </div>
+                  </li>
+                ) : null}
+                {SETTINGS.username === comment.author_id && deleteComment ? (
+                  <li>
+                    <div
+                      className="comment-action-button delete-button"
+                      onClick={preventDefaultAndInvoke(() =>
+                        deleteComment(comment)
+                      )}
+                    >
+                      <a href="#">Delete</a>
+                    </div>
+                  </li>
+                ) : null}
+                {comment.num_reports && ignoreCommentReports ? (
+                  <li>
+                    <div
+                      className="comment-action-button ignore-button"
+                      onClick={preventDefaultAndInvoke(() =>
+                        ignoreCommentReports(comment)
+                      )}
+                    >
+                      <a href="#">Ignore reports</a>
+                    </div>
+                  </li>
+                ) : null}
+                <li>
+                  <CommentRemovalForm
+                    comment={comment}
+                    remove={remove}
+                    approve={approve}
+                    isModerator={isModerator}
+                  />
+                </li>
+                {moderationUI || userIsAnonymous() || !reportComment ? null : (
+                  <li>
+                    <div
+                      className="comment-action-button report-button"
+                      onClick={preventDefaultAndInvoke(() =>
+                        reportComment(comment)
+                      )}
+                    >
+                      <a href="#">Report</a>
+                    </div>
+                  </li>
+                )}
+              </DropdownMenu>
+            ) : null}
+          </div>
         ) : null}
         <ReportCount count={comment.num_reports} />
-        {commentMenuOpen ? (
-          <DropdownMenu
-            closeMenu={hideDropdown}
-            className="post-comment-dropdown"
-          >
-            {userIsAnonymous() ? null : this.renderFollowButton(comment)}
-            {SETTINGS.username === comment.author_id && !moderationUI ? (
-              <li>
-                <div
-                  className="comment-action-button edit-button"
-                  onClick={e => {
-                    if (beginEditing) {
-                      beginEditing(editFormKey, comment, e)
-                    }
-                  }}
-                >
-                  <a href="#">Edit</a>
-                </div>
-              </li>
-            ) : null}
-            {SETTINGS.username === comment.author_id && deleteComment ? (
-              <li>
-                <div
-                  className="comment-action-button delete-button"
-                  onClick={preventDefaultAndInvoke(() =>
-                    deleteComment(comment)
-                  )}
-                >
-                  <a href="#">Delete</a>
-                </div>
-              </li>
-            ) : null}
-            {comment.num_reports && ignoreCommentReports ? (
-              <li>
-                <div
-                  className="comment-action-button ignore-button"
-                  onClick={preventDefaultAndInvoke(() =>
-                    ignoreCommentReports(comment)
-                  )}
-                >
-                  <a href="#">Ignore reports</a>
-                </div>
-              </li>
-            ) : null}
-            <li>
-              <CommentRemovalForm
-                comment={comment}
-                remove={remove}
-                approve={approve}
-                isModerator={isModerator}
-              />
-            </li>
-            {moderationUI || userIsAnonymous() || !reportComment ? null : (
-              <li>
-                <div
-                  className="comment-action-button report-button"
-                  onClick={preventDefaultAndInvoke(() =>
-                    reportComment(comment)
-                  )}
-                >
-                  <a href="#">Report</a>
-                </div>
-              </li>
-            )}
-          </DropdownMenu>
-        ) : null}
       </div>
     )
   }

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -87,7 +87,7 @@ $replyPaddingLeftPhone: 10px;
 
         .dropdown-menu {
           top: 20px;
-          left: 48px;
+          margin-left: 5px;
           right: inherit;
         }
 

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -87,7 +87,7 @@ $replyPaddingLeftPhone: 10px;
 
         .dropdown-menu {
           top: 20px;
-          left: 78px;
+          left: 48px;
           right: inherit;
         }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
Fixes #1321 

#### What's this PR do?
Adjusts the `left` value of the css for the dropdown menu to fix alignment

#### How should this be manually tested?
-Open the dropdown for a comment in a channel's 'Reported Content' tab, it should be in the right place.
-Open the dropdown for a comment on a post detail page, it should be in the right place.

#### Screenshots (if appropriate)
<img width="295" alt="screen shot 2018-10-18 at 4 10 42 pm" src="https://user-images.githubusercontent.com/187676/47182427-63ea8580-d2f3-11e8-8021-88e912a11588.png">

<img width="405" alt="screen shot 2018-10-18 at 4 31 56 pm" src="https://user-images.githubusercontent.com/187676/47182418-5c2ae100-d2f3-11e8-94b4-66438e50bc3d.png">

