### PR TITLE
Added posts and comments feed to the profile page

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -849,6 +849,16 @@ class Api:
         channel = self.get_channel(channel_name)
         return self._get_listing(channel, listing_params)
 
+    def list_user_posts(self, username, listing_params):
+        """List posts submitted by a given user"""
+        redditor = Redditor(self.reddit, name=username)
+        return self._get_listing(redditor.submissions, listing_params)
+
+    def list_user_comments(self, username, listing_params):
+        """List comments submitted by a given user"""
+        redditor = Redditor(self.reddit, name=username)
+        return self._get_listing(redditor.comments, listing_params)
+
     def _get_listing(self, listing, listing_params):
         """
         List posts using the 'hot' algorithm

--- a/channels/serializers/posts.py
+++ b/channels/serializers/posts.py
@@ -22,7 +22,7 @@ User = get_user_model()
 
 class BasePostSerializer(RedditObjectSerializer):
     """
-    Basic serializer class for reddit posts. Only includes serialization functionality
+    Basic serializer class for PostProxy objects. Only includes serialization functionality
     (no deserialization or validation), and does not fetch/serialize Subscription data
     """
 

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -47,16 +47,17 @@ def get_listing_params(request):
     return ListingParams(before, after, count, sort)
 
 
-def get_pagination_and_posts(posts, listing_params):
+def get_pagination_and_reddit_obj_list(reddit_obj_listing, listing_params):
     """
     Creates pagination data
 
     Args:
-        posts (praw.models.listing.generator.ListingGenerator): listing generator for posts
+        reddit_obj_listing (praw.models.listing.generator.ListingGenerator):
+            listing generator for reddit objects (posts, comments, etc.)
         listing_params (ListingParams): listing params for this page
 
     Returns:
