### PR TITLE
Fix recreate_index error handling

### DIFF
--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -1,5 +1,5 @@
 """Management command to index reddit content"""
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from open_discussions.utils import now_in_utc
 from search.tasks import start_recreate_index
@@ -18,7 +18,10 @@ class Command(BaseCommand):
         )
         self.stdout.write("Waiting on task...")
         start = now_in_utc()
-        task.get()
+        error = task.get()
+        if error:
+            raise CommandError(f"Recreate index errored: {error}")
+
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
             "Recreate index finished, took {} seconds".format(total_seconds)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Exceptions raised in the `start_recreate_index` task are being caught and returned as strings to workaround a celery exception handling limitation. This adds code to fail the management command if an error is received.

#### How should this be manually tested?
Change the mapping to have some incorrect syntax so that Elasticsearch errors right away when reindexing. Run `recreate_index` on master and note that the management command succeeds. Switch to this branch, restart celery and rerun the management command. You should see an error in the command line.

On both master and this PR, you should see the exception stack trace in the celery output, and this exception will get logged to sentry.