### PR TITLE
Add indexing user as first moderator to every channel if not already a moderator

### DIFF
--- a/cassettes/channels.views.channels_test.test_create_channel.json
+++ b/cassettes/channels.views.channels_test.test_create_channel.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-24T20:36:37",
+      "recorded_at": "2018-10-23T20:56:38",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPTE7ZS1RGGGJD9YMPW461W"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBE1488HFBAT1MK9C7J4YE"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNyw6CMBREf4V0aTRBqVDcGl9NjDTGdYPlEhvR1l5U0PjvUlm5nJM5M2+SKwWIsjZnuJJZQKIJHS3XDMQ0Xc15ei/jtrqVxQ4T5DJjZBgQaKx2gFJ7IYrDsGM/X9atBT9yhNyB811UpkcDnxyUnXj6f7N8fMhcuqdssX3ihdpGGFu9kg0X3ingoRVIXfjhPpDPF4FEjhG4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxMNUtdEsqyvPOLC1NN0jMNcp39EwM9C7ID4svS05X0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZlZlm4mDmWl5UFWoT4VyQWm5sluptGuWQYmWWD9KSklmUmp8ZnpoAMhnCUagEIZiI8uAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:37 GMT"
+            "Tue, 23 Oct 2018 20:56:38 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=7xjYwgRCH7Om3i1RwE; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 20:36:37 GMT",
-            "loidcreated=2018-08-24T20%3A36%3A36.940Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 20:36:37 GMT"
+            "loid=oJscLn7JY3TK4Y7utD; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:56:38 GMT",
+            "loidcreated=2018-10-23T20%3A56%3A38.296Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:56:38 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,83 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPTE7ZS1RGGGJD9YMPW461W"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBE1488HFBAT1MK9C7J4YE"
       }
     },
     {
-      "recorded_at": "2018-08-24T20:36:40",
+      "recorded_at": "2018-10-23T20:56:42",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "allow_top=True&api_type=json&description=Natus+error+veritatis+veniam+mollitia+aliquam+ea.+Et+veniam+eos+minima+vel+dicta+nisi+officia+consequatur.+Sint+accusamus+placeat+assumenda+velit.%0AQuibusdam+nobis+quisquam+perspiciatis.+Vero+ipsam+recusandae+voluptatem+eaque+quaerat+earum+eaque.+Sit+sit+odit+non+voluptatem.+Unde+corporis+at+at.%0AA+ipsum+blanditiis+harum+incidunt+esse.+Nihil+quod+modi+sequi.+Excepturi+laborum+rerum+sunt+quibusdam+inventore.&link_type=any&name=1535142997_nesciunt&public_description=Odio+vitae+adipisci+commodi+expedita.+Explicabo+voluptatum+iste+ipsam+veritatis.&title=Veniam+magnam+corporis+esse+deleniti+quibusdam.&type=public&wikimode=disabled"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=oJscLn7JY3TK4Y7utD; loidcreated=2018-10-23T20%3A56%3A38.296Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBE4GSQME0P1GFY53T3YNX"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAWjhoxuU9Zhh8LQotOY8y8OI8e2xIi+ey5PHd+P93vvjZTW4L0MQw8PtE8Qwemm0j29kdJyr8SW0UJKZi0/jM8jR+sEwWSNAy9NFHYpxjP7+TK8LMSRGpQDF7teDwtaxeSgncXu/628hDtU0ApRXKk4n1ibp1meT1lNotPAaDRI08ThJaDPF4+12zS4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:56:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBE4GSQME0P1GFY53T3YNX"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:56:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Aliquam+quod+asperiores+perspiciatis+ratione+eligendi+laudantium+quidem+quod.+Assumenda+placeat+nostrum+magnam+itaque+molestias+debitis+ducimus+accusamus.+Odio+architecto+voluptate+ab+exercitationem+provident+repellendus.+Inventore+quos+nobis+blanditiis+quis+earum+expedita.%0AError+reiciendis+molestiae+molestiae+facere+quas.+Placeat+nam+repudiandae+animi+illum+ex+quam+voluptates+quam.+Voluptates+aliquam+dolorum+officiis+nam.+Ipsa+placeat+ipsa+consequuntur+recusandae.&link_type=any&name=1540328202_non&public_description=Minus+nam+ducimus+ea.+Possimus+tempore+vitae+voluptatem+repellendus+doloremque.&title=Vero+praesentium+dolore+incidunt.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +152,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 324-FH8eQ59GCJ9uf6ylqfdOs7sJ_P8"
+            "bearer 405-qFbrnKiuug0am2oAIaQKpoV_vcg"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "676"
+            "716"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=7xjYwgRCH7Om3i1RwE; loidcreated=2018-08-24T20%3A36%3A36.940Z"
+            "loid=oJscLn7JY3TK4Y7utD; loidcreated=2018-10-23T20%3A56%3A38.296Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:40 GMT"
+            "Tue, 23 Oct 2018 20:56:45 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +210,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "200"
+            "195"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,11 +230,11 @@
       }
     },
     {
-      "recorded_at": "2018-08-24T20:36:40",
+      "recorded_at": "2018-10-23T20:56:45",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01CTHBE4GSQME0P1GFY53T3YNX&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -176,38 +244,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 324-FH8eQ59GCJ9uf6ylqfdOs7sJ_P8"
+            "bearer 405-qFbrnKiuug0am2oAIaQKpoV_vcg"
           ],
           "Connection": [
             "keep-alive"
           ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
           "Cookie": [
-            "loid=7xjYwgRCH7Om3i1RwE; loidcreated=2018-08-24T20%3A36%3A36.940Z"
+            "loid=oJscLn7JY3TK4Y7utD; loidcreated=2018-10-23T20%3A56%3A38.296Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1535142997_nesciunt/about/?raw_json=1"
+        "method": "POST",
+        "uri": "https://reddit.local/r/1540328202_non/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"33\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1535142997_nesciunt\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ENatus error veritatis veniam mollitia aliquam ea. Et veniam eos minima vel dicta nisi officia consequatur. Sint accusamus placeat assumenda velit.\\nQuibusdam nobis quisquam perspiciatis. Vero ipsam recusandae voluptatem eaque quaerat earum eaque. Sit sit odit non voluptatem. Unde corporis at at.\\nA ipsum blanditiis harum incidunt esse. Nihil quod modi sequi. Excepturi laborum rerum sunt quibusdam inventore.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Veniam magnam corporis esse deleniti quibusdam.\", \"collapse_deleted_comments\": false, \"public_description\": \"Odio vitae adipisci commodi expedita. Explicabo voluptatum iste ipsam veritatis.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EOdio vitae adipisci commodi expedita. Explicabo voluptatum iste ipsam veritatis.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Natus error veritatis veniam mollitia aliquam ea. Et veniam eos minima vel dicta nisi officia consequatur. Sint accusamus placeat assumenda velit.\\nQuibusdam nobis quisquam perspiciatis. Vero ipsam recusandae voluptatem eaque quaerat earum eaque. Sit sit odit non voluptatem. Unde corporis at at.\\nA ipsum blanditiis harum incidunt esse. Nihil quod modi sequi. Excepturi laborum rerum sunt quibusdam inventore.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_33\", \"created\": 1535143000.0, \"url\": \"/r/1535142997_nesciunt/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1535143000.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "2347"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:40 GMT"
+            "Tue, 23 Oct 2018 20:56:45 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -228,13 +302,10 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "200"
+            "195"
           ],
           "x-ratelimit-used": [
             "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=FMPXMC3frspugOqrKWBtAHQa8PhLj7pPFRGIzrE2hL3shjyr3u%2FgMAaYsEmtspjf4JJtILEZCeX8GzQwQTvukI7inHOpqFEK"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -247,7 +318,188 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1535142997_nesciunt/about/?raw_json=1"
+        "url": "https://reddit.local/r/1540328202_non/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:56:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 406-Uck8Y4TpEsaJ2A8Q__AppEFvuNE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=oJscLn7JY3TK4Y7utD; loidcreated=2018-10-23T20%3A56%3A38.296Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1540328202_non/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:56:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "195"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1540328202_non/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:56:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 405-qFbrnKiuug0am2oAIaQKpoV_vcg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=oJscLn7JY3TK4Y7utD; loidcreated=2018-10-23T20%3A56%3A38.296Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1540328202_non/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"2h\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1540328202_non\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EAliquam quod asperiores perspiciatis ratione eligendi laudantium quidem quod. Assumenda placeat nostrum magnam itaque molestias debitis ducimus accusamus. Odio architecto voluptate ab exercitationem provident repellendus. Inventore quos nobis blanditiis quis earum expedita.\\nError reiciendis molestiae molestiae facere quas. Placeat nam repudiandae animi illum ex quam voluptates quam. Voluptates aliquam dolorum officiis nam. Ipsa placeat ipsa consequuntur recusandae.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Vero praesentium dolore incidunt.\", \"collapse_deleted_comments\": false, \"public_description\": \"Minus nam ducimus ea. Possimus tempore vitae voluptatem repellendus doloremque.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMinus nam ducimus ea. Possimus tempore vitae voluptatem repellendus doloremque.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Aliquam quod asperiores perspiciatis ratione eligendi laudantium quidem quod. Assumenda placeat nostrum magnam itaque molestias debitis ducimus accusamus. Odio architecto voluptate ab exercitationem provident repellendus. Inventore quos nobis blanditiis quis earum expedita.\\nError reiciendis molestiae molestiae facere quas. Placeat nam repudiandae animi illum ex quam voluptates quam. Voluptates aliquam dolorum officiis nam. Ipsa placeat ipsa consequuntur recusandae.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_2h\", \"created\": 1540328205.0, \"url\": \"/r/1540328202_non/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1540328205.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2442"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:56:46 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "195"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=4BghVw7mOkk5wIB%2BvFHgYksc6nZiBoW9YV9dnhdUndZZr6v9qyvYWDIbDZA0o%2FheMzKA%2FmXXdr%2BrGdkYtgjahwRbBNtXXzLR"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1540328202_non/about/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.channels_test.test_create_channel_already_exists.json
+++ b/cassettes/channels.views.channels_test.test_create_channel_already_exists.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-24T17:47:35",
+      "recorded_at": "2018-10-23T20:58:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPGRQQHAHB02YWZQSFCA0GJ"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGQA8YGE871Z0K07X8H8B"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNyw6CMBREf4V0aSThIQbcucJo3BAx7prSXkJDbJtbJEXjv0th5XJO5sx8COMcrKWD7kGRQ0DipAh3+VXFos5kTasE8VnqN20e6Ezek21AwBmJYKn0QrqPopktPh0mA36kAYaAvmu5XtHGJ4R2Frv/t6obT6+yqeqEuUt6nArBFM9u5/C+vAkYJQcqhR9eA/n+AN9wRmm4AAAA",
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxsNTN93cxzE3KCvT1sax0zMsKtjDIcPcM9so1rUhW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaFZwa5OfrHO7v5xZu5+wZkFGZYGAWGJ8eHGlmA9KSklmUmp8ZnpoAMhnCUagGm6fbauAAAAA==",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 17:47:35 GMT"
+            "Tue, 23 Oct 2018 20:58:06 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=Udsn6Pza3pALryGm6R; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 17:47:35 GMT",
-            "loidcreated=2018-08-24T17%3A47%3A34.976Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 17:47:35 GMT"
+            "loid=j4rteuEhbBOb3uXNV1; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:06 GMT",
+            "loidcreated=2018-10-23T20%3A58%3A06.490Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:06 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,83 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPGRQQHAHB02YWZQSFCA0GJ"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGQA8YGE871Z0K07X8H8B"
       }
     },
     {
-      "recorded_at": "2018-08-24T17:47:35",
+      "recorded_at": "2018-10-23T20:58:10",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "allow_top=True&api_type=json&description=Asperiores+eum+perferendis+nisi+voluptatem+amet.+Modi+quasi+laborum+quisquam+vel+accusantium.+Quod+reiciendis+ea+neque+blanditiis.%0AAdipisci+fuga+doloremque+fugit+dolores+voluptas+harum+iure+expedita.+Error+alias+inventore+in+dolor+hic+qui+dolorem+illo.+Placeat+debitis+quas+ipsam+perferendis+voluptatibus.+Doloribus+expedita+quaerat+doloremque+iste.%0AAliquam+culpa+id+eaque+earum+debitis.+Ullam+eligendi+aut+adipisci+eligendi.+Amet+delectus+qui+laudantium+illo+inventore+temporibus+porro+mollitia.&link_type=any&name=1535132855_harum&public_description=Facilis+voluptatum+possimus+nulla.+Blanditiis+excepturi+facilis+voluptas+eos+nisi+autem.&title=Maxime+omnis+deserunt+illo+fugiat+ullam.&type=private&wikimode=disabled"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=j4rteuEhbBOb3uXNV1; loidcreated=2018-10-23T20%3A58%3A06.490Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGTMM2JJMT9DJAMHVAZCY"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxNNB1MywqNDDLSQ3w9qtIcswyzQsK9jcNz87IMXRU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLYZeydHGroaZ2TnGeYVlHob5nk4RrhUuFVFeRWD9KSklmUmp8ZnpoAMhnCUagGpeApmuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGTMM2JJMT9DJAMHVAZCY"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:58:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Quibusdam+iusto+ex+earum+veritatis+mollitia.+Atque+necessitatibus+rem+exercitationem+eum.+Sint+similique+non+amet+optio+molestias+accusamus.+Fugiat+sit+ducimus+corporis+atque+enim+ut+tempore.%0AExplicabo+soluta+totam+nesciunt+iste.+Dolores+in+odit+numquam+quibusdam.+Similique+commodi+natus+eum+vel+non+perspiciatis.%0AEsse+ex+vitae+illum+harum.+Facere+porro+alias+cupiditate+earum+totam.+Aut+aliquid+sequi+qui+dolor.&link_type=any&name=1540328290_ex&public_description=Quo+possimus+ipsa+necessitatibus+id+possimus+neque+maxime+praesentium.&title=Iure+nam+ratione+porro+magni.&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +152,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 129-48Mn1dU5iU_R2rrmGoz_bXrxp8k"
+            "bearer 409-oOD1mbjQML9yAnjS80hGISJm5xc"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "763"
+            "648"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Udsn6Pza3pALryGm6R; loidcreated=2018-08-24T17%3A47%3A34.976Z"
+            "loid=j4rteuEhbBOb3uXNV1; loidcreated=2018-10-23T20%3A58%3A06.490Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 17:47:35 GMT"
+            "Tue, 23 Oct 2018 20:58:10 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +210,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "145"
+            "110"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,11 +230,11 @@
       }
     },
     {
-      "recorded_at": "2018-08-24T17:47:38",
+      "recorded_at": "2018-10-23T20:58:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "allow_top=True&api_type=json&description=a+description+of+the+channel&link_type=any&name=1535132855_harum&public_description=public&title=Channel+title&type=private&wikimode=disabled"
+          "string": "allow_top=True&api_type=json&description=a+description+of+the+channel&link_type=any&name=1540328290_ex&public_description=public&title=Channel+title&type=private&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -176,22 +244,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 129-48Mn1dU5iU_R2rrmGoz_bXrxp8k"
+            "bearer 410-F1rq06lePKNxbAj5nRSO5Wkhl1A"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "182"
+            "179"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=Udsn6Pza3pALryGm6R; loidcreated=2018-08-24T17%3A47%3A34.976Z"
+            "loid=j4rteuEhbBOb3uXNV1; loidcreated=2018-10-23T20%3A58%3A06.490Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -213,7 +281,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 17:47:38 GMT"
+            "Tue, 23 Oct 2018 20:58:13 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -231,13 +299,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "298.0"
+            "299.0"
           ],
           "x-ratelimit-reset": [
-            "142"
+            "107"
           ],
           "x-ratelimit-used": [
-            "2"
+            "1"
           ],
           "x-ua-compatible": [
             "IE=edge"

--- a/cassettes/channels.views.channels_test.test_create_channel_no_descriptions.json
+++ b/cassettes/channels.views.channels_test.test_create_channel_no_descriptions.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-08-24T20:36:44",
+      "recorded_at": "2018-10-23T20:57:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,11 +22,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPTEEGRKGBVG70TT8TBRXYV"
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGCR9TXXTRYR81WT2JW50"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA1WNyw6CMBREf4V0aTSpxRJxKyaKIia4b6DcQuODpkWRGP9drqxczsmcmTfJpQTnRNtc4E5WHvEZn1VZfDTuFqeLbbyMlOGMBQV9XKHZkalH4GW0BSc0Cn5A6cB+vmh7AzhSQG7BYtfJZkQTTBbUINb/b2GdnDfBXHc8gl6d9utDEqZdkvm0QqeEp5YgdInDYyCfL/mLgbC4AAAA",
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMBzFv4rsGAnDxKBjVkKHaMOg29DtPxqCW9twafTdc3nq+H6833tv1HAOzjGvO+jRLkE53qac0nq4FKR+VsGFsjuM9kxaDv6eo3WC4GWUBcdUFDYFxjP7+cyPBuJIC40FG7uO6wWtYrIgZ/Hx/3bsb5OQp5Be7d4RVWVUlsLQqcx0dAQMigNTIg4vAX2+k8CTgLgAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
@@ -40,7 +40,7 @@
             "text/html; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:44 GMT"
+            "Tue, 23 Oct 2018 20:57:56 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -49,8 +49,8 @@
             "chunked"
           ],
           "set-cookie": [
-            "loid=UAEzFGagPKiC80zt8q; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 20:36:44 GMT",
-            "loidcreated=2018-08-24T20%3A36%3A43.649Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 23-Aug-2020 20:36:44 GMT"
+            "loid=l7fPQIU06jsNJ5H8WM; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:57:56 GMT",
+            "loidcreated=2018-10-23T20%3A57%3A55.684Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:57:56 GMT"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -66,15 +66,83 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CNPTEEGRKGBVG70TT8TBRXYV"
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGCR9TXXTRYR81WT2JW50"
       }
     },
     {
-      "recorded_at": "2018-08-24T20:36:47",
+      "recorded_at": "2018-10-23T20:57:59",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "allow_top=True&api_type=json&description=&link_type=any&name=1535143004_voluptatib&public_description=&title=Modi+quae+omnis+sequi+omnis+nam+cumque.&type=restricted&wikimode=disabled"
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=l7fPQIU06jsNJ5H8WM; loidcreated=2018-10-23T20%3A57%3A55.684Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGG2956SW15MPV94ASHQN"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNwQqCQBRFf0XeMgoG1JR2UWGLkFxEthqmN09mktRmBlGif8/JVct7uOfeNwhEspa7tqYGNgFELF31Od322+bidsXRjgNGJ4dtWTxrVcMyABo6bchy7YVwzdjEfj53Y0d+5E7CkPFdi+2MFj4ZqiZR/b9dq15mTS4wSdDF8TljIqzU41C+Uu9I6jUS19IPzwE+X4TkWFK4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:57:59 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBGG2956SW15MPV94ASHQN"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:58:02",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=&link_type=any&name=1540328279_aspernatur&public_description=&title=Sint+minus+molestiae+excepturi.&type=restricted&wikimode=disabled"
         },
         "headers": {
           "Accept": [
@@ -84,22 +152,22 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 325-gSJNpsmJO4HJ8Dfp5226b0uleoI"
+            "bearer 407-cRRTvN6QTqGwswCkDyrJQbcetX4"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "182"
+            "174"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "loid=UAEzFGagPKiC80zt8q; loidcreated=2018-08-24T20%3A36%3A43.649Z"
+            "loid=l7fPQIU06jsNJ5H8WM; loidcreated=2018-10-23T20%3A57%3A55.684Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
         "method": "POST",
@@ -121,7 +189,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:47 GMT"
+            "Tue, 23 Oct 2018 20:58:02 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -142,7 +210,7 @@
             "299.0"
           ],
           "x-ratelimit-reset": [
-            "193"
+            "118"
           ],
           "x-ratelimit-used": [
             "1"
@@ -162,11 +230,11 @@
       }
     },
     {
-      "recorded_at": "2018-08-24T20:36:47",
+      "recorded_at": "2018-10-23T20:58:03",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": ""
+          "string": "api_type=json&name=01CTHBGG2956SW15MPV94ASHQN&permissions=%2Ball&type=moderator"
         },
         "headers": {
           "Accept": [
@@ -176,38 +244,44 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "bearer 325-gSJNpsmJO4HJ8Dfp5226b0uleoI"
+            "bearer 407-cRRTvN6QTqGwswCkDyrJQbcetX4"
           ],
           "Connection": [
             "keep-alive"
           ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
           "Cookie": [
-            "loid=UAEzFGagPKiC80zt8q; loidcreated=2018-08-24T20%3A36%3A43.649Z"
+            "loid=l7fPQIU06jsNJ5H8WM; loidcreated=2018-10-23T20%3A57%3A55.684Z"
           ],
           "User-Agent": [
-            "MIT-Open: 0.42.0 PRAW/4.5.1 prawcore/0.10.1"
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
           ]
         },
-        "method": "GET",
-        "uri": "https://reddit.local/r/1535143004_voluptatib/about/?raw_json=1"
+        "method": "POST",
+        "uri": "https://reddit.local/r/1540328279_aspernatur/api/friend/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"34\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1535143004_voluptatib\", \"header_img\": null, \"description_html\": null, \"title\": \"Modi quae omnis sequi omnis nam cumque.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 0, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_34\", \"created\": 1535143007.0, \"url\": \"/r/1535143004_voluptatib/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1535143007.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"restricted\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+          "string": "{\"json\": {\"errors\": []}}"
         },
         "headers": {
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "1127"
+            "24"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Fri, 24 Aug 2018 20:36:47 GMT"
+            "Tue, 23 Oct 2018 20:58:03 GMT"
           ],
           "Server": [
             "PasteWSGIServer/0.5 Python/2.7.6"
@@ -228,13 +302,10 @@
             "298.0"
           ],
           "x-ratelimit-reset": [
-            "193"
+            "118"
           ],
           "x-ratelimit-used": [
             "2"
-          ],
-          "x-reddit-tracking": [
-            "https://reddit.local/pixel/of_destiny.png?v=KAeHhFMEex4kBBDFTEIPdEgzRvH5EeoZpNSGvhe%2BNxp%2FGtL%2B3cJq0bnpm9E0zKEdlzqpXYDDoQDCwEgarGPrma9nPeMtY8gB"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -247,7 +318,188 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://reddit.local/r/1535143004_voluptatib/about/?raw_json=1"
+        "url": "https://reddit.local/r/1540328279_aspernatur/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:58:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 408-vNeYDAnUtCQHsyxc4LtcoXQmkhk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=l7fPQIU06jsNJ5H8WM; loidcreated=2018-10-23T20%3A57%3A55.684Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1540328279_aspernatur/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:03 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "117"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1540328279_aspernatur/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:58:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 407-cRRTvN6QTqGwswCkDyrJQbcetX4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=l7fPQIU06jsNJ5H8WM; loidcreated=2018-10-23T20%3A57%3A55.684Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.50.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1540328279_aspernatur/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"2i\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1540328279_aspernatur\", \"header_img\": null, \"description_html\": null, \"title\": \"Sint minus molestiae excepturi.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_2i\", \"created\": 1540328282.0, \"url\": \"/r/1540328279_aspernatur/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1540328282.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"restricted\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1119"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:03 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "117"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=SfK44uMJMVJEVfSF4RjjVbEq%2FHQ5xRyLg868yghwUgRBq2ak8KvbWOwQ5YPj0hiw8zrJ71U1Qm58QGygLwlIcF1d60zBFXJ9"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1540328279_aspernatur/about/?raw_json=1"
       }
     }
   ],

