### PR TITLE
Article search

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -779,8 +779,6 @@ class Api:
 
         submission = channel.submit(title, selftext=text, url=url)
 
-        post = None
-
         with transaction.atomic():
             # select_for_update so no one else can write to this
             post, created = Post.objects.select_for_update().get_or_create(

--- a/channels/proxies.py
+++ b/channels/proxies.py
@@ -66,7 +66,7 @@ def proxy_post(submission):
     Helper function to proxy a submission
 
     Args:
-        praw.models.Submission): submission to proxy
+        submission (praw.models.Submission): submission to proxy
 
     Returns:
         ProxyPost: proxied post

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -289,3 +289,38 @@ def num_items_not_none(items):
     """
 
     return len(list(filter(lambda val: val is not None, items)))
+
+
+def _render_article_nodes(node):
+    """
+    Render article nodes into pieces of text
+
+    Args:
+        node (list or dict): A node in the article content
+
+    Yields:
+        str: A string containing text from the article nodes
+    """
+    if isinstance(node, list):
+        for item in node:
+            yield from _render_article_nodes(item)
+    elif isinstance(node, dict):
+        if "text" in node:
+            yield node["text"]
+        if "children" in node:
+            yield from _render_article_nodes(node["children"])
+        if node.get("name") == "p":
+            yield " "
+
+
+def render_article_text(content):
+    """
+    Render article text based on the article content data structure
+
+    Args:
+        content (list or dict): The article content
+
+    Returns:
+         str: A string containing the text from the text nodes of the article
+    """
+    return "".join(_render_article_nodes(content))

--- a/channels/utils.py
+++ b/channels/utils.py
@@ -305,11 +305,14 @@ def _render_article_nodes(node):
         for item in node:
             yield from _render_article_nodes(item)
     elif isinstance(node, dict):
+        should_have_spaces = node.get("name") in ("p", "li", "td", "figcaption")
+        if should_have_spaces:
+            yield " "
         if "text" in node:
             yield node["text"]
         if "children" in node:
             yield from _render_article_nodes(node["children"])
-        if node.get("name") == "p":
+        if should_have_spaces:
             yield " "
 
 

--- a/channels/utils_test.py
+++ b/channels/utils_test.py
@@ -18,6 +18,7 @@ from channels.utils import (
     get_reddit_slug,
     get_kind_and_id,
     num_items_not_none,
+    render_article_text,
 )
 
 
@@ -214,3 +215,19 @@ def test_num_items_not_none():
     assert num_items_not_none([1, None]) == 1
 
     assert num_items_not_none([0, 1, "", "abc", False, True, None]) == 6
+
+
+@pytest.mark.parametrize(
+    "input_node,output_text",
+    [
+        [{"text": " some text "}, " some text "],
+        [[{"text": "first part "}, {"text": "second part"}], "first part second part"],
+        [
+            {"name": "p", "children": [{"text": "child text here."}]},
+            "child text here. ",
+        ],
+    ],
+)
+def test_render_article_text(input_node, output_text):
+    """render_article_text should extract the text from any arbitrary article node tree"""
+    assert render_article_text(input_node) == output_text

--- a/channels/utils_test.py
+++ b/channels/utils_test.py
@@ -223,9 +223,15 @@ def test_num_items_not_none():
         [{"text": " some text "}, " some text "],
         [[{"text": "first part "}, {"text": "second part"}], "first part second part"],
         [
-            {"name": "p", "children": [{"text": "child text here."}]},
-            "child text here. ",
+            {
+                "name": "p",
+                "children": [{"text": "child text he"}, {"text": "re some more text."}],
+            },
+            " child text here some more text. ",
         ],
+        [{"name": "li", "text": "item in a bullet point"}, " item in a bullet point "],
+        [{"name": "td", "text": "item in a cell"}, " item in a cell "],
+        [{"name": "figcaption", "text": "item in a caption"}, " item in a caption "],
     ],
 )
 def test_render_article_text(input_node, output_text):

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -114,6 +114,7 @@ def reddit_submission_obj():
     """A dummy Post object"""
     return SimpleNamespace(
         author=SimpleNamespace(name="testuser"),
+        article_content={"text": "some text"},
         subreddit=SimpleNamespace(
             display_name="channel_1", title="Channel", subreddit_type="public"
         ),

--- a/search/api.py
+++ b/search/api.py
@@ -14,20 +14,6 @@ from search.connection import get_conn, get_default_alias_name
 from search.constants import ALIAS_ALL_INDICES
 
 
-def get_reddit_object_type(reddit_obj):
-    """
-    Return the type of the given reddit object
-
-    Args:
-        reddit_obj (praw.models.reddit.submission.Submission, praw.models.reddit.comment.Comment):
-            A PRAW post/'submission' or comment object
-
-    Returns:
-        str: A string constant indicating the object type
-    """
-    return COMMENT_TYPE if hasattr(reddit_obj, "submission") else POST_TYPE
-
-
 def gen_post_id(reddit_obj_id):
     """
     Generates the Elasticsearch document id for a post

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -1,38 +1,18 @@
 """Search API function tests"""
