### PR TITLE
API to retrieve channel followers (subscribers)

### DIFF
--- a/cassettes/channels.views.subscribers_test.test_list_subscribers.json
+++ b/cassettes/channels.views.subscribers_test.test_list_subscribers.json
@@ -1,0 +1,486 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-11-16T19:32:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04EQC40Z680Y42KD877BH"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNUtSAwKdC/38k8xNM7xzPE0c/HJCfPNMMzMyAxU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZFeZiEeIdHevlGmbokpqQY+qfk+qdmGfqH6LqC9KSklmUmp8ZnpoAMhnCUagHPU5dhuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 15-Nov-2020 04:19:06 GMT",
+            "loidcreated=2018-11-16T04%3A19%3A06.285Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sun, 15-Nov-2020 04:19:06 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04EQC40Z680Y42KD877BH"
+      }
+    },
+    {
+      "recorded_at": "2018-11-16T19:32:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Eligendi+optio+sunt+provident+suscipit+veniam+unde.+Repellat+saepe+id+minima+molestiae+numquam+ducimus+cum.%0ADeserunt+esse+veniam+sapiente+numquam+eveniet+illum+facilis.+Officiis+iste+quo+quod+consequuntur.+Iste+optio+veniam+eveniet+optio.%0AEsse+soluta+quae+dolorum+incidunt+sequi+molestiae.+Doloribus+delectus+officiis+molestias+ex.+Libero+cum+ea+quibusdam+asperiores.+Accusamus+laborum+cumque+nemo+ipsam+ea+corrupti+dolorum.&link_type=any&name=1542396725_sint&public_description=Perspiciatis+qui+esse+dolorem+laboriosam.&title=Quae+sapiente+dolore+beatae+suscipit.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 185-paRQGwJOd13lIlI6DLlVMh1ihiQ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "639"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; loidcreated=2018-11-16T04%3A19%3A06.285Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.53.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "54"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-11-16T19:32:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; loidcreated=2018-11-16T04%3A19%3A06.285Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.53.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04N621TD888PKTEC6YVEX"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNN1rCjMTitLDTJ0zkoJrMrOMYus8kr3Nc+vykxX0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVOzrqeodlmvq7prtlZHr6u4aVROSEeKekF5aD9KSklmUmp8ZnpoAMhnCUagHB68BruAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04N621TD888PKTEC6YVEX"
+      }
+    },
+    {
+      "recorded_at": "2018-11-16T19:32:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1542396725_sint"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 186-AxqkfveR1CjdQzkl6YzJgM7ozig"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "74"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; loidcreated=2018-11-16T04%3A19%3A06.285Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.53.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "50"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-11-16T19:32:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; loidcreated=2018-11-16T04%3A19%3A06.285Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.53.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04N6JXYB9RGTPVW9GG3Q3"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDK0MNf1KHDzqMx3dg2pCE4OdM92cyvPqgrTjS/I9vNU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblBPlWllbFJxmnVfmkZOsWxYckeoebuGdnliWD9KSklmUmp8ZnpoAMhnCUagErqEzOuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CWF04N6JXYB9RGTPVW9GG3Q3"
+      }
+    },
+    {
+      "recorded_at": "2018-11-16T19:32:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "action=sub&api_type=json&skip_inital_defaults=True&sr_name=1542396725_sint"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 187-HpFHyoCETxScQGkFFwjzV-_pkNI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "74"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=0XNN2C5g7ooIAv81Ld; loidcreated=2018-11-16T04%3A19%3A06.285Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.53.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/subscribe/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 16 Nov 2018 04:19:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "50"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/subscribe/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.subscribers_test.test_list_subscribers_allowed.json
+++ b/cassettes/channels.views.subscribers_test.test_list_subscribers_allowed.json
@@ -1,0 +1,74 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-11-16T14:53:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CWEG780363E4E12Y13GZY7GC"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNyw6CMBREf4V0aTSpwfeORBtNIHFDXDZwe4EGwqOFKjX+u1RWLudkzsybJACoNe+bEmty8sh6f1xFYQP+RgRp+mQ1FMZcaWDjre1ETpYewVcrFWouneDvKJ3Yz+f92KIbSTFRqFxXQzOjhUsKs0ks/t9GZsaD1FDGVRZVdnhEd3o5D2HHbs4RaCQgl8INz4F8vqluak64AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 15 Nov 2018 23:41:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=ptVc0D5a7HkSMYSlGA; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 14-Nov-2020 23:41:00 GMT",
+            "loidcreated=2018-11-15T23%3A41%3A00.477Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 14-Nov-2020 23:41:00 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CWEG780363E4E12Y13GZY7GC"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/models.py
+++ b/channels/models.py
@@ -148,6 +148,21 @@ class Channel(TimestampedModel):
 
         return super().save(*args, **kwargs)
 
+    @property
+    def subscribers(self):
+        """
+        Retrieve channel subscribers
+
+        Returns:
+            iterable of User: users who are channel subscribers
+
+        """
+        return User.objects.filter(
+            id__in=ChannelSubscription.objects.filter(channel=self).values_list(
+                "user", flat=True
+            )
+        ).iterator()
+
     def __str__(self):
         return f"{self.name}"
 

--- a/channels/models.py
+++ b/channels/models.py
@@ -158,9 +158,9 @@ class Channel(TimestampedModel):
 
         """
         return User.objects.filter(
-            id__in=ChannelSubscription.objects.filter(channel=self).values_list(
-                "user", flat=True
-            )
+            id__in=ChannelSubscription.objects.filter(channel=self)
+            .order_by("created_on")
+            .values_list("user", flat=True)
         ).iterator()
 
     def __str__(self):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -18,7 +18,7 @@ from channels.utils import (
     num_items_not_none,
 )
 from channels.constants import VALID_CHANNEL_TYPES, VALID_LINK_TYPES
-from channels.models import Channel, Subscription
+from channels.models import Channel, Subscription, ChannelSubscription
 from channels.proxies import proxy_post
 from open_discussions.utils import filter_dict_with_renamed_keys
 from profiles.models import Profile
@@ -898,7 +898,9 @@ class SubscriberSerializer(serializers.Serializer):
         channel_name = self.context["view"].kwargs["channel_name"]
         username = validated_data["subscriber_name"]
         api.add_subscriber(username, channel_name)
-        return list(Channel.objects.get(name=channel_name).subscribers)[-1]
+        return ChannelSubscription.objects.get(
+            channel__name=channel_name, user__username=username
+        ).user
 
 
 class ReportSerializer(serializers.Serializer):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -883,7 +883,7 @@ class SubscriberSerializer(serializers.Serializer):
 
     def get_subscriber_name(self, instance):
         """Returns the name for the subscriber"""
-        return instance.name
+        return instance.username
 
     def validate_subscriber_name(self, value):
         """Validates the subscriber name"""
@@ -896,7 +896,9 @@ class SubscriberSerializer(serializers.Serializer):
     def create(self, validated_data):
         api = self.context["channel_api"]
         channel_name = self.context["view"].kwargs["channel_name"]
-        return api.add_subscriber(validated_data["subscriber_name"], channel_name)
+        username = validated_data["subscriber_name"]
+        api.add_subscriber(username, channel_name)
+        return list(Channel.objects.get(name=channel_name).subscribers)[-1]
 
 
 class ReportSerializer(serializers.Serializer):

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -8,6 +8,7 @@ from praw.models.reddit.redditor import Redditor
 from rest_framework.exceptions import ValidationError
 
 from channels.api import sync_channel_subscription_model
+from channels.factories import ChannelFactory
 from channels.models import Channel
 from channels.serializers import (
     ChannelSerializer,
@@ -569,6 +570,7 @@ def test_subscriber_validate_name():
 def test_subscriber_create():
     """Adds a subscriber"""
     user = UserFactory.create()
+    ChannelFactory.create(name="foo_channel")
     subscriber_user = UserFactory.create()
     api_mock = Mock(
         add_subscriber=Mock(

--- a/channels/views/subscribers.py
+++ b/channels/views/subscribers.py
@@ -1,14 +1,14 @@
 """Views for REST APIs for channels"""
-
-from praw.models import Redditor
+from django.conf import settings
 from rest_framework import status
 from rest_framework.exceptions import NotFound
-from rest_framework.generics import CreateAPIView
+from rest_framework.generics import ListCreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from channels.api import Api
+from channels.models import Channel, ChannelSubscription
 from channels.serializers import SubscriberSerializer
 from open_discussions.permissions import (
     IsStaffOrReadonlyPermission,
@@ -16,7 +16,7 @@ from open_discussions.permissions import (
 )
 
 
-class SubscriberListView(CreateAPIView):
+class SubscriberListView(ListCreateAPIView):
     """
     View to add subscribers in channels
     """
@@ -27,6 +27,16 @@ class SubscriberListView(CreateAPIView):
     def get_serializer_context(self):
         """Context for the request and view"""
         return {"channel_api": self.request.channel_api, "view": self}
+
+    def get_queryset(self):
+        """Get generator for subscribers in channel"""
+        return (
+            subscriber
+            for subscriber in list(
+                Channel.objects.get(name=self.kwargs["channel_name"]).subscribers
+            )
+            if subscriber.username != settings.INDEXING_API_USERNAME
+        )
 
 
 class SubscriberDetailView(APIView):
@@ -42,19 +52,19 @@ class SubscriberDetailView(APIView):
 
     def get(self, request, *args, **kwargs):
         """Get subscriber for the channel"""
-        api = Api(user=request.user)
         subscriber_name = self.kwargs["subscriber_name"]
         channel_name = self.kwargs["channel_name"]
+        subscription = ChannelSubscription.objects.filter(
+            channel__name=channel_name, user__username=subscriber_name
+        ).first()
 
-        if not api.is_subscriber(subscriber_name, channel_name):
+        if not subscription:
             raise NotFound(
                 "User {} is not a subscriber of {}".format(
                     subscriber_name, channel_name
                 )
             )
-        return Response(
-            SubscriberSerializer(Redditor(api.reddit, name=subscriber_name)).data
-        )
+        return Response(SubscriberSerializer(subscription.user).data)
 
     def delete(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """

--- a/channels/views/subscribers_test.py
+++ b/channels/views/subscribers_test.py
@@ -4,6 +4,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from channels.factories import ChannelFactory
 from open_discussions.constants import NOT_AUTHENTICATED_ERROR_TYPE
 from open_discussions.factories import UserFactory
 from open_discussions.features import ANONYMOUS_ACCESS
@@ -11,12 +12,13 @@ from open_discussions.features import ANONYMOUS_ACCESS
 pytestmark = [pytest.mark.betamax, pytest.mark.usefixtures("mock_channel_exists")]
 
 
-def test_list_subscribers_not_allowed(staff_client):
+def test_list_subscribers_allowed(staff_client):
     """
-    Get method not allowed on the list of subscribers
+    Get method allowed on the list of subscribers
     """
-    url = reverse("subscriber-list", kwargs={"channel_name": "test_channel"})
-    assert staff_client.get(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+    channel = ChannelFactory.create()
+    url = reverse("subscriber-list", kwargs={"channel_name": channel.name})
+    assert staff_client.get(url).status_code == status.HTTP_200_OK
 
 
 @pytest.mark.parametrize("attempts", [1, 2])

--- a/factory_data/channels.views.subscribers_test.test_list_subscribers.json
+++ b/factory_data/channels.views.subscribers_test.test_list_subscribers.json
@@ -1,0 +1,16 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Eligendi optio sunt provident suscipit veniam unde. Repellat saepe id minima molestiae numquam ducimus cum.\nDeserunt esse veniam sapiente numquam eveniet illum facilis. Officiis iste quo quod consequuntur. Iste optio veniam eveniet optio.\nEsse soluta quae dolorum incidunt sequi molestiae. Doloribus delectus officiis molestias ex. Libero cum ea quibusdam asperiores. Accusamus laborum cumque nemo ipsam ea corrupti dolorum.",
+      "name": "1542396725_sint",
+      "public_description": "Perspiciatis qui esse dolorem laboriosam.",
+      "title": "Quae sapiente dolore beatae suscipit."
+    }
+  },
+  "users": {
+    "staff_user": {
+      "username": "01CWF04EQC40Z680Y42KD877BH"
+    }
+  }
+}

