### PR TITLE
Django management command to create missing `Post` objects

### DIFF
--- a/channels/management/commands/backpopulate_missing_posts.py
+++ b/channels/management/commands/backpopulate_missing_posts.py
@@ -1,0 +1,65 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from channels.api import Api
+from channels.constants import LINK_TYPE_SELF, LINK_TYPE_LINK, COMMENTS_SORT_NEW
+from channels.models import Channel, Post, Comment
+from channels.utils import get_or_create_link_meta
+from search.tasks import index_post_with_comments
+
+
+class Command(BaseCommand):
+    """Find and create missing Post objects (and associated comments) for reddit submissions"""
+
+    help = "Find and create missing Post, Comment objects for reddit submissions"
+
+    def handle(self, *args, **options):
+        """Find and create missing Post and Comment objects for reddit submissions"""
+        total_missing = 0
+        api_client = Api(user=User.objects.get(username=settings.INDEXING_API_USERNAME))
+        for channel in Channel.objects.all():
+            subreddit = api_client.reddit.subreddit(channel.name)
+            reddit_posts = set([a.id for a in subreddit.hot(limit=1000)])
+            django_posts = set([a.post_id for a in channel.post_set.all()])
+            missing_posts = reddit_posts.difference(django_posts)
+            for post_id in missing_posts:
+                submission = api_client.get_post(post_id)
+                submission.comment_limit = 1000
+                submission_type = (
+                    LINK_TYPE_LINK if hasattr(submission, "url") else LINK_TYPE_SELF
+                )
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Creating missing {} post {} in channel {}".format(
+                            submission_type, post_id, channel.name
+                        )
+                    )
+                )
+                with transaction.atomic():
+                    post, created = Post.objects.get_or_create(
+                        post_id=post_id, channel=channel, post_type=submission_type
+                    )
+                    if (
+                        created
+                        and submission_type == LINK_TYPE_LINK
+                        and post.link_meta is None
+                        and settings.EMBEDLY_KEY
+                    ):
+                        post.link_meta = get_or_create_link_meta(submission.url)
+                        post.save()
+                    for reddit_comment in api_client.list_comments(
+                        post_id, COMMENTS_SORT_NEW
+                    ):
+                        self.stdout.write("{}".format(reddit_comment.__dict__))
+                        Comment.objects.get_or_create(
+                            post=post,
+                            comment_id=reddit_comment.id,
+                            parent_id=reddit_comment.parent_id,
+                        )
+                    index_post_with_comments.delay(post_id)
+            total_missing += len(missing_posts)
+        self.stdout.write(
+            self.style.SUCCESS("Created {} missing posts".format(total_missing))
+        )

--- a/channels/management/commands/backpopulate_missing_posts.py
+++ b/channels/management/commands/backpopulate_missing_posts.py
@@ -1,4 +1,6 @@
 """Management command for creating missing Post objects"""
+import traceback
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import BaseCommand
@@ -18,7 +20,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # pylint:disable=too-many-locals
         """Find and create missing Post objects for reddit submissions"""
-        total_missing = 0
+        total_recovered = 0
         api_client = Api(user=User.objects.get(username=settings.INDEXING_API_USERNAME))
         for channel in Channel.objects.all():
             subreddit = api_client.reddit.subreddit(channel.name)
@@ -28,36 +30,46 @@ class Command(BaseCommand):
             }
             missing_posts = reddit_posts.difference(django_posts)
             for post_id in missing_posts:
-                submission = api_client.get_post(post_id)
-                submission_type = (
-                    LINK_TYPE_LINK if hasattr(submission, "url") else LINK_TYPE_SELF
-                )
-                with transaction.atomic():
-                    post, _ = Post.objects.get_or_create(
-                        post_id=post_id, channel=channel, post_type=submission_type
+                try:
+                    submission = api_client.get_post(post_id)
+                    submission_type = (
+                        LINK_TYPE_LINK if hasattr(submission, "url") else LINK_TYPE_SELF
                     )
-                    if (
-                        submission_type == LINK_TYPE_LINK
-                        and post.link_meta is None
-                        and settings.EMBEDLY_KEY
-                    ):
-                        post.link_meta = get_or_create_link_meta(submission.url)
-                        post.save()
-                    for reddit_comment in submission.comments.list():
-                        Comment.objects.get_or_create(
-                            post=post,
-                            comment_id=reddit_comment.id,
-                            parent_id=reddit_comment.parent_id,
+                    with transaction.atomic():
+                        post, _ = Post.objects.get_or_create(
+                            post_id=post_id, channel=channel, post_type=submission_type
                         )
-                    index_post_with_comments.delay(post_id)
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        "Created missing {} post {} in channel {}".format(
-                            submission_type, post_id, channel.name
+                        if (
+                            submission_type == LINK_TYPE_LINK
+                            and post.link_meta is None
+                            and settings.EMBEDLY_KEY
+                        ):
+                            post.link_meta = get_or_create_link_meta(submission.url)
+                            post.save()
+                        for reddit_comment in submission.comments.list():
+                            Comment.objects.get_or_create(
+                                post=post,
+                                comment_id=reddit_comment.id,
+                                parent_id=reddit_comment.parent_id,
+                            )
+                        index_post_with_comments.delay(post_id)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Created missing {} post {} in channel {}".format(
+                                submission_type, post_id, channel.name
+                            )
                         )
                     )
-                )
-            total_missing += len(missing_posts)
+                    total_recovered += 1
+                except:  # pylint:disable=bare-except
+                    self.stderr.write(
+                        "Error creating missing {} post {} in channel {}: {}".format(
+                            submission_type,
+                            post_id,
+                            channel.name,
+                            traceback.format_exc(),
+                        )
+                    )
         self.stdout.write(
-            self.style.SUCCESS("Created {} missing posts".format(total_missing))
+            self.style.SUCCESS("Created {} missing posts".format(total_recovered))
         )

--- a/channels/management/commands/backpopulate_missing_posts.py
+++ b/channels/management/commands/backpopulate_missing_posts.py
@@ -22,8 +22,10 @@ class Command(BaseCommand):
         api_client = Api(user=User.objects.get(username=settings.INDEXING_API_USERNAME))
         for channel in Channel.objects.all():
             subreddit = api_client.reddit.subreddit(channel.name)
-            reddit_posts = {a.id for a in subreddit.hot(limit=1000)}
-            django_posts = {a.post_id for a in channel.post_set.all()}
+            reddit_posts = {reddit_post.id for reddit_post in subreddit.hot(limit=1000)}
+            django_posts = {
+                django_post.post_id for django_post in channel.post_set.all()
+            }
             missing_posts = reddit_posts.difference(django_posts)
             for post_id in missing_posts:
                 submission = api_client.get_post(post_id)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1566 

#### What's this PR do?
Adds a new command for adding missing `Post` objects to Django. 

#### How should this be manually tested?
- Manually delete a few of your `Post` objects, both text and link types.
- Try to go to a detail page for one of those posts, you should get an error.
- Reindex and verify that they no longer show up in Elasticsearch results.
- Run `docker-compose run web python manage.py backpopulate_missing_posts`
- Your deleted posts and their associated `Comment` and `Metalink` objects should be recreated and added back to the ES index.