--- a/cassettes/channels.views.channels_test.test_create_channel_noauth.json
+++ b/cassettes/channels.views.channels_test.test_create_channel_noauth.json
@@ -1,4 +1,74 @@
 {
-  "http_interactions": [],
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-23T20:58:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH7X0J7RDHCVR0PP94ZBX"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxNNY193X3zTB2DYj0LM519ipNDdQNSvX0DEos9vBV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLalBxsWFXmVOzkGWRqaBBh55YSmBMUbuThXBZWD9KSklmUmp8ZnpoAMhnCUagEiWM9auAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=dvK0ptya9lfl2cPB59; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:23 GMT",
+            "loidcreated=2018-10-23T20%3A58%3A23.460Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:23 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH7X0J7RDHCVR0PP94ZBX"
+      }
+    }
+  ],
   "recorded_with": "betamax/0.8.0"
 }

--- a/cassettes/channels.views.channels_test.test_create_channel_nonstaff.json
+++ b/cassettes/channels.views.channels_test.test_create_channel_nonstaff.json
@@ -1,4 +1,142 @@
 {
-  "http_interactions": [],
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-23T20:58:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH1562G5HDYARQYZS12WB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxNNTNyvfJSjVOj7KsDPKvqiwLKa00cfEwiyzxcglV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZVhXokO/p7p5d5BRenuWQ5hhcnBmbHmxiGWmSD9KSklmUmp8ZnpoAMhnCUagGxDa27uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=mQbwmR9cvjQI2jtuUy; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:16 GMT",
+            "loidcreated=2018-10-23T20%3A58%3A16.552Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 22-Oct-2020 20:58:16 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH1562G5HDYARQYZS12WB"
+      }
+    },
+    {
+      "recorded_at": "2018-10-23T20:58:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=mQbwmR9cvjQI2jtuUy; loidcreated=2018-10-23T20%3A58%3A16.552Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH4FT6Y564RDAA2B3XJ64"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDIxNNL1NMyo8g8I8ffwDnS3KMwrNTDUTckJyvFJMk5W0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaZBKeHVLhbhjlXRoU6lYY6uRf45BobZJiUBmaD9KSklmUmp8ZnpoAMhnCUagGYBki6uAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 23 Oct 2018 20:58:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CTHBH4FT6Y564RDAA2B3XJ64"
+      }
+    }
+  ],
   "recorded_with": "betamax/0.8.0"
 }

