### PR TITLE
Add article_text and post_type to REST API

### DIFF
--- a/channels/serializers/posts.py
+++ b/channels/serializers/posts.py
@@ -12,6 +12,7 @@ from channels.utils import get_reddit_slug, num_items_not_none
 from channels.models import Channel, Subscription
 from channels.serializers.base import RedditObjectSerializer
 from channels.serializers.utils import parse_bool
+from channels.utils import render_article_text
 from open_discussions.settings import SITE_BASE_URL
 from open_discussions.serializers import WriteableSerializerMethodField
 from profiles.utils import image_uri
@@ -30,7 +31,9 @@ class BasePostSerializer(RedditObjectSerializer):
     thumbnail = WriteableSerializerMethodField(allow_null=True)
     text = WriteableSerializerMethodField(allow_null=True)
     article_content = serializers.JSONField(allow_null=True, default=None)
+    article_text = serializers.SerializerMethodField()
     title = serializers.CharField()
+    post_type = serializers.CharField(read_only=True)
     slug = serializers.SerializerMethodField()
     upvoted = WriteableSerializerMethodField()
     removed = WriteableSerializerMethodField()
@@ -122,6 +125,14 @@ class BasePostSerializer(RedditObjectSerializer):
     def get_deleted(self, instance):
         """Returns True if the post was deleted"""
         return instance.selftext == "[deleted]"  # only way to tell
+
+    def get_article_text(self, instance):
+        """Return article content rendered as text"""
+        return (
+            render_article_text(instance.article.content)
+            if instance.article is not None
+            else None
+        )
 
 
 class PostSerializer(BasePostSerializer):

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -9,7 +9,13 @@ from rest_framework import status
 
 from profiles.utils import image_uri
 from channels.factories import LinkMetaFactory
