### PR TITLE
Hide comment share button in search results

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -145,21 +145,23 @@ export default class CommentTree extends React.Component<Props> {
               }}
             />
           )}
-        <div className="share-button-wrapper">
-          <div
-            className="comment-action-button share-button"
-            onClick={showShareMenu}
-          >
-            share
+        {useSearchPageUI ? null : (
+          <div className="share-button-wrapper">
+            <div
+              className="comment-action-button share-button"
+              onClick={showShareMenu}
+            >
+              share
+            </div>
+            {commentShareOpen ? (
+              <SharePopup
+                url={absolutizeURL(commentPermalink(comment.id))}
+                closePopup={hideShareMenu}
+                hideSocialButtons={isPrivateChannel}
+              />
+            ) : null}
           </div>
-          {commentShareOpen ? (
-            <SharePopup
-              url={absolutizeURL(commentPermalink(comment.id))}
-              closePopup={hideShareMenu}
-              hideSocialButtons={isPrivateChannel}
-            />
-          ) : null}
-        </div>
+        )}
         {!userIsAnonymous() && !useSearchPageUI ? (
           <div>
             <i className="material-icons more_vert" onClick={showDropdown}>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -108,6 +108,17 @@ describe("CommentTree", () => {
     assert.equal(url, absolutizeURL(permalinkFunc(comments[0].id)))
   })
 
+  //
+  ;[true, false].forEach(useSearchPageUI => {
+    it(`${shouldIf(!useSearchPageUI)} show the Share button`, () => {
+      const wrapper = renderCommentTree({ useSearchPageUI })
+      assert.equal(
+        wrapper.find(".share-button-wrapper").exists(),
+        !useSearchPageUI
+      )
+    })
+  })
+
   it("should render all replies to a top-level comment", () => {
     const wrapper = renderCommentTree()
     const firstComment = wrapper.find(".top-level-comment").at(0)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1553

#### What's this PR do?
- Hides the share button on comment cards in search results

#### How should this be manually tested?
 - Do a global and a channel-specific search.  The comment cards should not display the 'Share' link.
 - View a post detail page with comments.  The comment cards should display a working 'Share' link. 
