### PR TITLE
Add english analyzer to Elasticsearch mapping, and update search to use it

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -48,7 +48,7 @@ ENGLISH_TEXT_FIELD = {
 BASE_OBJECT_TYPE = {
     "object_type": {"type": "keyword"},
     "author_id": {"type": "keyword"},
-    "author_name": {"type": "keyword"},
+    "author_name": {"type": "text"},
     "author_avatar_small": {"type": "keyword"},
     "author_headline": ENGLISH_TEXT_FIELD,
 }

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -40,17 +40,22 @@ GLOBAL_DOC_TYPE = "_doc"
 SCRIPTING_LANG = "painless"
 UPDATE_CONFLICT_SETTING = "proceed"
 
+ENGLISH_TEXT_FIELD = {
+    "type": "text",
+    "fields": {"english": {"type": "text", "analyzer": "english"}},
+}
+
 BASE_OBJECT_TYPE = {
     "object_type": {"type": "keyword"},
     "author_id": {"type": "keyword"},
     "author_name": {"type": "keyword"},
     "author_avatar_small": {"type": "keyword"},
-    "author_headline": {"type": "text"},
+    "author_headline": ENGLISH_TEXT_FIELD,
 }
 
 PROFILE_OBJECT_TYPE = {
     **BASE_OBJECT_TYPE,
-    "author_bio": {"type": "text"},
+    "author_bio": ENGLISH_TEXT_FIELD,
     "author_channel_membership": {"type": "keyword"},
     "author_avatar_medium": {"type": "keyword"},
 }
@@ -58,12 +63,12 @@ PROFILE_OBJECT_TYPE = {
 CONTENT_OBJECT_TYPE = {
     **BASE_OBJECT_TYPE,
     "channel_name": {"type": "keyword"},
-    "channel_title": {"type": "text"},
+    "channel_title": ENGLISH_TEXT_FIELD,
     "channel_type": {"type": "keyword"},
-    "text": {"type": "text"},
+    "text": ENGLISH_TEXT_FIELD,
     "score": {"type": "long"},
     "post_id": {"type": "keyword"},
-    "post_title": {"type": "text"},
+    "post_title": ENGLISH_TEXT_FIELD,
     "post_slug": {"type": "keyword"},
     "created": {"type": "date"},
     "deleted": {"type": "boolean"},

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -73,9 +73,9 @@ export const searchResultToProfile = (result: ProfileResult): Profile => ({
   username:             result.author_id
 })
 
-const POST_QUERY_FIELDS = ["text", "post_title"]
-const COMMENT_QUERY_FIELDS = ["text"]
-const PROFILE_QUERY_FIELDS = ["author_headline", "author_bio"]
+const POST_QUERY_FIELDS = ["text.english", "post_title.english"]
+const COMMENT_QUERY_FIELDS = ["text.english"]
+const PROFILE_QUERY_FIELDS = ["author_headline.english", "author_bio.english"]
 const _searchFields = (type: ?string) => {
   if (type === "post") {
     return POST_QUERY_FIELDS

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -298,9 +298,9 @@ describe("search functions", () => {
 
   describe("searchFields", () => {
     [
-      ["post", ["text", "post_title"]],
-      ["comment", ["text"]],
-      ["profile", ["author_headline", "author_bio"]]
+      ["post", ["text.english", "post_title.english"]],
+      ["comment", ["text.english"]],
+      ["profile", ["author_headline.english", "author_bio.english"]]
     ].forEach(([type, fields]) => {
       it(`has the right searchFields for ${type}`, () => {
         assert.deepEqual(searchFields(type), fields)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1497 
Fixes #1333 

#### What's this PR do?
Adds a field using the [english](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#english-analyzer) analyzer for every `text` field in the mapping. Searches would then use these specific fields for search to make use of stemming and other english-specific analysis. This does not include phonetic or synonym analysis which looks complicated to configure properly (though we can at some later date if we want).

Also changes `author_name` from `keyword` to `text`

Search will be broken after the PR is merged but before the reindex finishes. However the search UI is not yet enabled on production so it shouldn't matter.

#### How should this be manually tested?
Do a search for the plural variation of a word, or a verb with a different tense for example.