-from types import SimpleNamespace
-
 from django.contrib.auth.models import AnonymousUser
 import pytest
 
-from channels.constants import (
-    CHANNEL_TYPE_PUBLIC,
-    CHANNEL_TYPE_RESTRICTED,
-    COMMENT_TYPE,
-    POST_TYPE,
-)
+from channels.constants import CHANNEL_TYPE_PUBLIC, CHANNEL_TYPE_RESTRICTED
 from channels.api import add_user_role
 from channels.factories import ChannelFactory
 from search.api import (
     execute_search,
-    get_reddit_object_type,
     is_reddit_object_removed,
     gen_post_id,
     gen_comment_id,
 )
 from search.connection import get_default_alias_name
 from search.constants import ALIAS_ALL_INDICES
-
-
-@pytest.mark.parametrize(
-    "reddit_obj,expected_type",
-    [
-        (SimpleNamespace(id=1), POST_TYPE),
-        (SimpleNamespace(id=1, submission={}), COMMENT_TYPE),
-    ],
-)
-def test_get_reddit_object_type(reddit_obj, expected_type):
-    """Test that get_reddit_object_type returns the right object types"""
-    assert get_reddit_object_type(reddit_obj) == expected_type
 
 
 def test_gen_post_id():

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -82,6 +82,7 @@ MAPPING = {
         "post_link_url": {"type": "keyword"},
         "post_link_thumbnail": {"type": "keyword"},
         "num_comments": {"type": "long"},
+        "article_text": ENGLISH_TEXT_FIELD,
     },
     COMMENT_TYPE: {
         **CONTENT_OBJECT_TYPE,

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -9,7 +9,7 @@ from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.models import Post
 from channels.serializers.posts import BasePostSerializer
 from channels.serializers.comments import BaseCommentSerializer
-from channels.utils import get_reddit_slug
+from channels.utils import get_reddit_slug, render_article_text
 from profiles.api import get_channels
 from profiles.models import Profile
 from search.api import gen_post_id, gen_comment_id, gen_profile_id
@@ -91,6 +91,7 @@ class ESPostSerializer(ESSerializer):
 
     object_type = POST_TYPE
     use_keys = [
+        "article_content",
         "author_id",
         "author_name",
         "author_headline",
@@ -125,6 +126,7 @@ class ESPostSerializer(ESSerializer):
             "author_name": None
             if serialized_data["author_name"] == "[deleted]"
             else serialized_data["author_name"],
+            "article_text": render_article_text(serialized_data.get("article_content")),
         }
 
 

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.factories import PostFactory, CommentFactory
-from channels.utils import get_reddit_slug
+from channels.utils import get_reddit_slug, render_article_text
 from open_discussions.factories import UserFactory
 from profiles.models import Profile
 from profiles.utils import image_uri, IMAGE_MEDIUM
@@ -28,6 +28,7 @@ def patched_base_post_serializer(mocker):
         "author_id": 1,
         "author_name": "Author Name",
         "author_headline": "Author Headline",
+        "article_content": {"text": "hello world"},
         "profile_image": "/media/profile/1/208c7d959608417eb13bc87392cb5f77-2018-09-21T163449_small.jpg",
         "channel_title": "channel 1",
         "channel_name": "channel_1",
@@ -106,6 +107,8 @@ def test_es_post_serializer(
     patched_base_post_serializer.assert_called_once_with(reddit_submission_obj)
     assert serialized == {
         "object_type": POST_TYPE,
+        "article_content": base_serialized["article_content"],
+        "article_text": render_article_text(base_serialized["article_content"]),
         "author_id": base_serialized["author_id"],
         "author_name": base_serialized["author_name"],
         "author_headline": base_serialized["author_headline"],

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -8,6 +8,7 @@ from django.conf import settings
 
 from open_discussions.features import INDEX_UPDATES, if_feature_enabled
 from channels.constants import POST_TYPE, COMMENT_TYPE, VoteActions
+from channels.utils import render_article_text
 
 from search.api import (
     gen_post_id,
@@ -102,7 +103,12 @@ def update_post_text(post_obj):
         post_obj (praw.models.reddit.submission.Submission): A PRAW post ('submission') object
     """
     update_document_with_partial.delay(
-        gen_post_id(post_obj.id), {"text": post_obj.selftext}, POST_TYPE
+        gen_post_id(post_obj.id),
+        {
+            "article_text": render_article_text(post_obj.article_content),
+            "text": post_obj.selftext,
+        },
+        POST_TYPE,
     )
 
 

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from open_discussions.features import INDEX_UPDATES
 from channels.constants import POST_TYPE, COMMENT_TYPE, VoteActions
+from channels.utils import render_article_text
 from search.constants import PROFILE_TYPE
 from search.task_helpers import (
     reddit_object_persist,
@@ -156,7 +157,10 @@ def test_update_post_text(mocker, reddit_submission_obj):
     assert patched_task.delay.called is True
     assert patched_task.delay.call_args[0] == (
         gen_post_id(reddit_submission_obj.id),
-        {"text": reddit_submission_obj.selftext},
+        {
+            "text": reddit_submission_obj.selftext,
+            "article_text": render_article_text(reddit_submission_obj.article_content),
+        },
         POST_TYPE,
     )
 

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -74,7 +74,11 @@ export const searchResultToProfile = (result: ProfileResult): Profile => ({
   username:             result.author_id
 })
 
-const POST_QUERY_FIELDS = ["text.english", "post_title.english"]
+const POST_QUERY_FIELDS = [
+  "text.english",
+  "post_title.english",
+  "article_text.english"
+]
 const COMMENT_QUERY_FIELDS = ["text.english"]
 const PROFILE_QUERY_FIELDS = [
   "author_headline.english",

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -264,7 +264,7 @@ describe("search functions", () => {
 
   describe("searchFields", () => {
     [
-      ["post", ["text.english", "post_title.english"]],
+      ["post", ["text.english", "post_title.english", "article_text.english"]],
       ["comment", ["text.english"]],
       [
         "profile",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1519 

#### What's this PR do?
Adds `cover_image` and `article_content` fields to the profile documents in the search index. The `article_content` field is also parsed to be searchable.

#### How should this be manually tested?
Create an article then view it in search. It should look exactly the same as it does on the post list page.

#### Screenshots (if appropriate)
![screenshot from 2019-01-02 13-54-37](https://user-images.githubusercontent.com/863262/50607073-fc75b800-0e95-11e9-8d8f-deea7873cf03.png)