--- a/channels/factories.py
+++ b/channels/factories.py
@@ -416,7 +416,7 @@ class ChannelFactory(factory.Factory):
     api = None
     title = factory.Faker("text", max_nb_chars=50)
     description = factory.Faker("text", max_nb_chars=500)
-    public_description = factory.Faker("text", max_nb_chars=100)
+    public_description = factory.Faker("text", max_nb_chars=80)
     channel_type = FuzzyChoice(VALID_CHANNEL_TYPES)
     link_type = LINK_TYPE_ANY
     ga_tracking_id = None

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -1,0 +1,68 @@
+"""Management command to add the indexing user account as a moderator to all channels"""
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from prawcore import Forbidden
+
+from channels.api import Api
+from channels.models import Channel
+
+
+class Command(BaseCommand):
+    """Add indexing user as moderator to all channels"""
+
+    help = "Add indexing user as moderator to all channels"
+
+    def handle(self, *args, **options):
+        """Adds the indexing user as the moderator on all channels"""
+
+        index_api = Api(User.objects.get(username=settings.INDEXING_API_USERNAME))
+        failed = False
+        for channel in Channel.objects.values_list("name", flat=True):
+            processed = False
+            for user in User.objects.filter(is_staff=True):
+                user_api = Api(user)
+                try:
+                    existing_mods = sorted(
+                        user_api.list_moderators(channel),
+                        key=lambda moderator: moderator.date,
+                    )
+                    if settings.INDEXING_API_USERNAME not in [mod.name for mod in existing_mods]:
+                        if existing_mods and existing_mods[0] != user.username:
+                            # First mod is most powerful mod, use that one.
+                            user_api = Api(User.objects.get(username=existing_mods[0]))
+                        # Add the indexing user as moderator if not present
+                        user_api.add_moderator(settings.INDEXING_API_USERNAME, channel)
+                        # Remove all the old moderators in reverse order
+                        for mod in reversed(existing_mods):
+                            user_api.remove_moderator(mod, channel)
+                        # Add back all the old moderators in original order
+                        for mod in existing_mods:
+                            index_api.add_moderator(mod, channel)
+                    processed = True
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Channel '{}' SUCCESS: Indexing user added or already present.".format(
+                                channel
+                            )
+                        )
+                    )
+                    break
+                except Forbidden:
+                    # Just try the next user
+                    pass
+                except Exception as exc:  # pylint: disable=broad-except
+                    self.stderr.write(
+                        "Channel '{}' ERROR: {}".format(channel, str(exc))
+                    )
+                    failed = True
+            if not processed:
+                self.stderr.write(
+                    "No working user found for Channel '{}'".format(channel)
+                )
+                failed = True
+
+        if failed:
+            sys.exit(1)

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -32,17 +32,17 @@ class Command(BaseCommand):
                     if settings.INDEXING_API_USERNAME not in [
                         mod.name for mod in existing_mods
                     ]:
