### PR TITLE
Remove errorHandling, use async/await, refactor API functions

### DIFF
--- a/static/js/components/widgets/EditWidgetForm.js
+++ b/static/js/components/widgets/EditWidgetForm.js
@@ -2,7 +2,7 @@ import React, { Component } from "react"
 
 import WidgetForm from "./WidgetForm"
 
-import { apiPath } from "../../lib/widgets"
+import { getWidget, updateWidget } from "../../lib/api"
 
 export default class EditWidgetForm extends Component {
   state = {
@@ -12,31 +12,29 @@ export default class EditWidgetForm extends Component {
   }
 
   componentDidMount() {
-    const { errorHandler, fetchData, widgetId } = this.props
-    fetchData(apiPath("widget", widgetId))
-      .then(data =>
-        this.setState({
-          currentWidgetData:        data.widgetData,
-          widgetClassConfiguration: data.widgetClassConfigurations,
-          widgetClass:              Object.keys(data.widgetClassConfigurations)[0]
-        })
-      )
-      .catch(errorHandler)
+    this.loadData()
   }
 
-  onSubmit = (widgetClass, formData) => {
-    const { errorHandler, fetchData, onSubmit, widgetId } = this.props
-    const { title, ...configuration } = formData
-    fetchData(apiPath("widget", widgetId), {
-      body: JSON.stringify({
-        configuration: configuration,
-        title:         title,
-        widget_class:  widgetClass
-      }),
-      method: "PATCH"
+  loadData = async () => {
+    const { widgetId } = this.props
+
+    const data = await getWidget(widgetId)
+    this.setState({
+      currentWidgetData:        data.widgetData,
+      widgetClassConfiguration: data.widgetClassConfigurations,
+      widgetClass:              Object.keys(data.widgetClassConfigurations)[0]
     })
-      .then(onSubmit)
-      .catch(errorHandler)
+  }
+
+  onSubmit = async (widgetClass, formData) => {
+    const { onSubmit, widgetId } = this.props
+    const { title, ...configuration } = formData
+    const data = await updateWidget(widgetId, {
+      configuration: configuration,
+      title:         title,
+      widget_class:  widgetClass
+    })
+    onSubmit(data)
   }
 
   render() {

--- a/static/js/components/widgets/NewWidgetForm.js
+++ b/static/js/components/widgets/NewWidgetForm.js
@@ -1,8 +1,7 @@
 import React, { Component } from "react"
 
 import WidgetForm from "./WidgetForm"
-
-import { apiPath } from "../../lib/widgets"
+import { getWidgetConfigurations, addWidget } from "../../lib/api"
 
 export default class NewWidgetForm extends Component {
   state = {
@@ -11,38 +10,28 @@ export default class NewWidgetForm extends Component {
   }
 
   componentDidMount() {
-    const { errorHandler, fetchData } = this.props
-    fetchData(apiPath("get_configurations"))
-      .then(data => {
-        this.setState({
-          widgetClassConfigurations: data.widgetClassConfigurations,
-          widgetClasses:             Object.keys(data.widgetClassConfigurations)
-        })
-      })
-      .catch(errorHandler)
+    this.loadData()
   }
 
-  onSubmit = (widgetClass, formData) => {
-    const {
-      errorHandler,
-      fetchData,
-      onSubmit,
-      widgetListId,
-      listLength
-    } = this.props
-    const { title, ...configuration } = formData
-    fetchData(apiPath("widget"), {
-      body: JSON.stringify({
-        configuration: configuration,
-        title:         title,
-        position:      listLength,
-        widget_list:   widgetListId,
-        widget_class:  widgetClass
-      }),
-      method: "POST"
+  loadData = async () => {
+    const data = await getWidgetConfigurations()
+    this.setState({
+      widgetClassConfigurations: data.widgetClassConfigurations,
+      widgetClasses:             Object.keys(data.widgetClassConfigurations)
     })
-      .then(onSubmit)
-      .catch(errorHandler)
+  }
+
+  onSubmit = async (widgetClass, formData) => {
+    const { onSubmit, widgetListId, listLength } = this.props
+    const { title, ...configuration } = formData
+    const data = await addWidget({
+      configuration: configuration,
+      title:         title,
+      position:      listLength,
+      widget_list:   widgetListId,
+      widget_class:  widgetClass
+    })
+    onSubmit(data)
   }
 
   render() {

--- a/static/js/components/widgets/WidgetList.js
+++ b/static/js/components/widgets/WidgetList.js
@@ -8,7 +8,7 @@ import WidgetWrapper from "./WidgetWrapper"
 import EditWidgetForm from "./EditWidgetForm"
 import NewWidgetForm from "./NewWidgetForm"
 
-import { apiPath } from "../../lib/widgets"
+import { getWidgetList, deleteWidget, updateWidget } from "../../lib/api"
 
 export default class WidgetList extends Component {
   static defaultProps = {
@@ -21,11 +21,7 @@ export default class WidgetList extends Component {
     widgetWrapperProps:     null,
     defaultRenderer:        Renderer,
     disableWidgetFramework: false,
-    errorHandler:           console.error, // eslint-disable-line no-console
-    fetchData:              () => {
-      throw new Error("unimplemented")
-    },
-    renderers: {}
+    renderers:              {}
   }
 
   state = { widgetInstances: null }
@@ -40,32 +36,26 @@ export default class WidgetList extends Component {
     }
   }
 
-  loadData = () => {
-    const { widgetListId, errorHandler, fetchData } = this.props
-    fetchData(apiPath("widget_list", widgetListId))
-      .then(this.updateWidgetList)
-      .catch(errorHandler)
+  loadData = async () => {
+    const { widgetListId } = this.props
+    const data = await getWidgetList(widgetListId)
+    this.updateWidgetList(data)
   }
 
   updateWidgetList = data => {
     this.setState({ widgetInstances: data })
   }
 
-  deleteWidget = widgetId => {
-    const { errorHandler, fetchData } = this.props
-    fetchData(apiPath("widget", widgetId), { method: "DELETE" })
-      .then(this.updateWidgetList)
-      .catch(errorHandler)
+  deleteWidget = async widgetId => {
+    const data = await deleteWidget(widgetId)
+    this.updateWidgetList(data)
   }
 
-  moveWidget = (widgetId, position) => {
-    const { errorHandler, fetchData } = this.props
-    fetchData(apiPath("widget", widgetId), {
-      body:   JSON.stringify({ position: position }),
-      method: "PATCH"
+  moveWidget = async (widgetId, position) => {
+    const data = await updateWidget(widgetId, {
+      position: position
     })
-      .then(this.updateWidgetList)
-      .catch(errorHandler)
+    this.updateWidgetList(data)
   }
 
   makePassThroughProps = widgetInstance => {
@@ -96,11 +86,9 @@ export default class WidgetList extends Component {
   }
 
   makeFormProps = () => {
-    const { widgetListId, errorHandler, fetchData, Loader } = this.props
+    const { widgetListId, Loader } = this.props
     const { widgetInstances } = this.state
     return {
-      fetchData:    fetchData,
-      errorHandler: errorHandler,
       Loader:       Loader,
       widgetListId: widgetListId,
       listLength:   widgetInstances.length,

--- a/static/js/flow/widgetTypes.js
+++ b/static/js/flow/widgetTypes.js
@@ -1,0 +1,38 @@
+// @flow
+
+export type WidgetListsResponse = Array<{
+  id: number,
+}>
+
+export type WidgetListResponse = Array<{
+  id: number,
+  widget_class: string,
+  react_renderer: string,
+  postition: number,
+  title: string,
+  widget_list: number,
+  source: string,
+}>
+
+type WidgetConfiguration = {
+  key: string,
+  label: string,
+  inputType: string,
+  props: Object
+}
+
+export type WidgetConfigurationsResponse = {
+  widgetClassConfigurations: {
+    [widgetClass: string]: Array<WidgetConfiguration>
+  }
+}
+
+export type WidgetResponse = {
+  widgetClassConfigurations: {
+    [widgetClass: string]: Array<WidgetConfiguration>
+  },
+  widgetData: {
+    source: string,
+    title: string,
+  }
+}

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -38,6 +38,12 @@ import type {
   PostListResponse
 } from "../flow/discussionTypes"
 import type { NotificationSetting } from "../flow/settingsTypes"
+import type {
+  WidgetConfigurationsResponse,
+  WidgetListsResponse,
+  WidgetListResponse,
+  WidgetResponse
+} from "../flow/widgetTypes"
 import type { EmbedlyResponse } from "../reducers/embedly"
 import type { SearchParams } from "../flow/searchTypes"
 
@@ -556,3 +562,32 @@ export function getSocialAuthTypes(): Promise<Array<SocialAuth>> {
 }
 
 export const getCKEditorJWT = () => fetchWithAuthFailure("/api/v0/ckeditor/")
+
+export const getWidgetLists = (): Promise<WidgetListsResponse> =>
+  fetchJSONWithAuthFailure("/api/v1/list/")
+export const getWidgetList = (
+  widgetListId: number
+): Promise<WidgetListResponse> =>
+  fetchJSONWithAuthFailure(`/api/v1/list/${widgetListId}/`)
+export const getWidget = (widgetListId: number): Promise<WidgetResponse> =>
+  fetchJSONWithAuthFailure(`/api/v1/widget/${widgetListId}/`)
+export const addWidget = (payload: Object): Promise<WidgetResponse> =>
+  // TODO: what is the response really?
+  fetchJSONWithAuthFailure("/api/v1/widget/", {
+    body:   JSON.stringify(payload),
+    method: "POST"
+  })
+export const updateWidget = (
+  widgetListId: number,
+  payload: Object
+): Promise<WidgetResponse> =>
+  // TODO: what is the response really?
+  fetchJSONWithAuthFailure(`/api/v1/widget/${widgetListId}/`, {
+    body:   JSON.stringify(payload),
+    method: "PATCH"
+  })
+export const deleteWidget = (widgetListId: number): Promise<any> =>
+  fetchJSONWithAuthFailure(`/api/v1/widget/${widgetListId}/`, {
+    method: "DELETE"
+  })
+export const getWidgetConfigurations = (): Promise<WidgetConfigurationsResponse> => fetchJSONWithAuthFailure(`/api/v1/list/get_configurations/`)

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -922,4 +922,6 @@ describe("api", function() {
       })
     })
   })
+
+  describe("widget functions", () => {})
 })

--- a/static/js/lib/widgets.js
+++ b/static/js/lib/widgets.js
@@ -1,28 +1,6 @@
 import _ from "lodash"
 
-function apiPath(name, pk) {
-  /**
-   * constructs an api path based on the view name and the list and widget ids
-   */
-  const apiBase = "/api/v1"
-  switch (name) {
-  case "get_lists":
-    return `${apiBase}/list/`
-
-  case "get_configurations":
-    return `${apiBase}/list/get_configurations/`
-
-  case "widget_list":
-    return `${apiBase}/list/${pk ? `${pk}/` : ""}`
-
-  case "widget":
-    return `${apiBase}/widget/${pk ? `${pk}/` : ""}`
-  }
-}
-
-// TODO: split into two functions
-
-function makeOptionsFromList(values) {
+export function makeOptionsFromList(values) {
   /**
    * constructs an options object from a list of values
    */
@@ -33,7 +11,7 @@ function makeOptionsFromList(values) {
   }))
 }
 
-function makeOptionsFromObject(options) {
+export function makeOptionsFromObject(options) {
   /**
    * constructs an options object from an object of key, value mappings where the keys are the value and the value
    * is the key and label
@@ -45,5 +23,3 @@ function makeOptionsFromObject(options) {
     value: keys[index]
   }))
 }
-
-export { makeOptionsFromList, makeOptionsFromObject, apiPath }

--- a/static/js/lib/widgets_test.js
+++ b/static/js/lib/widgets_test.js
@@ -1,37 +1,8 @@
 import { expect } from "chai"
 
-import { apiPath, makeOptionsFromList, makeOptionsFromObject } from "./widgets"
+import { makeOptionsFromList, makeOptionsFromObject } from "./widgets"
 
 describe("widget utility functions", () => {
-  describe("apiPath", () => {
-    const dummyWidgetListId = 11
-    const dummyWidgetId = 5
-
-    it("returns the get_lists url properly", () => {
-      expect(apiPath("get_lists")).to.equal("/api/v1/list/")
-    })
-
-    it("returns the get_configurations url properly", () => {
-      expect(apiPath("get_configurations")).to.equal(
-        "/api/v1/list/get_configurations/"
-      )
-    })
-
-    it("returns the widget_list url properly", () => {
-      expect(apiPath("widget_list")).to.equal(`/api/v1/list/`)
-      expect(apiPath("widget_list", dummyWidgetListId)).to.equal(
-        `/api/v1/list/${dummyWidgetListId}/`
-      )
-    })
-
-    it("returns the widget url properly", () => {
-      expect(apiPath("widget")).to.equal(`/api/v1/widget/`)
-      expect(apiPath("widget", dummyWidgetId)).to.equal(
-        `/api/v1/widget/${dummyWidgetId}/`
-      )
-    })
-  })
-
   describe("makeOptionsFromList", () => {
     const optionsList = ["some", "great", "options"]
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Part of #1460 

#### What's this PR do?
 - Remove errorHandling prop and convert methods referencing it into promises. Unresolved promise rejections will be shown in the console.
 - Remove fetchData prop, add functions to `api.js` and replace fetch calls with calls to those functions. There are no tests for the api functions yet because I'm expecting some backwards incompatible changes with the REST API

#### How should this be manually tested?
Nothing to do yet