### PR TITLE
Always align sort menu to the right

### DIFF
--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -1,6 +1,6 @@
 .post-list-title {
   display: flex;
-  justify-content: right;
+  justify-content: flex-end;
   padding-bottom: 10px;
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
Fixes #1414

#### What's this PR do?
Aligns sort menu to the right in Mac Chrome/Safari browsers (and hopefully all others).

#### How should this be manually tested?
Check the home page and channel listing page on a Mac: Chrome, Safari, FF.  The sort menu should be aligned to the right.

<img width="383" alt="screen shot 2018-10-25 at 8 15 42 am" src="https://user-images.githubusercontent.com/187676/47499552-3c814480-d82e-11e8-9948-5e39c1b4d67a.png">
<img width="754" alt="screen shot 2018-10-25 at 8 15 17 am" src="https://user-images.githubusercontent.com/187676/47499553-3c814480-d82e-11e8-9066-796465234f93.png">
<img width="868" alt="screen shot 2018-10-25 at 8 14 54 am" src="https://user-images.githubusercontent.com/187676/47499554-3c814480-d82e-11e8-82fb-3ab84956cd30.png">