--- a/factory_data/channels.views.subscribers_test.test_list_subscribers_allowed.json
+++ b/factory_data/channels.views.subscribers_test.test_list_subscribers_allowed.json
@@ -1,7 +1,0 @@
-{
-  "users": {
-    "staff_user": {
-      "username": "01CWEG780363E4E12Y13GZY7GC"
-    }
-  }
-}

--- a/factory_data/channels.views.subscribers_test.test_list_subscribers_allowed.json
+++ b/factory_data/channels.views.subscribers_test.test_list_subscribers_allowed.json
@@ -1,0 +1,7 @@
+{
+  "users": {
+    "staff_user": {
+      "username": "01CWEG780363E4E12Y13GZY7GC"
+    }
+  }
+}

--- a/factory_data/channels.views.subscribers_test.test_list_subscribers_not_allowed.json
+++ b/factory_data/channels.views.subscribers_test.test_list_subscribers_not_allowed.json
@@ -1,7 +1,0 @@
-{
-  "users": {
-    "staff_user": {
-      "username": "01BZJPGDK7XYJ7ME7JR56WA4ZP"
-    }
-  }
-}


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1466

#### What's this PR do?
- Allows a list of subscribers to be returned by the API
- Changes serializer and API views for subscribers to query django instead of reddit.

#### How should this be manually tested?
Subscriber API:
 - Go to `/api/v0/channels/<channel_name>/subscribers/`.  You should get a list of usernames back on this branch, and a 405 on master.
 - Go to `/api/v0/channels/<channel_name/subscribers/<subscriber_name>/`.  You should get the same result on this branch and on master: `{"subscriber_name":  <username>}`
