### PR TITLE
Prevent non-superusers from editing a channel title

### DIFF
--- a/cassettes/channels.views.channels_test.test_patch_title_non_superuser_forbidden.json
+++ b/cassettes/channels.views.channels_test.test_patch_title_non_superuser_forbidden.json
@@ -1,0 +1,436 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-12-05T19:17:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CXZWTYERDENZ6VPYW2QGZTRM"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0NtQtDgooNK2oKsrO8rQwzElzLymvSM71tQxPTg5V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLbF61ZlW3jHezgGGfv6hxsE50ZWBrmEO5sY+0WC9KSklmUmp8ZnpoAMhnCUagEZ+FCZuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 05 Dec 2018 19:17:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=uXp16Iw8QtqxWPx4fk; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 04-Dec-2020 19:17:15 GMT",
+            "loidcreated=2018-12-05T19%3A17%3A14.928Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Fri, 04-Dec-2020 19:17:15 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CXZWTYERDENZ6VPYW2QGZTRM"
+      }
+    },
+    {
+      "recorded_at": "2018-12-05T19:17:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Enim+perspiciatis+porro+omnis+hic+quasi.+Dolore+possimus+sed+corporis+vitae.+Et+nemo+exercitationem+reprehenderit+expedita.+Alias+nam+at+nulla.%0APraesentium+qui+nulla+odit.+Quas+unde+dolorum+unde+recusandae+quod+ab.+Nemo+eaque+optio+dolorum+consectetur.%0AMolestias+tempora+ad+iste+veritatis+autem.+Magnam+aliquam+suscipit+sit+reiciendis+placeat+hic+accusamus.+Magni+ad+quibusdam+impedit+consequatur+maxime+ea+quisquam.&link_type=any&name=1544037435_id&public_description=Quod+voluptatum+quia+natus+in+culpa+eligendi+autem.&title=Laboriosam+debitis+nihil+animi+corrupti.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 131-sRPq5xzrkjI81lfGtwxcmM9WccU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "642"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=uXp16Iw8QtqxWPx4fk; loidcreated=2018-12-05T19%3A17%3A14.928Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 05 Dec 2018 19:17:15 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "165"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-05T19:17:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 131-sRPq5xzrkjI81lfGtwxcmM9WccU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=uXp16Iw8QtqxWPx4fk; loidcreated=2018-12-05T19%3A17%3A14.928Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544037435_id/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": true, \"subreddit_id\": \"t5_c\", \"domain\": null, \"allow_images\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_links\": null, \"title\": \"Laboriosam debitis nihil animi corrupti.\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"suggested_comment_sort\": null, \"description\": \"Enim perspiciatis porro omnis hic quasi. Dolore possimus sed corporis vitae. Et nemo exercitationem reprehenderit expedita. Alias nam at nulla.\\nPraesentium qui nulla odit. Quas unde dolorum unde recusandae quod ab. Nemo eaque optio dolorum consectetur.\\nMolestias tempora ad iste veritatis autem. Magnam aliquam suscipit sit reiciendis placeat hic accusamus. Magni ad quibusdam impedit consequatur maxime ea quisquam.\", \"submit_link_label\": null, \"spam_comments\": null, \"spam_selfposts\": null, \"submit_text_label\": null, \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": null, \"public_traffic\": false, \"public_description\": \"Quod voluptatum quia natus in culpa eligendi autem.\", \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1238"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 05 Dec 2018 19:17:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "162"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=hoAwW4sbnr%2FYtPzYlu4HyoqnpXJm%2Fnz1GWdFxVBarEyVEIhlP%2BLBcWy1IkeMOvcAM3bu6b2aYurIZ0%2FYxIoB8BS59IGJgL%2FK"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544037435_id/about/edit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-05T19:17:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&collapse_deleted_comments=False&comment_score_hide_mins=0&description=Enim+perspiciatis+porro+omnis+hic+quasi.+Dolore+possimus+sed+corporis+vitae.+Et+nemo+exercitationem+reprehenderit+expedita.+Alias+nam+at+nulla.%0APraesentium+qui+nulla+odit.+Quas+unde+dolorum+unde+recusandae+quod+ab.+Nemo+eaque+optio+dolorum+consectetur.%0AMolestias+tempora+ad+iste+veritatis+autem.+Magnam+aliquam+suscipit+sit+reiciendis+placeat+hic+accusamus.+Magni+ad+quibusdam+impedit+consequatur+maxime+ea+quisquam.&exclude_banned_modqueue=False&hide_ads=False&lang=en&link_type=any&over_18=False&public_description=Quod+voluptatum+quia+natus+in+culpa+eligendi+autem.&public_traffic=False&show_media=False&show_media_preview=True&sr=t5_c&submit_text=&title=Laboriosam+debitis+nihil+animi+corrupti.&type=public&wiki_edit_age=0&wiki_edit_karma=0&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 131-sRPq5xzrkjI81lfGtwxcmM9WccU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "865"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=uXp16Iw8QtqxWPx4fk; loidcreated=2018-12-05T19%3A17%3A14.928Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 05 Dec 2018 19:17:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "162"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-05T19:17:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 131-sRPq5xzrkjI81lfGtwxcmM9WccU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=uXp16Iw8QtqxWPx4fk; loidcreated=2018-12-05T19%3A17%3A14.928Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544037435_id/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"c\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1544037435_id\", \"header_img\": null, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EEnim perspiciatis porro omnis hic quasi. Dolore possimus sed corporis vitae. Et nemo exercitationem reprehenderit expedita. Alias nam at nulla.\\nPraesentium qui nulla odit. Quas unde dolorum unde recusandae quod ab. Nemo eaque optio dolorum consectetur.\\nMolestias tempora ad iste veritatis autem. Magnam aliquam suscipit sit reiciendis placeat hic accusamus. Magni ad quibusdam impedit consequatur maxime ea quisquam.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"title\": \"Laboriosam debitis nihil animi corrupti.\", \"collapse_deleted_comments\": false, \"public_description\": \"Quod voluptatum quia natus in culpa eligendi autem.\", \"over18\": false, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EQuod voluptatum quia natus in culpa eligendi autem.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"Enim perspiciatis porro omnis hic quasi. Dolore possimus sed corporis vitae. Et nemo exercitationem reprehenderit expedita. Alias nam at nulla.\\nPraesentium qui nulla odit. Quas unde dolorum unde recusandae quod ab. Nemo eaque optio dolorum consectetur.\\nMolestias tempora ad iste veritatis autem. Magnam aliquam suscipit sit reiciendis placeat hic accusamus. Magni ad quibusdam impedit consequatur maxime ea quisquam.\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_c\", \"created\": 1544037435.0, \"url\": \"/r/1544037435_id/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544037435.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2284"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 05 Dec 2018 19:17:18 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "162"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=VDVPhT5tc3Y50Rp%2Bt9uu%2F%2FRK0HsLWWe2ZHHpUBGwB1KAJaES5NxQtB9g07mUSMgp6hXdfY7lUxhq21tqQl9LPWWahm6eDt%2Bi"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544037435_id/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.channels_test.test_update_title_non_superuser_forbidden[patch].json
+++ b/cassettes/channels.views.channels_test.test_update_title_non_superuser_forbidden[patch].json
@@ -1,0 +1,777 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-12-06T22:17:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJ3BX6972SDHVZ376F0DX"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0ttBNzgt3jig2Do60NHLM8EgqyvdyDvP0yjfyyA5V0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaF5YcamHoZJfklBZjn55iHJebpxmeEBbql+FqA9KSklmUmp8ZnpoAMhnCUagGyz7vbuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:33 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Dec-2020 22:17:33 GMT",
+            "loidcreated=2018-12-06T22%3A17%3A33.152Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Dec-2020 22:17:33 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJ3BX6972SDHVZ376F0DX"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJ6QFX89TZGM9Z2QNXT2Z"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0ttQNKPOsdPNMNylLSg8qzcgr9M7KyCktKvaPsAhU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZlVeTH+4alFhV45BnkuSe7+BmFBQSUFfpYRkWC9KSklmUmp8ZnpoAMhnCUagHKcMQiuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:36 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJ6QFX89TZGM9Z2QNXT2Z"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=&link_type=any&name=1544134666_porro&public_description=&title=Minus+illum+excepturi+ipsum+mollitia+culpa.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 138-cnWCXs3SY92AhHbroJCVIJo2HkU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "178"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CY2SJ6QFX89TZGM9Z2QNXT2Z&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 138-cnWCXs3SY92AhHbroJCVIJo2HkU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1544134666_porro/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134666_porro/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 139-PvIyFIg4vbgRuhnqKjhlursOX8Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1544134666_porro/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134666_porro/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 138-cnWCXs3SY92AhHbroJCVIJo2HkU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134666_porro/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"j\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1544134666_porro\", \"header_img\": null, \"description_html\": null, \"title\": \"Minus illum excepturi ipsum mollitia culpa.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_j\", \"created\": 1544134660.0, \"url\": \"/r/1544134666_porro/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134660.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1116"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=E9PMx6f98LCwJg5sI76x9B1FN3r7PN5ppk6FclYNdnhNNTIAoASM9DwcE7ITpi9zZz1YUej%2FbzeB5%2B%2FIGtaxE5dgBPYlxsS3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134666_porro/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 139-PvIyFIg4vbgRuhnqKjhlursOX8Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134666_porro/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": true, \"subreddit_id\": \"t5_j\", \"domain\": null, \"allow_images\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_links\": null, \"title\": \"Minus illum excepturi ipsum mollitia culpa.\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"suggested_comment_sort\": null, \"description\": \"\", \"submit_link_label\": null, \"spam_comments\": null, \"spam_selfposts\": null, \"submit_text_label\": null, \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": null, \"public_traffic\": false, \"public_description\": \"\", \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "773"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=P8P9dqjCFwd4zAPTRn8ZPfPb6mkIY555yYaCCvewikXjxHZf6g8ujrGW2WEI1DpOvhrg6YeSTlq0X04ty1c8PE%2FCx1ij2%2B3I"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134666_porro/about/edit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&collapse_deleted_comments=False&comment_score_hide_mins=0&description=&exclude_banned_modqueue=False&hide_ads=False&lang=en&link_type=any&over_18=False&public_description=&public_traffic=False&show_media=False&show_media_preview=True&sr=t5_j&submit_text=&title=Minus+illum+excepturi+ipsum+mollitia+culpa.&type=private&wiki_edit_age=0&wiki_edit_karma=0&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 139-PvIyFIg4vbgRuhnqKjhlursOX8Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "398"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 139-PvIyFIg4vbgRuhnqKjhlursOX8Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=CiCJnRlkyWeZyMGZms; loidcreated=2018-12-06T22%3A17%3A33.152Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134666_porro/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"j\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"1544134666_porro\", \"header_img\": null, \"description_html\": null, \"title\": \"Minus illum excepturi ipsum mollitia culpa.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_j\", \"created\": 1544134660.0, \"url\": \"/r/1544134666_porro/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134660.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "140"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=j5rjQmOV9gj58xIoBg%2FlY%2FvXUk4pBQXW02KEKUu3YmlHZUU2AyLs%2BmZgGyr0MBCADc36wi39Y8ySpT1CXQGzSLyR1e2FdMAG"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134666_porro/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.channels_test.test_update_title_non_superuser_forbidden[put].json
+++ b/cassettes/channels.views.channels_test.test_update_title_non_superuser_forbidden[put].json
@@ -1,0 +1,955 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-12-06T22:17:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJDW3QRHD4P45SFQN2Q9G"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdA18C91yY5yjA9yLcr3qMzxyjUvCQg3yQ7J9/VU0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLZlpniEuJflWgQb6YbkOvu4ViRbGJqlW0a5BpuA9KSklmUmp8ZnpoAMhnCUagEuteIMuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=heHF47KSPvP6Giy4KI; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Dec-2020 22:17:44 GMT",
+            "loidcreated=2018-12-06T22%3A17%3A43.862Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Dec-2020 22:17:44 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJDW3QRHD4P45SFQN2Q9G"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:17:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJH5MTEG11NEHDZK15W47"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MdRNzvBLTTPw8HGp8DHy8Yw0igqKD/QsCiwNDrBQ0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVZwZUWMSHOrskVlUap5qYGean+0W5pBiEZRWD9KSklmUmp8ZnpoAMhnCUagFPD1XOuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01CY2SJH5MTEG11NEHDZK15W47"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=&link_type=any&name=1544134676_officia&public_description=&title=Laboriosam+maiores+inventore+ab+laboriosam.&type=private&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 140-0OuDkZA_REroHylJm7tPW4kToMI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "180"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "130"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=01CY2SJH5MTEG11NEHDZK15W47&permissions=%2Ball&type=moderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 140-0OuDkZA_REroHylJm7tPW4kToMI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "79"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1544134676_officia/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "130"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "13"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/r/1544134676_officia/api/accept_moderator_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:51 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "130"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/api/accept_moderator_invite?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 140-0OuDkZA_REroHylJm7tPW4kToMI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"k\", \"user_is_contributor\": true, \"submit_text\": \"\", \"display_name\": \"1544134676_officia\", \"header_img\": null, \"description_html\": null, \"title\": \"Laboriosam maiores inventore ab laboriosam.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_k\", \"created\": 1544134670.0, \"url\": \"/r/1544134676_officia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134670.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": true}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1120"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:17:51 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "129"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=BoIoO8L0amRVCHbEdtMQQl1OiU3G8W0rf07PPIh0sAL4K5EL8NOrg8mWrNG8VXMWM1ZIqL%2B1gF7eni1%2BZQr07n%2FlRZ8ZLfX2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"k\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"1544134676_officia\", \"header_img\": null, \"description_html\": null, \"title\": \"Laboriosam maiores inventore ab laboriosam.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_k\", \"created\": 1544134670.0, \"url\": \"/r/1544134676_officia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134670.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1122"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:18:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2Fiw82g5q%2F7XaSriFKTY9ipp058qScLEBbbgSGfaf%2FVvNcrx20k6OKbVwNobsJY9mkR26zBMjPor972Q4xiT%2B7ONsHW48Cw7p"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134676_officia/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": true, \"subreddit_id\": \"t5_k\", \"domain\": null, \"allow_images\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_links\": null, \"title\": \"Laboriosam maiores inventore ab laboriosam.\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"suggested_comment_sort\": null, \"description\": \"\", \"submit_link_label\": null, \"spam_comments\": null, \"spam_selfposts\": null, \"submit_text_label\": null, \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": null, \"public_traffic\": false, \"public_description\": \"\", \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "773"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:18:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=pQki1JV%2FNbhvxemguwS7jsHN1LUG%2B0xeyqOnJP0s8MnVsbkA%2BonJK8N5s1SwCy0RY17%2Fgy39Pql3I0HipikVfnpP8EiywXMQ"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/about/edit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&collapse_deleted_comments=False&comment_score_hide_mins=0&description=&exclude_banned_modqueue=False&hide_ads=False&lang=en&link_type=any&over_18=False&public_description=&public_traffic=False&show_media=False&show_media_preview=True&sr=t5_k&submit_text=&title=Laboriosam+maiores+inventore+ab+laboriosam.&type=private&wiki_edit_age=0&wiki_edit_karma=0&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "398"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:18:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"k\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"1544134676_officia\", \"header_img\": null, \"description_html\": null, \"title\": \"Laboriosam maiores inventore ab laboriosam.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_k\", \"created\": 1544134670.0, \"url\": \"/r/1544134676_officia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134670.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1122"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:18:22 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=X6WBot0Q8NlZ%2BCVYpqjU%2B2zaISHQjTQGpg0Wodyuo77nx%2FmQL14rKNqPmbmUII10wZ6oJt%2Fia9XPMCv6PVFSW80yh6hNwQTE"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-12-06T22:18:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 141-chNef0HLDxL2LIY2ZR_QIrQuSP8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=heHF47KSPvP6Giy4KI; loidcreated=2018-12-06T22%3A17%3A43.862Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.55.3 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": false, \"show_media\": false, \"id\": \"k\", \"user_is_contributor\": false, \"submit_text\": \"\", \"display_name\": \"1544134676_officia\", \"header_img\": null, \"description_html\": null, \"title\": \"Laboriosam maiores inventore ab laboriosam.\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"community_rules\": [], \"icon_size\": null, \"suggested_comment_sort\": null, \"icon_img\": \"\", \"header_title\": null, \"description\": \"\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"lang\": \"en\", \"name\": \"t5_k\", \"created\": 1544134670.0, \"url\": \"/r/1544134676_officia/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1544134670.0, \"banner_size\": null, \"user_is_moderator\": true, \"user_sr_theme_enabled\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1122"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 06 Dec 2018 22:18:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "294.0"
+          ],
+          "x-ratelimit-reset": [
+            "98"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=qh2NOndDKHZcwpboCqYun83aisX6e27X0sjFEODT5l5NYL80o%2BpL99MBoQ41lppL3SyqsJeqlTBNQ2tr2abJi0UX%2BV%2BJ%2BPbE"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1544134676_officia/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/factories.py
+++ b/channels/factories.py
@@ -49,16 +49,20 @@ def _channel_name():
     ]  # maximum of 21-char channel names
 
 
