### PR TITLE
add profile admin

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -1,0 +1,35 @@
+"""
+Admin site bindings for profiles
+"""
+
+from django.contrib import admin
+
+from .models import Profile
+
+
+class ProfileAdmin(admin.ModelAdmin):
+    """Admin for Profile"""
+    model = Profile
+    list_display = [
+        'user',
+        'name',
+        'email_optin',
+        'toc_optin',
+    ]
+    search_fields = [
+        'name',
+        'user__email',
+        'user__username',
+    ]
+    list_filter = [
+        'email_optin',
+        'toc_optin',
+        'user__is_active',
+    ]
+    raw_id_fields = ('user',)
+    readonly_fields = ('image',
+        'image_small',
+        'image_medium',
+    )
+
+admin.site.register(Profile, ProfileAdmin)

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -9,27 +9,13 @@ from .models import Profile
 
 class ProfileAdmin(admin.ModelAdmin):
     """Admin for Profile"""
+
     model = Profile
-    list_display = [
-        'user',
-        'name',
-        'email_optin',
-        'toc_optin',
-    ]
-    search_fields = [
-        'name',
-        'user__email',
-        'user__username',
-    ]
-    list_filter = [
-        'email_optin',
-        'toc_optin',
-        'user__is_active',
-    ]
-    raw_id_fields = ('user',)
-    readonly_fields = ('image',
-        'image_small',
-        'image_medium',
-    )
+    list_display = ["user", "name", "email_optin", "toc_optin"]
+    search_fields = ["name", "user__email", "user__username"]
+    list_filter = ["email_optin", "toc_optin", "user__is_active"]
+    raw_id_fields = ("user",)
+    readonly_fields = ("image", "image_small", "image_medium")
+
 
 admin.site.register(Profile, ProfileAdmin)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

fixes #1475 

#### What's this PR do?

- add an admin view for profile
- search on username, email
- user is a raw field, to avoid the long load time that comes from getting a full list of all users
- thumbnail images are read-only, which I hope will make it easier to save changes to a profile without getting a validation error 

#### How should this be manually tested?

go to /admin/profiles/profile/

