### PR TITLE
Refactor channel header

### DIFF
--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -1,0 +1,72 @@
+// @flow
+import React from "react"
+import { Link, NavLink } from "react-router-dom"
+
+import ChannelBanner from "../containers/ChannelBanner"
+import { Cell, Grid } from "./Grid"
+import ChannelAvatar, {
+  CHANNEL_AVATAR_MEDIUM
+} from "../containers/ChannelAvatar"
+import IntraPageNav from "./IntraPageNav"
+
+import { editChannelBasicURL, channelURL } from "../lib/url"
+
+import type { Channel } from "../flow/discussionTypes"
+
+type Props = {
+  channel: Channel,
+  isModerator: boolean
+}
+
+export default class ChannelHeader extends React.Component<Props> {
+  render() {
+    const { channel, isModerator } = this.props
+    return (
+      <React.Fragment>
+        <ChannelBanner editable={false} channel={channel} />
+        <Grid className="main-content two-column channel-header">
+          <Cell className="avatar-headline-row" width={12}>
+            <div className="left">
+              <ChannelAvatar
+                editable={false}
+                channel={channel}
+                imageSize={CHANNEL_AVATAR_MEDIUM}
+              />
+              <div className="title-and-headline">
+                <div className="title">{channel.title}</div>
+                {channel.public_description ? (
+                  <div className="headline">{channel.public_description}</div>
+                ) : null}
+              </div>
+            </div>
+            <div className="right">
+              {isModerator ? (
+                <Link
+                  to={editChannelBasicURL(channel.name)}
+                  className="edit-button"
+                >
+                  <i className="material-icons settings">settings</i>
+                </Link>
+              ) : null}
+            </div>
+          </Cell>
+        </Grid>
+        <div className="channel-intra-nav-wrapper">
+          <Grid className="main-content two-column channel-intra-nav">
+            <Cell width={8}>
+              <IntraPageNav>
+                <NavLink
+                  exact
+                  to={channelURL(channel.name)}
+                  activeClassName="active"
+                >
+                  Home
+                </NavLink>
+              </IntraPageNav>
+            </Cell>
+          </Grid>
+        </div>
+      </React.Fragment>
+    )
+  }
+}

--- a/static/js/components/ChannelHeader_test.js
+++ b/static/js/components/ChannelHeader_test.js
@@ -1,0 +1,56 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import ChannelHeader from "./ChannelHeader"
+
+import { makeChannel } from "../factories/channels"
+import { channelURL } from "../lib/url"
+
+describe("ChannelHeader", () => {
+  let channel
+
+  beforeEach(() => {
+    channel = makeChannel()
+  })
+
+  const render = (props = {}) =>
+    shallow(<ChannelHeader channel={channel} isModerator={false} {...props} />)
+
+  it("renders a channel page header", () => {
+    const wrapper = render()
+    assert.deepEqual(
+      wrapper.find("Connect(ChannelAvatar)").prop("channel"),
+      channel
+    )
+    assert.equal(wrapper.find(".title").text(), channel.title)
+
+    const links = wrapper.find("IntraPageNav NavLink")
+    assert.equal(links.length, 1)
+    const props = links.props()
+    assert.equal(props.to, channelURL(channel.name))
+  })
+  ;[true, false].forEach(hasHeadline => {
+    it(`${
+      hasHeadline ? "shows" : "doesn't show"
+    } the headline for the channel`, () => {
+      const headline = "a headline"
+      channel.public_description = hasHeadline ? headline : ""
+      const wrapper = render()
+      assert.equal(wrapper.find(".headline").length, hasHeadline ? 1 : 0)
+      if (hasHeadline) {
+        assert.equal(wrapper.find(".headline").text(), headline)
+      }
+    })
+  })
+  ;[true, false].forEach(isModerator => {
+    it(`${
+      isModerator ? "shows" : "doesn't show"
+    } the moderator edit button`, () => {
+      const wrapper = render({ isModerator })
+
+      assert.equal(wrapper.find(".edit-button").length, isModerator ? 1 : 0)
+    })
+  })
+})