-class RedditChannel:
+class RedditChannel:  # pylint: disable=too-many-instance-attributes
     """Simple factory representation for a reddit channel (subreddit)"""
 
     def __init__(self, **kwargs):
         self.name = kwargs.get("name", None)
         self.title = kwargs.get("title", None)
+        self.display_name = kwargs.get("display_name", None)
+        self.subreddit_type = kwargs.get("subreddit_type", None)
         self.channel_type = kwargs.get("channel_type", None)
         self.link_type = kwargs.get("link_type", None)
         self.description = kwargs.get("description", None)
         self.public_description = kwargs.get("public_description", None)
+        self.user_is_contributor = kwargs.get("user_is_contributor", True)
+        self.user_is_moderator = kwargs.get("user_is_moderator", True)
         self.api = kwargs.get("api", None)
 
 

--- a/factory_data/channels.views.channels_test.test_update_title_non_superuser_forbidden[patch].json
+++ b/factory_data/channels.views.channels_test.test_update_title_non_superuser_forbidden[patch].json
@@ -1,0 +1,19 @@
+{
+  "channels": {
+    "private": {
+      "channel_type": "private",
+      "description": "Magni tenetur quos magnam aut nobis incidunt. Fugiat natus fugit unde id. Consectetur iusto earum eius tempore tenetur quibusdam excepturi. Fuga placeat deleniti quidem eveniet voluptas consequatur.\nQuidem corrupti consectetur deserunt optio doloribus vero voluptatibus cumque. Amet illo voluptatibus velit assumenda vero. Molestiae ipsum minus neque officiis maxime corporis nesciunt.",
+      "name": "1544134666_porro",
+      "public_description": "Sint doloribus dolores vel iusto eveniet inventore.",
+      "title": "Minus illum excepturi ipsum mollitia culpa."
+    }
+  },
+  "users": {
+    "index_user": {
+      "username": "01CY2SJ3BX6972SDHVZ376F0DX"
+    },
+    "staff_user": {
+      "username": "01CY2SJ6QFX89TZGM9Z2QNXT2Z"
+    }
+  }
+}

