### PR TITLE
require confirmation when the user switches post types

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -4,6 +4,7 @@ import { createAction } from "redux-actions"
 export const DIALOG_REMOVE_POST = "DIALOG_REMOVE_POST"
 export const DIALOG_REMOVE_COMMENT = "DIALOG_REMOVE_COMMENT"
 export const DIALOG_REMOVE_MEMBER = "DIALOG_REMOVE_MEMBER"
+export const DIALOG_CLEAR_POST_TYPE = "DIALOG_CLEAR_POST_TYPE"
 
 export const SET_SHOW_DRAWER_DESKTOP = "SET_SHOW_DRAWER_DESKTOP"
 export const setShowDrawerDesktop = createAction(SET_SHOW_DRAWER_DESKTOP)

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -14,8 +14,9 @@ import {
   LINK_TYPE_TEXT,
   LINK_TYPE_ARTICLE
 } from "../lib/channels"
-import { goBackAndHandleEvent } from "../lib/util"
+import { goBackAndHandleEvent, preventDefaultAndInvoke } from "../lib/util"
 import { validationMessage } from "../lib/validation"
+import { postFormIsContentless } from "../lib/posts"
 
 import type { Channel, PostForm, PostValidation } from "../flow/discussionTypes"
 
@@ -31,7 +32,8 @@ type Props = {
   channels: Map<string, Channel>,
   updateChannelSelection: Function,
   embedly: Object,
-  embedlyInFlight: boolean
+  embedlyInFlight: boolean,
+  openClearPostTypeDialog: Function
 }
 
 const channelOptions = (channels: Map<string, Channel>) =>
@@ -94,11 +96,22 @@ export default class CreatePostForm extends React.Component<Props> {
     )
   }
 
+  clearInputClickHandler = () => {
+    const { postForm, updatePostType, openClearPostTypeDialog } = this.props
+    if (postFormIsContentless(postForm)) {
+      updatePostType(null)
+    } else {
+      openClearPostTypeDialog()
+    }
+  }
+
   clearInputButton = () => {
-    const { updatePostType, channel } = this.props
+    const { channel } = this.props
 
     return !channel || channel.allowed_post_types.length > 1 ? (
-      <CloseButton onClick={() => updatePostType(null)} />
+      <CloseButton
+        onClick={preventDefaultAndInvoke(this.clearInputClickHandler)}
+      />
     ) : null
   }
 

--- a/static/js/containers/ProfileEditPage_test.js
+++ b/static/js/containers/ProfileEditPage_test.js
@@ -9,13 +9,13 @@ import { editProfileURL } from "../lib/url"
 import { makeProfile } from "../factories/profiles"
 import { actions } from "../actions"
 import { makeChannelPostList } from "../factories/posts"
+import { makeEvent } from "../lib/test_utils"
 
 import type { ProfilePayload } from "../flow/discussionTypes"
 
 describe("ProfileEditPage", function() {
   let helper, listenForActions, renderComponent, profile
 
-  const makeEvent = (name, value) => ({ target: { value, name } })
   const makeLocationEvent = json => ({ suggestion: json })
 
   const setName = (wrapper, name) =>

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -365,7 +365,6 @@ export const getEmbedly = async (url: string): Promise<EmbedlyResponse> => {
   const response = await fetchJSONWithAuthFailure(
     `/api/v0/embedly/${encodeURIComponent(encodeURIComponent(url))}/`
   )
-
   return { url, response }
 }
 

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -15,12 +15,18 @@ import type {
 } from "../flow/discussionTypes"
 
 export const newPostForm = (): PostForm => ({
-  postType: null,
-  text:     "",
-  url:      "",
-  title:    "",
-  article:  []
+  postType:  null,
+  text:      "",
+  url:       "",
+  title:     "",
+  thumbnail: null,
+  article:   []
 })
+
+export const postFormIsContentless = R.useWith(
+  R.equals,
+  R.repeat(R.omit(["postType", "title"]), 2)
+)(newPostForm())
 
 export const formatCommentsCount = (post: Post): string =>
   post.num_comments === 1 ? "1 comment" : `${post.num_comments || 0} comments`

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -9,7 +9,8 @@ import {
   formatCommentsCount,
   PostTitleAndHostname,
   formatPostTitle,
-  mapPostListResponse
+  mapPostListResponse,
+  postFormIsContentless
 } from "./posts"
 import { makeChannelPostList, makePost } from "../factories/posts"
 import { urlHostname } from "./url"
@@ -17,12 +18,22 @@ import { urlHostname } from "./url"
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
     assert.deepEqual(newPostForm(), {
-      postType: null,
-      text:     "",
-      url:      "",
-      title:    "",
-      article:  []
+      postType:  null,
+      text:      "",
+      url:       "",
+      title:     "",
+      article:   [],
+      thumbnail: null
     })
+  })
+
+  it("should let us check if a post form is empty of post content", () => {
+    assert.isTrue(postFormIsContentless(newPostForm()))
+    assert.isFalse(postFormIsContentless({ ...newPostForm(), text: "hey!" }))
+    assert.isFalse(postFormIsContentless({ ...newPostForm(), url: "a url" }))
+    assert.isFalse(
+      postFormIsContentless({ ...newPostForm(), article: [{ boop: "doop" }] })
+    )
   })
 
   it("should correctly format comments", () => {

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from "chai"
 import { shallow } from "enzyme"
+import sinon from "sinon"
 
 import { S } from "./sanctuary"
 import React from "react"
@@ -42,3 +43,8 @@ export const configureShallowRenderer = (
   defaultProps: Object
 ) => (extraProps: Object = {}) =>
   shallow(<Component {...defaultProps} {...extraProps} />)
+
+export const makeEvent = (name: string, value: string) => ({
+  target:         { value, name },
+  preventDefault: sinon.stub()
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] tag @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

part of #1583 

#### What's this PR do?

This adds a confirmation dialog if the user tries to remove the post content from their post (click the little 'x') and they have already added some input. If they haven't made any input (typed in a url, text post, or article) we don't put up the confirmation.

I just did my best guess as to what the copy should be.

#### How should this be manually tested?

Go to the post creation page. If you click the post-type buttons you should be able to click the 'x' and it should clear away the input straightaway. If you click a post-type button and then add some input, it should confirm before it clears it away. Cancelling with the dialog should not clear away your input.

#### Screenshots (if appropriate)
![clearpostconetnttt](https://user-images.githubusercontent.com/6207644/50306016-7489ba00-0462-11e9-98cf-c8cc0d0b7cab.png)
