### PR TITLE
Updated mobile navbar and drawer header styling

### DIFF
--- a/static/js/components/DropdownMenu.js
+++ b/static/js/components/DropdownMenu.js
@@ -3,6 +3,8 @@
 import React from "react"
 import onClickOutside from "react-onclickoutside"
 
+import { spaceSeparated } from "../lib/util"
+
 type DropdownMenuProps = {
   closeMenu: Function,
   children: any,
@@ -29,14 +31,13 @@ export class _DropdownMenu extends React.Component<DropdownMenuProps> {
     )
   }
 
-  className = () => {
-    const { className } = this.props
-    return className ? `dropdown-menu ${className}` : "dropdown-menu"
-  }
-
   render() {
+    const { className } = this.props
+
     return (
-      <ul className={this.className()}>{this.setClickHandlersOnChildren()}</ul>
+      <ul className={spaceSeparated(["dropdown-menu", className])}>
+        {this.setClickHandlersOnChildren()}
+      </ul>
     )
   }
 }

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -1,29 +1,19 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { Link } from "react-router-dom"
 import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
 
 import UserMenu from "./UserMenu"
 import HamburgerAndLogo from "../components/HamburgerAndLogo"
 
-import { LOGIN_URL } from "../lib/url"
-
 import type { Profile } from "../flow/discussionTypes"
 
 type Props = {
-  profile: Profile,
+  profile: ?Profile,
   showUserMenu: boolean,
   toggleShowDrawer: Function,
   toggleShowUserMenu: Function
 }
