### PR TITLE
Enable comment voting in search results

### DIFF
--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -324,11 +324,13 @@ def update_indexed_score(instance, instance_type, vote_action=None):
     else:
         raise ValueError("Received an invalid vote action value: %s" % vote_action)
 
-    if instance_type != POST_TYPE:
+    if instance_type not in [POST_TYPE, COMMENT_TYPE]:
         return
+    content_id = gen_post_id(instance.id) if instance_type == POST_TYPE else gen_comment_id(instance.id)
+
     increment_document_integer_field.delay(
-        gen_post_id(instance.id),
+        content_id,
         field_name="score",
         incr_amount=vote_increment,
-        object_type=POST_TYPE,
+        object_type=instance_type,
     )

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -326,7 +326,11 @@ def update_indexed_score(instance, instance_type, vote_action=None):
 
     if instance_type not in [POST_TYPE, COMMENT_TYPE]:
         return
-    content_id = gen_post_id(instance.id) if instance_type == POST_TYPE else gen_comment_id(instance.id)
+    content_id = (
+        gen_post_id(instance.id)
+        if instance_type == POST_TYPE
+        else gen_comment_id(instance.id)
+    )
 
     increment_document_integer_field.delay(
         content_id,

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -176,7 +176,7 @@ def test_start_recreate_index(mock_index_functions, mocker, mocked_celery, user)
     settings.INDEXING_API_USERNAME = user.username
     settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE = 2
     users = UserFactory.create_batch(4)
-    channels = ChannelFactory.create_batch(3)
+    channels = [ChannelFactory.create(name=name) for name in ["a", "b", "c"]]
     index_channel_mock = mocker.patch("search.tasks.index_channel", autospec=True)
     index_profiles_mock = mocker.patch("search.tasks.index_profiles", autospec=True)
     backing_index = "backing"

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -15,8 +15,8 @@ import {
 import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
 
-import type { CommentResult, ProfileResult, Result } from "../flow/searchTypes"
-import type { Post } from "../flow/discussionTypes"
+import type { ProfileResult, Result } from "../flow/searchTypes"
+import type {CommentInTree, Post} from "../flow/discussionTypes"
 
 type PostProps = {
   post: Post,
@@ -33,23 +33,26 @@ const PostSearchResult = ({ post, toggleUpvote }: PostProps) => (
 )
 
 type CommentProps = {
-  result: CommentResult
+  comment: CommentInTree,
+  downvote?: Function,
+  upvote?: Function,
+  channel: string,
+  slug: string
 }
-const CommentSearchResult = ({ result }: CommentProps) => {
-  const comment = searchResultToComment(result)
+const CommentSearchResult = ({ comment, upvote, downvote, channel, slug }: CommentProps) => {
   return (
     <CommentTree
       comments={[comment]}
       remove={() => undefined}
       approve={() => undefined}
-      upvote={async () => undefined}
-      downvote={async () => undefined}
+      upvote={upvote}
+      downvote={downvote}
       isModerator={false}
       isPrivateChannel={false}
       commentPermalink={commentPermalink(
-        result.channel_name,
-        result.post_id,
-        result.post_slug
+        channel,
+        comment.post_id,
+        slug
       )}
       curriedDropdownMenufunc={dropdownMenuFuncs(() => null)}
       dropdownMenus={new Set()}
@@ -77,18 +80,36 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 }
 
 type Props = {
+  commentUpvote?: Function,
+  commentDownvote?: Function,
   result: Result,
-  upvotedPost: ?Post,
-  toggleUpvote?: Post => void
+  toggleUpvote?: Post => void,
+  upvotedPost?: ?Post,
+  votedComment?: ?CommentInTree,
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
-    const { result, toggleUpvote, upvotedPost } = this.props
+    const { result, toggleUpvote, upvotedPost, votedComment, commentUpvote, commentDownvote } = this.props
     if (result.object_type === "post") {
       const post = upvotedPost || searchResultToPost(result)
       return <PostSearchResult post={post} toggleUpvote={toggleUpvote} />
     } else if (result.object_type === "comment") {
-      return <CommentSearchResult result={result} />
+      let comment = searchResultToComment(result)
+      if (votedComment) {
+        comment = {
+          ...comment,
+          upvoted:    votedComment.upvoted,
+          downvoted:  votedComment.downvoted,
+          score:      votedComment.score
+        }
+      }
+      return <CommentSearchResult
+        comment={comment}
+        upvote={commentUpvote}
+        downvote={commentDownvote}
+        channel={result.channel_name}
+        slug={result.post_slug}
+      />
     } else if (result.object_type === "profile") {
       return <ProfileSearchResult result={result} />
     }

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -16,7 +16,7 @@ import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
 
 import type { ProfileResult, Result } from "../flow/searchTypes"
-import type {CommentInTree, Post} from "../flow/discussionTypes"
+import type { CommentInTree, Post } from "../flow/discussionTypes"
 
 type PostProps = {
   post: Post,
@@ -39,7 +39,13 @@ type CommentProps = {
   channel: string,
   slug: string
 }
-const CommentSearchResult = ({ comment, upvote, downvote, channel, slug }: CommentProps) => {
+const CommentSearchResult = ({
+  comment,
+  upvote,
+  downvote,
+  channel,
+  slug
+}: CommentProps) => {
   return (
     <CommentTree
       comments={[comment]}
@@ -49,11 +55,7 @@ const CommentSearchResult = ({ comment, upvote, downvote, channel, slug }: Comme
       downvote={downvote}
       isModerator={false}
       isPrivateChannel={false}
-      commentPermalink={commentPermalink(
-        channel,
-        comment.post_id,
-        slug
-      )}
+      commentPermalink={commentPermalink(channel, comment.post_id, slug)}
       curriedDropdownMenufunc={dropdownMenuFuncs(() => null)}
       dropdownMenus={new Set()}
       useSearchPageUI
@@ -85,11 +87,18 @@ type Props = {
   result: Result,
   toggleUpvote?: Post => void,
   upvotedPost?: ?Post,
-  votedComment?: ?CommentInTree,
+  votedComment?: ?CommentInTree
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
-    const { result, toggleUpvote, upvotedPost, votedComment, commentUpvote, commentDownvote } = this.props
+    const {
+      result,
+      toggleUpvote,
+      upvotedPost,
+      votedComment,
+      commentUpvote,
+      commentDownvote
+    } = this.props
     if (result.object_type === "post") {
       const post = upvotedPost || searchResultToPost(result)
       return <PostSearchResult post={post} toggleUpvote={toggleUpvote} />
@@ -98,18 +107,20 @@ export default class SearchResult extends React.Component<Props> {
       if (votedComment) {
         comment = {
           ...comment,
-          upvoted:    votedComment.upvoted,
-          downvoted:  votedComment.downvoted,
-          score:      votedComment.score
+          upvoted:   votedComment.upvoted,
+          downvoted: votedComment.downvoted,
+          score:     votedComment.score
         }
       }
-      return <CommentSearchResult
-        comment={comment}
-        upvote={commentUpvote}
-        downvote={commentDownvote}
-        channel={result.channel_name}
-        slug={result.post_slug}
-      />
+      return (
+        <CommentSearchResult
+          comment={comment}
+          upvote={commentUpvote}
+          downvote={commentDownvote}
+          channel={result.channel_name}
+          slug={result.post_slug}
+        />
+      )
     } else if (result.object_type === "profile") {
       return <ProfileSearchResult result={result} />
     }

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,12 +18,12 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = (props = {}) =>
-    shallow(<SearchResult {...props} />)
+  const render = (result, props = {}) =>
+    shallow(<SearchResult result={result} {...props} />)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
-    const wrapper = render({ result }).dive()
+    const wrapper = render(result).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)
@@ -47,7 +47,7 @@ describe("SearchResult", () => {
 
   it("renders a post", () => {
     const result = makePostResult()
-    const wrapper = render({ result }).dive()
+    const wrapper = render(result).dive()
     const post = searchResultToPost(result)
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), post)
@@ -59,14 +59,14 @@ describe("SearchResult", () => {
     const upvotedPost = Object.assign({}, post)
     upvotedPost.upvoted = true
     upvotedPost.score += 1
-    const wrapper = render({ result, upvotedPost }).dive()
+    const wrapper = render(result, { upvotedPost }).dive()
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), upvotedPost)
   })
 
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const wrapper = render({ result }).dive()
+    const wrapper = render(result).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])
@@ -80,7 +80,7 @@ describe("SearchResult", () => {
       upvoted: true,
       score:   (comment.score += 1)
     }
-    const wrapper = render({ result, votedComment}).dive()
+    const wrapper = render(result, {votedComment}).dive()
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [votedComment])
   })

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -19,7 +19,7 @@ import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
   const render = ({ result, props }) =>
-    shallow(<SearchResult result={result} {...props}/>)
+    shallow(<SearchResult result={result} {...props} />)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
@@ -61,7 +61,7 @@ describe("SearchResult", () => {
     const upvotedPost = Object.assign({}, post)
     upvotedPost.upvoted = true
     upvotedPost.score += 1
-    const props = {upvotedPost}
+    const props = { upvotedPost }
     const wrapper = render({ result, props }).dive()
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), upvotedPost)
@@ -81,13 +81,12 @@ describe("SearchResult", () => {
     const comment = searchResultToComment(result)
     const votedComment = {
       ...comment,
-      upvoted:  true,
-      score:    comment.score += 1
+      upvoted: true,
+      score:   (comment.score += 1)
     }
-    const props = {votedComment}
+    const props = { votedComment }
     const wrapper = render({ result, props }).dive()
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [votedComment])
   })
-
 })

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -80,7 +80,7 @@ describe("SearchResult", () => {
       upvoted: true,
       score:   (comment.score += 1)
     }
-    const wrapper = render(result, {votedComment}).dive()
+    const wrapper = render(result, { votedComment }).dive()
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [votedComment])
   })

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,13 +18,13 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = ({ result, upvotedPost }) =>
-    shallow(<SearchResult result={result} upvotedPost={upvotedPost} />)
+  const render = ({ result, props }) =>
+    shallow(<SearchResult result={result} {...props}/>)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
-    const upvotedPost = null
-    const wrapper = render({ result, upvotedPost }).dive()
+    const props = {}
+    const wrapper = render({ result, props }).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)
@@ -48,8 +48,8 @@ describe("SearchResult", () => {
 
   it("renders a post", () => {
     const result = makePostResult()
-    const upvotedPost = null
-    const wrapper = render({ result, upvotedPost }).dive()
+    const props = {}
+    const wrapper = render({ result, props }).dive()
     const post = searchResultToPost(result)
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), post)
@@ -61,17 +61,33 @@ describe("SearchResult", () => {
     const upvotedPost = Object.assign({}, post)
     upvotedPost.upvoted = true
     upvotedPost.score += 1
-    const wrapper = render({ result, upvotedPost }).dive()
+    const props = {upvotedPost}
+    const wrapper = render({ result, props }).dive()
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), upvotedPost)
   })
 
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const upvotedPost = null
-    const wrapper = render({ result, upvotedPost }).dive()
+    const props = {}
+    const wrapper = render({ result, props }).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])
   })
