### PR TITLE
Added support for configuring article post types in the frontend

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -12,8 +12,7 @@ import {
   userCanPost,
   LINK_TYPE_LINK,
   LINK_TYPE_TEXT,
-  LINK_TYPE_ARTICLE,
-  LINK_TYPE_ANY
+  LINK_TYPE_ARTICLE
 } from "../lib/channels"
 import { goBackAndHandleEvent } from "../lib/util"
 import { validationMessage } from "../lib/validation"
@@ -69,15 +68,16 @@ export default class CreatePostForm extends React.Component<Props> {
               Share a link
             </button>
           ) : null}
-          {SETTINGS.article_ui_enabled ? (
-            <button
-              className="write-an-article dark-outlined compact"
-              onClick={() => updatePostType(LINK_TYPE_ARTICLE)}
-            >
-              <i className="material-icons text_fields">text_fields</i>
+          {SETTINGS.article_ui_enabled &&
+          isLinkTypeAllowed(channel, LINK_TYPE_ARTICLE) ? (
+              <button
+                className="write-an-article dark-outlined compact"
+                onClick={() => updatePostType(LINK_TYPE_ARTICLE)}
+              >
+                <i className="material-icons text_fields">text_fields</i>
               Write an Article
-            </button>
-          ) : null}
+              </button>
+            ) : null}
         </div>
         {validationMessage(validation.post_type)}
       </div>
