### PR TITLE
Add `post_slug` to post and comment docs in Elasticsearch index

### DIFF
--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -116,6 +116,7 @@ def reddit_submission_obj():
         likes=1,
         banned_by=None,
         edited=False,
+        permalink="http://reddit.local/r/channel_1/a/post-title",
     )
 
 

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -66,6 +66,9 @@ CONTENT_OBJECT_TYPE = {
     "created": {"type": "date"},
     "deleted": {"type": "boolean"},
     "removed": {"type": "boolean"},
+    "post_id": {"type": "keyword"},
+    "post_title": {"type": "text"},
+    "post_slug": {"type": "keyword"},
 }
 
 

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -63,12 +63,10 @@ CONTENT_OBJECT_TYPE = {
     "score": {"type": "long"},
     "post_id": {"type": "keyword"},
     "post_title": {"type": "text"},
+    "post_slug": {"type": "keyword"},
     "created": {"type": "date"},
     "deleted": {"type": "boolean"},
     "removed": {"type": "boolean"},
-    "post_id": {"type": "keyword"},
-    "post_title": {"type": "text"},
-    "post_slug": {"type": "keyword"},
 }
 
 

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -1,6 +1,7 @@
 """Serializers for elasticsearch data"""
 from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.serializers import BasePostSerializer, BaseCommentSerializer
+from channels.utils import get_reddit_slug
 from profiles.models import Profile
 from search.api import gen_post_id, gen_comment_id, gen_profile_id
 from search.constants import PROFILE_TYPE
@@ -103,6 +104,7 @@ class ESPostSerializer(ESSerializer):
         "url": "post_link_url",
         "thumbnail": "post_link_thumbnail",
         "profile_image": "author_avatar_small",
+        "slug": "post_slug",
     }
 
     @property
@@ -155,6 +157,7 @@ class ESCommentSerializer(ESSerializer):
             "channel_name": discussions_obj.subreddit.display_name,
             "post_id": discussions_obj.submission.id,
             "post_title": discussions_obj.submission.title,
+            "post_slug": get_reddit_slug(discussions_obj.submission.permalink),
         }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1411 

#### What's this PR do?
Adds `post_slug` to post and comment documents in the search index

#### How should this be manually tested?
- Run `docker-compose run web python manage.py recreate_index`
- Query elasticsearch.  Posts and comments returned by ES should include `post_slug`.
