### PR TITLE
remove micromasters logo & text in email

### DIFF
--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -244,7 +244,8 @@
                         <span style="color: #A31F34; font-family: sans-serif; font-size: 28px; line-height: 28px;">{{ site_name }}</span>
                       </h1>
                       {% else %}
-                      <img src="{{ base_url }}/static/images/mit-logo-micromasters.jpg" width="241" alt="MicroMasters" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34;"/>
+                      <img src="{{ base_url }}/static/images/mit-logo.jpg" width="78" height="41" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;  margin-right: 10px;""/>
+                        <span style="color: #A31F34; font-family: sans-serif; font-size: 28px; line-height: 28px;">{{ site_name }}</span>
                       {% endif %}
                       {% endblock %}
 	                </td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots (sort of)
  - [ ] tag @ferdi or @pdpinch for review  
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

Fixes #592 (the last two checkboxes)

#### What's this PR do?

Replaces the "MITx MicroMasters" logo with a combination of the "MIT red" logo and site name. Also changes the ALT text to be the site name. 

#### How should this be manually tested?

1. You may need to set `FEATURE_USE_NEW_BRANDING=False` in .env
2. go to http://od.odl.local:8063/__emaildebugger__/ to see if the logic is correct.
3. If you can, send yourself an email to your phone to see if the layout looks ok. 

In my testing, the `__emaildebugger__` view was not sufficient to test the layout for mobile. 

#### Any background context you want to provide?

This should not make any changes to the "New" branding, which we haven't turned on in Production yet. 

#### Screenshots (if appropriate)

<img width="50%" src="https://user-images.githubusercontent.com/430126/48289589-02bf5900-e43e-11e8-8dac-712c473d09c8.jpg">

![screen shot 2018-11-09 at 4 32 30 pm](https://user-images.githubusercontent.com/430126/48289564-f0451f80-e43d-11e8-9937-e6f5c107fd69.png)

<img width="50%" src="https://user-images.githubusercontent.com/430126/48290608-7747c700-e441-11e8-9bbc-18a02de4d995.PNG">

