### PR TITLE
Enable post voting in search results

### DIFF
--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -14,11 +14,7 @@ import {
 } from "../lib/search"
 import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
-import type {
-  CommentResult,
-  ProfileResult,
-  Result
-} from "../flow/searchTypes"
+import type { CommentResult, ProfileResult, Result } from "../flow/searchTypes"
 import type { Post } from "../flow/discussionTypes"
 
 type PostProps = {

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -76,15 +76,14 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 
 type Props = {
   result: Result,
-  upvotedPosts: Map<string, Post>,
+  upvotedPost: ?Post,
   toggleUpvote?: Post => void
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
-    const { result, toggleUpvote, upvotedPosts } = this.props
-    let post
+    const { result, toggleUpvote, upvotedPost } = this.props
     if (result.object_type === "post") {
-      post = upvotedPosts.get(result.post_id) || searchResultToPost(result)
+      const post = upvotedPost || searchResultToPost(result)
       return <PostSearchResult post={post} toggleUpvote={toggleUpvote} />
     } else if (result.object_type === "comment") {
       return <CommentSearchResult result={result} />

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -14,22 +14,24 @@ import {
 } from "../lib/search"
 import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
-
 import type {
   CommentResult,
   PostResult,
   ProfileResult,
   Result
 } from "../flow/searchTypes"
+import type {Post} from "../flow/discussionTypes";
 
 type PostProps = {
-  result: PostResult
+  result: PostResult,
+  toggleUpvote: Post => void,
 }
-const PostSearchResult = ({ result }: PostProps) => (
+const PostSearchResult = ({ result, toggleUpvote }: PostProps) => (
   <CompactPostDisplay
     post={searchResultToPost(result)}
     isModerator={false}
     menuOpen={false}
+    toggleUpvote={toggleUpvote}
   />
 )
 
@@ -77,13 +79,14 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 }
 
 type Props = {
-  result: Result
+  result: Result,
+  toggleUpvote: Post => void,
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
-    const { result } = this.props
+    const { result, toggleUpvote } = this.props
     if (result.object_type === "post") {
-      return <PostSearchResult result={result} />
+      return <PostSearchResult result={result} toggleUpvote={toggleUpvote}/>
     } else if (result.object_type === "comment") {
       return <CommentSearchResult result={result} />
     } else if (result.object_type === "profile") {

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -16,19 +16,18 @@ import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
 import type {
   CommentResult,
-  PostResult,
   ProfileResult,
   Result
 } from "../flow/searchTypes"
-import type {Post} from "../flow/discussionTypes";
+import type { Post } from "../flow/discussionTypes"
 
 type PostProps = {
-  result: PostResult,
-  toggleUpvote: Post => void,
+  post: Post,
+  toggleUpvote?: Function
 }
-const PostSearchResult = ({ result, toggleUpvote }: PostProps) => (
+const PostSearchResult = ({ post, toggleUpvote }: PostProps) => (
   <CompactPostDisplay
-    post={searchResultToPost(result)}
+    post={post}
     isModerator={false}
     menuOpen={false}
     toggleUpvote={toggleUpvote}
@@ -80,13 +79,16 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 
 type Props = {
   result: Result,
-  toggleUpvote: Post => void,
+  upvotedPosts: Map<string, Post>,
+  toggleUpvote?: Post => void
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
-    const { result, toggleUpvote } = this.props
+    const { result, toggleUpvote, upvotedPosts } = this.props
+    let post
     if (result.object_type === "post") {
-      return <PostSearchResult result={result} toggleUpvote={toggleUpvote}/>
+      post = upvotedPosts.get(result.post_id) || searchResultToPost(result)
+      return <PostSearchResult post={post} toggleUpvote={toggleUpvote} />
     } else if (result.object_type === "comment") {
       return <CommentSearchResult result={result} />
     } else if (result.object_type === "profile") {

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -14,6 +14,7 @@ import {
 } from "../lib/search"
 import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
+
 import type { CommentResult, ProfileResult, Result } from "../flow/searchTypes"
 import type { Post } from "../flow/discussionTypes"
 

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,11 +18,12 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = ({ result }) => shallow(<SearchResult result={result} />)
+  const render = ({ result, upvotedPosts }) => shallow(<SearchResult result={result} upvotedPosts={upvotedPosts}/>)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
-    const wrapper = render({ result }).dive()
+    const upvotedPosts = new Map()
+    const wrapper = render({ result, upvotedPosts }).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)
@@ -46,15 +47,29 @@ describe("SearchResult", () => {
 
   it("renders a post", () => {
     const result = makePostResult()
-    const wrapper = render({ result }).dive()
+    const upvotedPosts = new Map()
+    const wrapper = render({ result, upvotedPosts }).dive()
     const post = searchResultToPost(result)
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), post)
   })
 
+  it("renders an upvoted post", () => {
+    const result = makePostResult()
+    const post = searchResultToPost(result)
+    const upvotedPost = Object.assign({}, post)
+    upvotedPost.upvoted = true
+    upvotedPost.score += 1
+    const upvotedPosts = new Map([[upvotedPost.id, upvotedPost]])
+    const wrapper = render({ result, upvotedPosts }).dive()
+    const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
+    assert.deepEqual(postDisplay.prop("post"), upvotedPost)
+  })
+
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const wrapper = render({ result }).dive()
+    const upvoted = new Map()
+    const wrapper = render({ result, upvoted }).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -24,7 +24,7 @@ describe("SearchResult", () => {
   it("renders a profile card", () => {
     const result = makeProfileResult()
     const upvotedPost = null
-    const wrapper = render({ result, upvotedPost}).dive()
+    const wrapper = render({ result, upvotedPost }).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,13 +18,13 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = ({ result, upvotedPosts }) =>
-    shallow(<SearchResult result={result} upvotedPosts={upvotedPosts} />)
+  const render = ({ result, upvotedPost }) =>
+    shallow(<SearchResult result={result} upvotedPost={upvotedPost} />)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
-    const upvotedPosts = new Map()
-    const wrapper = render({ result, upvotedPosts }).dive()
+    const upvotedPost = null
+    const wrapper = render({ result, upvotedPost}).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)
@@ -48,8 +48,8 @@ describe("SearchResult", () => {
 
   it("renders a post", () => {
     const result = makePostResult()
-    const upvotedPosts = new Map()
-    const wrapper = render({ result, upvotedPosts }).dive()
+    const upvotedPost = null
+    const wrapper = render({ result, upvotedPost }).dive()
     const post = searchResultToPost(result)
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), post)
@@ -61,16 +61,15 @@ describe("SearchResult", () => {
     const upvotedPost = Object.assign({}, post)
     upvotedPost.upvoted = true
     upvotedPost.score += 1
-    const upvotedPosts = new Map([[upvotedPost.id, upvotedPost]])
-    const wrapper = render({ result, upvotedPosts }).dive()
+    const wrapper = render({ result, upvotedPost }).dive()
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), upvotedPost)
   })
 
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const upvotedPosts = new Map()
-    const wrapper = render({ result, upvotedPosts }).dive()
+    const upvotedPost = null
+    const wrapper = render({ result, upvotedPost }).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,7 +18,8 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = ({ result, upvotedPosts }) => shallow(<SearchResult result={result} upvotedPosts={upvotedPosts}/>)
+  const render = ({ result, upvotedPosts }) =>
+    shallow(<SearchResult result={result} upvotedPosts={upvotedPosts} />)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
@@ -68,8 +69,8 @@ describe("SearchResult", () => {
 
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const upvoted = new Map()
-    const wrapper = render({ result, upvoted }).dive()
+    const upvotedPosts = new Map()
+    const wrapper = render({ result, upvotedPosts }).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -25,7 +25,13 @@ import type { Channel } from "../flow/discussionTypes"
 import type { SearchInputs, SearchParams, Result } from "../flow/searchTypes"
 import { Cell, Grid } from "../components/Grid"
 
+
+import {
+  toggleUpvote
+} from "../util/api_actions"
+
 type Props = {
+  dispatch: Dispatch<any>,
   location: Location,
   history: Object,
   channel: ?Channel,
@@ -158,7 +164,7 @@ export class SearchPage extends React.Component<Props, State> {
   }
 
   renderResults = () => {
-    const { results, searchProcessing, initialLoad, total } = this.props
+    const { results, searchProcessing, initialLoad, total, dispatch } = this.props
     const { from } = this.state
 
     if (searchProcessing && initialLoad) {
@@ -179,7 +185,7 @@ export class SearchPage extends React.Component<Props, State> {
         initialLoad={false}
         loader={<Loading className="infinite" key="loader" />}
       >
-        {results.map((result, i) => <SearchResult key={i} result={result} />)}
+        {results.map((result, i) => <SearchResult key={i} result={result} toggleUpvote={toggleUpvote(dispatch)}/>)}
       </InfiniteScroll>
     )
   }
@@ -271,7 +277,8 @@ const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps: Props) => ({
   getChannel: async () => {
     const channelName = getChannelName(ownProps)
     await dispatch(actions.channels.get(channelName))
-  }
+  },
+  dispatch: dispatch
 })
 
 export default R.compose(

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -202,7 +202,7 @@ export class SearchPage extends React.Component<Props, State> {
             key={i}
             result={result}
             toggleUpvote={toggleUpvote(dispatch)}
-            upvotedPosts={upvotedPosts}
+            upvotedPost={(result.object_type === "post") ? upvotedPosts.get(result.post_id) : null}
           />
         ))}
       </InfiniteScroll>

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -202,7 +202,11 @@ export class SearchPage extends React.Component<Props, State> {
             key={i}
             result={result}
             toggleUpvote={toggleUpvote(dispatch)}
-            upvotedPost={(result.object_type === "post") ? upvotedPosts.get(result.post_id) : null}
+            upvotedPost={
+              result.object_type === "post"
+                ? upvotedPosts.get(result.post_id)
+                : null
+            }
           />
         ))}
       </InfiniteScroll>

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -76,7 +76,7 @@ describe("SearchPage", () => {
   })
 
   it("renders search results", async () => {
-    const { inner } = await renderPage()
+    const { wrapper, inner } = await renderPage()
 
     sinon.assert.calledWith(helper.searchStub, {
       channelName: channel.name,
@@ -85,6 +85,10 @@ describe("SearchPage", () => {
       text:        undefined,
       type:        undefined
     })
+    assert.deepEqual(
+      wrapper.props().upvotedPosts.get(upvotedPost.id),
+      upvotedPost
+    )
     searchResponse.hits.hits.forEach((result, i) => {
       assert.deepEqual(
         inner

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -25,6 +25,9 @@ describe("SearchPage", () => {
         data:   new Map([[channel.name, channel]]),
         loaded: true
       },
+      postUpvotes: {
+        data: {}
+      },
       search: {
         loaded: true,
         data:   {
@@ -186,7 +189,8 @@ describe("SearchPage", () => {
       }
     )
     const text = "some text"
-    inner.setState({ text, from: 7 })
+    const upvotedPosts = new Map()
+    inner.setState({ text, from: 7, upvotedPosts })
     inner.find("SearchTextbox").prop("onSubmit")({
       preventDefault: helper.sandbox.stub()
     })
@@ -194,7 +198,8 @@ describe("SearchPage", () => {
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
       from: 0,
-      text
+      text,
+      upvotedPosts
     })
   })
   ;[true, false].forEach(hasChannel => {
@@ -254,7 +259,8 @@ describe("SearchPage", () => {
 
   it("triggers a non-incremental search when the filter type changes", async () => {
     const { inner, store } = await renderPage()
-    inner.setState({ from: 7 })
+    const upvotedPosts = new Map()
+    inner.setState({ from: 7, upvotedPosts })
     const type = "comment"
     helper.searchStub.reset()
     inner.find("SearchFilterPicker").prop("updatePickerParam")(type, {
@@ -271,7 +277,8 @@ describe("SearchPage", () => {
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
       from: 0,
-      text: undefined
+      text: undefined,
+      upvotedPosts
     })
     assert.equal(
       store.getActions()[store.getActions().length - 2].type,

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -9,6 +9,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
 import { makeSearchResponse } from "../factories/search"
 import { makeChannel } from "../factories/channels"
+import {makePost} from "../factories/posts";
 
 describe("SearchPage", () => {
   let helper, renderPage, searchResponse, channel, initialState, initialProps
@@ -259,7 +260,8 @@ describe("SearchPage", () => {
 
   it("triggers a non-incremental search when the filter type changes", async () => {
     const { inner, store } = await renderPage()
-    const upvotedPosts = new Map()
+    const upvotedPost = makePost()
+    const upvotedPosts = new Map([[upvotedPost.id, upvotedPost]])
     inner.setState({ from: 7, upvotedPosts })
     const type = "comment"
     helper.searchStub.reset()

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -9,7 +9,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
 import { makeSearchResponse } from "../factories/search"
 import { makeChannel } from "../factories/channels"
-import {makePost} from "../factories/posts";
+import {makePost} from "../factories/posts"
 
 describe("SearchPage", () => {
   let helper, renderPage, searchResponse, channel, initialState, initialProps

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -9,7 +9,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
 import { makeSearchResponse } from "../factories/search"
 import { makeChannel } from "../factories/channels"
-import {makePost} from "../factories/posts"
+import { makePost } from "../factories/posts"
 
 describe("SearchPage", () => {
   let helper, renderPage, searchResponse, channel, initialState, initialProps


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Partially fixes #1539

#### What's this PR do?
Makes the upvote button work for posts in search results.  It does this by adding `toggleUpvote` and `upvotedPost` props to the `SearchResult` component.  `toggleUpvote` is the standard upvote function.  `upvotedPost` is the result returned after the `toggleUpvote` function is dispatched.  An `upvotedPosts` map has also been added to the state of `SearchPage` to keep track of all the posts that have been voted on.

This allows for the upvote buttons to be rendered correctly (black if upvoted, gray if upvote removed) with updated scores after they are clicked.  However, all the buttons will initially be rendered as gray because ElasticSearch has no way of knowing if the current user has already upvoted that post or not.  


#### How should this be manually tested?
- Do a channel-specific search and a global search.  
- For each search, upvote multiple posts by other authors (not your own).  The upvote buttons for those posts should all turn black.  The score may or may not increase depending on whether or not you already upvoted that post in the past.  
- Click the upvote button again on some of those posts to cancel your upvotes.  They should turn gray and the scores should decrease by 1.