-
-const loginButton = () =>
-  SETTINGS.allow_email_auth ? (
-    <Link to={LOGIN_URL} className="link-button outlined login-link">
-      Log In
-    </Link>
-  ) : null
 
 export default class Toolbar extends React.Component<Props> {
   toolbarRoot: HTMLElement | null
@@ -61,15 +51,11 @@ export default class Toolbar extends React.Component<Props> {
               </span>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
-              {SETTINGS.username ? (
-                <UserMenu
-                  toggleShowUserMenu={toggleShowUserMenu}
-                  showUserMenu={showUserMenu}
-                  profile={profile}
-                />
-              ) : (
-                loginButton()
-              )}
+              <UserMenu
+                toggleShowUserMenu={toggleShowUserMenu}
+                showUserMenu={showUserMenu}
+                profile={profile}
+              />
             </section>
           </div>
         </header>

--- a/static/js/components/Toolbar_test.js
+++ b/static/js/components/Toolbar_test.js
@@ -8,7 +8,6 @@ import { shallow } from "enzyme"
 import Toolbar from "./Toolbar"
 
 import { makeProfile } from "../factories/profiles"
-import { shouldIf } from "../lib/test_utils"
 
 describe("Toolbar", () => {
   let toggleShowDrawerStub, sandbox
@@ -43,36 +42,11 @@ describe("Toolbar", () => {
     assert.ok(toggleShowDrawerStub.called)
   })
 
-  //
-  ;[true, false].forEach(isLoggedIn => {
-    it(`should ${isLoggedIn ? "" : "not"} display UserMenu if user is logged ${
-      isLoggedIn ? "in" : "out"
-    }`, () => {
-      SETTINGS.username = isLoggedIn ? "username" : null
-      assert.equal(
-        renderToolbar()
-          .find("UserMenu")
-          .exists(),
-        isLoggedIn
-      )
-    })
+  it("should include UserMenu", () => {
+    assert.isTrue(
+      renderToolbar()
+        .find("UserMenu")
+        .exists()
+    )
   })
-
-  //
-  ;[[true, "enabled"], [false, "disabled"]].forEach(
-    ([isEmailEnabled, desc]) => {
-      it(`${shouldIf(
-        isEmailEnabled
-      )} display login button if allow_email_auth is ${desc}`, () => {
-        SETTINGS.username = null
-        SETTINGS.allow_email_auth = isEmailEnabled
-        assert.equal(
-          renderToolbar()
-            .find("Link")
-            .exists(),
-          isEmailEnabled
-        )
-      })
-    }
-  )
 })

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -7,14 +7,19 @@ import DropdownMenu from "./DropdownMenu"
 import ProfileImage, { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 
 import { isProfileComplete } from "../lib/util"
-import { profileURL, SETTINGS_URL } from "../lib/url"
+import { profileURL, SETTINGS_URL, LOGIN_URL, REGISTER_URL } from "../lib/url"
 
 import type { Profile } from "../flow/discussionTypes"
 
 type Props = {
-  profile: Profile,
+  profile: ?Profile,
   toggleShowUserMenu: Function,
   showUserMenu: boolean
+}
+
+type DropdownMenuProps = {
+  closeMenu: Function,
+  className?: string
 }
 
 export const DropDownArrow = () => (
@@ -25,9 +30,40 @@ export const DropUpArrow = () => (
   <i className="material-icons arrow_drop_up">arrow_drop_up</i>
 )
 
+export const LoggedInMenu = (props: DropdownMenuProps) => (
+  <DropdownMenu {...props}>
+    <li>
+      <Link to={SETTINGS_URL}>Settings</Link>
+    </li>
+    {SETTINGS.profile_ui_enabled && SETTINGS.username ? (
+      <li>
+        <Link to={profileURL(SETTINGS.username)}>Profile</Link>
+      </li>
+    ) : null}
+    {SETTINGS.allow_email_auth ? (
+      <li>
+        <a href="/logout">Sign Out</a>
+      </li>
+    ) : null}
+  </DropdownMenu>
+)
+
+export const LoggedOutMenu = (props: DropdownMenuProps) => (
+  <DropdownMenu {...props}>
+    <li>
+      <Link to={LOGIN_URL}>Log In</Link>
+    </li>
+    <li>
+      <Link to={REGISTER_URL}>Sign Up</Link>
+    </li>
+  </DropdownMenu>
+)
+
 export default class UserMenu extends React.Component<Props> {
   render() {
     const { toggleShowUserMenu, showUserMenu, profile } = this.props
+
+    const ListComponent = profile ? LoggedInMenu : LoggedOutMenu
 
     return (
       <div className="user-menu">
@@ -44,21 +80,10 @@ export default class UserMenu extends React.Component<Props> {
           ) : null}
         </div>
         {showUserMenu ? (
-          <DropdownMenu closeMenu={toggleShowUserMenu}>
-            <li>
-              <Link to={SETTINGS_URL}>Settings</Link>
-            </li>
-            {SETTINGS.profile_ui_enabled && SETTINGS.username ? (
-              <li>
-                <Link to={profileURL(SETTINGS.username)}>Profile</Link>
-              </li>
-            ) : null}
-            {SETTINGS.allow_email_auth ? (
-              <li>
-                <a href="/logout">Sign Out</a>
-              </li>
-            ) : null}
-          </DropdownMenu>
+          <ListComponent
+            className="user-menu-dropdown"
+            closeMenu={toggleShowUserMenu}
+          />
         ) : null}
       </div>
     )

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -66,7 +66,7 @@ type AppProps = {
   banner: BannerState,
   dispatch: Dispatch<*>,
   showUserMenu: boolean,
-  profile: Profile
+  profile: ?Profile
 }
 
 class App extends React.Component<AppProps> {

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -20,7 +20,7 @@ type ImageSize =
 
 type Props = {
   imageSize: ImageSize,
-  profile: Profile,
+  profile: ?Profile,
   userName?: ?string,
   editable: boolean,
   getProfile: (username: string) => Promise<*>,

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -64,7 +64,7 @@ export const userIsAnonymous = () => R.isNil(SETTINGS.username)
 
 export const defaultProfileImageUrl = "/static/images/avatar_default.png"
 
-export function isProfileComplete(profile: Profile): boolean {
+export function isProfileComplete(profile: ?Profile): boolean {
   if (
     !profile ||
     (profile.name &&
@@ -112,3 +112,6 @@ export const removeTrailingSlash = (str: string) =>
 
 export const emptyOrNil = R.either(R.isEmpty, R.isNil)
 export const allEmptyOrNil = R.all(emptyOrNil)
+
+export const spaceSeparated = (strings: Array<?string>): string =>
+  strings.filter(str => str).join(" ")

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -14,7 +14,8 @@ import {
   truncate,
   getTokenFromUrl,
   defaultProfileImageUrl,
-  makeUUID
+  makeUUID,
+  spaceSeparated
 } from "./util"
 
 describe("utility functions", () => {
@@ -166,6 +167,19 @@ describe("utility functions", () => {
 
     it("it uhh shouldnt return the same thing twice :D", () => {
       assert.notEqual(makeUUID(10), makeUUID(10))
+    })
+  })
+
+  describe("spaceSeparated", () => {
+    it("should return a space separated string when given an array of strings or nulls", () => {
+      [
+        [["a", "b", "c"], "a b c"],
+        [[null, null], ""],
+        [[null, "a", "b"], "a b"],
+        [["a", "b", null], "a b"]
+      ].forEach(([inputArr, expectedStr]) => {
+        assert.deepEqual(spaceSeparated(inputArr), expectedStr)
+      })
     })
   })
 })

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -159,18 +159,4 @@ $footer-height: 132px;
   flex-direction: row;
   align-items: center;
   height: 60px;
-
-  a {
-    @include breakpoint(materialmobile) {
-      padding-left: 15px;
-    }
-  }
-
-  a.material-icons {
-    color: $navy;
-  }
-
-  .mitlogo {
-    margin-top: 4px;
-  }
 }

--- a/static/scss/dropdown-menu.scss
+++ b/static/scss/dropdown-menu.scss
@@ -1,9 +1,9 @@
 ul.dropdown-menu {
   margin: 0;
-  padding: 10px;
+  padding: 3px 10px;
   position: absolute;
-  top: 46px;
-  right: 24px;
+  top: 0;
+  right: 0;
   background-color: $card-background;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   list-style: none;
@@ -16,17 +16,17 @@ ul.dropdown-menu {
   }
 
   li {
-    margin-bottom: 14px;
+    margin-top: 7px;
+    margin-bottom: 7px;
     cursor: pointer;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 
   &.post-comment-dropdown {
-    li:not(:last-child) {
-      margin-bottom: 10px;
+    padding: 0 10px;
+
+    li {
+      margin-top: 5px;
+      margin-bottom: 5px;
     }
 
     a {

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -1,7 +1,24 @@
+$header-element-spacing: 8px;
+
 a.mitlogo {
+  color: $navy;
+  height: 25px;
+  line-height: 25px;
+
   img {
-    width: 46px;
+    width: 25px;
+    margin-left: $text-padding-left;
+
+    @include breakpoint(materialmobile) {
+      margin-left: 8px;
+    }
   }
+}
+
+.drawer-mobile-header .mdc-toolbar__icon--menu,
+.navbar .mdc-toolbar__icon--menu {
+  color: $navy;
+  padding: 0 0 0 $icon-padding-left;
 }
 
 .navbar {
@@ -27,23 +44,20 @@ a.mitlogo {
 
     .mdc-toolbar__title,
     .mdc-toolbar__title a {
-      color: #5d5d5d;
-      font-size: 1.1rem;
+      color: $navy;
+      font-size: 14px;
+      font-weight: bold;
+    }
+
+    // Needed to override !important definition from MDC
+    span.mdc-toolbar__title {
+      margin-left: 8px !important;
     }
 
     .mdc-toolbar__section--align-start {
       align-items: center;
       justify-content: flex-start;
     }
-  }
-
-  .mdc-toolbar__icon--menu {
-    color: $navy;
-    padding: 0 0 0 $icon-padding-left;
-  }
-
-  a.mitlogo img {
-    margin-left: $text-padding-left;
   }
 
   .user-menu-section {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -70,7 +70,6 @@
 
   .dropdown-menu {
     top: 22px;
-    right: 11px;
   }
 }
 

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -1,13 +1,23 @@
 .user-menu {
   position: relative;
   cursor: pointer;
-  margin-right: 30px;
+  margin-right: $icon-padding-left;
+
+  .avatar .profile-image {
+    width: 30px;
+    height: 30px;
+  }
 
   i {
     color: black;
     position: absolute;
-    top: 28px;
-    right: -6px;
+    top: 14px;
+    right: -8px;
+  }
+
+  .user-menu-dropdown {
+    top: 31px;
+    right: 0;
   }
 
   .profile-incomplete {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1404

#### What's this PR do?
- Updates navbar and mobile drawer header styling 
- Removes navbar login button and replaces it with an anonymous profile image with dropdown
- Updates some styling in the navbar at desktop widths to match the designs

#### How should this be manually tested?
Look at the app at mobile and desktops widths, compare with the designs: https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5bb6295275c1ab10c74353ba

#### Screenshots (if appropriate)
![ss 2018-11-02 at 13 35 17](https://user-images.githubusercontent.com/14932219/47932216-6c23f280-dea7-11e8-8104-f1bfb5a0a4a5.png)
![ss 2018-11-02 at 13 34 53](https://user-images.githubusercontent.com/14932219/47932217-6c23f280-dea7-11e8-9912-da915f0c13c6.png)
![ss 2018-11-02 at 13 35 22](https://user-images.githubusercontent.com/14932219/47932215-6c23f280-dea7-11e8-9529-9bb11643078a.png)
![ss 2018-11-02 at 13 53 16](https://user-images.githubusercontent.com/14932219/47932214-6b8b5c00-dea7-11e8-8b92-4dc049f60873.png)


