### PR TITLE
Fix other calls to fetch()

### DIFF
--- a/channels/proxies.py
+++ b/channels/proxies.py
@@ -53,7 +53,7 @@ class PostProxy(ObjectProxy):
     @property
     def article(self):
         """Return the Article for this post"""
-        return self._self_post.article
+        return self._self_post.article if hasattr(self._self_post, "article") else None
 
     @property
     def article_content(self):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -296,7 +296,7 @@ class BasePostSerializer(RedditObjectSerializer):
 
     def get_thumbnail(self, instance):
         """Returns a thumbnail url or null"""
-        if hasattr(instance, "article") and instance.article.cover_image_small:
+        if instance.article and instance.article.cover_image_small:
             return urljoin(SITE_BASE_URL, instance.article.cover_image_small.url)
         return instance.link_meta.thumbnail if instance.link_meta is not None else None
 
@@ -375,7 +375,7 @@ class PostSerializer(BasePostSerializer):
 
     def get_cover_image(self, instance):
         """Get the cover image URL"""
-        if hasattr(instance, "article") and instance.article.cover_image:
+        if instance.article and instance.article.cover_image:
             return urljoin(SITE_BASE_URL, instance.article.cover_image.url)
         return None
 

--- a/channels/views/test_utils.py
+++ b/channels/views/test_utils.py
@@ -114,3 +114,11 @@ def default_comment_response_data(post, comment, user):
         "text": comment.text,
         **user_dependent_defaults,
     }
+
+
+def raise_error_on_submission_fetch(mocker):
+    """Raise an error if Submission._fetch() is called"""
+    return mocker.patch(
+        "praw.models.reddit.submission.Submission._fetch",
+        side_effect=Exception("_fetch() should not be called"),
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1604 

#### What's this PR do?
This should wrap up any lingering performance issues relative to the combination of django model nullable relations, `ObjectProxy`, and `praw`'s fetch behavior.

Namely, this what the cause of extraneous requests to reddit on serializing the reponse:

1. `praw` does not set `Submission._fetched = True` for objects coming form listing generators
2. Check for a nullable django relation with `hasattr()`
3. Implementation of that attribute raises an `AttributeError`
4. This trigger's python's defualt behavior of calling the object's `__hasattr__` implementation, which is `ObjectProxy`'s one
5. `ObjectProxy.__hasattr__` proxies to praw's `_getattr__`, which calls `_fetch()` if `_fetched is False`

You'll not that I refactored relation attributes on `PostProxy` to perform the `hasattr()` checks and coerce to  `None` if the attribute doesn't exist, this avoids triggering the proxy behavior, although is non-standard as far as django goes so there's a small tradeoff here.

I also added a patch on `Submission.fetch()` to ensure we don't regress this issue in the future accidentally since `betamax` didn't help us catch this. 

#### How should this be manually tested?
Ensure that you can view and paginate the frontpage and channel listing pages.