### PR TITLE
Fix post type assignment in backpopulate_missing_posts command

### DIFF
--- a/channels/management/commands/backpopulate_missing_posts.py
+++ b/channels/management/commands/backpopulate_missing_posts.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                 try:
                     submission = api_client.get_post(post_id)
                     submission_type = (
-                        LINK_TYPE_LINK if hasattr(submission, "url") else LINK_TYPE_SELF
+                        LINK_TYPE_SELF if submission.is_self else LINK_TYPE_LINK
                     )
                     with transaction.atomic():
                         post, _ = Post.objects.get_or_create(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixed #1585 

#### What's this PR do?
Rewrites the logic used to determine if a post type should be `self` or `link`

#### How should this be manually tested?
Follow the same steps as in PR #1567 and make sure that the missing posts are assigned the correct post type.