### PR TITLE
Fix login page button label

### DIFF
--- a/static/js/components/auth/AuthEmailForm.js
+++ b/static/js/components/auth/AuthEmailForm.js
@@ -10,7 +10,9 @@ import { validationMessage } from "../../lib/validation"
 import type { EmailForm } from "../../flow/authTypes"
 import type { FormProps } from "../../flow/formTypes"
 
-type Props = FormProps<EmailForm>
+type Props = {
+  submitLabel?: string
+} & FormProps<EmailForm>
 type State = {
   recaptchaScale: number
 }
@@ -73,7 +75,8 @@ class AuthEmailForm extends React.Component<Props, State> {
       onSubmit,
       onUpdate,
       onRecaptcha,
-      processing
+      processing,
+      submitLabel
     } = this.props
     const { recaptchaScale } = this.state
 
@@ -106,7 +109,7 @@ class AuthEmailForm extends React.Component<Props, State> {
             className={`submit-login ${processing ? "disabled" : ""}`}
             disabled={processing}
           >
-            Sign Up
+            {submitLabel || "Next"}
           </button>
         </div>
       </form>

--- a/static/js/containers/auth/RegisterPage.js
+++ b/static/js/containers/auth/RegisterPage.js
@@ -52,7 +52,7 @@ export const RegisterPage = ({
           <title>{formatTitle("Register")}</title>
           <CanonicalLink match={match} />
         </MetaTags>
-        {renderForm({ formError })}
+        {renderForm({ formError, submitLabel: "Sign Up" })}
         <ExternalLogins />
         <div className="alternate-auth-link">
           Already have an account?{" "}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1423 

#### What's this PR do?
Parameterizes the form submit button label with the old default of "Next", parameterizes as "Sign Up" for that page.

#### How should this be manually tested?
Go to /login and /signup and verify you see appropriate labels.
