### PR TITLE
add cover image to create post form

### DIFF
--- a/static/js/babelhook.js
+++ b/static/js/babelhook.js
@@ -1,6 +1,7 @@
 const { babelSharedLoader } = require("../../webpack.config.shared")
 const idlUtils = require("jsdom/lib/jsdom/living/generated/utils")
 const whatwgURL = require("whatwg-url")
+const uuid = require("uuid/v4")
 
 babelSharedLoader.query.presets = [
   "@babel/preset-env",
@@ -34,6 +35,14 @@ const changeURL = (window, urlString) => {
   const doc = idlUtils.implForWrapper(window._document)
   doc._URL = whatwgURL.parseURL(urlString)
   doc._origin = whatwgURL.serializeURLOrigin(doc._URL)
+}
+
+// sketchy polyfill :/
+URL.createObjectURL = function() {
+  const url = new URL("http://fake/")
+  url.path = []
+  const objectURL = `blob:${whatwgURL.serializeURL(url)}/${uuid()}`
+  return objectURL
 }
 
 // We need to explicitly change the URL when window.location is used

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -1,6 +1,7 @@
 /* global SETTINGS: false */
 // @flow
 import React from "react"
+import Dropzone from "react-dropzone"
 
 import Embedly, { EmbedlyLoader } from "./Embedly"
 import Editor, { editorUpdateFormShim } from "./Editor"
@@ -33,8 +34,11 @@ type Props = {
   updateChannelSelection: Function,
   embedly: Object,
   embedlyInFlight: boolean,
-  openClearPostTypeDialog: Function
+  openClearPostTypeDialog: Function,
+  setPhotoError: Function
 }
+
+const imageUploaderName = "coverImage"
 
 const channelOptions = (channels: Map<string, Channel>) =>
   Array.from(channels)
@@ -115,6 +119,37 @@ export default class CreatePostForm extends React.Component<Props> {
     ) : null
   }
 
