### PR TITLE
small tweaks to embedly 'link' display

### DIFF
--- a/static/scss/embedly.scss
+++ b/static/scss/embedly.scss
@@ -41,6 +41,10 @@
     @include breakpoint(desktopwide) {
       &.compact {
         flex-direction: row;
+
+        .thumbnail {
+          margin-right: 15px;
+        }
       }
     }
 
@@ -64,8 +68,6 @@
       }
 
       &.compact {
-        margin-right: 5px;
-
         @include breakpoint(desktopwide) {
           height: 200px;
           width: 300px;
@@ -86,7 +88,7 @@
       }
 
       .description {
-        font-size: 15px;
+        font-size: 16px;
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?

closes #1356 

#### What's this PR do?

For the 'compact' version of the link display, this just adds a little more padding between the text and the image, and bumps up the font size for the text.

#### How should this be manually tested?

Grab a link (like a nytimes story or something like that), and then make this code change to make it display in the 'compact' mode:

```diff
diff --git a/static/js/components/Embedly.js b/static/js/components/Embedly.js
index 4667bf0c..29ca3e1a 100644
--- a/static/js/components/Embedly.js
+++ b/static/js/components/Embedly.js
@@ -67,9 +67,9 @@ export default class Embedly extends React.Component<Props> {
       )
     }
 
-    const compactView =
-      embedly.thumbnail_url &&
-      (embedly.thumbnail_height < 400 || embedly.thumbnail_width < 400)
+    const compactView =true
+      // embedly.thumbnail_url &&
+      // (embedly.thumbnail_height < 400 || embedly.thumbnail_width < 400)
 
     return (
       <React.Fragment>
```

then you should see the changes on the post page.


#### Screenshots (if appropriate)

![spacingjjojojojo](https://user-images.githubusercontent.com/6207644/48785082-ff379780-ecb1-11e8-8988-a4a58a885a69.png)

