### PR TITLE
Handle PRAW errors during backpopulate

### DIFF
--- a/search/exceptions.py
+++ b/search/exceptions.py
@@ -7,3 +7,7 @@ class RetryException(Exception):
 
 class ReindexException(Exception):
     """An error during reindexing"""
+
+
+class PopulateUserRolesException(Exception):
+    """An error during populating user roles"""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #1316 

#### What's this PR do?
When the `backpopulate_subscriptions_roles` command is run and it is unable to access a channel, an exception is raised. However Celery assumes the first argument of an exception is a string so this causes another exception, swallowing the original error. 

#### How should this be manually tested?
Add a `Channel` object with a nonexistent name, then run the `backpopulate_subscriptions_roles` management command. You should see an exception raised with a stacktrace and a channel name

