### PR TITLE
Change page width from 12 to 8

### DIFF
--- a/static/js/hoc/withSingleColumn.js
+++ b/static/js/hoc/withSingleColumn.js
@@ -12,7 +12,7 @@ const withSingleColumn = R.curry(
       render() {
         return (
           <Grid className={`main-content one-column ${className}`}>
-            <Cell width={12}>
+            <Cell width={8}>
               <WrappedComponent {...this.props} />
             </Cell>
           </Grid>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?
Closes #1357

#### What's this PR do?
Sets content page width to 8 columns instead of 12 for all pages that use the `withSingleColumn` HOC.

#### How should this be manually tested?
View all pages that use `withSingleColumn` in desktop and mobile mode and verify that they look correct as described in the issue.

#### Screenshots (if appropriate)

**Create a post desktop:**
<img width="1421" alt="screen shot 2019-01-02 at 4 24 23 pm" src="https://user-images.githubusercontent.com/187676/50642155-4adb9300-0f38-11e9-87e5-aeebc955b0e7.png">

**Create a post mobile:**
<img width="377" alt="screen shot 2019-01-02 at 4 24 37 pm" src="https://user-images.githubusercontent.com/187676/50642153-4adb9300-0f38-11e9-8c06-63f47b257559.png">

**Channel page desktop**
<img width="1419" alt="screen shot 2019-01-02 at 4 23 21 pm" src="https://user-images.githubusercontent.com/187676/50642157-4adb9300-0f38-11e9-8ba5-0baa2f62fea0.png">

**Channel page mobile**
<img width="379" alt="screen shot 2019-01-02 at 4 23 38 pm" src="https://user-images.githubusercontent.com/187676/50642156-4adb9300-0f38-11e9-8eb5-5961463bbea3.png">

**Post detail page desktop**
<img width="1420" alt="screen shot 2019-01-02 at 4 22 29 pm" src="https://user-images.githubusercontent.com/187676/50642160-4adb9300-0f38-11e9-9618-5b4f6f8a10da.png">

**Post detail page mobile**
<img width="380" alt="screen shot 2019-01-02 at 4 22 55 pm" src="https://user-images.githubusercontent.com/187676/50642159-4adb9300-0f38-11e9-87ce-3fdbfccfbe09.png">

**Home page desktop**
<img width="1418" alt="screen shot 2019-01-02 at 4 21 55 pm" src="https://user-images.githubusercontent.com/187676/50642161-4adb9300-0f38-11e9-9c42-4abd6ad74e4b.png">

**Home page mobile**
<img width="380" alt="screen shot 2019-01-02 at 4 21 41 pm" src="https://user-images.githubusercontent.com/187676/50642162-4b742980-0f38-11e9-984b-01638b25d64e.png">

**Profile page desktop**
<img width="1300" alt="screen shot 2019-01-02 at 4 20 51 pm" src="https://user-images.githubusercontent.com/187676/50642165-4b742980-0f38-11e9-9c66-5a75ff5ff5a5.png">

**Profile page mobile**
<img width="374" alt="screen shot 2019-01-02 at 4 21 21 pm" src="https://user-images.githubusercontent.com/187676/50642164-4b742980-0f38-11e9-8e72-2ef60ea6ad0c.png">
