### PR TITLE
Hide reply and menu icons on search post/comment result cards

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -59,7 +59,7 @@ type Props = {
   toggleFollowComment?: Function,
   curriedDropdownMenufunc: (key: string) => Object,
   dropdownMenus: Set<string>,
-  menuDisabled?: boolean
+  useSearchPageUI?: boolean
 }
 
 export const commentDropdownKey = (c: CommentInTree) =>
@@ -106,7 +106,7 @@ export default class CommentTree extends React.Component<Props> {
       ignoreCommentReports,
       curriedDropdownMenufunc,
       dropdownMenus,
-      menuDisabled
+      useSearchPageUI
     } = this.props
     const editFormKey = editCommentKey(comment)
 
@@ -132,7 +132,7 @@ export default class CommentTree extends React.Component<Props> {
         {atMaxDepth ||
         moderationUI ||
         comment.deleted ||
-        !beginEditing ? null : (
+        useSearchPageUI ? null : (
             <ReplyButton
               beginEditing={e => {
                 if (beginEditing) {
@@ -160,7 +160,7 @@ export default class CommentTree extends React.Component<Props> {
             />
           ) : null}
         </div>
-        {!userIsAnonymous() && !menuDisabled ? (
+        {!userIsAnonymous() && !useSearchPageUI ? (
           <div>
             <i className="material-icons more_vert" onClick={showDropdown}>
               more_vert

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -58,7 +58,8 @@ type Props = {
   ignoreCommentReports?: (c: CommentInTree) => void,
   toggleFollowComment?: Function,
   curriedDropdownMenufunc: (key: string) => Object,
-  dropdownMenus: Set<string>
+  dropdownMenus: Set<string>,
+  menuDisabled?: boolean
 }
 
 export const commentDropdownKey = (c: CommentInTree) =>
@@ -104,7 +105,8 @@ export default class CommentTree extends React.Component<Props> {
       moderationUI,
       ignoreCommentReports,
       curriedDropdownMenufunc,
-      dropdownMenus
+      dropdownMenus,
+      menuDisabled
     } = this.props
     const editFormKey = editCommentKey(comment)
 
@@ -127,19 +129,22 @@ export default class CommentTree extends React.Component<Props> {
             downvote={downvote}
           />
         ) : null}
-        {atMaxDepth || moderationUI || comment.deleted ? null : (
-          <ReplyButton
-            beginEditing={e => {
-              if (beginEditing) {
-                beginEditing(
-                  replyToCommentKey(comment),
-                  getCommentReplyInitialValue(comment),
-                  e
-                )
-              }
-            }}
-          />
-        )}
+        {atMaxDepth ||
+        moderationUI ||
+        comment.deleted ||
+        !beginEditing ? null : (
+            <ReplyButton
+              beginEditing={e => {
+                if (beginEditing) {
+                  beginEditing(
+                    replyToCommentKey(comment),
+                    getCommentReplyInitialValue(comment),
+                    e
+                  )
+                }
+              }}
+            />
+          )}
         <div className="share-button-wrapper">
           <div
             className="comment-action-button share-button"
@@ -155,7 +160,7 @@ export default class CommentTree extends React.Component<Props> {
             />
           ) : null}
         </div>
-        {!userIsAnonymous() ? (
+        {!userIsAnonymous() && !menuDisabled ? (
           <div>
             <i className="material-icons more_vert" onClick={showDropdown}>
               more_vert

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -169,8 +169,8 @@ describe("CommentTree", () => {
     assert.ok(beginEditingStub.calledWith(replyToCommentKey(comments[0])))
   })
 
-  it('should not include a "reply" button if beginEditing function is null', () => {
-    const wrapper = renderCommentTree({ beginEditing: null })
+  it('should not include a "reply" button if useSearchPageUI is true', () => {
+    const wrapper = renderCommentTree({ useSearchPageUI: true })
     assert.notOk(wrapper.find(".comment-action-button.reply-button").exists())
   })
 
@@ -187,16 +187,16 @@ describe("CommentTree", () => {
   })
 
   //
-  ;[true, false].forEach(menuDisabled => {
+  ;[true, false].forEach(useSearchPageUI => {
     ["testuser", null].forEach(username => {
       it(`${shouldIf(
-        username !== null && !menuDisabled
+        username !== null && !useSearchPageUI
       )} include a showMenu icon`, () => {
         SETTINGS.username = username
-        const wrapper = renderCommentTree({ menuDisabled })
+        const wrapper = renderCommentTree({ useSearchPageUI })
         assert.equal(
           wrapper.find(".more_vert").exists(),
-          username !== null && !menuDisabled
+          username !== null && !useSearchPageUI
         )
       })
     })

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -169,6 +169,11 @@ describe("CommentTree", () => {
     assert.ok(beginEditingStub.calledWith(replyToCommentKey(comments[0])))
   })
 
+  it('should not include a "reply" button if beginEditing function is null', () => {
+    const wrapper = renderCommentTree({ beginEditing: null })
+    assert.notOk(wrapper.find(".comment-action-button.reply-button").exists())
+  })
+
   it('should not include a "reply" button for deleted posts', () => {
     comments[0].deleted = true
     const wrapper = renderCommentTree()
@@ -182,11 +187,18 @@ describe("CommentTree", () => {
   })
 
   //
-  ;["testuser", null].forEach(username => {
-    it(`${shouldIf(username !== null)} include a showMenu icon`, () => {
-      SETTINGS.username = username
-      const wrapper = renderCommentTree()
-      assert.equal(wrapper.find(".more_vert").exists(), username !== null)
+  ;[true, false].forEach(menuDisabled => {
+    ["testuser", null].forEach(username => {
+      it(`${shouldIf(
+        username !== null && !menuDisabled
+      )} include a showMenu icon`, () => {
+        SETTINGS.username = username
+        const wrapper = renderCommentTree({ menuDisabled })
+        assert.equal(
+          wrapper.find(".more_vert").exists(),
+          username !== null && !menuDisabled
+        )
+      })
     })
   })
 

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -37,6 +37,7 @@ type Props = {
   ignorePostReports?: (post: Post) => Promise<*>,
   reportPost?: ?(post: Post) => void,
   menuOpen: boolean,
+  menuDisabled?: boolean,
   dispatch: Dispatch<*>
 }
 
@@ -66,6 +67,7 @@ export class CompactPostDisplay extends React.Component<Props> {
       ignorePostReports,
       reportPost,
       menuOpen,
+      menuDisabled,
       dispatch
     } = this.props
     const formattedDate = moment(post.created).fromNow()
@@ -161,7 +163,7 @@ export class CompactPostDisplay extends React.Component<Props> {
               </i>
               <span>{post.num_comments}</span>
             </Link>
-            {userIsAnonymous() ? null : (
+            {userIsAnonymous() || menuDisabled ? null : (
               <i
                 className="material-icons more_vert post-menu-button grey-surround"
                 onClick={menuOpen ? null : showPostMenu}

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -37,7 +37,7 @@ type Props = {
   ignorePostReports?: (post: Post) => Promise<*>,
   reportPost?: ?(post: Post) => void,
   menuOpen: boolean,
-  menuDisabled?: boolean,
+  useSearchPageUI?: boolean,
   dispatch: Dispatch<*>
 }
 
@@ -67,7 +67,7 @@ export class CompactPostDisplay extends React.Component<Props> {
       ignorePostReports,
       reportPost,
       menuOpen,
-      menuDisabled,
+      useSearchPageUI,
       dispatch
     } = this.props
     const formattedDate = moment(post.created).fromNow()
@@ -163,7 +163,7 @@ export class CompactPostDisplay extends React.Component<Props> {
               </i>
               <span>{post.num_comments}</span>
             </Link>
-            {userIsAnonymous() || menuDisabled ? null : (
+            {userIsAnonymous() || useSearchPageUI ? null : (
               <i
                 className="material-icons more_vert post-menu-button grey-surround"
                 onClick={menuOpen ? null : showPostMenu}

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -335,15 +335,15 @@ describe("CompactPostDisplay", () => {
 
   //
   ;[true, false].forEach(isAnonymous => {
-    [true, false].forEach(menuDisabled => {
+    [true, false].forEach(useSearchPageUI => {
       it(`${shouldIf(
-        isAnonymous || menuDisabled
+        isAnonymous || useSearchPageUI
       )} hide the menu open button`, () => {
         helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(isAnonymous)
-        const wrapper = renderPostDisplay({ post, menuDisabled })
+        const wrapper = renderPostDisplay({ post, useSearchPageUI })
         assert.equal(
           wrapper.find("i.more_vert").exists(),
-          !isAnonymous && !menuDisabled
+          !isAnonymous && !useSearchPageUI
         )
       })
     })

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -333,9 +333,19 @@ describe("CompactPostDisplay", () => {
     )
   })
 
-  it("should hide the menu open button when anonymous", () => {
-    helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(true)
-    const wrapper = renderPostDisplay({ post })
-    assert.isNotOk(wrapper.find("i.more_vert").exists())
+  //
+  ;[true, false].forEach(isAnonymous => {
+    [true, false].forEach(menuDisabled => {
+      it(`${shouldIf(
+        isAnonymous || menuDisabled
+      )} hide the menu open button`, () => {
+        helper.sandbox.stub(utilFuncs, "userIsAnonymous").returns(isAnonymous)
+        const wrapper = renderPostDisplay({ post, menuDisabled })
+        assert.equal(
+          wrapper.find("i.more_vert").exists(),
+          !isAnonymous && !menuDisabled
+        )
+      })
+    })
   })
 })

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -27,6 +27,7 @@ const PostSearchResult = ({ post, toggleUpvote }: PostProps) => (
     post={post}
     isModerator={false}
     menuOpen={false}
+    menuDisabled={true}
     toggleUpvote={toggleUpvote}
   />
 )
@@ -52,6 +53,7 @@ const CommentSearchResult = ({ result }: CommentProps) => {
       )}
       curriedDropdownMenufunc={dropdownMenuFuncs(() => null)}
       dropdownMenus={new Set()}
+      menuDisabled={true}
     />
   )
 }

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -27,7 +27,7 @@ const PostSearchResult = ({ post, toggleUpvote }: PostProps) => (
     post={post}
     isModerator={false}
     menuOpen={false}
-    menuDisabled={true}
+    useSearchPageUI
     toggleUpvote={toggleUpvote}
   />
 )
@@ -53,7 +53,7 @@ const CommentSearchResult = ({ result }: CommentProps) => {
       )}
       curriedDropdownMenufunc={dropdownMenuFuncs(() => null)}
       dropdownMenus={new Set()}
-      menuDisabled={true}
+      useSearchPageUI
     />
   )
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [ ] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1551 
Fixes #1541 

#### What's this PR do?
- Hides the reply button on search comment cards
- Hides the overflow menu icon on search cards (posts, comments)

#### How should this be manually tested?
Search for posts and comments.  The results should not have overflow menu icons or reply buttons.
On the frontpage and channel pages, post cards should still have overflow menus.
On post pages, replies should still have overflow menus and reply buttons.

#### Screenshots (if appropriate)
Mobile:
<img width="370" alt="screen shot 2018-12-04 at 1 01 33 pm" src="https://user-images.githubusercontent.com/187676/49462734-c674e380-f7c4-11e8-8a8a-15660a504ad2.png">

Desktop:
<img width="674" alt="screen shot 2018-12-04 at 1 00 47 pm" src="https://user-images.githubusercontent.com/187676/49462735-c674e380-f7c4-11e8-9c9e-49a0063a15bd.png">