@@ -97,7 +97,7 @@ export default class CreatePostForm extends React.Component<Props> {
   clearInputButton = () => {
     const { updatePostType, channel } = this.props
 
-    return !channel || channel.link_type === LINK_TYPE_ANY ? (
+    return !channel || channel.allowed_post_types.length > 1 ? (
       <CloseButton onClick={() => updatePostType(null)} />
     ) : null
   }

--- a/static/js/components/admin/EditChannelBasicForm.js
+++ b/static/js/components/admin/EditChannelBasicForm.js
@@ -1,6 +1,8 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import Checkbox from "rmwc/Checkbox"
+import R from "ramda"
 
 import Card from "../Card"
 
@@ -11,7 +13,7 @@ import {
   CHANNEL_TYPE_PRIVATE,
   LINK_TYPE_LINK,
   LINK_TYPE_TEXT,
-  isLinkTypeChecked
+  LINK_TYPE_ARTICLE
 } from "../../lib/channels"
 import { validationMessage } from "../../lib/validation"
 
@@ -93,23 +95,35 @@ export default class EditChannelBasicForm extends React.Component<Props> {
         <Card title="Allowed post types">
           <div className="post-types">
             <Checkbox
-              name="link_type"
+              name="allowed_post_types"
               value={LINK_TYPE_TEXT}
-              checked={isLinkTypeChecked(form.link_type, LINK_TYPE_TEXT)}
+              checked={R.contains(LINK_TYPE_TEXT, form.allowed_post_types)}
               onChange={onUpdate}
             >
               Short text posts
             </Checkbox>
             <Checkbox
-              name="link_type"
+              name="allowed_post_types"
               value={LINK_TYPE_LINK}
-              checked={isLinkTypeChecked(form.link_type, LINK_TYPE_LINK)}
+              checked={R.contains(LINK_TYPE_LINK, form.allowed_post_types)}
               onChange={onUpdate}
             >
               Links to external sites
             </Checkbox>
+            {SETTINGS.article_ui_enabled ? (
+              <Checkbox
+                name="allowed_post_types"
+                value={LINK_TYPE_ARTICLE}
+                checked={R.contains(LINK_TYPE_ARTICLE, form.allowed_post_types)}
+                onChange={onUpdate}
+              >
+                Article posts
+              </Checkbox>
+            ) : null}
           </div>
-          <div className="row">{validationMessage(validation.link_type)}</div>
+          <div className="row">
+            {validationMessage(validation.allowed_post_types)}
+          </div>
         </Card>
         <div className="row actions">
           <button

--- a/static/js/components/admin/EditChannelBasicForm_test.js
+++ b/static/js/components/admin/EditChannelBasicForm_test.js
@@ -72,7 +72,7 @@ describe("EditChannelBasicForm", () => {
     //
     ;[
       ["channel_type", CHANNEL_TYPE_PUBLIC],
-      ["link_type", LINK_TYPE_TEXT],
+      ["allowed_post_types", LINK_TYPE_TEXT],
       ["description", "Channel description"]
     ].forEach(([name, value]) => {
       describe("onUpdate", () => {

--- a/static/js/containers/admin/EditChannelBasicPage.js
+++ b/static/js/containers/admin/EditChannelBasicPage.js
@@ -9,7 +9,7 @@ import EditChannelNavbar from "../../components/admin/EditChannelNavbar"
 import withSingleColumn from "../../hoc/withSingleColumn"
 
 import { actions } from "../../actions"
-import { editChannelForm, updateLinkType } from "../../lib/channels"
+import { editChannelForm, updatePostTypes } from "../../lib/channels"
 import { channelURL } from "../../lib/url"
 import { formatTitle } from "../../lib/title"
 import { getChannelName } from "../../lib/util"
@@ -76,10 +76,10 @@ class EditChannelBasicPage extends React.Component<Props> {
     const updates = {
       [e.target.name]: e.target.value
     }
-    if (e.target.name === "link_type") {
+    if (e.target.name === "allowed_post_types") {
       // $FlowFixMe
-      updates.link_type = updateLinkType(
-        channelForm.value.link_type,
+      updates.allowed_post_types = updatePostTypes(
+        channelForm.value.allowed_post_types,
         e.target.value,
         e.target.checked
       )
@@ -110,7 +110,7 @@ class EditChannelBasicPage extends React.Component<Props> {
       )
     } else {
       const patchValue = R.pickAll(
-        ["name", "channel_type", "description", "link_type"],
+        ["name", "channel_type", "description", "allowed_post_types"],
         channelForm.value
       )
       dispatch(actions.channels.patch(patchValue)).then(channel => {

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -53,7 +53,7 @@ describe("EditChannelBasicPage", () => {
   const setPostType = (wrapper, value) =>
     wrapper
       .find(`input[value='${value}']`)
-      .simulate("change", makeEvent("link_type", value, true))
+      .simulate("change", makeEvent("allowed_post_types", value, true))
 
   const setDescription = (wrapper, value) =>
     wrapper
@@ -114,7 +114,7 @@ describe("EditChannelBasicPage", () => {
       "name",
       "channel_type",
       "description",
-      "link_type"
+      "allowed_post_types"
     ])
 
     assert.equal(helper.currentLocation.pathname, channelURL(channel.name))

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -2,7 +2,11 @@
 import casual from "casual-browserify"
 import R from "ramda"
 
-import { LINK_TYPE_ANY } from "../lib/channels"
+import {
+  LINK_TYPE_TEXT,
+  LINK_TYPE_LINK,
+  LINK_TYPE_ARTICLE
+} from "../lib/channels"
 import { incrementer } from "../factories/util"
 
 import type {
@@ -24,7 +28,6 @@ export const makeChannel = (privateChannel: boolean = false): Channel => {
     name:                  `channel_${incr.next().value}`,
     title:                 casual.title,
     channel_type:          privateChannel ? "private" : "public",
-    link_type:             LINK_TYPE_ANY,
     description:           casual.description,
     public_description:    casual.description,
     num_users:             casual.integer(0, 500),
@@ -37,7 +40,8 @@ export const makeChannel = (privateChannel: boolean = false): Channel => {
     avatar_small:          hasAvatar ? "http://avatar.small.url" : null,
     avatar_medium:         hasAvatar ? "http://avatar.medium.url" : null,
     banner:                casual.coin_flip ? "http://banner.url" : null,
-    widget_list_id:        null
+    widget_list_id:        null,
+    allowed_post_types:    [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_ARTICLE]
   }
 }
 

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -16,7 +16,6 @@ export type Channel = {
   num_users:             number,
   user_is_contributor:   boolean,
   user_is_moderator:     boolean,
-  link_type:             LinkType,
   membership_is_managed: boolean,
   ga_tracking_id:        ?string,
   avatar:                string|null,
@@ -24,6 +23,7 @@ export type Channel = {
   avatar_medium:         string|null,
   banner:                string|null,
   widget_list_id:        ?number,
+  allowed_post_types:    Array<LinkType>,
 }
 
 export type ChannelForm = {
@@ -32,7 +32,7 @@ export type ChannelForm = {
   description:            string,
   public_description:     string,
   channel_type:           ChannelType,
-  link_type:              LinkType,
+  allowed_post_types:     Array<LinkType>,
   membership_is_managed:  boolean,
   avatar?:            {
     edit:  Blob,
@@ -51,7 +51,7 @@ export type ChannelAppearanceEditValidation = {
 }
 
 export type ChannelBasicEditValidation = {
-  link_type: string
+  allowed_post_types: string
 }
 
 export type AddMemberForm = {

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -192,7 +192,7 @@ export function updateChannel(channel: Channel): Promise<Channel> {
           "description",
           "public_description",
           "channel_type",
-          "link_type"
+          "allowed_post_types"
         ],
         channel
       )

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -153,7 +153,7 @@ export const validateChannelAppearanceEditForm = validate([
 export const validateChannelBasicEditForm = validate([
   validation(
     R.isEmpty,
-    formLens("link_type"),
+    formLens("allowed_post_types"),
     "At least one of the post type options must be selected"
   )
 ])

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -217,15 +217,16 @@ describe("validation library", () => {
     it("should complain about no link types being selected", () => {
       const channel = {
         value: {
-          link_type: []
+          allowed_post_types: []
         }
       }
       assert.deepEqual(validateChannelBasicEditForm(channel), {
         value: {
-          link_type: "At least one of the post type options must be selected"
+          allowed_post_types:
+            "At least one of the post type options must be selected"
         }
       })
-      channel.value.link_type = [LINK_TYPE_LINK]
+      channel.value.allowed_post_types = [LINK_TYPE_LINK]
       assert.deepEqual(validateChannelBasicEditForm(channel), {})
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1517 

#### What's this PR do?
Updates the frontend to use `allowed_post_types` for managing channels and which types a user is allowed to post.

#### How should this be manually tested?
- Go to channel settings, verify you can enable/disable article types and the settings are saved
- Go to create a new post, verify the available post types per channel respect their respective channel's settings

#### Screenshots

Desktop:
![screenshot_2018-12-12 edit channel mit open learning](https://user-images.githubusercontent.com/28598/49900878-d7110380-fe2d-11e8-98ea-8e9894af4d53.png)
Mobile:
![screenshot_2018-12-12 edit channel mit open learning 1](https://user-images.githubusercontent.com/28598/49900956-03c51b00-fe2e-11e8-9757-3ea34fa0bbaf.png)