--- a/factory_data/channels.views.channels_test.test_update_title_non_superuser_forbidden[put].json
+++ b/factory_data/channels.views.channels_test.test_update_title_non_superuser_forbidden[put].json
@@ -1,0 +1,19 @@
+{
+  "channels": {
+    "private": {
+      "channel_type": "private",
+      "description": "Ducimus mollitia quod cupiditate dolor quibusdam porro. Officiis rem occaecati quo assumenda. Maxime nobis reprehenderit reiciendis aliquid qui repudiandae adipisci eum.\nPossimus magnam accusantium ipsa commodi inventore quae modi. Consequuntur aut aliquam mollitia tenetur amet. Dolorum harum natus culpa amet assumenda. Ipsa totam doloremque ullam voluptas itaque labore tempora.",
+      "name": "1544134676_officia",
+      "public_description": "Facilis voluptates incidunt quam dolorem sed ratione numquam.",
+      "title": "Laboriosam maiores inventore ab laboriosam."
+    }
+  },
+  "users": {
+    "index_user": {
+      "username": "01CY2SJDW3QRHD4P45SFQN2Q9G"
+    },
+    "staff_user": {
+      "username": "01CY2SJH5MTEG11NEHDZK15W47"
+    }
+  }
+}

--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -22,12 +22,14 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
     username = None
     user_full_name = None
     user_email = None