+  handleImageDrop = (images: Array<File>) => {
+    const { onUpdate } = this.props
+
+    const [image] = images
+    editorUpdateFormShim(imageUploaderName, onUpdate)(image)
+  }
+
+  articleCoverImageInput = () => {
+    const { postForm, setPhotoError } = this.props
+
+    return postForm && postForm.coverImage ? (
+      <img src={URL.createObjectURL(postForm.coverImage)} />
+    ) : (
+      <Dropzone
+        onDrop={this.handleImageDrop}
+        className="photo-upload-dialog photo-active-item photo-dropzone dashed-border"
+        style={{ height: 150 }}
+        accept="image/*"
+        onDropRejected={() => setPhotoError("Please select a valid photo")}
+      >
+        <div className="desktop-upload-message">
+          Optional: Add a cover image to your post<br />Drag an image here or<br />
+          <button type="button" className="outlined">
+            Click to select an image
+          </button>
+        </div>
+        <div className="mobile-upload-message">Click to select a photo.</div>
+      </Dropzone>
+    )
+  }
+
   postContentInputs = () => {
     const {
       postForm,
@@ -143,6 +178,12 @@ export default class CreatePostForm extends React.Component<Props> {
     } else if (postType === LINK_TYPE_ARTICLE) {
       return (
         <div className="article row post-content">
+          <div className="article-banner-image-wrapper">
+            <div className="article-banner-image">
+              {this.articleCoverImageInput()}
+            </div>
+          </div>
+          {validationMessage(validation.coverImage)}
           <ArticleEditor onChange={editorUpdateFormShim("article", onUpdate)} />
           {this.clearInputButton()}
           {validationMessage(validation.article)}

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -296,6 +296,18 @@ describe("CreatePostPage", () => {
     assert.lengthOf(wrapper.find(".channel-select .validation-message"), 0)
   })
 
+  it("should let us set a validation error for invalid cover image", async () => {
+    const wrapper = await renderPage("/create_post/")
+    const state = await listenForActions([actions.forms.FORM_VALIDATE], () => {
+      wrapper
+        .find("CreatePostPage")
+        .instance()
+        .setPhotoError("my error")
+    })
+    const { errors } = state.forms[CREATE_POST_KEY]
+    assert.equal(errors.coverImage, "my error")
+  })
+
   it(`should display a banner message if error on form submit`, async () => {
     helper.createPostStub.returns(Promise.reject({ errorStatusCode: 500 }))
     const wrapper = await renderPage()

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -7,6 +7,11 @@ import {
 
 import type { LinkType, ChannelType } from "../lib/channels"
 
+export type FormImage = {
+  edit:  Blob,
+  image: File
+}
+
 export type Channel = {
   name:                  string,
   title:                 string,
@@ -34,14 +39,8 @@ export type ChannelForm = {
   channel_type:           ChannelType,
   allowed_post_types:     Array<LinkType>,
   membership_is_managed:  boolean,
-  avatar?:            {
-    edit:  Blob,
-    image: File
-  },
-  banner?:            {
-    edit:  Blob,
-    image: File
-  },
+  avatar?:                FormImage,
+  banner?:                FormImage
 }
 
 export type ChannelAppearanceEditValidation = {
@@ -96,27 +95,30 @@ export type PostFormType =
   | null
 
 export type PostForm = {
-  postType: PostFormType,
-  text:     string,
-  url:      string,
-  title:    string,
-  article:  Array<Object>
+  postType:     PostFormType,
+  text:         string,
+  url:          string,
+  title:        string,
+  article:      Array<Object>,
+  coverImage?:  ?File
 }
 
 export type PostValidation = {
-  text?:      string,
-  url?:       string,
-  title?:     string,
-  channel?:   string,
-  post_type?: string,
-  article?:   string,
+  text?:       string,
+  url?:        string,
+  title?:      string,
+  channel?:    string,
+  post_type?:  string,
+  article?:    string,
+  coverImage?: string,
 }
 
 export type CreatePostPayload = {
-  url?:     string,
-  text?:    string,
-  title:    string,
-  article?: Array<Object>
+  url?:         string,
+  text?:        string,
+  title:        string,
+  article?:     Array<Object>,
+  coverImage?:  ?File,
 }
 
 export type PostListPagination = {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -71,6 +71,7 @@ import * as authFuncs from "./fetch_auth"
 import * as searchFuncs from "./search"
 import { makeProfile } from "../factories/profiles"
 import { makeWidgetListResponse } from "../factories/widgets"
+import { objectToFormData } from "../lib/forms"
 
 describe("api", function() {
   this.timeout(5000) // eslint-disable-line no-invalid-this
@@ -193,15 +194,39 @@ describe("api", function() {
 
     it("creates a post", async () => {
       const post = makePost()
-      fetchJSONStub.returns(Promise.resolve(post))
+      fetchStub.returns(Promise.resolve(JSON.stringify(post)))
 
       const text = "Text"
       const title = "Title"
       const url = "URL"
       const result = await createPost("channelname", { text, title, url })
-      const body = JSON.stringify({ url, text, title })
+      const body = objectToFormData({ url, text, title })
       sinon.assert.calledWith(
-        fetchJSONStub,
+        fetchStub,
+        "/api/v0/channels/channelname/posts/",
+        {
+          body,
+          method: POST
+        }
+      )
+      assert.deepEqual(result, post)
+    })
+
+    it("creates a post with a coverImage", async () => {
+      const post = makePost()
+      fetchStub.returns(Promise.resolve(JSON.stringify(post)))
+
+      const title = "Title"
+      const article = [{ an: "article" }]
+      const coverImage = new File([], "asdf.jpg")
+      const result = await createPost("channelname", {
+        title,
+        coverImage,
+        article
+      })
+      const body = objectToFormData({ title, coverImage, article })
+      sinon.assert.calledWith(
+        fetchStub,
         "/api/v0/channels/channelname/posts/",
         {
           body,

--- a/static/js/lib/forms.js
+++ b/static/js/lib/forms.js
@@ -67,3 +67,15 @@ export const getAuthResponseFieldErrors = R.curry(
     }
   }
 )
+
+export const objectToFormData = (object: Object) => {
+  const formData = new FormData()
+
+  Object.entries(object).forEach(([k, v]) => {
+    if (!R.isNil(v)) {
+      // $FlowFixMe: flow things that 'v' here can only be a Blob or File
+      formData.append(k, v)
+    }
+  })
+  return formData
+}

--- a/static/js/lib/forms_test.js
+++ b/static/js/lib/forms_test.js
@@ -1,7 +1,11 @@
 // @flow
 import { assert } from "chai"
 
-import { configureForm, getAuthResponseFieldErrors } from "./forms"
+import {
+  configureForm,
+  getAuthResponseFieldErrors,
+  objectToFormData
+} from "./forms"
 import {
   FORM_BEGIN_EDIT,
   FORM_END_EDIT,
@@ -106,6 +110,16 @@ describe("forms lib", () => {
         const returnValue = getAuthResponseFieldErrors(field, responseObj)
         assert.deepEqual(returnValue, expReturnValue)
       })
+    })
+  })
+
+  describe("objectToFormData", () => {
+    it("includes all fields which are not null", () => {
+      const obj = { foo: "bar", biz: null, baz: undefined }
+      const formData = objectToFormData(obj)
+      assert.equal("bar", formData.get("foo"))
+      assert.isFalse(formData.has("biz"))
+      assert.isFalse(formData.has("baz"))
     })
   })
 })

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -15,12 +15,13 @@ import type {
 } from "../flow/discussionTypes"
 
 export const newPostForm = (): PostForm => ({
-  postType:  null,
-  text:      "",
-  url:       "",
-  title:     "",
-  thumbnail: null,
-  article:   []
+  postType:   null,
+  text:       "",
+  url:        "",
+  title:      "",
+  thumbnail:  null,
+  article:    [],
+  coverImage: null
 })
 
 export const postFormIsContentless = R.useWith(

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -18,12 +18,13 @@ import { urlHostname } from "./url"
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
     assert.deepEqual(newPostForm(), {
-      postType:  null,
-      text:      "",
-      url:       "",
-      title:     "",
-      article:   [],
-      thumbnail: null
+      postType:   null,
+      text:       "",
+      url:        "",
+      title:      "",
+      article:    [],
+      thumbnail:  null,
+      coverImage: null
     })
   })
 

--- a/static/scss/create-post.scss
+++ b/static/scss/create-post.scss
@@ -44,4 +44,31 @@
     display: flex;
     justify-content: flex-end;
   }
+
+  .article {
+    .article-banner-image-wrapper {
+      display: inline-block;
+      width: 100%;
+      background-color: white;
+      border-radius: $std-border-radius;
+
+      .article-banner-image {
+        margin: 10px;
+        min-height: 115px;
+        background-color: $pale-grey;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+
+        .msg {
+          color: $font-grey-light;
+          padding-bottom: 15px;
+        }
+
+        img {
+          max-width: 100%;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1594 

#### What's this PR do?

This PR implements an initial version of the cover image for the article post type, which lets you upload a photo to use with the article type post.

Basically, there is a new input on the create post post, which we show alongside the article editor, which lets the user select an image to upload. I also added stuff to have some basic validation (just that the thing is an image and not, say, a PDF).

#### How should this be manually tested?

I think just mess around on the create post page and make sure all existing functionality works as it should. Make sure that if you make an article post you can add a cover image, and that this cover image gets returned by the post API afterwards.

#### Screenshots (if appropriate)
![emeeeefaffffdffff](https://user-images.githubusercontent.com/6207644/50848419-3df8de00-1342-11e9-9e02-ea3138cd64bc.png)
![emeeeefaffffdf](https://user-images.githubusercontent.com/6207644/50848420-3df8de00-1342-11e9-98f8-b2d05f0b0ef4.png)
![emeeeefaff](https://user-images.githubusercontent.com/6207644/50848421-3df8de00-1342-11e9-811b-70ecc3aec2de.png)
![emeeeefa](https://user-images.githubusercontent.com/6207644/50848422-3df8de00-1342-11e9-94de-3ffc30059597.png)