-                        if existing_mods and existing_mods[0] != user.username:
+                        if existing_mods and existing_mods[0].name != user.username:
                             # First mod is most powerful mod, use that one.
                             user_api = Api(User.objects.get(username=existing_mods[0]))
                         # Add the indexing user as moderator if not present
                         user_api.add_moderator(settings.INDEXING_API_USERNAME, channel)
                         # Remove all the old moderators in reverse order
                         for mod in reversed(existing_mods):
-                            user_api.remove_moderator(mod, channel)
+                            user_api.remove_moderator(mod.name, channel)
                         # Add back all the old moderators in original order
                         for mod in existing_mods:
-                            index_api.add_moderator(mod, channel)
+                            index_api.add_moderator(mod.name, channel)
                     processed = True
                     self.stdout.write(
                         self.style.SUCCESS(

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -43,14 +43,22 @@ class Command(BaseCommand):
                         # Add back all the old moderators in original order
                         for mod in existing_mods:
                             index_api.add_moderator(mod.name, channel)
-                    processed = True
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            "Channel '{}' SUCCESS: Indexing user added or already present.".format(
-                                channel
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                "Channel '{}' SUCCESS: Indexing user added.".format(
+                                    channel
+                                )
                             )
                         )
-                    )
+                    else:
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                "Channel '{}' Indexing user already present.".format(
+                                    channel
+                                )
+                            )
+                        )
+                    processed = True
                     break
                 except Forbidden:
                     # Just try the next user

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
                         user_api.list_moderators(channel),
                         key=lambda moderator: moderator.date,
                     )