+
+  it("renders a comment that has been voted on", () => {
+    const result = makeCommentResult()
+    const comment = searchResultToComment(result)
+    const votedComment = {
+      ...comment,
+      upvoted:  true,
+      score:    comment.score += 1
+    }
+    const props = {votedComment}
+    const wrapper = render({ result, props }).dive()
+    const commentTree = wrapper.find("CommentTree")
+    assert.deepEqual(commentTree.prop("comments"), [votedComment])
+  })
+
 })

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -18,13 +18,12 @@ import { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
 import { profileURL } from "../lib/url"
 
 describe("SearchResult", () => {
-  const render = ({ result, props }) =>
-    shallow(<SearchResult result={result} {...props} />)
+  const render = (props = {}) =>
+    shallow(<SearchResult {...props} />)
 
   it("renders a profile card", () => {
     const result = makeProfileResult()
-    const props = {}
-    const wrapper = render({ result, props }).dive()
+    const wrapper = render({ result }).dive()
     const profile = searchResultToProfile(result)
     const profileImage = wrapper.find("Connect(ProfileImage)")
     assert.deepEqual(profileImage.prop("profile"), profile)
@@ -48,8 +47,7 @@ describe("SearchResult", () => {
 
   it("renders a post", () => {
     const result = makePostResult()
-    const props = {}
-    const wrapper = render({ result, props }).dive()
+    const wrapper = render({ result }).dive()
     const post = searchResultToPost(result)
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), post)
@@ -61,16 +59,14 @@ describe("SearchResult", () => {
     const upvotedPost = Object.assign({}, post)
     upvotedPost.upvoted = true
     upvotedPost.score += 1
-    const props = { upvotedPost }
-    const wrapper = render({ result, props }).dive()
+    const wrapper = render({ result, upvotedPost }).dive()
     const postDisplay = wrapper.find("Connect(CompactPostDisplay)")
     assert.deepEqual(postDisplay.prop("post"), upvotedPost)
   })
 
   it("renders a comment", () => {
     const result = makeCommentResult()
-    const props = {}
-    const wrapper = render({ result, props }).dive()
+    const wrapper = render({ result }).dive()
     const comment = searchResultToComment(result)
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [comment])
@@ -84,8 +80,7 @@ describe("SearchResult", () => {
       upvoted: true,
       score:   (comment.score += 1)
     }
-    const props = { votedComment }
-    const wrapper = render({ result, props }).dive()
+    const wrapper = render({ result, votedComment}).dive()
     const commentTree = wrapper.find("CommentTree")
     assert.deepEqual(commentTree.prop("comments"), [votedComment])
   })

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -21,7 +21,7 @@ import { getChannelName } from "../lib/util"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
-import type {Channel, CommentInTree, Post} from "../flow/discussionTypes"
+import type { Channel, CommentInTree, Post } from "../flow/discussionTypes"
 import type { SearchInputs, SearchParams, Result } from "../flow/searchTypes"
 import { Cell, Grid } from "../components/Grid"
 
@@ -80,8 +80,8 @@ export class SearchPage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      text: qs.parse(props.location.search).q,
-      from: 0,
+      text:          qs.parse(props.location.search).q,
+      from:          0,
       votedComments: new Map()
     }
   }
@@ -246,9 +246,8 @@ export class SearchPage extends React.Component<Props, State> {
     const { votedComments } = this.state
     const upvotedCommentMap = new Map(votedComments)
     upvotedCommentMap.set(comment.id, comment)
-    this.setState({votedComments: upvotedCommentMap})
+    this.setState({ votedComments: upvotedCommentMap })
   }
-
 
   render() {
     const {

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -10,8 +10,7 @@ import { actions } from "../actions"
 import { makePostResult, makeSearchResponse } from "../factories/search"
 import { makeChannel } from "../factories/channels"
 import { makePost } from "../factories/posts"
-import {createCommentTree} from "../reducers/comments";
-import {makeCommentsResponse} from "../factories/comments";
+import { makeComment } from "../factories/comments"
 
 describe("SearchPage", () => {
   let helper,
@@ -223,7 +222,7 @@ describe("SearchPage", () => {
     assert.deepEqual(qs.parse(helper.currentLocation.search), { q: text, type })
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
-      from: 0,
+      from:          0,
       text,
       votedComments: new Map()
     })
@@ -301,8 +300,8 @@ describe("SearchPage", () => {
     assert.deepEqual(qs.parse(helper.currentLocation.search), { type })
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
-      from: 0,
-      text: undefined,
+      from:          0,
+      text:          undefined,
       votedComments: new Map()
     })
     assert.equal(
@@ -377,17 +376,20 @@ describe("SearchPage", () => {
     })
   })
 
-  it("calls updateVotedComments when upvote or downvote is triggered", async() => {
+  it("calls updateVotedComments when upvote or downvote is triggered", async () => {
     const { inner } = await renderPage()
-    const comment = createCommentTree(makeCommentsResponse(makePost()))[0]
-    helper.updateCommentStub.returns(Promise.resolve(comment))
-    comment.score = 215
-    await inner.instance().upvote(comment)
-    assert.deepEqual(inner.state().votedComments.get(comment.id).score, 215)
-    comment.score = 213
-    await inner.instance().downvote(comment)
-    assert.deepEqual(inner.state().votedComments.get(comment.id).score, 213)
+    const comments = [makeComment(makePost()), makeComment(makePost())]
+    helper.updateCommentStub.returns(Promise.resolve(comments[0]))
+    await inner.instance().upvote(comments[0])
+    assert.deepEqual(
+      inner.state().votedComments.get(comments[0].id),
+      comments[0]
+    )
+    helper.updateCommentStub.returns(Promise.resolve(comments[1]))
+    await inner.instance().downvote(comments[1])
+    assert.deepEqual(
+      inner.state().votedComments.get(comments[1].id),
+      comments[1]
+    )
   })
-
-
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1539 
Fixes #1559

#### What's this PR do?
- Makes comment voting work in search results
- Updates comment scores in the ES index (bug fix)

#### How should this be manually tested?
- Do a channel-specific search and a global search
- Upvote and downvote multiple comments in the search results.  The button styles and comment scores should update appropriately (scores may not change on the first vote if you've already voted on that comment previously - ES doesn't track who voted for what).
- Check the ES doc for a comment before and after voting.  The score should change correctly.

A reindex should probably be done again after this is merged to make sure comments have correct scores.