+    user_is_superuser = False
 
     if request.user.is_authenticated:
         user = request.user
-        username = request.user.username
+        username = user.username
         user_full_name = user.profile.name
         user_email = user.email
+        user_is_superuser = user.is_superuser
 
     site = get_default_site()
 
@@ -42,6 +44,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "username": username,
         "user_full_name": user_full_name,
         "user_email": user_email,
+        "is_admin": user_is_superuser,
         "authenticated_site": {
             "title": site.title,
             "base_url": site.base_url,

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -40,12 +40,14 @@ def test_webpack_url(
             "user_email": test_user.email,
             "username": test_user.username,
             "user_full_name": test_user.profile.name,
+            "is_admin": test_user.is_superuser,
         }
     else:
         expected_user_values = {
             "user_email": None,
             "username": None,
             "user_full_name": None,
+            "is_admin": False,
         }
 
     response = client.get(reverse("open_discussions-index"))

--- a/static/js/components/admin/EditChannelAppearanceForm.js
+++ b/static/js/components/admin/EditChannelAppearanceForm.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS */
 import React from "react"
 
 import Card from "../Card"
@@ -35,6 +36,27 @@ export default class EditChannelAppearanceForm extends React.Component<Props> {
       validation,
       history
     } = this.props
+
+    let titleInputProps, titleInputMessage
+    if (SETTINGS.is_admin) {
+      titleInputProps = {}
+      titleInputMessage = null
+    } else {
+      titleInputProps = { disabled: true }
+      titleInputMessage = (
+        <label className="bottom-label">
+          Need to change the channel title?{" "}
+          <a
+            href={`mailto:${SETTINGS.support_email}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Contact us
+          </a>
+        </label>
+      )
+    }
+
     return (
       <form onSubmit={onSubmit} className="form channel-form">
         <Card>
@@ -59,7 +81,9 @@ export default class EditChannelAppearanceForm extends React.Component<Props> {
                 placeholder="Title"
                 value={form.title}
                 onChange={onUpdate}
+                {...titleInputProps}
               />
+              {titleInputMessage}
               {validationMessage(validation.title)}
             </div>
           </div>

--- a/static/js/containers/admin/EditChannelAppearancePage.js
+++ b/static/js/containers/admin/EditChannelAppearancePage.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import R from "ramda"
 import { connect } from "react-redux"
@@ -103,7 +104,10 @@ export class EditChannelAppearancePage extends React.Component<Props> {
 
     const formValue = channelForm.value
     const channelName = formValue.name
-    const patchValue = R.omit(["avatar", "banner"], formValue)
+    const patchValue = R.omit(
+      ["avatar", "banner", !SETTINGS.is_admin ? "title" : null],
+      formValue
+    )
     const promises = [dispatch(actions.channels.patch(patchValue))]
 
     if (formValue.avatar) {

--- a/static/js/containers/admin/EditChannelBasicPage.js
+++ b/static/js/containers/admin/EditChannelBasicPage.js
@@ -109,7 +109,11 @@ class EditChannelBasicPage extends React.Component<Props> {
         })
       )
     } else {
-      dispatch(actions.channels.patch(channelForm.value)).then(channel => {
+      const patchValue = R.pickAll(
+        ["name", "channel_type", "description", "link_type"],
+        channelForm.value
+      )
+      dispatch(actions.channels.patch(patchValue)).then(channel => {
         history.push(channelURL(channel.name))
       })
     }

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -109,6 +109,13 @@ describe("EditChannelBasicPage", () => {
     )
 
     helper.updateChannelStub.calledWith(expected)
+    const channelUpdateArg = helper.updateChannelStub.firstCall.args[0]
+    assert.deepEqual(Object.keys(channelUpdateArg), [
+      "name",
+      "channel_type",
+      "description",
+      "link_type"
+    ])
 
     assert.equal(helper.currentLocation.pathname, channelURL(channel.name))
   })

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -20,6 +20,7 @@ declare var SETTINGS: {
     tos_url: string
   },
   is_authenticated: boolean,
+  is_admin: boolean,
   allow_anonymous: boolean,
   allow_saml_auth: boolean,
   allow_email_auth: boolean,

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -21,6 +21,7 @@ const _createSettings = () => ({
   allow_saml_auth:       false,
   allow_email_auth:      false,
   is_authenticated:      true,
+  is_admin:              false,
   username:              "greatusername",
   user_full_name:        "Great User",
   profile_ui_enabled:    false,

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -27,6 +27,8 @@ export const shouldIf = (tf: boolean) => (tf ? "should" : "should not")
 
 export const shouldIfGt0 = (num: number) => shouldIf(num > 0)
 
+export const isIf = (tf: boolean) => (tf ? "is" : "is not")
+
 export class TestPage extends React.Component<*, *> {
   props: {}
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1537 

#### What's this PR do?
Prevents non-superusers from editing a channel title. Non-superusers will see a disabled title field in the channel appearance settings page, and any request to the API to change the title with a non-superuser will be denied

#### How should this be manually tested?
- Log in as a superuser and a non-superuser. Confirm that the channel title field is enabled and disable (respectively) on the channel appearance settings page
- Try to send a patch request to update a channel in a django shell using the django client. If the client is logged in with a non-superuser and the request data includes a `title` key, it should result in a 403

#### Screenshots (if appropriate)
![ss 2018-12-06 at 12 27 48](https://user-images.githubusercontent.com/14932219/49601066-cefb2480-f952-11e8-9c8f-d3bd1c9989e7.png)