-                    if settings.INDEXING_API_USERNAME not in [mod.name for mod in existing_mods]:
+                    if settings.INDEXING_API_USERNAME not in [
+                        mod.name for mod in existing_mods
+                    ]:
                         if existing_mods and existing_mods[0] != user.username:
                             # First mod is most powerful mod, use that one.
                             user_api = Api(User.objects.get(username=existing_mods[0]))

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -1,5 +1,6 @@
 """Management command to add the indexing user account as a moderator to all channels"""
 import sys
+import traceback
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -65,7 +66,7 @@ class Command(BaseCommand):
                     pass
                 except Exception as exc:  # pylint: disable=broad-except
                     self.stderr.write(
-                        "Channel '{}' ERROR: {}".format(channel, str(exc))
+                        "Channel '{}' ERROR: {}".format(channel, traceback.format_exc())
                     )
                     failed = True
             if not processed:

--- a/channels/management/commands/add_index_user_to_channels.py
+++ b/channels/management/commands/add_index_user_to_channels.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                 except Forbidden:
                     # Just try the next user
                     pass
-                except Exception as exc:  # pylint: disable=broad-except
+                except:  # pylint: disable=bare-except
                     self.stderr.write(
                         "Channel '{}' ERROR: {}".format(channel, traceback.format_exc())
                     )

