### PR TITLE
Update comment style colors

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -52,4 +52,3 @@ $rouge: #a31f34;
 $navy: #03152d;
 $pale-grey: #f4f6fa;
 $white-smoky: #4f4f4f;
-$gray69: #b0b0b0;

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -51,3 +51,5 @@ $text-padding-left: 26px;
 $rouge: #a31f34;
 $navy: #03152d;
 $pale-grey: #f4f6fa;
+$white-smoky: #4f4f4f;
+$gray69: #b0b0b0;

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -110,7 +110,7 @@ $replyPaddingLeftPhone: 10px;
 
       p {
         margin: 0;
-        color: rgba(0, 0, 0, 0.77);
+        color: #4f4f4f;
         line-height: 1.3;
         font-size: $submission-font-size;
         overflow-wrap: break-word;
@@ -166,7 +166,7 @@ $replyPaddingLeftPhone: 10px;
 
       .authored-date {
         font-size: 14px;
-        color: $navy;
+        color: #b0b0b0;
       }
 
       .author-name {
@@ -174,7 +174,7 @@ $replyPaddingLeftPhone: 10px;
         padding-right: 6px;
         font-weight: 500;
         font-size: $author-font-size;
-        color: $font-black;
+        color: $navy;
       }
 
       .removed-note {

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -166,7 +166,7 @@ $replyPaddingLeftPhone: 10px;
 
       .authored-date {
         font-size: 14px;
-        color: $gray69;
+        color: $font-grey-light;
       }
 
       .author-name {

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -110,7 +110,7 @@ $replyPaddingLeftPhone: 10px;
 
       p {
         margin: 0;
-        color: #4f4f4f;
+        color: $white-smoky;
         line-height: 1.3;
         font-size: $submission-font-size;
         overflow-wrap: break-word;
@@ -166,7 +166,7 @@ $replyPaddingLeftPhone: 10px;
 
       .authored-date {
         font-size: 14px;
-        color: #b0b0b0;
+        color: $gray69;
       }
 
       .author-name {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
Fixes #1462

#### What's this PR do?
Updates comment style colors to match Zeplin

#### How should this be manually tested?
View some comments and inspect the styling of the comment author, date, and text.  They should match the colors in [zeplin](https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5ba4f573f5019c5726109435).

Mobile:
<img width="360" alt="screen shot 2018-11-27 at 11 37 18 am" src="https://user-images.githubusercontent.com/187676/49096596-da569d80-f238-11e8-8665-dbe4f1a7ef89.png">

Desktop:
<img width="675" alt="screen shot 2018-11-27 at 11 36 59 am" src="https://user-images.githubusercontent.com/187676/49096598-daef3400-f238-11e8-9190-4085d1499b4a.png">
