### PR TITLE
add the site name to mobile nav drawer

### DIFF
--- a/static/js/components/HamburgerAndLogo.js
+++ b/static/js/components/HamburgerAndLogo.js
@@ -24,6 +24,11 @@ const HamburgerAndLogo = ({ onHamburgerClick }: Props) => (
         }`}
       />
     </a>
+    <span className="mdc-toolbar__title">
+      <a href={SETTINGS.authenticated_site.base_url}>
+        {SETTINGS.authenticated_site.title}
+      </a>{" "}
+    </span>
   </React.Fragment>
 )
 

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -47,11 +47,6 @@ export default class Toolbar extends React.Component<Props> {
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
               <HamburgerAndLogo onHamburgerClick={this.toggleShowDrawer} />
-              <span className="mdc-toolbar__title">
-                <a href={SETTINGS.authenticated_site.base_url}>
-                  {SETTINGS.authenticated_site.title}
-                </a>{" "}
-              </span>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
               {SETTINGS.allow_search ? (

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -21,6 +21,18 @@ a.mitlogo {
   padding: 0 0 0 $icon-padding-left;
 }
 
+.mdc-toolbar__title,
+.mdc-toolbar__title a {
+  color: $navy;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+// Needed to override !important definition from MDC
+span.mdc-toolbar__title {
+  margin-left: 8px !important;
+}
+
 .navbar {
   .mdc-toolbar {
     background-color: #fff;
@@ -71,18 +83,6 @@ a.mitlogo {
 
     .mdc-toolbar__section {
       padding: $toolbar-vert-padding 0;
-    }
-
-    .mdc-toolbar__title,
-    .mdc-toolbar__title a {
-      color: $navy;
-      font-size: 14px;
-      font-weight: bold;
-    }
-
-    // Needed to override !important definition from MDC
-    span.mdc-toolbar__title {
-      margin-left: 8px !important;
     }
 
     .mdc-toolbar__section--align-start {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
closes #1467 

#### What's this PR do?

This PR basically adds the site name to the top of the mobile navigation drawer. We have it in the top of the toolbar already, and it was supposed to be on the mobile drawer the same way, but it didn't get added.

#### How should this be manually tested?

Look at the app in a mobile simulator or on a phone and make sure the site name appears at the top of the mobile nav drawer. The toolbar at the top of the page should look as it did before, as should the desktop drawer.

#### Screenshots (if appropriate)

![sitenamemob](https://user-images.githubusercontent.com/6207644/48642747-c2b32580-e9ab-11e8-8b82-3b253b87c3c0.png)
