### PR TITLE
fix comment button floating through banner

### DIFF
--- a/static/scss/banner.scss
+++ b/static/scss/banner.scss
@@ -15,6 +15,7 @@
   background-color: $message-component-bg-color;
   text-align: center;
   color: #ffffff;
+  z-index: 15;
 
   &.banner--active {
     top: $toolbar-height-desktop;

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -8,6 +8,10 @@
     height: 30px;
   }
 
+  .dropdown-menu {
+    z-index: 20;
+  }
+
   i {
     color: black;
     position: absolute;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1405 

#### What's this PR do?

This changes the z-index on two things, the banner and the user menu, so that some stacking order stuff is fixed.

Basically, before there was an issue that caused some of the buttons on the post list view cards to show up on top of the banner (see linked issue for a screenshot). this was easily fixed by setting a sufficiently high `z-index` on the banner, but that then caused some issued with the user menu (specifically, it would appear under the banner...)

So, to get around that, I also added a `z-index` to the user-menu dropdown, so it should float above the banner.

#### How should this be manually tested?

Do something to get a banner to appear. I often change line 18 in `components/material/Banner.js` to look like this:

```js
    const activeClass = true ? "banner--active" : ""
```

which makes the banner always appear. then go on to a post list and make sure that there's no stacking weirdness!