### PR TITLE
Update index when channel is updated

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -475,6 +475,7 @@ class Api:
 
         return channel
 
+    @reddit_object_persist(search_task_helpers.update_channel_index)
     def update_channel(self, name, title=None, channel_type=None, **other_settings):
         """
         Updates a channel

--- a/open_discussions/recorder.py
+++ b/open_discussions/recorder.py
@@ -16,7 +16,7 @@ def record(name, user):
 
     Usage:
         with record('cassette_name', my_user) as api:
-            api.update_channel('channel', title='new_title')
+            api.update_channel_index('channel', title='new_title')
 
     Args:
         name (str): The name of the new cassette

--- a/open_discussions/recorder.py
+++ b/open_discussions/recorder.py
@@ -16,7 +16,7 @@ def record(name, user):
 
     Usage:
         with record('cassette_name', my_user) as api:
-            api.update_channel_index('channel', title='new_title')
+            api.update_channel('channel', title='new_title')
 
     Args:
         name (str): The name of the new cassette

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -159,6 +159,30 @@ def update_fields_by_username(username, field_dict, object_types):
 
 
 @if_feature_enabled(INDEX_UPDATES)
+def update_channel_index(channel_obj):
+    """
+    Runs a task to update the channel title for all posts and comments associated with the given channel.
+
+    Args:
+        channel_obj (praw.models.Subreddit): A PRAW channel ('subreddit') object
+    """
+    update_field_values_by_query.delay(
+        query={
+            "query": {
+                "bool": {
+                    "must": [{"match": {"channel_name": channel_obj.display_name}}]
+                }
+            }
+        },
+        field_dict={
+            "channel_title": channel_obj.title,
+            "channel_type": channel_obj.subreddit_type,
+        },
+        object_types=[COMMENT_TYPE, POST_TYPE],
+    )
+
+
+@if_feature_enabled(INDEX_UPDATES)
 def update_author(user_obj):
     """
     Run a task to update all fields of a profile document except id (username)

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -161,7 +161,7 @@ def update_fields_by_username(username, field_dict, object_types):
 @if_feature_enabled(INDEX_UPDATES)
 def update_channel_index(channel_obj):
     """
-    Runs a task to update the channel title for all posts and comments associated with the given channel.
+    Runs a task to update the channel title, type for all posts and comments associated with the given channel.
 
     Args:
         channel_obj (praw.models.Subreddit): A PRAW channel ('subreddit') object

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -1,7 +1,5 @@
 """Task helper tests"""
 # pylint: disable=redefined-outer-name,unused-argument
-from unittest.mock import Mock
-
 import pytest
 
 from open_discussions.features import INDEX_UPDATES
@@ -392,7 +390,7 @@ def test_update_channel_index(mocker, mock_index_functions):
     Tests that update_channel_index calls update_field_values_by_query with the right parameters
     """
     patched_task = mocker.patch("search.task_helpers.update_field_values_by_query")
-    channel = Mock(
+    channel = mocker.Mock(
         display_name="name",
         title="title",
         subreddit_type="public",

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -1,5 +1,7 @@
 """Task helper tests"""
 # pylint: disable=redefined-outer-name,unused-argument
+from unittest.mock import Mock
+
 import pytest
 
 from open_discussions.features import INDEX_UPDATES
@@ -21,6 +23,7 @@ from search.task_helpers import (
     index_new_profile,
     update_author,
     update_author_posts_comments,
+    update_channel_index,
 )
 from search.api import gen_post_id, gen_comment_id, gen_profile_id
 
@@ -381,4 +384,33 @@ def test_update_author_posts_comments(
         query={"query": {"bool": {"must": [{"match": {"author_id": user.username}}]}}},
         field_dict=call_data,
         object_types=[POST_TYPE, COMMENT_TYPE],
+    )
+
+
+def test_update_channel_index(mocker, mock_index_functions):
+    """
+    Tests that update_channel_index calls update_field_values_by_query with the right parameters
+    """
+    patched_task = mocker.patch("search.task_helpers.update_field_values_by_query")
+    channel = Mock(
+        display_name="name",
+        title="title",
+        subreddit_type="public",
+        description="description",
+        public_description="public_description",
+        submission_type="link",
+    )
+    update_channel_index(channel)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[1] == dict(
+        query={
+            "query": {
+                "bool": {"must": [{"match": {"channel_name": channel.display_name}}]}
+            }
+        },
+        field_dict={
+            "channel_title": channel.title,
+            "channel_type": channel.subreddit_type,
+        },
+        object_types=[COMMENT_TYPE, POST_TYPE],
     )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1358 

#### What's this PR do?
- Updates all the post and comment ES index docs for a channel when the channel is changed.

#### How should this be manually tested?
- Search ES for posts and comments within a certain channel, note the values for 'channel_title' and 'channel_type'
- Change the title of the channel.  Search ES again, the values for 'channel_title' should equal the new title.
- Change the type of the channel. Search ES again, the values for 'channel_type' should equal the new type.