--- a/static/js/components/SortPicker.js
+++ b/static/js/components/SortPicker.js
@@ -11,7 +11,7 @@ import {
 } from "../lib/sorting"
 
 type Props = {
-  updateSortParam: (t: string) => void,
+  updateSortParam: (value: string) => (event: Event) => void,
   value: string
 }
 
@@ -19,7 +19,7 @@ type State = {
   menuOpen: boolean
 }
 
-const SortPicker = labels => {
+const SortPicker = (labels, className) => {
   class SortPicker extends React.Component<Props, State> {
     constructor(props: Props) {
       super(props)
@@ -38,7 +38,7 @@ const SortPicker = labels => {
       const { menuOpen } = this.state
 
       return (
-        <MenuAnchor className="sorter">
+        <MenuAnchor className={`sorter ${className}`}>
           <Menu open={menuOpen} onClose={this.toggleMenuOpen}>
             {labels.map(([type, label]) => (
               <MenuItem key={label} onClick={updateSortParam(type)}>
@@ -57,8 +57,14 @@ const SortPicker = labels => {
   return SortPicker
 }
 
-export const PostSortPicker = SortPicker(VALID_POST_SORT_LABELS)
+export const PostSortPicker = SortPicker(
+  VALID_POST_SORT_LABELS,
+  "post-sort-picker"
+)
 PostSortPicker.displayName = "PostSortPicker"
 
-export const CommentSortPicker = SortPicker(VALID_COMMENT_SORT_LABELS)
+export const CommentSortPicker = SortPicker(
+  VALID_COMMENT_SORT_LABELS,
+  "comment-sort-picker"
+)
 CommentSortPicker.displayName = "CommentSortPicker"

--- a/static/js/components/SortPicker_test.js
+++ b/static/js/components/SortPicker_test.js
@@ -82,4 +82,14 @@ describe("PostSortPicker", () => {
       assert.isTrue(wrapper.state("menuOpen"))
     })
   })
+
+  it("sets the className", () => {
+    [
+      ["post-sort-picker", PostSortPicker],
+      ["comment-sort-picker", CommentSortPicker]
+    ].forEach(([cssClass, Component]) => {
+      const wrapper = renderComponent(Component)()
+      assert.equal(wrapper.prop("className"), `sorter ${cssClass}`)
+    })
+  })
 })

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -5,8 +5,8 @@ import R from "ramda"
 import qs from "query-string"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
-import { Link } from "react-router-dom"
 
+import ChannelHeader from "../components/ChannelHeader"
 import CanonicalLink from "../components/CanonicalLink"
 import { withPostLoadingSidebar } from "../components/Loading"
 import { PostSortPicker } from "../components/SortPicker"
@@ -15,15 +15,10 @@ import {
   postModerationSelector
 } from "../hoc/withPostModeration"
 import withPostList from "../hoc/withPostList"
-import IntraPageNav from "../components/IntraPageNav"
 import { withChannelTracker } from "../hoc/withChannelTracker"
 import ChannelSidebar from "../components/ChannelSidebar"
 import Sidebar from "../components/Sidebar"
 import { Grid, Cell } from "../components/Grid"
-import ChannelBanner from "../containers/ChannelBanner"
-import ChannelAvatar, {
-  CHANNEL_AVATAR_MEDIUM
-} from "../containers/ChannelAvatar"
 
 import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
@@ -36,7 +31,6 @@ import { formatTitle } from "../lib/title"
 import { clearChannelError } from "../actions/channel"
 import { evictPostsForChannel } from "../actions/posts_for_channel"
 import { updatePostSortParam, POSTS_SORT_HOT } from "../lib/sorting"
-import { editChannelBasicURL } from "../lib/url"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -128,45 +122,7 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
     } else {
       return (
         <div className="channel-page-wrapper">
-          <ChannelBanner editable={false} channel={channel} />
-          <Grid className="main-content two-column channel-header">
-            <Cell className="avatar-headline-row" width={12}>
-              <div className="left">
-                <ChannelAvatar
-                  editable={false}
-                  channel={channel}
-                  imageSize={CHANNEL_AVATAR_MEDIUM}
-                />
-                <div className="title-and-headline">
-                  <div className="title">{channel.title}</div>
-                  {channel.public_description ? (
-                    <div className="headline">{channel.public_description}</div>
-                  ) : null}
-                </div>
-              </div>
-              <div className="right">
-                {isModerator ? (
-                  <Link
-                    to={editChannelBasicURL(channel.name)}
-                    className="edit-button"
-                  >
-                    <i className="material-icons settings">settings</i>
-                  </Link>
-                ) : null}
-              </div>
-            </Cell>
-          </Grid>
-          <div className="channel-intra-nav-wrapper">
-            <Grid className="main-content two-column channel-intra-nav">
-              <Cell width={12}>
-                <IntraPageNav>
-                  <a href="#" className="active">
-                    Home
-                  </a>
-                </IntraPageNav>
-              </Cell>
-            </Grid>
-          </div>
+          <ChannelHeader channel={channel} isModerator={isModerator} />
           <Grid className="main-content two-column channel-page">
             <Cell width={8}>
               <MetaTags>

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -8,6 +8,7 @@ import { Provider } from "react-redux"
 import { createStoreWithMiddleware } from "../store/configureStore"
 import casual from "casual-browserify"
 
+import ChannelHeader from "../components/ChannelHeader"
 import {
   editCommentKey,
   editPostKey,
@@ -491,5 +492,33 @@ storiesOf("Comment", module)
           dropdownMenus={new Set()}
         />
       </StoryWrapper>
+    )
+  })
+
+storiesOf("Channel header", module)
+  .addDecorator(withKnobs)
+  .addDecorator(withRandom)
+  .addDecorator(withRouter)
+  .addDecorator(withRedux)
+  .add("header", () => {
+    const channel = makeChannel()
+    const hasPic = boolean("Has background pic", false)
+    const hasAvatar = boolean("Has avatar", false)
+    channel.banner = hasPic ? "https://picsum.photos/1024/200" : null
+    channel.avatar_small = hasAvatar ? fakeUrl("pr", channel.name) : null
+    channel.avatar_medium = channel.avatar_small
+    return (
+      <div className="app">
+        <div className="content">
+          <div className="loaded">
+            <div className="channel-page-wrapper">
+              <ChannelHeader
+                channel={channel}
+                isModerator={boolean("Is moderator", false)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     )
   })

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -16,16 +16,18 @@
 
 .channel-intra-nav-wrapper {
   background-color: #ffffff;
-  padding: 10px 0 0;
+  padding: 6px 0 0;
 
   .intra-page-nav {
-    margin-bottom: 9px;
+    display: flex;
+    margin-bottom: 0;
+    font-size: 18px;
 
     a {
-      color: $rouge;
-      padding: 5px 15px;
+      padding: 4px 15px;
 
       &.active {
+        color: $rouge;
         border-bottom-color: $rouge;
       }
     }

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -1,7 +1,10 @@
 .post-list-title {
   display: flex;
-  justify-content: flex-end;
   padding-bottom: 10px;
+
+  .post-sort-picker {
+    margin-left: auto;
+  }
 }
 
 .post-list {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #1316 

#### What's this PR do?
Refactors the channel header to make it a separate component. In a future PR this will be reused on the channel search page. There is also a slight font size change to better match Zeplin:

Before (in master):
![channel_header_before](https://user-images.githubusercontent.com/863262/47664829-3ebd0900-db76-11e8-9e6a-392082bb560c.png)


After (in this PR):
![channel_header_after](https://user-images.githubusercontent.com/863262/47664841-42509000-db76-11e8-9a46-baac51a15753.png)


#### How should this be manually tested?
Click around, nothing should break. Except for the slight font size change everything should look like it did before.
