### PR TITLE
add editing for 'article' type posts

### DIFF
--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -40,12 +40,16 @@ export default class ArticleEditor extends React.Component<Props> {
           }
         })
 
-        this.node.appendChild(editor.ui.view.toolbar.element)
+        if (this.node) {
+          this.node.appendChild(editor.ui.view.toolbar.element)
+        }
       } else {
         editor.isReadOnly = true
       }
 
-      this.node.appendChild(editor.ui.view.editable.element)
+      if (this.node) {
+        this.node.appendChild(editor.ui.view.editable.element)
+      }
       this.editor = editor
     } catch (err) {
       console.error(err) // eslint-disable-line no-console

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -569,6 +569,8 @@ describe("CommentForms", () => {
         { text: "edited text", id: comment.id }
       ])
     })
+
+    //
     ;[
       [410, "This comment has been deleted and cannot be edited"],
       [500, "Something went wrong editing your comment"]
@@ -612,9 +614,15 @@ describe("CommentForms", () => {
       wrapper = renderEditPostForm()
     })
 
-    it("should use the <Editor /> rather than a textarea", () => {
+    it("should use the <Editor /> if a text post", () => {
       assert.ok(wrapper.find("Editor").exists())
       assert.isNotOk(wrapper.find("textarea").exists())
+    })
+
+    it("should use the ArticleEditor if an article post", () => {
+      post.article = []
+      wrapper = renderEditPostForm()
+      assert.ok(wrapper.find("ArticleEditor"))
     })
 
     it("should have the autofocus prop", () => {

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -49,14 +49,18 @@ type Props = {
 }
 
 export default class ExpandedPostDisplay extends React.Component<Props> {
-  renderTextContent = () => {
+  renderTextOrArticleContent = () => {
     const { forms, post } = this.props
 
-    return R.has(editPostKey(post), forms) ? (
-      <EditPostForm post={post} editing />
-    ) : (
-      renderTextContent(post)
-    )
+    if (R.has(editPostKey(post), forms)) {
+      return <EditPostForm post={post} editing />
+    } else {
+      return post.text ? (
+        renderTextContent(post)
+      ) : (
+        <ArticleEditor readOnly initialData={post.article_content || []} />
+      )
+    }
   }
 
   approvePost = (e: Event) => {
@@ -100,15 +104,16 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
           <ReportCount count={post.num_reports} />
         </div>
         <div className="right">
-          {SETTINGS.username === post.author_id && post.text ? (
-            <div
-              className="post-action edit-post grey-surround"
-              onClick={beginEditing(editPostKey(post), post)}
-            >
-              <i className="material-icons edit">edit</i>
-              <span>Edit</span>
-            </div>
-          ) : null}
+          {SETTINGS.username === post.author_id &&
+          (post.text || post.article_content) ? (
+              <div
+                className="post-action edit-post grey-surround"
+                onClick={beginEditing(editPostKey(post), post)}
+              >
+                <i className="material-icons edit">edit</i>
+                <span>Edit</span>
+              </div>
+            ) : null}
           <div
             className="post-action share-action grey-surround"
             onClick={showPostShareMenu}
@@ -210,10 +215,9 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
           ) : null}
           {post && post.url ? <Embedly embedly={embedly} /> : null}
         </div>
-        {!showPermalinkUI && post.text ? this.renderTextContent() : null}
-        {!showPermalinkUI && post.article_content ? (
-          <ArticleEditor readOnly initialData={post.article_content} />
-        ) : null}
+        {!showPermalinkUI && (post.text || post.article_content)
+          ? this.renderTextOrArticleContent()
+          : null}
         {R.has(editPostKey(post), forms) ? null : this.postActionButtons()}
       </div>
     )

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -183,14 +183,22 @@ describe("ExpandedPostDisplay", () => {
     assert.equal(to, postDetailURL(post.channel_name, post.id, post.slug))
   })
 
-  it("should only show an edit link if a text post and authored by the user", () => {
+  it("should show an edit link if a text or article post and authored by the user", () => {
     [
-      [false, true, true],
-      [false, false, false],
-      [true, true, false],
-      [true, false, false]
-    ].forEach(([urlPost, userAuthor, shouldShowLink]) => {
-      const post = makePost(urlPost)
+      ["text", true, true],
+      ["article", true, true],
+      ["url", true, false],
+      ["text", false, false],
+      ["article", false, false],
+      ["url", false, false]
+    ].forEach(([postType, userAuthor, shouldShowLink]) => {
+      const post = makePost(postType === "url")
+
+      if (postType === "article") {
+        post.text === null
+        post.article = [{ foo: "bar" }]
+      }
+
       if (userAuthor) {
         SETTINGS.username = post.author_id
       }
@@ -392,6 +400,7 @@ describe("ExpandedPostDisplay", () => {
 
   it("should use ArticleEditor to display if an article post", () => {
     post.article_content = []
+    post.text = null
     const wrapper = shallow(<ExpandedPostDisplay {...postProps()} />)
     assert.ok(wrapper.find("ArticleEditor"))
     assert.deepEqual(wrapper.find("ArticleEditor").props(), {

--- a/static/scss/article.scss
+++ b/static/scss/article.scss
@@ -1,12 +1,21 @@
-// this is a fix for these issues:
+// these are a few fixes for these issues:
 // https://github.com/ckeditor/ckeditor5-media-embed/issues/58
 // https://github.com/ckeditor/ckeditor5-media-embed/issues/57
-//
-// the fix is in master, we can remove this when they do another release
+// (this fix is in master, we can remove this when they do another release)
 .ck-editor.read-only {
   *[contenteditable="false"] {
     .ck-media__wrapper > *:not(.ck-media__placeholder) {
       pointer-events: all;
+    }
+  }
+
+  // and
+  // https://github.com/ckeditor/ckeditor5/issues/1261
+  .ck {
+    .ck-widget,
+    .ck-widget:hover,
+    .ck-widget_selected {
+      outline: none;
     }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes #1549

#### What's this PR do?

this adds the ability to edit an 'article' type post.

#### How should this be manually tested?

you should be able to edit an article post. to be able to edit articles, you can follow the setup instructions on the PR that added it, here: https://github.com/mitodl/open-discussions/pull/1557

then you should be able to navigate to an article post and edit it. you should also be able to edit existing text posts as normal, and you should be able to make comments and reply to comments.