### PR TITLE
Ckeditor / create post page appearance tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@material/rtl": "^0.1.7",
     "@material/snackbar": "^0.25.0",
     "@material/toolbar": "^0.4.4",
-    "@mitodl/ckeditor-custom-build": "0.0.3",
+    "@mitodl/ckeditor-custom-build": "0.0.4",
     "@mitodl/mdl-react-components": "^0.0.3",
     "@trust/webcrypto": "^0.9.2",
     "autoprefixer": "^8.6.4",

--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -51,6 +51,10 @@ export default class ArticleEditor extends React.Component<Props> {
         this.node.appendChild(editor.ui.view.editable.element)
       }
       this.editor = editor
+
+      if (!readOnly) {
+        this.editor.editing.view.focus()
+      }
     } catch (err) {
       console.error(err) // eslint-disable-line no-console
     }

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -208,14 +208,13 @@ export default class CreatePostForm extends React.Component<Props> {
             {validationMessage(validation.channel)}
           </div>
           <div className="titlefield row">
-            <textarea
+            <input
               type="text"
-              placeholder="Add the title of your post..."
+              className="title h1"
+              placeholder="Headline"
               name="title"
               value={title}
               onChange={onUpdate}
-              rows="1"
-              className="no-height"
             />
             {validationMessage(validation.title)}
           </div>

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -14,7 +14,7 @@ import IntraPageNav from "../components/IntraPageNav"
 import Dialog from "../components/Dialog"
 
 import { actions } from "../actions"
-import { setBannerMessage } from "../actions/ui"
+import { setBannerMessage, setShowDrawerDesktop } from "../actions/ui"
 import { clearPostError } from "../actions/post"
 import {
   LINK_TYPE_LINK,
@@ -212,6 +212,10 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
         }
       })
     )
