### PR TITLE
Add search textbox component

### DIFF
--- a/static/js/components/SearchTextbox.js
+++ b/static/js/components/SearchTextbox.js
@@ -1,0 +1,30 @@
+// @flow
+import React from "react"
+
+type Props = {
+  onChange: Function,
+  onClear: Function,
+  onSubmit: Function,
+  value: string
+}
+
+const SearchTextbox = ({ onChange, onClear, onSubmit, value }: Props) => (
+  <div className="search-textbox">
+    <i className="material-icons search-icon" onClick={onSubmit}>
+      search
+    </i>
+    {value ? (
+      <i className="material-icons clear-icon" onClick={onClear}>
+        clear
+      </i>
+    ) : null}
+    <input
+      type="text"
+      className="underlined"
+      value={value}
+      onChange={onChange}
+    />
+  </div>
+)
+
+export default SearchTextbox

--- a/static/js/components/SearchTextbox_test.js
+++ b/static/js/components/SearchTextbox_test.js
@@ -1,0 +1,61 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import SearchTextbox from "./SearchTextbox"
+
+describe("SearchTextbox", () => {
+  let sandbox, onChangeStub, onSubmitStub, onClearStub
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    onChangeStub = sandbox.stub()
+    onSubmitStub = sandbox.stub()
+    onClearStub = sandbox.stub()
+  })
+
+  const render = (props = {}) =>
+    shallow(
+      <SearchTextbox
+        onChange={onChangeStub}
+        onSubmit={onSubmitStub}
+        onClear={onClearStub}
+        value={""}
+        {...props}
+      />
+    )
+
+  it("passes onChange events and the value prop to the input element", () => {
+    const value = "hello"
+    const wrapper = render({ value })
+    assert.equal(wrapper.find("input").prop("value"), value)
+
+    const event = { target: { value: "new value" } }
+    wrapper.find("input").prop("onChange")(event)
+    sinon.assert.calledWith(onChangeStub, event)
+  })
+
+  it("triggers onClear when the 'x' is clicked", () => {
+    const wrapper = render({ value: "text" })
+    const event = { target: { value: "click" } }
+    wrapper.find(".clear-icon").prop("onClick")(event)
+    sinon.assert.calledWith(onClearStub, event)
+  })
+
+  it("triggers onSubmit when the spyglass is clicked", () => {
+    const wrapper = render()
+    const event = { target: { value: "click" } }
+    wrapper.find(".search-icon").prop("onClick")(event)
+    sinon.assert.calledWith(onSubmitStub, event)
+  })
+  ;[true, false].forEach(hasText => {
+    it(`if there ${hasText ? "is text" : "isn't text"} then there should ${
+      hasText ? "" : "not "
+    }be a clear button`, () => {
+      const wrapper = render({ value: hasText ? "text" : "" })
+      assert.equal(wrapper.find(".clear-icon").length, hasText ? 1 : 0)
+    })
+  })
+})

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -38,6 +38,7 @@ import {
   PostSortPicker,
   SearchFilterPicker
 } from "../components/Picker"
+import SearchTextbox from "../components/SearchTextbox"
 
 // delay import so fonts get applied first
 setTimeout(() => {
@@ -557,5 +558,21 @@ storiesOf("Channel header", module)
           </div>
         </div>
       </div>
+    )
+  })
+
+storiesOf("Search textbox", module)
+  .addDecorator(withKnobs)
+  .add("search", () => {
+    return (
+      <StoryWrapper>
+        <SearchTextbox
+          className="search-field"
+          onSubmit={action("search")}
+          onClear={action("clear")}
+          onChange={action("change")}
+          value={text("text", "terms to search for")}
+        />
+      </StoryWrapper>
     )
   })

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -85,6 +85,14 @@ input[type="text"] {
   &.no-height {
     height: auto;
   }
+
+  &.underlined {
+    border-radius: 6.5px 6.5px 0 0;
+    border-bottom: 2px solid black;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+  }
 }
 
 textarea {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -54,6 +54,7 @@
 @import "markdown";
 @import "link";
 @import "home-page";
+@import "search";
 
 body {
   font-family: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -1,0 +1,28 @@
+.search-textbox {
+  position: relative;
+
+  input {
+    padding: 3px 40px 2px 40px;
+    font-size: 22px;
+    font-weight: 600;
+    box-sizing: border-box;
+  }
+
+  .material-icons {
+    cursor: pointer;
+    position: absolute;
+    z-index: 3;
+    top: 6px;
+    height: 21px;
+    width: 21px;
+  }
+
+  .search-icon {
+    left: 10px;
+  }
+
+  .clear-icon {
+    right: 10px;
+    font-size: 20px;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #1316 

#### What's this PR do?
Adds a search textbox component

#### How should this be manually tested?
Run storybook: `docker-compose run -p 9001:9001 watch npm run storybook` then go to localhost:9001. View the search textbox.

#### Screenshots (if appropriate)
Desktop:
![search](https://user-images.githubusercontent.com/863262/47669313-0bcc4280-db81-11e8-9151-e61256146878.png)

Mobile:
![search_mobile](https://user-images.githubusercontent.com/863262/47669319-0ec73300-db81-11e8-8e08-a3cb415e0fd9.png)
