### PR TITLE
Remove the widget list from the channel admin

### DIFF
--- a/channels/admin.py
+++ b/channels/admin.py
@@ -9,7 +9,7 @@ class ChannelAdmin(admin.ModelAdmin):
     """Customized Channel admin model"""
 
     model = Channel
-    exclude = ("banner", "avatar")
+    exclude = ("banner", "avatar", "widget_list")
     search_fields = ("name",)
     readonly_fields = ("name",)
     list_filter = ("ga_tracking_id",)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Possible fix for #1606 

#### What's this PR do?
This is a theoretical fix for the 500 errors, there is a cursor error on the page in RC, and the only field that could plausibly cause this is the widget list selector.

#### How should this be manually tested?
Ensure you can view the channel admin detail page and that the widgetlist option is gone.