--- a/channels/views/channels_test.py
+++ b/channels/views/channels_test.py
@@ -76,10 +76,13 @@ def test_list_channels_anonymous(client, settings, allow_anonymous):
         assert resp.data["error_type"] == NOT_AUTHENTICATED_ERROR_TYPE
 
 
-def test_create_channel(staff_client, staff_user, reddit_factories):
+def test_create_channel(
+    index_user, staff_client, staff_user, reddit_factories, settings
+):
     """
     Create a channel and assert the response
     """
+    settings.INDEXING_API_USERNAME = index_user.username
     url = reverse("channel-list")
     channel = reddit_factories.channel(
         "private", user=staff_user, strategy=STRATEGY_BUILD
@@ -104,14 +107,17 @@ def test_create_channel(staff_client, staff_user, reddit_factories):
         "banner": None,
         "ga_tracking_id": None,
     }
-    assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == expected
+    assert resp.status_code == status.HTTP_201_CREATED
 
 
-def test_create_channel_no_descriptions(staff_client, staff_user, reddit_factories):
+def test_create_channel_no_descriptions(
+    index_user, staff_client, staff_user, reddit_factories, settings
+):
     """
     Create a channel and assert the response for no descriptions
     """
+    settings.INDEXING_API_USERNAME = index_user.username
     url = reverse("channel-list")
     channel = reddit_factories.channel(
         "private", user=staff_user, strategy=STRATEGY_BUILD
@@ -140,10 +146,13 @@ def test_create_channel_no_descriptions(staff_client, staff_user, reddit_factori
     assert resp.json() == expected
 
 
-def test_create_channel_already_exists(staff_client, private_channel):
+def test_create_channel_already_exists(
+    index_user, staff_client, private_channel, settings
+):
     """
     Create a channel which already exists
     """
+    settings.INDEXING_API_USERNAME = index_user.username
     url = reverse("channel-list")
     payload = {
         "channel_type": "private",

--- a/factory_data/channels.views.channels_test.test_create_channel.json
+++ b/factory_data/channels.views.channels_test.test_create_channel.json
@@ -1,16 +1,19 @@
 {
   "channels": {
     "private": {
-      "channel_type": "public",
-      "description": "Natus error veritatis veniam mollitia aliquam ea. Et veniam eos minima vel dicta nisi officia consequatur. Sint accusamus placeat assumenda velit.\nQuibusdam nobis quisquam perspiciatis. Vero ipsam recusandae voluptatem eaque quaerat earum eaque. Sit sit odit non voluptatem. Unde corporis at at.\nA ipsum blanditiis harum incidunt esse. Nihil quod modi sequi. Excepturi laborum rerum sunt quibusdam inventore.",
-      "name": "1535142997_nesciunt",
-      "public_description": "Odio vitae adipisci commodi expedita. Explicabo voluptatum iste ipsam veritatis.",
-      "title": "Veniam magnam corporis esse deleniti quibusdam."
+      "channel_type": "private",
+      "description": "Aliquam quod asperiores perspiciatis ratione eligendi laudantium quidem quod. Assumenda placeat nostrum magnam itaque molestias debitis ducimus accusamus. Odio architecto voluptate ab exercitationem provident repellendus. Inventore quos nobis blanditiis quis earum expedita.\nError reiciendis molestiae molestiae facere quas. Placeat nam repudiandae animi illum ex quam voluptates quam. Voluptates aliquam dolorum officiis nam. Ipsa placeat ipsa consequuntur recusandae.",
+      "name": "1540328202_non",
+      "public_description": "Minus nam ducimus ea. Possimus tempore vitae voluptatem repellendus doloremque.",
+      "title": "Vero praesentium dolore incidunt."
     }
   },
   "users": {
+    "index_user": {
+      "username": "01CTHBE1488HFBAT1MK9C7J4YE"
+    },
     "staff_user": {
-      "username": "01CNPTE7ZS1RGGGJD9YMPW461W"
+      "username": "01CTHBE4GSQME0P1GFY53T3YNX"
     }
   }
 }

--- a/factory_data/channels.views.channels_test.test_create_channel_already_exists.json
+++ b/factory_data/channels.views.channels_test.test_create_channel_already_exists.json
@@ -2,15 +2,18 @@
   "channels": {
     "private_channel": {
       "channel_type": "private",
-      "description": "Asperiores eum perferendis nisi voluptatem amet. Modi quasi laborum quisquam vel accusantium. Quod reiciendis ea neque blanditiis.\nAdipisci fuga doloremque fugit dolores voluptas harum iure expedita. Error alias inventore in dolor hic qui dolorem illo. Placeat debitis quas ipsam perferendis voluptatibus. Doloribus expedita quaerat doloremque iste.\nAliquam culpa id eaque earum debitis. Ullam eligendi aut adipisci eligendi. Amet delectus qui laudantium illo inventore temporibus porro mollitia.",
-      "name": "1535132855_harum",
-      "public_description": "Facilis voluptatum possimus nulla. Blanditiis excepturi facilis voluptas eos nisi autem.",
-      "title": "Maxime omnis deserunt illo fugiat ullam."
+      "description": "Quibusdam iusto ex earum veritatis mollitia. Atque necessitatibus rem exercitationem eum. Sint similique non amet optio molestias accusamus. Fugiat sit ducimus corporis atque enim ut tempore.\nExplicabo soluta totam nesciunt iste. Dolores in odit numquam quibusdam. Similique commodi natus eum vel non perspiciatis.\nEsse ex vitae illum harum. Facere porro alias cupiditate earum totam. Aut aliquid sequi qui dolor.",
+      "name": "1540328290_ex",
+      "public_description": "Quo possimus ipsa necessitatibus id possimus neque maxime praesentium.",
+      "title": "Iure nam ratione porro magni."
     }
   },
   "users": {
+    "index_user": {
+      "username": "01CTHBGTMM2JJMT9DJAMHVAZCY"
+    },
     "staff_user": {
-      "username": "01CNPGRQQHAHB02YWZQSFCA0GJ"
+      "username": "01CTHBGQA8YGE871Z0K07X8H8B"
     }
   }
 }

--- a/factory_data/channels.views.channels_test.test_create_channel_no_descriptions.json
+++ b/factory_data/channels.views.channels_test.test_create_channel_no_descriptions.json
@@ -2,15 +2,18 @@
   "channels": {
     "private": {
       "channel_type": "restricted",
-      "description": "Eligendi unde omnis eos sequi tenetur. Iste totam ducimus cumque assumenda veritatis. Veniam cumque natus quaerat assumenda possimus omnis atque.\nLabore iusto odio nulla est cum ullam nemo. Placeat deserunt adipisci nulla similique quasi delectus. Reprehenderit ipsa laboriosam reprehenderit ipsum sint.\nEligendi illo a aspernatur omnis laboriosam numquam. Beatae molestias a fugiat explicabo recusandae fugit. Tempore consequatur deleniti ab veniam aliquam sapiente quidem optio.",
-      "name": "1535143004_voluptatib",
-      "public_description": "Rerum at modi occaecati labore architecto. Facilis libero impedit labore laudantium repellendus.",
-      "title": "Modi quae omnis sequi omnis nam cumque."
+      "description": "Corporis eum voluptas aut officia necessitatibus aperiam. Dolorum soluta aspernatur quia corporis quo corporis voluptates ut. Velit totam vel neque iusto ipsam quia distinctio dolorum. Nihil illum rerum repudiandae dolore.\nOccaecati id sed nemo magni id facilis nostrum ullam. Consequuntur fugit reprehenderit veritatis sequi cum error. Doloremque nobis impedit officia repellendus voluptatibus accusantium. Veniam doloremque ducimus sed quos veritatis iure.",
+      "name": "1540328279_aspernatur",
+      "public_description": "Eveniet error quidem iusto nam fugit iste.",
+      "title": "Sint minus molestiae excepturi."
     }
   },
   "users": {
+    "index_user": {
+      "username": "01CTHBGCR9TXXTRYR81WT2JW50"
+    },
     "staff_user": {
-      "username": "01CNPTEEGRKGBVG70TT8TBRXYV"
+      "username": "01CTHBGG2956SW15MPV94ASHQN"
     }
   }
 }

--- a/factory_data/channels.views.channels_test.test_create_channel_noauth.json
+++ b/factory_data/channels.views.channels_test.test_create_channel_noauth.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "index_user": {
+      "username": "01CTHBH7X0J7RDHCVR0PP94ZBX"
+    }
+  }
+}

