### PR TITLE
Enable profile search

### DIFF
--- a/static/js/lib/picker.js
+++ b/static/js/lib/picker.js
@@ -48,7 +48,8 @@ export const VALID_SEARCH_FILTER_TYPES = [
 export const VALID_SEARCH_FILTER_LABELS = [
   [SEARCH_FILTER_ALL, "All"],
   [SEARCH_FILTER_POST, "Post"],
-  [SEARCH_FILTER_COMMENT, "Comment"]
+  [SEARCH_FILTER_COMMENT, "Comment"],
+  [SEARCH_FILTER_PROFILE, "Profile"]
 ]
 
 const updatePickerParam = R.curry(

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -75,7 +75,11 @@ export const searchResultToProfile = (result: ProfileResult): Profile => ({
 
 const POST_QUERY_FIELDS = ["text.english", "post_title.english"]
 const COMMENT_QUERY_FIELDS = ["text.english"]
-const PROFILE_QUERY_FIELDS = ["author_headline.english", "author_bio.english"]
+const PROFILE_QUERY_FIELDS = [
+  "author_headline.english",
+  "author_bio.english",
+  "author_name"
+]
 const _searchFields = (type: ?string) => {
   if (type === "post") {
     return POST_QUERY_FIELDS
@@ -126,8 +130,7 @@ export const buildSearchQuery = ({
   if (!R.isNil(size)) {
     builder = builder.size(size)
   }
-  // Temporary: no "profile" in whole list
-  const types = type ? [type] : ["comment", "post"]
+  const types = type ? [type] : ["comment", "post", "profile"]
   for (const type of types) {
     // One of the text fields must match
     const matchQuery = text

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -105,26 +105,15 @@ describe("search functions", () => {
       assert.deepEqual(buildSearchQuery({}), {
         query: {
           bool: {
-            should: [
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "comment" } }]
-                    }
-                  }
-                }
-              },
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "post" } }]
-                    }
+            should: ["comment", "post", "profile"].map(objectType => ({
+              bool: {
+                filter: {
+                  bool: {
+                    must: [{ term: { object_type: objectType } }]
                   }
                 }
               }
-            ]
+            }))
           }
         }
       })
@@ -134,17 +123,15 @@ describe("search functions", () => {
       assert.deepEqual(buildSearchQuery({ type: "xyz" }), {
         query: {
           bool: {
-            should: [
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "xyz" } }]
-                    }
+            should: ["xyz"].map(objectType => ({
+              bool: {
+                filter: {
+                  bool: {
+                    must: [{ term: { object_type: objectType } }]
                   }
                 }
               }
-            ]
+            }))
           }
         }
       })
@@ -155,26 +142,15 @@ describe("search functions", () => {
         from:  0,
         query: {
           bool: {
-            should: [
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "comment" } }]
-                    }
-                  }
-                }
-              },
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "post" } }]
-                    }
+            should: ["comment", "post", "profile"].map(objectType => ({
+              bool: {
+                filter: {
+                  bool: {
+                    must: [{ term: { object_type: objectType } }]
                   }
                 }
               }
-            ]
+            }))
           }
         }
       })
@@ -185,26 +161,15 @@ describe("search functions", () => {
         size:  4,
         query: {
           bool: {
-            should: [
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "comment" } }]
-                    }
-                  }
-                }
-              },
-              {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [{ term: { object_type: "post" } }]
-                    }
+            should: ["comment", "post", "profile"].map(objectType => ({
+              bool: {
+                filter: {
+                  bool: {
+                    must: [{ term: { object_type: objectType } }]
                   }
                 }
               }
-            ]
+            }))
           }
         }
       })
@@ -300,7 +265,10 @@ describe("search functions", () => {
     [
       ["post", ["text.english", "post_title.english"]],
       ["comment", ["text.english"]],
-      ["profile", ["author_headline.english", "author_bio.english"]]
+      [
+        "profile",
+        ["author_headline.english", "author_bio.english", "author_name"]
+      ]
     ].forEach(([type, fields]) => {
       it(`has the right searchFields for ${type}`, () => {
         assert.deepEqual(searchFields(type), fields)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1513 

#### What's this PR do?
Adds profile search. Users should be able to search profile headlines, bios and names. If a user searches within a channel they should only see profiles associated with that channel in some way. They should be able to search all profiles in site search.

#### How should this be manually tested?
Search various names and click on the link on the profiles. Make sure things look right.

