### PR TITLE
Fix handling of widget ids

### DIFF
--- a/static/js/components/widgets/WidgetInstance.js
+++ b/static/js/components/widgets/WidgetInstance.js
@@ -26,7 +26,7 @@ const SortableWidgetInstance: StatelessFunctionalComponent<Props> = SortableElem
     const WidgetClass =
       validWidgetRenderers[widgetInstance.react_renderer] || DefaultWidget
     return (
-      <Card className="widget" key={widgetInstance.id}>
+      <Card className="widget">
         <WidgetClass widgetInstance={widgetInstance} />
         {editing ? (
           <React.Fragment>

--- a/static/js/components/widgets/WidgetList.js
+++ b/static/js/components/widgets/WidgetList.js
@@ -4,6 +4,8 @@ import { SortableContainer } from "react-sortable-hoc"
 
 import WidgetInstance from "./WidgetInstance"
 
+import { getWidgetKey } from "../../lib/widgets"
+
 import type { StatelessFunctionalComponent } from "react"
 import type { WidgetInstance as WidgetInstanceType } from "../../flow/widgetTypes"
 
@@ -51,7 +53,7 @@ const SortableWidgetList: StatelessFunctionalComponent<Props> = SortableContaine
           <WidgetInstance
             startEditInstance={startEditInstance}
             widgetInstance={widgetInstance}
-            key={i}
+            key={getWidgetKey(widgetInstance)}
             index={i}
             editing={editing}
             deleteInstance={deleteInstance}

--- a/static/js/containers/widgets/WidgetListContainer.js
+++ b/static/js/containers/widgets/WidgetListContainer.js
@@ -19,7 +19,11 @@ import {
   setDialogData,
   showDialog
 } from "../../actions/ui"
-import { WIDGET_FORM_KEY } from "../../lib/widgets"
+import {
+  WIDGET_FORM_KEY,
+  newWidgetInstance,
+  getWidgetKey
+} from "../../lib/widgets"
 
 import type { Dispatch } from "redux"
 import type {
@@ -90,8 +94,9 @@ export class WidgetListContainer extends React.Component<Props> {
 
   deleteInstance = (widgetInstance: WidgetInstanceType) => {
     const { updateWidgetInstances } = this.props
+    const key = getWidgetKey(widgetInstance)
     const widgetInstances = this.getWidgetInstances().filter(
-      _widgetInstance => _widgetInstance.id !== widgetInstance.id
+      _widgetInstance => getWidgetKey(_widgetInstance) !== key
     )
     updateWidgetInstances(widgetInstances)
   }
@@ -123,12 +128,8 @@ export class WidgetListContainer extends React.Component<Props> {
 
     setDialogVisibility(true)
     setDialogData({
-      state:    WIDGET_TYPE_SELECT,
-      instance: {
-        configuration: {},
-        title:         "",
-        widget_type:   ""
-      },
+      state:      WIDGET_TYPE_SELECT,
+      instance:   newWidgetInstance(),
       validation: {}
     })
   }
@@ -153,14 +154,12 @@ export class WidgetListContainer extends React.Component<Props> {
       react_renderer: renderers[data.instance.widget_type],
       html:           ""
     }
-
+    const key = getWidgetKey(instanceFromDialog)
     const replacementInstances =
       data.state === WIDGET_EDIT
         ? instances.map(
           instance =>
-            instance.id === instanceFromDialog.id
-              ? instanceFromDialog
-              : instance
+            getWidgetKey(instance) === key ? instanceFromDialog : instance
         )
         : instances.concat([instanceFromDialog])
     updateWidgetInstances(replacementInstances)

--- a/static/js/containers/widgets/WidgetListContainer_test.js
+++ b/static/js/containers/widgets/WidgetListContainer_test.js
@@ -18,6 +18,7 @@ import {
 } from "../../factories/widgets"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import { WIDGET_FORM_KEY } from "../../lib/widgets"
+import * as widgetFuncs from "../../lib/widgets"
 import { FORM_END_EDIT, FORM_UPDATE } from "../../actions/forms"
 import { actions } from "../../actions"
 import {
@@ -192,6 +193,10 @@ describe("WidgetListContainer", () => {
     })
 
     it("opens a dialog to add a new widget", async () => {
+      const aNewWidgetInstance = { widget: "instance" }
+      const newWidgetInstanceStub = helper.sandbox
+        .stub(widgetFuncs, "newWidgetInstance")
+        .returns(aNewWidgetInstance)
       const { wrapper, store } = await render()
       wrapper
         .dive()
@@ -207,16 +212,13 @@ describe("WidgetListContainer", () => {
         payload: {
           dialogKey: DIALOG_EDIT_WIDGET,
           data:      {
-            instance: {
-              configuration: {},
-              title:         "",
-              widget_type:   ""
-            },
+            instance:   aNewWidgetInstance,
             state:      WIDGET_TYPE_SELECT,
             validation: {}
           }
         }
       })
+      sinon.assert.calledWith(newWidgetInstanceStub)
     })
 
     it("opens a dialog to edit a widget", async () => {

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -7,7 +7,7 @@ import {
   LINK_TYPE_LINK,
   LINK_TYPE_ARTICLE
 } from "../lib/channels"
-import { incrementer } from "../factories/util"
+import { incrementer } from "../lib/util"
 
 import type {
   Channel,

--- a/static/js/factories/comments.js
+++ b/static/js/factories/comments.js
@@ -1,7 +1,8 @@
 // @flow
 import casual from "casual-browserify"
 
-import { incrementer, arrayN } from "./util"
+import { arrayN } from "./util"
+import { incrementer } from "../lib/util"
 
 import type {
   Post,

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -2,7 +2,7 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
-import { incrementer } from "../factories/util"
+import { incrementer } from "../lib/util"
 import { VALID_POST_SORT_TYPES } from "../lib/picker"
 
 import type { Post, PostListPagination } from "../flow/discussionTypes"

--- a/static/js/factories/util.js
+++ b/static/js/factories/util.js
@@ -12,14 +12,6 @@ export const randomSelection = (n: number, xs: Array<any>) =>
 
 export const draw = (xs: Array<any>) => xs[casual.integer(0, xs.length - 1)]
 
-export function* incrementer(): Generator<number, *, *> {
-  let int = 1
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    yield int++
-  }
-}
-
 export const makeMatch = (url: string): Match => ({
   url:     url,
   isExact: true,

--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -2,7 +2,7 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
-import { incrementer } from "../factories/util"
+import { incrementer } from "../lib/util"
 import { validWidgetRenderers } from "../lib/widgets"
 
 import type {

--- a/static/js/flow/widgetTypes.js
+++ b/static/js/flow/widgetTypes.js
@@ -4,6 +4,7 @@ export type WidgetInstancePatchable = {
   widget_type: string,
   title: string,
   configuration: Object,
+  newId?: string
 }
 
 export type WidgetInstance = WidgetInstancePatchable & {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -115,3 +115,11 @@ export const allEmptyOrNil = R.all(emptyOrNil)
 
 export const spaceSeparated = (strings: Array<?string>): string =>
   strings.filter(str => str).join(" ")
+
+export function* incrementer(): Generator<number, *, *> {
+  let int = 1
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    yield int++
+  }
+}

--- a/static/js/lib/widgets.js
+++ b/static/js/lib/widgets.js
@@ -1,9 +1,24 @@
 // @flow
 import MarkdownWidget from "../components/widgets/MarkdownWidget"
 
+import { incrementer } from "./util"
+
+import type { WidgetInstancePatchable } from "../flow/widgetTypes"
+
 export const WIDGET_FORM_KEY = "widgets:edit"
-export const WIDGET_ADD_EDIT_FORM_KEY = "widgets:edit:widget"
 
 export const validWidgetRenderers = {
   markdown: MarkdownWidget
 }
+
+const newWidgetIncr = incrementer()
+
+export const newWidgetInstance = (): WidgetInstancePatchable => ({
+  configuration: {},
+  title:         "",
+  widget_type:   "",
+  newId:         `new-${String(newWidgetIncr.next().value)}`
+})
+
+export const getWidgetKey = (widgetInstance: WidgetInstancePatchable): string =>
+  String(widgetInstance.id || widgetInstance.newId)

--- a/static/js/lib/widgets_test.js
+++ b/static/js/lib/widgets_test.js
@@ -3,12 +3,30 @@ import { assert } from "chai"
 
 import MarkdownWidget from "../components/widgets/MarkdownWidget"
 
-import { validWidgetRenderers } from "./widgets"
+import {
+  validWidgetRenderers,
+  getWidgetKey,
+  newWidgetInstance
+} from "./widgets"
+import { makeWidgetInstance } from "../factories/widgets"
 
 describe("widget library functions", () => {
   describe("valid widget renderers", () => {
     it("renders with MarkdownWidget", () => {
       assert.equal(validWidgetRenderers.markdown, MarkdownWidget)
+    })
+  })
+
+  describe("getWidgetKey", () => {
+    it("renders a key for an existing widget", () => {
+      const instance = makeWidgetInstance()
+      const key = getWidgetKey(instance)
+      assert.equal(key, String(instance.id))
+    })
+
+    it("renders a key for a new widget", () => {
+      const key = getWidgetKey(newWidgetInstance())
+      assert.isTrue(key.startsWith("new-"))
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1626 
Fixes #1637 

#### What's this PR do?
 - Adds a new temporary widget id for new widgets
 - Adds a function to create a key based on the new widget id, or the widget's own id for existing widgets
 - Fixes the `WidgetInstance` key value to be based on the widget instance key instead of the index value. This fixes the reordering bug which was due to click handlers not being reattached after the widget instances moved. We were using the index value in the list as the key because that's how it worked in the draghandler example code here: https://github.com/clauderic/react-sortable-hoc/blob/master/examples/drag-handle.js

#### How should this be manually tested?
 - Start editing widgets and make sure you have at least three. You should be able to reorder the widgets arbitrarily, as many times as you want. When you click 'Done' the new order should preserve correctly.
 - Start editing widgets and add two new widgets. Reorder them a few times and make sure nothing strange happens. Before saving, delete one and check that the other one looks fine. Click 'done' and the new widget should be saved to the API.
