### PR TITLE
Search text input focus

### DIFF
--- a/static/js/components/SearchTextbox.js
+++ b/static/js/components/SearchTextbox.js
@@ -26,8 +26,12 @@ export default class SearchTextbox extends React.Component<Props> {
     this.focus()
   }
 
-  componentDidUpdate() {
-    this.focus()
+  componentDidUpdate(prevProps) {
+    // Focus again if input has been cleared
+    const { value } = this.props
+    if (!value && prevProps && prevProps.value !== value) {
+      this.focus()
+    }
   }
 
   render() {

--- a/static/js/components/SearchTextbox.js
+++ b/static/js/components/SearchTextbox.js
@@ -8,24 +8,49 @@ type Props = {
   value: string
 }
 
-const SearchTextbox = ({ onChange, onClear, onSubmit, value }: Props) => (
-  <div className="search-textbox">
-    <i className="material-icons search-icon" onClick={onSubmit}>
-      search
-    </i>
-    {value ? (
-      <i className="material-icons clear-icon" onClick={onClear}>
-        clear
-      </i>
-    ) : null}
-    <input
-      type="text"
-      className="underlined"
-      value={value}
-      onChange={onChange}
-      onKeyDown={event => (event.key === "Enter" ? onSubmit(event) : null)}
-    />
-  </div>
-)
+export default class SearchTextbox extends React.Component<Props> {
+  input: { current: null | React$ElementRef<typeof HTMLInputElement> }
 
-export default SearchTextbox
+  constructor(props: Props) {
+    super(props)
+    this.input = React.createRef()
+  }
+
+  focus() {
+    if (this.input.current) {
+      this.input.current.focus()
+    }
+  }
+
+  componentDidMount() {
+    this.focus()
+  }
+
+  componentDidUpdate() {
+    this.focus()
+  }
+
+  render() {
+    const { onSubmit, onClear, onChange, value } = this.props
+    return (
+      <div className="search-textbox">
+        <i className="material-icons search-icon" onClick={onSubmit}>
+          search
+        </i>
+        {value ? (
+          <i className="material-icons clear-icon" onClick={onClear}>
+            clear
+          </i>
+        ) : null}
+        <input
+          ref={this.input}
+          type="text"
+          className="underlined"
+          value={value}
+          onChange={onChange}
+          onKeyDown={event => (event.key === "Enter" ? onSubmit(event) : null)}
+        />
+      </div>
+    )
+  }
+}

--- a/static/js/components/SearchTextbox.js
+++ b/static/js/components/SearchTextbox.js
@@ -26,7 +26,7 @@ export default class SearchTextbox extends React.Component<Props> {
     this.focus()
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     // Focus again if input has been cleared
     const { value } = this.props
     if (!value && prevProps && prevProps.value !== value) {

--- a/static/js/components/SearchTextbox_test.js
+++ b/static/js/components/SearchTextbox_test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react"
 import sinon from "sinon"
-import { mount } from "enzyme"
+import { mount, shallow } from "enzyme"
 import { assert } from "chai"
 
 import SearchTextbox from "./SearchTextbox"
@@ -17,7 +17,17 @@ describe("SearchTextbox", () => {
   })
 
   const render = (props = {}) =>
-    // mount is necessary to check focus
+    shallow(
+      <SearchTextbox
+        onChange={onChangeStub}
+        onSubmit={onSubmitStub}
+        onClear={onClearStub}
+        value={""}
+        {...props}
+      />
+    )
+
+  const renderMount = (props = {}) =>
     mount(
       <SearchTextbox
         onChange={onChangeStub}
@@ -30,7 +40,7 @@ describe("SearchTextbox", () => {
 
   it("focuses on the input element, passes onChange events and the value prop to it", () => {
     const value = "hello"
-    const wrapper = render({ value })
+    const wrapper = renderMount({ value })
     assert.equal(wrapper.find("input").prop("value"), value)
     // $FlowFixMe: element will have value if focus is working
     assert.equal(document.activeElement.value, value)
@@ -40,7 +50,7 @@ describe("SearchTextbox", () => {
   })
 
   it("triggers onClear when the 'x' is clicked, retains focus on input element", () => {
-    const wrapper = render({ value: "text" })
+    const wrapper = renderMount({ value: "text" })
     const event = { target: { value: "click" } }
     wrapper.find(".clear-icon").prop("onClick")(event)
     sinon.assert.calledWith(onClearStub, event)

--- a/static/js/components/SearchTextbox_test.js
+++ b/static/js/components/SearchTextbox_test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react"
 import sinon from "sinon"
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 import { assert } from "chai"
 
 import SearchTextbox from "./SearchTextbox"
@@ -17,7 +17,8 @@ describe("SearchTextbox", () => {
   })
 
   const render = (props = {}) =>
-    shallow(
+    // mount is necessary to check focus
+    mount(
       <SearchTextbox
         onChange={onChangeStub}
         onSubmit={onSubmitStub}
@@ -27,21 +28,22 @@ describe("SearchTextbox", () => {
       />
     )
 
-  it("passes onChange events and the value prop to the input element", () => {
+  it("focuses on the input element, passes onChange events and the value prop to it", () => {
     const value = "hello"
     const wrapper = render({ value })
     assert.equal(wrapper.find("input").prop("value"), value)
-
+    assert.equal(document.activeElement.value, value)
     const event = { target: { value: "new value" } }
     wrapper.find("input").prop("onChange")(event)
     sinon.assert.calledWith(onChangeStub, event)
   })
 
-  it("triggers onClear when the 'x' is clicked", () => {
+  it("triggers onClear when the 'x' is clicked, retains focus on input element", () => {
     const wrapper = render({ value: "text" })
     const event = { target: { value: "click" } }
     wrapper.find(".clear-icon").prop("onClick")(event)
     sinon.assert.calledWith(onClearStub, event)
+    assert.equal(document.activeElement.type, "text")
   })
 
   it("triggers onSubmit when the spyglass is clicked", () => {

--- a/static/js/components/SearchTextbox_test.js
+++ b/static/js/components/SearchTextbox_test.js
@@ -32,6 +32,7 @@ describe("SearchTextbox", () => {
     const value = "hello"
     const wrapper = render({ value })
     assert.equal(wrapper.find("input").prop("value"), value)
+    // $FlowFixMe: element will have value if focus is working
     assert.equal(document.activeElement.value, value)
     const event = { target: { value: "new value" } }
     wrapper.find("input").prop("onChange")(event)
@@ -43,6 +44,8 @@ describe("SearchTextbox", () => {
     const event = { target: { value: "click" } }
     wrapper.find(".clear-icon").prop("onClick")(event)
     sinon.assert.calledWith(onClearStub, event)
+    wrapper.instance().componentDidUpdate()
+    // $FlowFixMe: element will have type if focus is working
     assert.equal(document.activeElement.type, "text")
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1538

#### What's this PR do?
Sets the focus to the search textbox input when it is displayed.

#### How should this be manually tested?
- Click the search icon for a channel.  The focus should move to the search text input field after it is rendered.  Run a search, then click the X to clear the search text.  The focus should still be on the input field.
- Do the same for the global search icon.
