### PR TITLE
CSS tweaks to hide image in greeting card

### DIFF
--- a/static/scss/home-page.scss
+++ b/static/scss/home-page.scss
@@ -9,6 +9,10 @@
     flex-grow: 0;
     align-self: flex-start;
 
+    @include breakpoint(phone) {
+      display: none;
+    }
+
     img {
       width: 67px;
       height: 67px;
@@ -28,6 +32,10 @@
     flex-wrap: wrap;
     flex-grow: 1;
     padding-left: 15px;
+
+    @include breakpoint(phone) {
+      padding-left: 0;
+    }
 
     .text-col {
       flex-shrink: 1;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?

closes #1484

#### What's this PR do?

This just hides the MIT logo on the little greeting card when on a phone.

#### How should this be manually tested?

make sure that the logo disappears on a phone-like device width, and that it appears otherwise.

![nologo](https://user-images.githubusercontent.com/6207644/48577340-f4ad8480-e8e4-11e8-89ce-7858cdb5feca.png)