+
+    if (postType === LINK_TYPE_ARTICLE) {
+      dispatch(setShowDrawerDesktop(false))
+    }
 
     dispatch(
       actions.forms.formValidate({

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -46,7 +46,7 @@ describe("CreatePostPage", () => {
 
   const setTitle = (wrapper, title) =>
     wrapper
-      .find(".titlefield textarea")
+      .find(".titlefield input")
       .simulate("change", makeEvent("title", title))
 
   const setText = (wrapper, text) => {
@@ -262,7 +262,7 @@ describe("CreatePostPage", () => {
     submitPost(wrapper)
     assert.equal(
       wrapper.find(".titlefield .validation-message").text(),
-      "Title is required"
+      "Headline is required"
     )
     setTitle(wrapper, "title")
     setLinkPost(wrapper)

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -119,7 +119,7 @@ export const validatePostCreateForm = validate([
     formLens("text"),
     "This post is too long. Please reduce the length and try again."
   ),
-  validation(emptyOrNil, formLens("title"), "Title is required"),
+  validation(emptyOrNil, formLens("title"), "Headline is required"),
   postURLValidation,
   postArticleValidation
 ])

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -111,7 +111,7 @@ describe("validation library", () => {
       const post = { value: { postType: LINK_TYPE_TEXT, text: "foobar" } }
       assert.deepEqual(validatePostCreateForm(post), {
         value: {
-          title: "Title is required"
+          title: "Headline is required"
         }
       })
     })

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -660,3 +660,47 @@ storiesOf("Widgets", module)
       </StoryWrapper>
     )
   })
+
+storiesOf("Form inputs", module)
+  .addDecorator(withKnobs)
+  .add("basic text input", () => {
+    return (
+      <StoryWrapper>
+        <input
+          type="text"
+          placeholder="type something!"
+          value={text("text", "")}
+          onChange={action("change")}
+          disabled={boolean("disabled")}
+        />
+      </StoryWrapper>
+    )
+  })
+  .add("underlined text input", () => {
+    return (
+      <StoryWrapper>
+        <input
+          type="text"
+          className="underlined"
+          placeholder="type something!"
+          value={text("text", "")}
+          onChange={action("change")}
+          disabled={boolean("disabled")}
+        />
+      </StoryWrapper>
+    )
+  })
+  .add("h1/title style text input", () => {
+    return (
+      <StoryWrapper>
+        <input
+          type="text"
+          className="h1"
+          placeholder="type something!"
+          value={text("text", "")}
+          onChange={action("change")}
+          disabled={boolean("disabled")}
+        />
+      </StoryWrapper>
+    )
+  })

--- a/static/scss/article.scss
+++ b/static/scss/article.scss
@@ -20,18 +20,46 @@
   }
 }
 
+.ck-editor__is-empty.ck-content.ck-editor__editable::before {
+  content: "Write your article here";
+  position: absolute;
+  display: block;
+  margin: var(--ck-spacing-large) 0;
+  color: #aaa;
+  cursor: text;
+}
+
 .ck-editor:not(.read-only) {
-  border: 1px solid $input-border-grey;
-  background: white;
   border-radius: $std-border-radius;
 
   .ck.ck-toolbar {
-    border: none;
-    border-bottom: 1px solid $input-border-grey;
+    border: 1px solid $input-border-grey;
     border-radius: $std-border-radius $std-border-radius 0 0;
+    position: sticky;
+    top: $toolbar-height-desktop;
+    z-index: 1;
+
+    @include breakpoint(materialmobile) {
+      top: $toolbar-height-mobile;
+    }
+
+    > button,
+    > div {
+      margin: 0;
+    }
+
+    .ck-dropdown {
+      .ck-dropdown__button {
+        margin: 0;
+      }
+    }
   }
 
   @include breakpoint(phone) {
     margin-left: 22px;
   }
+}
+
+:root {
+  --ck-icon-size: 22px !important;
 }

--- a/static/scss/form.scss
+++ b/static/scss/form.scss
@@ -93,6 +93,13 @@ input[type="text"] {
     border-left: none;
     border-right: none;
   }
+
+  &.h1 {
+    font-size: 24px;
+    font-weight: bold;
+    border: none;
+    outline: none;
+  }
 }
 
 textarea {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,9 +1282,9 @@
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.35.0.tgz#23ad7eb7c9789e69c7c3fa54df8fc311cd7fc4b1"
 
-"@mitodl/ckeditor-custom-build@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@mitodl/ckeditor-custom-build/-/ckeditor-custom-build-0.0.3.tgz#cddba4bcf73f0d097eb8222a51945d23d7da3665"
+"@mitodl/ckeditor-custom-build@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@mitodl/ckeditor-custom-build/-/ckeditor-custom-build-0.0.4.tgz#544cab8b1491ee702e99a84800f2c965f95e5474"
 
 "@mitodl/mdl-react-components@^0.0.3":
   version "0.0.3"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  


#### What are the relevant tickets?

this does most of #1583  
closes #1572 

#### What's this PR do?

This makes a few UI tweaks to the post creation page, specifically with reference to the article post type.

- the title field is renamed to 'headline', and is styled to more closely resemble how it will be styled on the post detail page
- the top menu for the article editor is now 'sticky', so it should stick to the top of the viewport if you scroll down on a long post
- these is now a placeholder when the article editor is empty
- the article editor should focus right away when you open it
- some styling tweaks to the article editor, the size of the icons in the bar, etc
- when you open the article editor, the navigation drawer should close, if open

I think that's about it

#### How should this be manually tested?

poke at the article editor a bunch and make sure nothing is weird. I think also read over the issue and make sure everything is addressed.


#### Screenshots (if appropriate)
![headlineblank](https://user-images.githubusercontent.com/6207644/50708452-4e534500-1032-11e9-9a99-402edaf7b9bf.png)


![headlineblanknot](https://user-images.githubusercontent.com/6207644/50708446-498e9100-1032-11e9-94e8-3d4d290bbb44.png)

![stickyattop](https://user-images.githubusercontent.com/6207644/50708533-9ffbcf80-1032-11e9-86cc-2f439f656630.png)
![mobilebuttonsheadline](https://user-images.githubusercontent.com/6207644/50708624-fec14900-1032-11e9-8777-7aaffd6cbbfc.png)

![mobilebuttonsheadlinefdfdf](https://user-images.githubusercontent.com/6207644/50708629-0254d000-1033-11e9-8b63-18083942a628.png)