--- a/factory_data/channels.views.channels_test.test_create_channel_nonstaff.json
+++ b/factory_data/channels.views.channels_test.test_create_channel_nonstaff.json
@@ -1,7 +1,10 @@
 {
   "users": {
     "contributor": {
-      "username": "01BZDEE0THYMRPX8BTXBHA0Y34"
+      "username": "01CTHBH4FT6Y564RDAA2B3XJ64"
+    },
+    "index_user": {
+      "username": "01CTHBH1562G5HDYARQYZS12WB"
     }
   }
 }

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -48,6 +48,15 @@ def reddit_staff_user(reddit_factories):
 
 
 @pytest.fixture()
+def reddit_index_user(reddit_factories):
+    """Override the staff_user fixture to use reddit_factories"""
+    from channels.test_utils import no_ssl_verification
+
+    with no_ssl_verification():
+        return reddit_factories.user("index_user", is_staff=True)
+
+
+@pytest.fixture()
 def private_channel(reddit_factories, staff_user):
     """Returns a standard private channel for tests"""
     return reddit_factories.channel(

--- a/fixtures/users.py
+++ b/fixtures/users.py
@@ -29,6 +29,16 @@ def staff_user(db, use_betamax, request):
 
 
 @pytest.fixture()
+def index_user(db, use_betamax, request):
+    """Create a user to be used for indexing"""
+    if use_betamax:
+        request.getfixturevalue("configure_betamax")
+        return request.getfixturevalue("reddit_index_user")
+    user = UserFactory.create(is_staff=True)
+    return user
+
+
+@pytest.fixture()
 def logged_in_user(client, user):
     """Log the user in and yield the user object"""
     client.force_login(user)

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -120,7 +120,7 @@ def test_update_user_profile(user, key, value):
     serializer.is_valid(raise_exception=True)
     serializer.save()
 
-    profile2 = Profile.objects.first()
+    profile2 = Profile.objects.get(user=user)
 
     for prop in (
         "name",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1369

#### What's this PR do?
- Creates every channel as the indexing user, then adds the user who is submitting the new channel as a moderator for that channel.
- Adds a management command `add_index_user_to_channels` that will iterate over every `Channel` object and insert the indexing user into the moderators list if not already present.

#### How should this be manually tested?
- On the master branch, while logged in as anyone besides the indexing user, create some channels at `/manage/c/new`.  Add another user or two as moderators to some of the channels.
- Switch to this branch and run `docker-compose run web python manage.py add_index_user_to_channels`.  You should see a bunch of messages like `Channel <name> SUCCESS: Indexing user added or already present`
- There may be errors if you have `Channel` objects that don't actually exist in reddit, or channels that have 0 moderators in reddit.  I don't think there's any way to fix those.
- Every channel where the indexing user was missing should now have the indexing user as the most senior moderator, and all the other moderators should still be present in their original order.

#### Where should the reviewer start?
[channels.management.commands.add_index_user_to_channels.py](https://github.com/mitodl/open-discussions/pull/1409/files#diff-4943cf61ee09cb70ba70d15b18b56884)

[channels.serializers.ChannelSerializer.create](https://github.com/mitodl/open-discussions/pull/1409/files#diff-7e5cbd3bde192b46904dbf56f630dc13R137)