### PR TITLE
Do not try to update the profile index for the indexing user

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -1028,7 +1028,7 @@ class Api:
             raise NotFound("User {} does not exist".format(contributor_name))
         self.get_channel(channel_name).contributor.add(user)
         add_user_role(channel_name, ROLE_CONTRIBUTORS, user)
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
         return Redditor(self.reddit, name=contributor_name)
 
     def remove_contributor(self, contributor_name, channel_name):
@@ -1048,7 +1048,7 @@ class Api:
         # regardless of their contributor status
         self.get_channel(channel_name).contributor.remove(user)
         remove_user_role(channel_name, ROLE_CONTRIBUTORS, user)
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
 
     def list_contributors(self, channel_name):
         """
@@ -1082,7 +1082,7 @@ class Api:
             if ex.error_type != "ALREADY_MODERATOR":
                 raise
         add_user_role(channel_name, ROLE_MODERATORS, user)
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
 
     def accept_invite(self, channel_name):
         """
@@ -1108,7 +1108,7 @@ class Api:
 
         self.get_channel(channel_name).moderator.remove(user)
         remove_user_role(channel_name, ROLE_MODERATORS, user)
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
 
     def _list_moderators(self, *, channel_name, moderator_name):
         """
@@ -1180,7 +1180,7 @@ class Api:
         except PrawForbidden as ex:
             raise PermissionDenied() from ex
         sync_channel_subscription_model(channel_name, user)
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
         return Redditor(self.reddit, name=subscriber_name)
 
     def remove_subscriber(self, subscriber_name, channel_name):
@@ -1207,7 +1207,7 @@ class Api:
         ChannelSubscription.objects.filter(
             user=user, channel__name=channel_name
         ).delete()
-        search_task_helpers.update_author(user.profile)
+        search_task_helpers.update_author(user)
 
     def is_subscriber(self, subscriber_name, channel_name):
         """

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -875,7 +875,7 @@ def test_add_contributor(mock_client, mock_update_author):
         ).group
         in contributor.groups.all()
     )
-    mock_update_author.assert_called_with(contributor.profile)
+    mock_update_author.assert_called_with(contributor)
     assert isinstance(redditor, Redditor)
     assert redditor.name == contributor.username
 
@@ -908,7 +908,7 @@ def test_remove_contributor(mock_client, mock_update_author):
         ).group
         not in contributor.groups.all()
     )
-    mock_update_author.assert_called_with(contributor.profile)
+    mock_update_author.assert_called_with(contributor)
 
 
 def test_list_contributors(mock_client):
@@ -935,7 +935,7 @@ def test_add_moderator(mock_client, mock_update_author):
         ).group
         in moderator.groups.all()
     )
-    mock_update_author.assert_called_with(moderator.profile)
+    mock_update_author.assert_called_with(moderator)
 
 
 def test_add_moderator_no_user(mock_client):
@@ -964,7 +964,7 @@ def test_remove_moderator(mock_client, mock_update_author):
         ).group
         not in moderator.groups.all()
     )
-    mock_update_author.assert_called_with(moderator.profile)
+    mock_update_author.assert_called_with(moderator)
 
 
 def test_list_moderator(mock_client):
@@ -1169,7 +1169,7 @@ def test_add_subscriber(mock_client, mock_update_author):
     assert ChannelSubscription.objects.filter(
         channel__name="channel", user=subscriber
     ).exists()
-    mock_update_author.assert_called_with(subscriber.profile)
+    mock_update_author.assert_called_with(subscriber)
 
 
 def test_add_remove_subscriber_no_user(mock_client):
@@ -1194,7 +1194,7 @@ def test_remove_subscriber(mock_client, mock_update_author):
     assert not ChannelSubscription.objects.filter(
         channel__name="testchannel5", user=subscriber
     ).exists()
-    mock_update_author.assert_called_with(subscriber.profile)
+    mock_update_author.assert_called_with(subscriber)
 
 
 def test_is_subscriber(mock_client):

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -125,7 +125,7 @@ class Profile(models.Model):
         if is_new:
             task_helpers.index_new_profile(self)
         else:
-            task_helpers.update_author(self)
+            task_helpers.update_author(self.user)
         if update_posts:
             task_helpers.update_author_posts_comments(self)
 

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -129,7 +129,7 @@ def test_update_user_profile(mock_index_functions, user, key, value):
         else:
             assert getattr(profile2, prop) == getattr(profile, prop)
 
-    mock_index_functions.update_author.assert_called_once_with(profile2)
+    mock_index_functions.update_author.assert_called_once_with(profile2.user)
     assert mock_index_functions.update_posts.call_count == (
         1 if key in ["name", "headline"] else 0
     )
@@ -175,7 +175,7 @@ def test_update_profile(mock_index_functions, user, key, value):
         mock_index_functions.update_posts.assert_called_once_with(profile2)
     else:
         mock_index_functions.update_posts.assert_not_called()
-        mock_index_functions.update_author.assert_called_with(profile2)
+        mock_index_functions.update_author.assert_called_with(profile2.user)
 
 
 def test_serialize_profile_websites(user):

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -167,8 +167,7 @@ def update_author(user_obj):
         user_obj(django.contrib.auth.models.User): the User whose profile to query by and update
     """
     if user_obj.username != settings.INDEXING_API_USERNAME:
-        profile = user_obj.profile
-        profile_data = ESProfileSerializer().serialize(profile)
+        profile_data = ESProfileSerializer().serialize(user_obj.profile)
         profile_data.pop("author_id", None)
         update_fields_by_username(user_obj.username, profile_data, [PROFILE_TYPE])
 

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -344,13 +344,23 @@ def test_update_author(mocker, mock_index_functions, mock_es_profile_serializer,
     patched_task = mocker.patch("search.task_helpers.update_field_values_by_query")
     call_data = es_profile_serializer_data
     call_data.pop("author_id")
-    update_author(user.profile)
+    update_author(user)
     assert patched_task.delay.called is True
     assert patched_task.delay.call_args[1] == dict(
         query={"query": {"bool": {"must": [{"match": {"author_id": user.username}}]}}},
         field_dict=call_data,
         object_types=[PROFILE_TYPE],
     )
+
+
+def test_update_indexing_author(mocker, mock_index_functions, index_user, settings):
+    """
+    Tests that update_author does not call update_field_values_by_query for the indexing user
+    """
+    settings.INDEXING_API_USERNAME = index_user.username
+    patched_task = mocker.patch("search.task_helpers.update_field_values_by_query")
+    update_author(index_user)
+    assert patched_task.delay.called is False
 
 
 def test_update_author_posts_comments(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1520 

#### What's this PR do?
Modifies `search.task_helpers.update_author` to take a `User` object instead of `Profile` as the input parameter, and tries to update the profile index only if that user is not the indexing user.

#### How should this be manually tested?
- In micromasters, set `OPEN_DISCUSSIONS_API_USERNAME` to a user without a profile.  In discussions, set `INDEXING_API_USERNAME` to the same user.
- Log into micromasters as someone who can create channels.  Create a channel.  No exceptions should occur.