### PR TITLE
Fixed article n+1 query

### DIFF
--- a/channels/proxies.py
+++ b/channels/proxies.py
@@ -107,7 +107,7 @@ def proxy_posts(submissions):
         post.post_id: post
         for post in Post.objects.filter(
             post_id__in=[submission.id for submission in submissions]
-        )
+        ).select_related("article")
     }
     return [
         PostProxy(submission, posts[submission.id])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #1604 

#### What's this PR do?
Fixes an n+1 query for `Article`s that was happening on channel pages/home page

#### How should this be manually tested?
Load one of the pages mentioned above and check your docker log output. You should not see a n+1 warning. You will still see as many HTTP requests as there are posts on the page (that can be addressed in a different PR)