-        (dict, list of praw.models.Submission): pagination and post data
+        (dict, list of reddit objects [e.g.: praw.models.Submission]): pagination and reddit object list
     """
     before, _, count, _ = listing_params
     pagination = {"sort": listing_params.sort}
@@ -64,13 +65,13 @@ def get_pagination_and_posts(posts, listing_params):
     # call _next_batch() so it pulls data
     # pylint: disable=protected-access
     try:
-        posts._next_batch()
+        reddit_obj_listing._next_batch()
     except StopIteration:
         # empty page
         return pagination, []
 
     # pylint: disable=protected-access
-    listing = posts._listing
+    listing = reddit_obj_listing._listing
 
     per_page = settings.OPEN_DISCUSSIONS_CHANNEL_POST_LIMIT
     count = count or 0
@@ -130,6 +131,9 @@ def lookup_users_for_posts(posts):
     Args:
         posts (list of praw.models.Submission):
             A list of submissions
+
+    Return:
+        dict: A map of usernames to the corresponding User object
     """
     users = User.objects.filter(
         username__in=[post.author.name for post in posts if post.author]

--- a/channels/utils_test.py
+++ b/channels/utils_test.py
@@ -13,7 +13,7 @@ from channels.utils import (
     ListingParams,
     DEFAULT_LISTING_PARAMS,
     get_listing_params,
-    get_pagination_and_posts,
+    get_pagination_and_reddit_obj_list,
     translate_praw_exceptions,
     get_reddit_slug,
     get_kind_and_id,
@@ -56,7 +56,7 @@ def test_get_pagination_and_posts_empty_page(mocker):
     posts = mocker.Mock()
     # pylint: disable=protected-access
     posts._next_batch.side_effect = StopIteration()
-    assert get_pagination_and_posts(posts, DEFAULT_LISTING_PARAMS) == (
+    assert get_pagination_and_reddit_obj_list(posts, DEFAULT_LISTING_PARAMS) == (
         {"sort": POSTS_SORT_HOT},
         [],
     )
@@ -71,7 +71,7 @@ def test_get_pagination_and_posts_small_page(mocker):
     listing.after = None
     listing.before = None
     posts._listing = listing
-    assert get_pagination_and_posts(posts, DEFAULT_LISTING_PARAMS) == (
+    assert get_pagination_and_reddit_obj_list(posts, DEFAULT_LISTING_PARAMS) == (
         {"sort": POSTS_SORT_HOT},
         list(items),
     )
@@ -87,7 +87,7 @@ def test_get_pagination_and_posts_before_first_page(mocker):
     listing.after = "def"
     listing.before = None
     posts._listing = listing
-    assert get_pagination_and_posts(
+    assert get_pagination_and_reddit_obj_list(
         posts, ListingParams("xyz", None, 26, POSTS_SORT_HOT)
     ) == ({"after": "def", "after_count": 25, "sort": POSTS_SORT_HOT}, list(items))
     posts._next_batch.assert_called_once_with()
@@ -102,7 +102,7 @@ def test_get_pagination_and_posts_before_second_page(mocker):
     listing.after = "def"
     listing.before = "abc"
     posts._listing = listing
-    assert get_pagination_and_posts(
+    assert get_pagination_and_reddit_obj_list(
         posts, ListingParams("xyz", None, 51, POSTS_SORT_HOT)
     ) == (
         {
@@ -126,7 +126,7 @@ def test_get_pagination_and_posts_after(mocker):
     listing.after = "def"
     listing.before = None
     posts._listing = listing
-    assert get_pagination_and_posts(
+    assert get_pagination_and_reddit_obj_list(
         posts, ListingParams(None, None, 25, POSTS_SORT_HOT)
     ) == ({"after": "def", "after_count": 50, "sort": POSTS_SORT_HOT}, list(items))
     posts._next_batch.assert_called_once_with()
@@ -141,7 +141,7 @@ def test_get_pagination_and_posts_before_and_after(mocker):
     listing.after = "def"
     listing.before = "abc"
     posts._listing = listing
-    assert get_pagination_and_posts(
+    assert get_pagination_and_reddit_obj_list(
         posts, ListingParams(None, None, 25, POSTS_SORT_HOT)
     ) == (
         {

--- a/channels/views/frontpage.py
+++ b/channels/views/frontpage.py
@@ -6,7 +6,7 @@ from channels.api import Api
 from channels.proxies import proxy_posts
 from channels.serializers.posts import PostSerializer
 from channels.utils import (
-    get_pagination_and_posts,
+    get_pagination_and_reddit_obj_list,
     get_listing_params,
     lookup_users_for_posts,
     lookup_subscriptions_for_posts,
@@ -34,7 +34,9 @@ class FrontPageView(APIView):
         listing_params = get_listing_params(self.request)
         api = Api(user=self.request.user)
         paginated_posts = api.front_page(listing_params)
-        pagination, posts = get_pagination_and_posts(paginated_posts, listing_params)
+        pagination, posts = get_pagination_and_reddit_obj_list(
+            paginated_posts, listing_params
+        )
         users = lookup_users_for_posts(posts)
         posts = proxy_posts(
             [post for post in posts if post.author and post.author.name in users]

--- a/channels/views/posts.py
+++ b/channels/views/posts.py
@@ -9,7 +9,7 @@ from channels.api import Api
 from channels.proxies import proxy_posts
 from channels.serializers.posts import PostSerializer
 from channels.utils import (
-    get_pagination_and_posts,
+    get_pagination_and_reddit_obj_list,
     get_listing_params,
     lookup_users_for_posts,
     lookup_subscriptions_for_posts,
@@ -42,7 +42,7 @@ class PostListView(APIView):
             paginated_posts = api.list_posts(
                 self.kwargs["channel_name"], listing_params
             )
-            pagination, posts = get_pagination_and_posts(
+            pagination, posts = get_pagination_and_reddit_obj_list(
                 paginated_posts, listing_params
             )
             users = lookup_users_for_posts(posts)

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ from fixtures.betamax import *
 from fixtures.common import *
 from fixtures.reddit import *
 from fixtures.users import *
-from open_discussions.exceptions import NoRequestException
+from open_discussions.exceptions import DoNotUseRequestException
 
 
 @pytest.fixture(autouse=True)
@@ -17,5 +17,5 @@ def prevent_requests(mocker, request):
     mocker.patch(
         "requests.sessions.Session.request",
         autospec=True,
-        side_effect=NoRequestException,
+        side_effect=DoNotUseRequestException,
     )

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -119,6 +119,14 @@ def mock_channel_exists(mocker):
 
 
 @pytest.fixture()
+def mock_req_channel_api(mocker):
+    """
+    Mocks the channel API object that is made available on a request via middleware
+    """
+    return mocker.patch("open_discussions.middleware.channel_api.Api", autospec=True)
+
+
+@pytest.fixture()
 def mocked_celery(mocker):
     """Mock object that patches certain celery functions"""
     exception_class = TabError

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -4,8 +4,9 @@ from types import SimpleNamespace
 import pytest
 
 from channels import api
-from channels.constants import CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC
-from channels.factories import RedditFactories, FactoryStore
+from channels.constants import CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC, LINK_TYPE_SELF
+from channels.factories import RedditFactories, FactoryStore, PostFactory
+from channels.proxies import PostProxy
 from channels.utils import render_article_text
 
 
@@ -150,4 +151,21 @@ def reddit_comment_obj(mocker, reddit_submission_obj):
         likes=1,
         banned_by=None,
         edited=False,
+        permalink=lambda: "/r/{}/{}".format(
+            reddit_submission_obj.subreddit.display_name,
+            "/r/{}/comments/a/post-title/43".format(
+                reddit_submission_obj.subreddit.display_name
+            ),
+        ),
     )
+
+
+@pytest.fixture()
+def post_proxy(reddit_submission_obj):
+    """A dummy PostProxy object based on the reddit_submission_obj fixture"""
+    post = PostFactory.create(
+        post_id=reddit_submission_obj.id,
+        channel__name=reddit_submission_obj.subreddit.display_name,
+        post_type=LINK_TYPE_SELF,
+    )
+    return PostProxy(reddit_submission_obj, post)

--- a/open_discussions/exceptions.py
+++ b/open_discussions/exceptions.py
@@ -18,5 +18,5 @@ def api_exception_handler(exc, context):
     return response
 
 
-class NoRequestException(Exception):
+class DoNotUseRequestException(Exception):
     """This exception is raised during unit tests if an HTTP request is attempted"""

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -8,6 +8,7 @@ from profiles.views import (
     ProfileViewSet,
     UserWebsiteViewSet,
     name_initials_avatar_view,
+    UserContributionListView,
 )
 
 router = DefaultRouter()
@@ -16,6 +17,11 @@ router.register(r"profiles", ProfileViewSet, basename="profile_api")
 router.register(r"websites", UserWebsiteViewSet, basename="user_websites_api")
 
 urlpatterns = [
+    url(
+        r"^api/v0/profiles/(?P<username>[A-Za-z0-9_]+)/(?P<object_type>posts|comments)/$",
+        UserContributionListView.as_view(),
+        name="user-contribution-list",
+    ),
     url(r"^api/v0/", include(router.urls)),
     # The URL that gravatar will redirect to if no gravatar exists for the user (no query parameters allowed).
     url(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -7,6 +7,8 @@ from django.views.decorators.cache import cache_page
 
 from rest_framework import viewsets, mixins
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.response import Response
 
 from cairosvg import svg2png  # pylint:disable=no-name-in-module
 
@@ -19,6 +21,14 @@ from profiles.serializers import (
     UserWebsiteSerializer,
 )
 from profiles.utils import generate_svg_avatar, DEFAULT_PROFILE_IMAGE
+from channels.proxies import proxy_posts
+from channels.serializers.posts import BasePostSerializer
+from channels.serializers.comments import BaseCommentSerializer
+from channels.utils import (
+    get_pagination_and_reddit_obj_list,
+    get_listing_params,
+    translate_praw_exceptions,
+)
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -65,3 +75,54 @@ def name_initials_avatar_view(
         return redirect(DEFAULT_PROFILE_IMAGE)
     svg = generate_svg_avatar(user.profile.name, int(size), color, bgcolor)
     return HttpResponse(svg2png(bytestring=svg), content_type="image/png")
+
+
+class UserContributionListView(APIView):
+    """View that returns user a user's posts or comments depending on the request URL"""
+
+    def get_serializer_context(self):
+        """Context for the request and view"""
+        return {
+            "include_permalink_data": True,
+            "channel_api": self.request.channel_api,
+            "current_user": self.request.user,
+            "request": self.request,
+            "view": self,
+        }
+
+    def get(self, request, *args, **kwargs):
+        """View method for HTTP GET request"""
+        with translate_praw_exceptions(request.user):
+            api = self.request.channel_api
+            profile_username = self.kwargs["username"]
+            profile_user = User.objects.get(username=profile_username)
+            object_type = self.kwargs["object_type"]
+            listing_params = get_listing_params(self.request)
+
+            if object_type == "posts":
+                serializer_cls = BasePostSerializer
+                listing_getter = api.list_user_posts
+            else:
+                serializer_cls = BaseCommentSerializer
+                listing_getter = api.list_user_comments
+
+            object_listing = listing_getter(profile_username, listing_params)
+            pagination, user_objects = get_pagination_and_reddit_obj_list(
+                object_listing, listing_params
+            )
+            if object_type == "posts":
+                user_objects = proxy_posts(user_objects)
+
+            return Response(
+                {
+                    object_type: serializer_cls(
+                        user_objects,
+                        many=True,
+                        context={
+                            **self.get_serializer_context(),
+                            "users": {profile_username: profile_user},
+                        },
+                    ).data,
+                    "pagination": pagination,
+                }
+            )

--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -308,7 +308,7 @@ export default class CommentTree extends React.Component<Props> {
         </Card>
         {atMaxDepth ? null : (
           <div className="replies">
-            {R.map(renderGenericComment, comment.replies)}
+            {R.map(renderGenericComment, comment.replies || [])}
           </div>
         )}
       </div>

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -258,6 +258,11 @@ class App extends React.Component<AppProps> {
             path={`${match.url}profile/:userName`}
             component={ProfilePage}
           />
+          <Route
+            exact
+            path={`${match.url}profile/:userName/:objectType(posts|comments)`}
+            component={ProfilePage}
+          />
           <Route exact path={`${match.url}login/`} component={LoginPage} />
           <Route
             exact

--- a/static/js/containers/ProfileContributionFeed.js
+++ b/static/js/containers/ProfileContributionFeed.js
@@ -1,0 +1,244 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import { connect } from "react-redux"
+import { NavLink } from "react-router-dom"
+import R from "ramda"
+import _ from "lodash"
+import InfiniteScroll from "react-infinite-scroller"
+
+import { Loading } from "../components/Loading"
+import IntraPageNav from "../components/IntraPageNav"
+import CompactPostDisplay from "../components/CompactPostDisplay"
+import CommentTree from "../components/CommentTree"
+
+import { actions } from "../actions"
+import { toggleUpvote } from "../util/api_actions"
+import { POSTS_SORT_NEW } from "../lib/picker"
+import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
+import { commentPermalink } from "../lib/url"
+import { dropdownMenuFuncs } from "../lib/ui"
+
+import type { Dispatch } from "redux"
+import type { CommentInTree, Post } from "../flow/discussionTypes"
+import type { UserContributionState } from "../reducers/user_contributions"
+
+type Props = {
+  dispatch: Dispatch<*>,
+  userName: string,
+  selectedTab: string,
+  contributions: UserContributionState,
+  upvotedPosts: Map<string, Post>,
+  canLoadMore: boolean
+}
+
+type State = {
+  votedComments: Map<string, CommentInTree>
+}
+
+const profileFeedDefaultParams = { sort: POSTS_SORT_NEW }
+const tabs = [POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE]
+
+class ProfileContributionFeed extends React.Component<Props, State> {
+  constructor() {
+    super()
+    this.state = {
+      votedComments: new Map()
+    }
+  }
+
+  componentDidMount() {
+    const { contributions, selectedTab } = this.props
+
+    if (!contributions || !contributions[selectedTab]) {
+      this.loadData()
+    }
+  }
+
+  componentDidUpdate() {
+    const { contributions, selectedTab, canLoadMore } = this.props
+
+    if (
+      canLoadMore &&
+      contributions &&
+      contributions[selectedTab].loaded === false
+    ) {
+      this.loadData()
+    }
+  }
+
+  loadData = async params => {
+    const { dispatch, userName, selectedTab } = this.props
+
+    params = params || profileFeedDefaultParams
+    await dispatch(actions.userContributions.get(selectedTab, userName, params))
+  }
+
+  loadMore = async () => {
+    const { canLoadMore, contributions, selectedTab } = this.props
+
+    if (!canLoadMore) {
+      return
+    }
+
+    const pagination = contributions[selectedTab].pagination
+    const paginationParams = {
+      ...profileFeedDefaultParams,
+      count: pagination.after_count,
+      after: pagination.after
+    }
+
+    await this.loadData(paginationParams)
+  }
+
+  updateVotedComments = (comment: CommentInTree) => {
+    const { votedComments } = this.state
+    const upvotedCommentMap = new Map(votedComments)
+    upvotedCommentMap.set(comment.id, comment)
+    this.setState({ votedComments: upvotedCommentMap })
+  }
+
+  setCommentVote = R.curry(
+    async (voteStatusName: string, comment: CommentInTree) => {
+      const { dispatch } = this.props
+      const updatedComment = await dispatch(
+        actions.comments.patch(comment.id, {
+          [voteStatusName]: !comment[voteStatusName]
+        })
+      )
+      this.updateVotedComments(updatedComment)
+    }
+  )
+
+  upvoteComment = this.setCommentVote("upvoted")
+
+  downvoteComment = this.setCommentVote("downvoted")
+
+  getUpdatedContributionsList = (objectKey, updatedObjects) => {
+    const { contributions } = this.props
+    return updatedObjects
+      ? contributions[objectKey].data.map(
+        contribution => updatedObjects.get(contribution.id) || contribution
+      )
+      : contributions[objectKey].data
+  }
+
+  renderContributionList = () => {
+    const { dispatch, upvotedPosts, selectedTab } = this.props
+    const { votedComments } = this.state
+
+    if (selectedTab === POSTS_OBJECT_TYPE) {
+      const posts = this.getUpdatedContributionsList(
+        POSTS_OBJECT_TYPE,
+        upvotedPosts
+      )
+      if (R.isEmpty(posts)) {
+        return (
+          <div className="empty-list-msg">There are no posts to display.</div>
+        )
+      }
+      return (
+        <div className="post-list">
+          {posts.map((post, i) => (
+            <CompactPostDisplay
+              key={i}
+              post={post}
+              isModerator={false}
+              menuOpen={false}
+              toggleUpvote={toggleUpvote(dispatch)}
+              useSearchPageUI
+            />
+          ))}
+        </div>
+      )
+    } else {
+      const comments = this.getUpdatedContributionsList(
+        COMMENTS_OBJECT_TYPE,
+        votedComments
+      )
+      if (R.isEmpty(comments)) {
+        return (
+          <div className="empty-list-msg">
+            There are no comments to display.
+          </div>
+        )
+      }
+      return (
+        <div className="comment-list">
+          {comments.map((comment, i) => (
+            <CommentTree
+              key={i}
+              comments={[comment]}
+              remove={() => undefined}
+              approve={() => undefined}
+              upvote={this.upvoteComment}
+              downvote={this.downvoteComment}
+              isModerator={false}
+              isPrivateChannel={false}
+              commentPermalink={commentPermalink(
+                comment.channel_name,
+                comment.post_id,
+                comment.post_slug
+              )}
+              curriedDropdownMenufunc={dropdownMenuFuncs(() => null)}
+              dropdownMenus={new Set()}
+              useSearchPageUI
+            />
+          ))}
+        </div>
+      )
+    }
+  }
+
+  render() {
+    const { contributions, selectedTab, userName } = this.props
+
+    const contributionsLoading =
+      !contributions || contributions[selectedTab].loaded === false
+
+    return (
+      <div>
+        <IntraPageNav>
+          {tabs.map(tabName => (
+            <NavLink
+              to={`/profile/${userName}/${tabName}`}
+              activeClassName="active"
+              isActive={() => {
+                return selectedTab === tabName
+              }}
+              key={tabName}
+            >
+              {_.capitalize(tabName)}
+            </NavLink>
+          ))}
+        </IntraPageNav>
+        {contributionsLoading ? (
+          <Loading className="infinite" />
+        ) : (
+          <InfiniteScroll
+            hasMore={!!contributions[selectedTab].pagination.after}
+            loadMore={this.loadMore}
+            initialLoad={false}
+            loader={<Loading className="infinite" key="loader" />}
+          >
+            {this.renderContributionList()}
+          </InfiniteScroll>
+        )}
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { userContributions, posts } = state
+  const contributions = userContributions.data.get(ownProps.userName)
+  const upvotedPosts = posts.data
+  const canLoadMore = !userContributions.processing
+  return {
+    contributions,
+    upvotedPosts,
+    canLoadMore
+  }
+}
+
+export default connect(mapStateToProps)(ProfileContributionFeed)

--- a/static/js/containers/ProfileContributionFeed_test.js
+++ b/static/js/containers/ProfileContributionFeed_test.js
@@ -1,0 +1,160 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { assert } from "chai"
+import { mount } from "enzyme"
+import sinon from "sinon"
+import Router from "../Router"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeProfile } from "../factories/profiles"
+import { makeChannelPostList } from "../factories/posts"
+import { makeCommentsList } from "../factories/comments"
+import { actions } from "../actions"
+import * as apiActions from "../util/api_actions"
+import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
+
+import ProfileContributionFeed from "./ProfileContributionFeed"
+
+describe("ProfileContributionFeed", function() {
+  const contributionFetchActions = [
+    actions.userContributions.get.requestType,
+    actions.userContributions.get.successType
+  ]
+
+  let helper, listenForActions, profile, postsResult, commentsResult
+
+  beforeEach(() => {
+    profile = makeProfile()
+    postsResult = makeChannelPostList()
+    commentsResult = makeCommentsList()
+    helper = new IntegrationTestHelper()
+    helper.getUserPostsStub.returns(
+      Promise.resolve({ [POSTS_OBJECT_TYPE]: postsResult, pagination: {} })
+    )
+    helper.getUserCommentsStub.returns(
+      Promise.resolve({
+        [COMMENTS_OBJECT_TYPE]: commentsResult,
+        pagination:             {}
+      })
+    )
+
+    listenForActions = helper.listenForActions.bind(helper)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  const renderFeed = async (props = {}) => {
+    let wrapper
+
+    const renderedWrapper = await listenForActions(
+      contributionFetchActions,
+      () => {
+        wrapper = mount(
+          <Router history={helper.browserHistory} store={helper.store}>
+            <ProfileContributionFeed
+              userName={profile.username}
+              selectedTab={POSTS_OBJECT_TYPE}
+              {...props}
+            />
+          </Router>
+        )
+      }
+    ).then(() => {
+      return Promise.resolve(wrapper)
+    })
+
+    return renderedWrapper.update()
+  }
+
+  it("should render user post feed by default", async () => {
+    const wrapper = await renderFeed()
+    sinon.assert.calledOnce(helper.getUserPostsStub)
+    assert.equal(wrapper.find("CompactPostDisplay").length, postsResult.length)
+  })
+
+  it("has correct tab links", async () => {
+    const wrapper = await renderFeed()
+    const tabLinks = wrapper.find("NavLink")
+    const postsTabProps = tabLinks.at(0).props()
+    assert.equal(postsTabProps.to, `/profile/${profile.username}/posts`)
+    assert.isTrue(postsTabProps.isActive())
+    const commentsTabProps = tabLinks.at(1).props()
+    assert.equal(commentsTabProps.to, `/profile/${profile.username}/comments`)
+    assert.isFalse(commentsTabProps.isActive())
+  })
+  ;[
+    [POSTS_OBJECT_TYPE, "getUserPostsStub", "CompactPostDisplay"],
+    [COMMENTS_OBJECT_TYPE, "getUserCommentsStub", "CommentTree"]
+  ].forEach(([tabName, expStubCalled, expFeedComponent]) => {
+    it(`should render proper object feed depending on the selected tab`, async () => {
+      const wrapper = await renderFeed({ selectedTab: tabName })
+      sinon.assert.calledOnce(helper[expStubCalled])
+      assert.isTrue(wrapper.find(expFeedComponent).exists())
+    })
+  })
+
+  it("should handle post voting", async () => {
+    const fakeUpvoteHandler = sinon.fake()
+    helper.sandbox.stub(apiActions, "toggleUpvote").returns(fakeUpvoteHandler)
+
+    const wrapper = await renderFeed()
+
+    const firstPost = wrapper.find("CompactPostDisplay").at(0)
+    firstPost.prop("toggleUpvote")()
+    sinon.assert.calledOnce(fakeUpvoteHandler)
+  })
+  ;[["upvote", "upvoted", true], ["downvote", "downvoted", true]].forEach(
+    ([voteFuncName, votePropertyName, isUpvote]) => {
+      it(`should handle comment ${voteFuncName}`, async () => {
+        const comment = commentsResult[0]
+        const wrapper = await renderFeed({ selectedTab: COMMENTS_OBJECT_TYPE })
+        const firstCommentComp = wrapper.find("CommentTree").at(0)
+        helper.updateCommentStub.returns(
+          Promise.resolve({
+            ...comment,
+            downvoted: !isUpvote,
+            upvoted:   isUpvote
+          })
+        )
+
+        await listenForActions(
+          [
+            actions.comments.patch.requestType,
+            actions.comments.patch.successType
+          ],
+          () => {
+            firstCommentComp.prop(voteFuncName)(comment)
+          }
+        )
+
+        sinon.assert.calledWith(helper.updateCommentStub, comment.id, {
+          // $FlowFixMe
+          [votePropertyName]: !comment[votePropertyName]
+        })
+      })
+    }
+  )
+  ;[
+    [POSTS_OBJECT_TYPE, "no posts to display"],
+    [COMMENTS_OBJECT_TYPE, "no comments to display"]
+  ].forEach(([tabName, expMessageFragment]) => {
+    it(`should show a message when feed is empty in the ${tabName} tab`, async () => {
+      helper.getUserPostsStub.returns(
+        Promise.resolve({ [POSTS_OBJECT_TYPE]: [], pagination: {} })
+      )
+      helper.getUserCommentsStub.returns(
+        Promise.resolve({
+          [COMMENTS_OBJECT_TYPE]: [],
+          pagination:             {}
+        })
+      )
+
+      const wrapper = await renderFeed({ selectedTab: tabName })
+
+      assert.include(wrapper.find(".empty-list-msg").html(), expMessageFragment)
+    })
+  })
+})

--- a/static/js/containers/ProfileEditPage_test.js
+++ b/static/js/containers/ProfileEditPage_test.js
@@ -55,6 +55,8 @@ describe("ProfileEditPage", function() {
     helper.getProfileStub.returns(Promise.resolve(profile))
     helper.getChannelsStub.returns(Promise.resolve([]))
     helper.getChannelStub.returns(Promise.resolve([]))
+    helper.getUserPostsStub.returns(Promise.resolve([]))
+    helper.getUserCommentsStub.returns(Promise.resolve([]))
     helper.getFrontpageStub.returns(
       Promise.resolve({ posts: makeChannelPostList() })
     )

--- a/static/js/containers/ProfilePage.js
+++ b/static/js/containers/ProfilePage.js
@@ -7,6 +7,7 @@ import { MetaTags } from "react-meta-tags"
 
 import Card from "../components/Card"
 import ProfileImage, { PROFILE_IMAGE_MEDIUM } from "./ProfileImage"
+import ProfileContributionFeed from "./ProfileContributionFeed"
 import { withSpinnerLoading } from "../components/Loading"
 import withSingleColumn from "../hoc/withSingleColumn"
 import CanonicalLink from "../components/CanonicalLink"
@@ -15,21 +16,25 @@ import { SocialSiteLogoLink, SiteLogoLink } from "../components/SiteLogoLink"
 import { actions } from "../actions"
 import { formatTitle } from "../lib/title"
 import { getUserName } from "../lib/util"
-import { PERSONAL_SITE_TYPE } from "../lib/constants"
+import { PERSONAL_SITE_TYPE, POSTS_OBJECT_TYPE } from "../lib/constants"
 import { any404Error, anyErrorExcept404 } from "../util/rest"
 import { clearPostError } from "../actions/post"
 
+import type { Match } from "react-router"
 import type { Profile } from "../flow/discussionTypes"
 import type { Dispatch } from "redux"
 
 type Props = {
   dispatch: Dispatch<*>,
+  match: Match,
   profile: Profile,
   userName: string,
   history: Object,
   notFound: boolean,
   errored: boolean
 }
+
+const defaultTab = POSTS_OBJECT_TYPE
 
 class ProfilePage extends React.Component<Props> {
   componentDidMount() {
@@ -81,7 +86,7 @@ class ProfilePage extends React.Component<Props> {
   }
 
   render() {
-    const { profile, userName } = this.props
+    const { profile, userName, match } = this.props
     if (!profile) {
       return null
     }
@@ -127,6 +132,10 @@ class ProfilePage extends React.Component<Props> {
             </button>
           </div>
         ) : null}
+        <ProfileContributionFeed
+          userName={userName}
+          selectedTab={match.params.objectType || defaultTab}
+        />
       </React.Fragment>
     )
   }

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -1,8 +1,10 @@
 // @flow
+import R from "ramda"
 import casual from "casual-browserify"
 
 import { arrayN } from "./util"
 import { incrementer } from "../lib/util"
+import { makePost } from "./posts"
 
 import type {
   Post,
@@ -120,4 +122,8 @@ export const makeMoreCommentsResponse = (
   }
 
   return comments
+}
+
+export const makeCommentsList = (): Array<CommentInTree> => {
+  return R.range(0, 5).map(() => makeComment(makePost()))
 }

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -6,6 +6,7 @@ import {
 } from "../lib/channels"
 
 import type { LinkType, ChannelType } from "../lib/channels"
+import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
 
 export type FormImage = {
   edit:  Blob,
@@ -146,6 +147,11 @@ export type PostListResponse = {
   posts:      Array<Post>
 }
 
+export type UserContributionResponse = {
+  pagination: PostListPagination,
+  [POSTS_OBJECT_TYPE | COMMENTS_OBJECT_TYPE]: Array<Post | CommentFromAPI>
+}
+
 type HasParentId = {
   parent_id: ?string
 }
@@ -171,6 +177,11 @@ export type CommentInTree = CommentFromAPI & {
 }
 
 export type MoreCommentsInTree = MoreCommentsFromAPI
+
+// Represents a comment serialized from a user's comment feed rather than from a post
+export type UserFeedComment = CommentFromAPI & {
+  post_slug: string
+}
 
 export type CommentForm = {
   post_id:     string,

--- a/static/js/lib/api/api.js
+++ b/static/js/lib/api/api.js
@@ -12,16 +12,19 @@ import {
   fetchWithAuthFailure,
   fetchJSONWithToken
 } from "./fetch_auth"
-import { getCommentSortQS } from "./util"
+import { getCommentSortQS, getPaginationSortQS } from "./util"
 
 import type { AuthResponse, AuthFlow } from "../../flow/authTypes"
 import type {
   GenericComment,
   CommentFromAPI,
   MoreCommentsFromAPI,
+  UserFeedComment,
+  Post,
   Profile,
   ProfilePayload,
-  SocialAuth
+  SocialAuth,
+  PostListPaginationParams
 } from "../../flow/discussionTypes"
 import type { NotificationSetting } from "../../flow/settingsTypes"
 import type { WidgetListResponse } from "../../flow/widgetTypes"
@@ -95,6 +98,24 @@ export function getMoreComments(
   }
   return fetchJSONWithAuthFailure(
     `/api/v0/morecomments/?${qs.stringify(payload)}`
+  )
+}
+
+export function getUserPosts(
+  username: string,
+  params: PostListPaginationParams
+): Promise<Array<Post>> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/profiles/${username}/posts/${getPaginationSortQS(params)}`
+  )
+}
+
+export function getUserComments(
+  username: string,
+  params: PostListPaginationParams
+): Promise<Array<UserFeedComment>> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/profiles/${username}/comments/${getPaginationSortQS(params)}`
   )
 }
 

--- a/static/js/lib/api/api_test.js
+++ b/static/js/lib/api/api_test.js
@@ -12,6 +12,8 @@ import {
   createComment,
   updateComment,
   getMoreComments,
+  getUserPosts,
+  getUserComments,
   deleteComment,
   getSettings,
   patchFrontpageSetting,
@@ -31,7 +33,7 @@ import {
   getWidgetList,
   patchWidgetList
 } from "./api"
-import { makePost } from "../../factories/posts"
+import { makePost, makeChannelPostList } from "../../factories/posts"
 import {
   makeCommentsResponse,
   makeMoreCommentsResponse
@@ -260,6 +262,40 @@ describe("api", function() {
         )
         assert.deepEqual(response, moreComments)
       })
+    })
+
+    it("gets user posts", async () => {
+      const posts = makeChannelPostList()
+      fetchJSONStub.returns(Promise.resolve({ posts }))
+
+      const result = await getUserPosts("someuser", {
+        before: "abc",
+        after:  "def",
+        count:  5
+      })
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/profiles/someuser/posts/?after=def&before=abc&count=5`
+        )
+      )
+      assert.deepEqual(result.posts, posts)
+    })
+
+    it("gets user comment", async () => {
+      const comments = makeCommentsResponse(makePost())
+      fetchJSONStub.returns(Promise.resolve({ comments }))
+
+      const result = await getUserComments("someuser", {
+        before: "abc",
+        after:  "def",
+        count:  5
+      })
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/profiles/someuser/comments/?after=def&before=abc&count=5`
+        )
+      )
+      assert.deepEqual(result.comments, comments)
     })
 
     describe("postEmailLogin", () => {

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -2,3 +2,6 @@ export const contentLoaderSpeed = 2
 
 export const PERSONAL_SITE_TYPE = "personal"
 export const SOCIAL_SITE_TYPE = "social"
+
+export const POSTS_OBJECT_TYPE = "posts"
+export const COMMENTS_OBJECT_TYPE = "comments"

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -16,6 +16,7 @@ import { accountSettingsEndpoint } from "../reducers/account_settings"
 import { embedlyEndpoint } from "../reducers/embedly"
 import { profilesEndpoint } from "../reducers/profiles"
 import { userWebsitesEndpoint } from "../reducers/websites"
+import { userContributionsEndpoint } from "../reducers/user_contributions"
 import { authEndpoint } from "../reducers/auth"
 import { passwordResetEndpoint } from "../reducers/password_reset"
 import { passwordChangeEndpoint } from "../reducers/password_change"
@@ -46,6 +47,7 @@ export const endpoints = [
   embedlyEndpoint,
   profilesEndpoint,
   userWebsitesEndpoint,
+  userContributionsEndpoint,
   authEndpoint,
   passwordResetEndpoint,
   passwordChangeEndpoint,

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -30,7 +30,8 @@ export const postDetailURL = (
 export const newPostURL = (channelName: ?string) =>
   channelName ? `/create_post/${channelName}` : "/create_post/"
 
-export const profileURL = (username: string) => `/profile/${username}/`
+export const profileURL = (username: string, selectedTab: ?string) =>
+  selectedTab ? `/profile/${username}/${selectedTab}` : `/profile/${username}/`
 
 export const editProfileURL = (username: string) => `/profile/${username}/edit`
 

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -115,6 +115,7 @@ describe("url helper functions", () => {
   describe("profileURL", () => {
     it("should return a url to view a profile", () => {
       assert.equal(profileURL("username"), "/profile/username/")
+      assert.equal(profileURL("username", "posts"), "/profile/username/posts")
     })
   })
 

--- a/static/js/reducers/user_contributions.js
+++ b/static/js/reducers/user_contributions.js
@@ -1,0 +1,97 @@
+// @flow
+import R from "ramda"
+import { GET, INITIAL_STATE } from "redux-hammock/constants"
+
+import * as api from "../lib/api/api"
+import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
+
+import type {
+  Post,
+  UserFeedComment,
+  PostListPaginationParams,
+  UserContributionResponse
+} from "../flow/discussionTypes"
+
+type ChannelEndpointResponse = {
+  username: string,
+  response: UserContributionResponse
+}
+
+export type UserContributionState =
+  | {
+      POSTS_OBJECT_TYPE: {
+        data: Array<Post>,
+        pagination: Object,
+        loaded: boolean
+      }
+    }
+  | {
+      COMMENTS_OBJECT_TYPE: {
+        data: Array<UserFeedComment>,
+        pagination: Object,
+        loaded: boolean
+      }
+    }
+
+type ContributionMap = Map<string, UserContributionState>
+
+const USER_INITIAL_STATE = {
+  posts: {
+    data:       [],
+    pagination: {},
+    loaded:     false
+  },
+  comments: {
+    data:       [],
+    pagination: {},
+    loaded:     false
+  }
+}
+
+const getObjectKeyFromResponse = R.compose(
+  R.head,
+  R.intersection([POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE]),
+  R.keys
+)
+
+export const userContributionsEndpoint = {
+  name:         "userContributions",
+  verbs:        [GET],
+  initialState: {
+    ...INITIAL_STATE,
+    data: new Map()
+  },
+  getFunc: async (
+    requestType: string,
+    username: string,
+    params: PostListPaginationParams
+  ) => {
+    const fetchFunc =
+      requestType === POSTS_OBJECT_TYPE ? api.getUserPosts : api.getUserComments
+    const response = await fetchFunc(username, params || {})
+    return { username, response }
+  },
+  getSuccessHandler: (
+    payload: ChannelEndpointResponse,
+    oldData: ContributionMap
+  ): ContributionMap => {
+    const { username, response } = payload
+    const usernameContributionMap = new Map(oldData)
+    // Get the existing state for the user's contributions or initialize it
+    const userState =
+      usernameContributionMap.get(username) || R.clone(USER_INITIAL_STATE)
+    // Response data will look like {posts: [...]} or {comments: [...]}. This will give us
+    // that key ("posts" or "comments").
+    const objectKey = getObjectKeyFromResponse(response)
+    if (!objectKey) {
+      return usernameContributionMap
+    }
+    userState[objectKey].data = userState[objectKey].data.concat(
+      response[objectKey]
+    )
+    userState[objectKey].pagination = response.pagination
+    userState[objectKey].loaded = true
+    usernameContributionMap.set(username, userState)
+    return usernameContributionMap
+  }
+}

--- a/static/js/reducers/user_contributions_test.js
+++ b/static/js/reducers/user_contributions_test.js
@@ -1,0 +1,104 @@
+// @flow
+import { assert } from "chai"
+import { INITIAL_STATE } from "redux-hammock/constants"
+import sinon from "sinon"
+
+import { actions } from "../actions"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { COMMENTS_OBJECT_TYPE, POSTS_OBJECT_TYPE } from "../lib/constants"
+
+import { makeChannelPostList } from "../factories/posts"
+import { makeCommentsList } from "../factories/comments"
+
+describe("userContributions reducer", () => {
+  const postsResult = makeChannelPostList(),
+    commentsResult = makeCommentsList(),
+    dummyPagination = { pagination: "params" },
+    username = "someuser"
+
+  let helper, store, dispatchThen
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.getUserPostsStub.returns(
+      Promise.resolve({
+        [POSTS_OBJECT_TYPE]: postsResult,
+        pagination:          dummyPagination
+      })
+    )
+    helper.getUserCommentsStub.returns(
+      Promise.resolve({
+        [COMMENTS_OBJECT_TYPE]: commentsResult,
+        pagination:             dummyPagination
+      })
+    )
+    store = helper.store
+    dispatchThen = store.createDispatchThen(state => state.userContributions)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should have some initial state", () => {
+    assert.deepEqual(store.getState().userContributions, {
+      ...INITIAL_STATE,
+      data: new Map()
+    })
+  })
+  ;[
+    [POSTS_OBJECT_TYPE, postsResult, "getUserPostsStub"],
+    [COMMENTS_OBJECT_TYPE, commentsResult, "getUserCommentsStub"]
+  ].forEach(([objType, expResultArray, expStubCalled]) => {
+    it(`should be able to fetch ${objType} and correctly manage the endpoint state`, async () => {
+      const { requestType, successType } = actions.userContributions.get
+      const { data } = await dispatchThen(
+        actions.userContributions.get(objType, username, dummyPagination),
+        [requestType, successType]
+      )
+      const userContribution = data.get(username)[objType]
+      assert.isTrue(userContribution.loaded)
+      assert.deepEqual(userContribution.pagination, dummyPagination)
+      assert.isArray(userContribution.data)
+      assert.deepEqual(userContribution.data, expResultArray)
+      sinon.assert.calledOnce(helper[expStubCalled])
+    })
+  })
+
+  it("should pass an empty object to the API method by default for pagination params", async () => {
+    const { requestType, successType } = actions.userContributions.get
+    await dispatchThen(
+      actions.userContributions.get(POSTS_OBJECT_TYPE, username),
+      [requestType, successType]
+    )
+    sinon.assert.calledWith(helper.getUserPostsStub, username, {})
+  })
+
+  it("should append new results to existing endpoint data", async () => {
+    const { requestType, successType } = actions.userContributions.get
+    await dispatchThen(
+      actions.userContributions.get(POSTS_OBJECT_TYPE, username),
+      [requestType, successType]
+    )
+
+    const newPostsResult = [...postsResult]
+    const newPagination = { new: "pagination" }
+    helper.getUserPostsStub.returns(
+      Promise.resolve({
+        [POSTS_OBJECT_TYPE]: newPostsResult,
+        pagination:          newPagination
+      })
+    )
+    const { data } = await dispatchThen(
+      actions.userContributions.get(POSTS_OBJECT_TYPE, username),
+      [requestType, successType]
+    )
+
+    const userContribution = data.get(username)[POSTS_OBJECT_TYPE]
+    assert.equal(
+      userContribution.data.length,
+      postsResult.length + newPostsResult.length
+    )
+    assert.deepEqual(userContribution.pagination, newPagination)
+  })
+})

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -8,6 +8,7 @@
 }
 
 .post-list,
+.comment-list,
 .search-page {
   .empty-list-msg {
     height: 200px;

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,7 +11,7 @@ pip-tools
 pylint==2.1.1
 pylint-django==2.0.2
 pytest
-pytest-cov
+pytest-cov>=2.6.1
 pytest-django
 pytest-pep8
 pytest-mock


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [ ] tag @ferdi or @pdpinch for review 
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1126

#### What's this PR do?
Adds the posts and comments feed to a user's profile page

#### How should this be manually tested?
Go to a profile page, scroll down to the posts/comments feed, click between the tabs, scroll to the bottom of the page to trigger infinite scrolling, and click around the actual 

#### Any background context you want to provide?
- The comments feed is not very performant at the moment. A new issue will be created to address this.
- There is some code repetition here with the search results page. A new issue will be created to address that too.
- I also tweaked the `PostProxy` query to prefetch `Article` objects. There was an n+1 query happening with those on channel pages and the home page

#### Screenshots (if appropriate)
<img width="719" alt="ss 2018-12-21 at 12 15 52" src="https://user-images.githubusercontent.com/14932219/50355633-592fb500-051d-11e9-8d9c-590266b287d3.png">
<img width="727" alt="ss 2018-12-21 at 12 15 46" src="https://user-images.githubusercontent.com/14932219/50355652-6cdb1b80-051d-11e9-8c31-c9449689328b.png">

Mobile:
![ss 2019-01-14 at 12 38 20](https://user-images.githubusercontent.com/14932219/51129780-5a40c300-17f9-11e9-8f87-c8addb850a30.png)
![ss 2019-01-14 at 12 38 12](https://user-images.githubusercontent.com/14932219/51129781-5a40c300-17f9-11e9-968c-577e784400e7.png)
![ss 2019-01-14 at 12 38 05](https://user-images.githubusercontent.com/14932219/51129782-5a40c300-17f9-11e9-94e9-1665fd9870ca.png)