-from channels.constants import VALID_POST_SORT_TYPES, POSTS_SORT_HOT
+from channels.constants import (
+    EXTENDED_POST_TYPE_ARTICLE,
+    VALID_POST_SORT_TYPES,
+    POSTS_SORT_HOT,
+    LINK_TYPE_LINK,
+    LINK_TYPE_SELF,
+)
 from channels.models import Subscription, LinkMeta, Article
 from channels.utils import THUMBNAIL_DIMENSIONS
 from channels.views.test_utils import (
@@ -46,12 +52,14 @@ def test_create_url_post_existing_meta(
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == {
         "title": "url title 🐨",
+        "post_type": LINK_TYPE_LINK,
         "url": link_url,
         "url_domain": "micromasters.mit.edu",
         "cover_image": None,
         "thumbnail": thumbnail,
         "text": None,
         "article_content": None,
+        "article_text": None,
         "author_id": user.username,
         "created": any_instance_of(str),
         "upvoted": True,
@@ -127,6 +135,7 @@ def test_create_text_post(user_client, private_channel_and_contributor):
         "title": "parameterized testing",
         "text": "tests are great",
         "article_content": None,
+        "article_text": None,
         "url": None,
         "url_domain": None,
         "cover_image": None,
@@ -150,6 +159,7 @@ def test_create_text_post(user_client, private_channel_and_contributor):
         "edited": False,
         "stickied": False,
         "num_reports": None,
+        "post_type": LINK_TYPE_SELF,
     }
 
 
@@ -159,7 +169,8 @@ def test_create_article_post(user_client, private_channel_and_contributor):
     """
     channel, user = private_channel_and_contributor
     url = reverse("post-list", kwargs={"channel_name": channel.name})
-    article_content = [{"key": "value", "nested": {"number": 4}}]
+    article_text = "some text"
+    article_content = [{"key": "value", "nested": {"number": 4}, "text": article_text}]
     resp = user_client.post(
         url, {"title": "parameterized testing", "article_content": article_content}
     )
@@ -168,6 +179,7 @@ def test_create_article_post(user_client, private_channel_and_contributor):
         "title": "parameterized testing",
         "text": "",
         "article_content": article_content,
+        "article_text": article_text,
         "url": None,
         "url_domain": None,
         "cover_image": None,
@@ -191,6 +203,7 @@ def test_create_article_post(user_client, private_channel_and_contributor):
         "edited": False,
         "stickied": False,
         "num_reports": None,
+        "post_type": EXTENDED_POST_TYPE_ARTICLE,
     }
     article = Article.objects.filter(post__post_id=resp.json()["id"])
     assert article.exists()
@@ -679,6 +692,7 @@ def test_create_post_without_upvote(user_client, private_channel_and_contributor
         "title": "x",
         "text": "y",
         "article_content": None,
+        "article_text": None,
         "url": None,
         "url_domain": None,
         "cover_image": None,
@@ -702,6 +716,7 @@ def test_create_post_without_upvote(user_client, private_channel_and_contributor
         "edited": False,
         "stickied": False,
         "num_reports": None,
+        "post_type": LINK_TYPE_SELF,
     }
 
 

--- a/channels/views/test_utils.py
+++ b/channels/views/test_utils.py
@@ -1,8 +1,8 @@
 """Utilities for tests"""
 from urllib.parse import urlparse
 
-from channels.models import Article, Channel
-from channels.utils import get_reddit_slug
+from channels.models import Article, Channel, Post
+from channels.utils import get_reddit_slug, render_article_text
 from profiles.utils import image_uri
 
 
@@ -47,7 +47,8 @@ def default_post_response_data(channel, post, user):
     else:
         user_dependent_defaults = {"upvoted": True, "num_reports": None}
 
-    article = Article.objects.filter(post__post_id=post.id).first()
+    post_obj = Post.objects.get(post_id=post.id)
+    article = Article.objects.filter(post=post_obj).first()
 
     text = post.text
 
@@ -61,6 +62,10 @@ def default_post_response_data(channel, post, user):
         "thumbnail": None,
         "text": text,
         "article_content": article.content if article is not None else None,
+        "article_text": render_article_text(article.content)
+        if article is not None
+        else None,
+        "post_type": post_obj.post_type,
         "title": post.title,
         "removed": False,
         "deleted": False,

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -6,6 +6,7 @@ import pytest
 from channels import api
 from channels.constants import CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC
 from channels.factories import RedditFactories, FactoryStore
+from channels.utils import render_article_text
 
 
 @pytest.fixture
@@ -112,9 +113,11 @@ def subscribed_channels(reddit_factories, staff_user, staff_api, user):
 @pytest.fixture()
 def reddit_submission_obj():
     """A dummy Post object"""
+    article_content = {"text": "some text"}
     return SimpleNamespace(
         author=SimpleNamespace(name="testuser"),
-        article_content={"text": "some text"},
+        article_content=article_content,
+        article_text=render_article_text(article_content),
         subreddit=SimpleNamespace(
             display_name="channel_1", title="Channel", subreddit_type="public"
         ),

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -83,6 +83,7 @@ MAPPING = {
         "post_link_thumbnail": {"type": "keyword"},
         "num_comments": {"type": "long"},
         "article_text": ENGLISH_TEXT_FIELD,
+        "post_type": {"type": "keyword"},
     },
     COMMENT_TYPE: {
         **CONTENT_OBJECT_TYPE,

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -9,7 +9,7 @@ from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.models import Post
 from channels.serializers.posts import BasePostSerializer
 from channels.serializers.comments import BaseCommentSerializer
-from channels.utils import get_reddit_slug, render_article_text
+from channels.utils import get_reddit_slug
 from profiles.api import get_channels
 from profiles.models import Profile
 from search.api import gen_post_id, gen_comment_id, gen_profile_id
@@ -92,12 +92,14 @@ class ESPostSerializer(ESSerializer):
     object_type = POST_TYPE
     use_keys = [
         "article_content",
+        "article_text",
         "author_id",
         "author_name",
         "author_headline",
         "channel_name",
         "channel_title",
         "channel_type",
+        "post_type",
         "text",
         "score",
         "created",
@@ -126,7 +128,6 @@ class ESPostSerializer(ESSerializer):
             "author_name": None
             if serialized_data["author_name"] == "[deleted]"
             else serialized_data["author_name"],
-            "article_text": render_article_text(serialized_data.get("article_content")),
         }
 
 

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name,unused-argument
 import pytest
 
-from channels.constants import POST_TYPE, COMMENT_TYPE
+from channels.constants import POST_TYPE, COMMENT_TYPE, LINK_TYPE_SELF
 from channels.factories import PostFactory, CommentFactory
 from channels.utils import get_reddit_slug, render_article_text
 from open_discussions.factories import UserFactory
@@ -24,15 +24,18 @@ from search.serializers import (
 @pytest.fixture
 def patched_base_post_serializer(mocker):
     """Fixture that patches the base serializer class for ESPostSerializer"""
+    article_content = {"text": "hello world"}
     base_serialized_data = {
         "author_id": 1,
         "author_name": "Author Name",
         "author_headline": "Author Headline",
-        "article_content": {"text": "hello world"},
+        "article_content": article_content,
+        "article_text": render_article_text(article_content),
         "profile_image": "/media/profile/1/208c7d959608417eb13bc87392cb5f77-2018-09-21T163449_small.jpg",
         "channel_title": "channel 1",
         "channel_name": "channel_1",
         "channel_type": "restricted",
+        "post_type": LINK_TYPE_SELF,
         "text": "Post Text",
         "score": 1,
         "created": 123,
@@ -127,6 +130,7 @@ def test_es_post_serializer(
         "post_link_url": base_serialized["url"],
         "post_link_thumbnail": base_serialized["thumbnail"],
         "post_slug": base_serialized["slug"],
+        "post_type": base_serialized["post_type"],
     }
 
 

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -2,6 +2,7 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
+import { LINK_TYPE_LINK, LINK_TYPE_TEXT } from "../lib/channels"
 import { incrementer } from "../lib/util"
 import { VALID_POST_SORT_TYPES } from "../lib/picker"
 
@@ -14,6 +15,7 @@ export const makePost = (
   channelName: string = casual.word
 ): Post => ({
   article_content: null,
+  article_text:    null,
   author_headline: casual.sentence,
   author_id:       `justareddituser${String(casual.random)}`,
   author_name:     casual.name,
@@ -26,6 +28,7 @@ export const makePost = (
   num_comments:    casual.integer(0, 25),
   num_reports:     null,
   profile_image:   casual.url,
+  post_type:       isURLPost ? LINK_TYPE_LINK : LINK_TYPE_TEXT,
   removed:         casual.boolean,
   score:           casual.integer(-5, 15),
   slug:            casual.word,

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -3,6 +3,8 @@
 import casual from "casual-browserify"
 import R from "ramda"
 
+import { LINK_TYPE_LINK, LINK_TYPE_TEXT } from "../lib/channels"
+
 import type {
   CommentResult,
   PostResult,
@@ -41,6 +43,7 @@ export const makeCommentResult = (): CommentResult => ({
 
 export const makePostResult = (): PostResult => ({
   article_content:     null,
+  article_text:        null,
   author_avatar_small: casual.url,
   author_headline:     casual.text,
   author_id:           casual.username,
@@ -56,6 +59,7 @@ export const makePostResult = (): PostResult => ({
   post_link_thumbnail: casual.url,
   post_slug:           casual.word,
   post_title:          casual.text,
+  post_type:           casual.coin_flip ? LINK_TYPE_LINK : LINK_TYPE_TEXT,
   removed:             casual.coin_flip,
   score:               casual.integer(-5, 15),
   text:                casual.text

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -78,13 +78,15 @@ export type Post = AuthoredContent & {
   url:             ?string,
   text:            ?string,
   article_content: ?Array<Object>,
+  article_text:    ?string,
   slug:            string,
   num_comments:    number,
   channel_name:    string,
   channel_title:   string,
   stickied:        boolean,
   removed:         boolean,
-  thumbnail:       ?string
+  thumbnail:       ?string,
+  post_type:       ?string
 }
 
 export type PostFormType =

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -36,6 +36,7 @@ type RESULT_TYPE_POST = "post"
 
 export type PostResult = ResultCommon & {
   article_content: ?Array<Object>,
+  article_text: ?string,
   channel_name: string,
   channel_title: string,
   created: string,
@@ -47,6 +48,7 @@ export type PostResult = ResultCommon & {
   post_link_thumbnail: ?string,
   post_slug: string,
   post_title: string,
+  post_type: string,
   removed: boolean,
   score: number,
   text: string,

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -36,6 +36,7 @@ export const searchResultToComment = (
 
 export const searchResultToPost = (result: PostResult): Post => ({
   article_content: result.article_content,
+  article_text:    result.article_text,
   author_headline: result.author_headline,
   author_id:       result.author_id,
   author_name:     result.author_name,
@@ -46,6 +47,7 @@ export const searchResultToPost = (result: PostResult): Post => ({
   id:              result.post_id,
   num_comments:    result.num_comments,
   num_reports:     0,
+  post_type:       result.post_type,
   profile_image:   result.author_avatar_small,
   removed:         result.removed,
   score:           result.score,

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -58,6 +58,7 @@ describe("search functions", () => {
     const post = searchResultToPost(result)
     assert.deepEqual(post, {
       article_content: result.article_content,
+      article_text:    result.article_text,
       author_id:       result.author_id,
       author_name:     result.author_name,
       author_headline: result.author_headline,
@@ -68,6 +69,7 @@ describe("search functions", () => {
       id:              result.post_id,
       num_comments:    result.num_comments,
       num_reports:     0,
+      post_type:       result.post_type,
       profile_image:   result.author_avatar_small,
       removed:         result.removed,
       score:           result.score,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

fixes https://github.com/mitodl/open-discussions/issues/1635
fixes #1636

#### What's this PR do?
Adds `post_type` and `article_text` to the REST API so we can use this information in the post summary card

#### How should this be manually tested?
Nothing should break