### PR TITLE
start splitting up `lib/api.js`

### DIFF
--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -3,7 +3,7 @@
 import React from "react"
 import CustomEditor from "@mitodl/ckeditor-custom-build"
 
-import { getCKEditorJWT } from "../lib/api"
+import { getCKEditorJWT } from "../lib/api/ckeditor"
 
 type Props = {
   initialData?: Array<Object>,

--- a/static/js/components/ArticleEditor_test.js
+++ b/static/js/components/ArticleEditor_test.js
@@ -9,7 +9,7 @@ import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 import ArticleEditor from "./ArticleEditor"
 
 import { wait } from "../lib/util"
-import { getCKEditorJWT } from "../lib/api"
+import { getCKEditorJWT } from "../lib/api/ckeditor"
 
 describe("ArticleEditor", () => {
   let sandbox, fetchStub

--- a/static/js/lib/api/channels.js
+++ b/static/js/lib/api/channels.js
@@ -1,0 +1,125 @@
+// @flow
+import R from "ramda"
+import { PATCH, POST, DELETE } from "redux-hammock/constants"
+
+import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./fetch_auth"
+import { getPaginationSortQS } from "./util"
+
+import type {
+  Channel,
+  ChannelContributors,
+  Contributor,
+  Subscriber,
+  PostListPaginationParams,
+  PostListResponse
+} from "../../flow/discussionTypes"
+
+export function getChannel(channelName: string): Promise<Channel> {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/`)
+}
+
+export function getChannels(): Promise<Array<Channel>> {
+  return fetchJSONWithAuthFailure("/api/v0/channels/")
+}
+
+export function createChannel(channel: Channel): Promise<Channel> {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/`, {
+    method: POST,
+    body:   JSON.stringify(
+      R.pickAll(
+        [
+          "name",
+          "title",
+          "description",
+          "public_description",
+          "channel_type",
+          "membership_is_managed"
+        ],
+        channel
+      )
+    )
+  })
+}
+
+export function updateChannel(channel: Channel): Promise<Channel> {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channel.name}/`, {
+    method: PATCH,
+    body:   JSON.stringify(
+      R.pickAll(
+        [
+          "title",
+          "description",
+          "public_description",
+          "channel_type",
+          "allowed_post_types"
+        ],
+        channel
+      )
+    )
+  })
+}
+
+export function getPostsForChannel(
+  channelName: string,
+  params: PostListPaginationParams
+): Promise<PostListResponse> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/posts/${getPaginationSortQS(params)}`
+  )
+}
+
+export function getChannelContributors(
+  channelName: string
+): Promise<ChannelContributors> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/contributors/`
+  )
+}
+
+export function addChannelContributor(
+  channelName: string,
+  email: string
+): Promise<Contributor> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/contributors/`,
+    {
+      method: POST,
+      body:   JSON.stringify({ email })
+    }
+  )
+}
+
+export function deleteChannelContributor(
+  channelName: string,
+  username: string
+): Promise<void> {
+  return fetchWithAuthFailure(
+    `/api/v0/channels/${channelName}/contributors/${username}/`,
+    { method: DELETE }
+  )
+}
+
+export function addChannelSubscriber(
+  channelName: string,
+  username: string
+): Promise<Subscriber> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/subscribers/`,
+    {
+      method: POST,
+      body:   JSON.stringify({
+        subscriber_name: username
+      })
+    }
+  )
+}
+
+export function deleteChannelSubscriber(
+  channelName: string,
+  username: string
+): Promise<void> {
+  return fetchWithAuthFailure(
+    `/api/v0/channels/${channelName}/subscribers/${username}/`,
+    { method: DELETE }
+  )
+}

--- a/static/js/lib/api/channels_test.js
+++ b/static/js/lib/api/channels_test.js
@@ -1,0 +1,192 @@
+import sinon from "sinon"
+import { assert } from "chai"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import { PATCH, POST, DELETE } from "redux-hammock/constants"
+
+import {
+  getChannel,
+  getChannels,
+  getPostsForChannel,
+  createChannel,
+  updateChannel,
+  getChannelContributors,
+  addChannelContributor,
+  deleteChannelContributor
+} from "./channels"
+import {
+  makeChannel,
+  makeChannelList,
+  makeContributors,
+  makeContributor
+} from "../../factories/channels"
+import { makeChannelPostList } from "../../factories/posts"
+
+describe("Channels API", () => {
+  let fetchJSONStub, fetchStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+    fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("gets channel posts", async () => {
+    const posts = makeChannelPostList()
+    fetchJSONStub.returns(Promise.resolve({ posts }))
+
+    const result = await getPostsForChannel("channelone", {})
+    assert.ok(fetchJSONStub.calledWith("/api/v0/channels/channelone/posts/"))
+    assert.deepEqual(result.posts, posts)
+  })
+
+  it("gets channel posts with pagination params", async () => {
+    const posts = makeChannelPostList()
+    fetchJSONStub.returns(Promise.resolve({ posts }))
+
+    const result = await getPostsForChannel("channelone", {
+      before: "abc",
+      after:  "def",
+      count:  5
+    })
+    assert.ok(
+      fetchJSONStub.calledWith(
+        `/api/v0/channels/channelone/posts/?after=def&before=abc&count=5`
+      )
+    )
+    assert.deepEqual(result.posts, posts)
+  })
+
+  it("gets channel", async () => {
+    const channel = makeChannel()
+    fetchJSONStub.returns(Promise.resolve(channel))
+
+    const result = await getChannel("channelone")
+    assert.ok(fetchJSONStub.calledWith("/api/v0/channels/channelone/"))
+    assert.deepEqual(result, channel)
+  })
+
+  it("gets a list of channels", async () => {
+    const channelList = makeChannelList()
+    fetchJSONStub.returns(Promise.resolve(channelList))
+
+    const result = await getChannels()
+    assert.ok(fetchJSONStub.calledWith("/api/v0/channels/"))
+    assert.deepEqual(result, channelList)
+  })
+
+  it("creates a channel", async () => {
+    const channel = makeChannel()
+    fetchJSONStub.returns(Promise.resolve(channel))
+
+    const input = {
+      name:               "name",
+      title:              "title",
+      description:        "description",
+      public_description: "public_description",
+      channel_type:       "public"
+    }
+
+    const result = await createChannel(input)
+    assert.ok(
+      fetchJSONStub.calledWith(`/api/v0/channels/`, {
+        method: POST,
+        body:   JSON.stringify({
+          ...input
+        })
+      })
+    )
+    assert.deepEqual(result, channel)
+  })
+
+  it("updates a channel", async () => {
+    const channel = makeChannel()
+    fetchJSONStub.returns(Promise.resolve(channel))
+
+    const input = {
+      name:               "name",
+      title:              "title",
+      description:        "description",
+      public_description: "public_description",
+      channel_type:       "public"
+    }
+
+    const result = await updateChannel(input)
+    assert.ok(
+      fetchJSONStub.calledWith(`/api/v0/channels/${input.name}/`, {
+        method: PATCH,
+        body:   JSON.stringify({
+          title:              input.title,
+          description:        input.description,
+          public_description: input.public_description,
+          channel_type:       input.channel_type
+        })
+      })
+    )
+    assert.deepEqual(result, channel)
+  })
+
+  describe("contributors", () => {
+    it("gets a list of contributors", async () => {
+      const channelName = "channel_name"
+      const contributors = makeContributors()
+
+      fetchJSONStub.returns(Promise.resolve(contributors))
+
+      assert.deepEqual(contributors, await getChannelContributors(channelName))
+
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/channels/${channelName}/contributors/`
+        )
+      )
+    })
+
+    it("adds a contributor", async () => {
+      const channelName = "channel_name"
+      const contributor = makeContributor()
+
+      fetchJSONStub.returns(Promise.resolve(contributor))
+
+      assert.deepEqual(
+        contributor,
+        await addChannelContributor(channelName, contributor.email)
+      )
+
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/channels/${channelName}/contributors/`
+        )
+      )
+      assert.deepEqual(fetchJSONStub.args[0][1], {
+        method: POST,
+        body:   JSON.stringify({
+          email: contributor.email
+        })
+      })
+    })
+
+    it("removes a contributor", async () => {
+      const channelName = "channel_name"
+      const contributor = makeContributor()
+
+      fetchJSONStub.returns(Promise.resolve(contributor))
+
+      await deleteChannelContributor(channelName, contributor.contributor_name)
+
+      assert.ok(
+        fetchStub.calledWith(
+          `/api/v0/channels/${channelName}/contributors/${
+            contributor.contributor_name
+          }/`
+        )
+      )
+      assert.deepEqual(fetchStub.args[0][1], {
+        method: DELETE
+      })
+    })
+  })
+})

--- a/static/js/lib/api/ckeditor.js
+++ b/static/js/lib/api/ckeditor.js
@@ -1,0 +1,4 @@
+// @flow
+import { fetchWithAuthFailure } from "./fetch_auth"
+
+export const getCKEditorJWT = () => fetchWithAuthFailure("/api/v0/ckeditor/")

--- a/static/js/lib/api/ckeditor_test.js
+++ b/static/js/lib/api/ckeditor_test.js
@@ -1,0 +1,23 @@
+// @flow
+import sinon from "sinon"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+
+import { getCKEditorJWT } from "./ckeditor.js"
+
+describe("CKEditor API", () => {
+  let fetchStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should get the token", async () => {
+    await getCKEditorJWT()
+    sinon.assert.calledWith(fetchStub, "/api/v0/ckeditor/")
+  })
+})

--- a/static/js/lib/api/embedly.js
+++ b/static/js/lib/api/embedly.js
@@ -1,0 +1,11 @@
+// @flow
+import { fetchJSONWithAuthFailure } from "./fetch_auth"
+
+import type { EmbedlyResponse } from "../../reducers/embedly"
+
+export const getEmbedly = async (url: string): Promise<EmbedlyResponse> => {
+  const response = await fetchJSONWithAuthFailure(
+    `/api/v0/embedly/${encodeURIComponent(encodeURIComponent(url))}/`
+  )
+  return { url, response }
+}

--- a/static/js/lib/api/embedly_test.js
+++ b/static/js/lib/api/embedly_test.js
@@ -1,0 +1,26 @@
+// @flow
+import sinon from "sinon"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+
+import { getEmbedly } from "./embedly"
+
+describe("Embedly API", () => {
+  let fetchJSONStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("issues a request with an escaped URL param", async () => {
+    await getEmbedly("https://en.wikipedia.org/wiki/Giant_panda")
+    sinon.assert.calledWith(
+      fetchJSONStub,
+      "/api/v0/embedly/https%253A%252F%252Fen.wikipedia.org%252Fwiki%252FGiant_panda/"
+    )
+  })
+})

--- a/static/js/lib/api/fetch_auth.js
+++ b/static/js/lib/api/fetch_auth.js
@@ -8,8 +8,8 @@ import {
 } from "redux-hammock/django_csrf_fetch"
 import qs from "query-string"
 
-import { AUTH_REQUIRED_URL, LOGIN_URL } from "./url"
-import { isNotAuthenticatedErrorType } from "../util/rest"
+import { AUTH_REQUIRED_URL, LOGIN_URL } from "../url"
+import { isNotAuthenticatedErrorType } from "../../util/rest"
 
 const redirectAndReject = async () => {
   // redirect to the authenticating app

--- a/static/js/lib/api/fetch_auth_test.js
+++ b/static/js/lib/api/fetch_auth_test.js
@@ -7,11 +7,11 @@ import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 
 import * as auth from "./fetch_auth"
 
-import { AUTH_REQUIRED_URL, LOGIN_URL } from "./url"
+import { AUTH_REQUIRED_URL, LOGIN_URL } from "../url"
 import {
   NOT_AUTHENTICATED_ERROR_TYPE,
   AUTHENTICATION_FAILED_ERROR_TYPE
-} from "../util/rest"
+} from "../../util/rest"
 
 describe("fetch_auth", function() {
   this.timeout(5000) // eslint-disable-line no-invalid-this

--- a/static/js/lib/api/frontpage.js
+++ b/static/js/lib/api/frontpage.js
@@ -1,0 +1,16 @@
+// @flow
+import { fetchJSONWithAuthFailure } from "./fetch_auth"
+import { getPaginationSortQS } from "./util"
+
+import type {
+  PostListPaginationParams,
+  PostListResponse
+} from "../../flow/discussionTypes"
+
+export function getFrontpage(
+  params: PostListPaginationParams
+): Promise<PostListResponse> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/frontpage/${getPaginationSortQS(params)}`
+  )
+}

--- a/static/js/lib/api/frontpage_test.js
+++ b/static/js/lib/api/frontpage_test.js
@@ -1,0 +1,51 @@
+// @flow
+import sinon from "sinon"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import { assert } from "chai"
+
+import { makeChannelPostList } from "../../factories/posts"
+import { getFrontpage } from "./frontpage"
+
+describe("Frontpage API", () => {
+  let fetchJSONStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("gets the frontpage", async () => {
+    const posts = makeChannelPostList()
+    fetchJSONStub.returns(Promise.resolve({ posts }))
+
+    const result = await getFrontpage({
+      before: undefined,
+      after:  undefined,
+      count:  undefined
+    })
+
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/frontpage/`))
+    assert.deepEqual(result.posts, posts)
+  })
+
+  it("gets the frontpage with pagination params", async () => {
+    const posts = makeChannelPostList()
+    fetchJSONStub.returns(Promise.resolve({ posts }))
+
+    const result = await getFrontpage({
+      before: "abc",
+      after:  "def",
+      count:  5
+    })
+    assert.ok(
+      fetchJSONStub.calledWith(
+        `/api/v0/frontpage/?after=def&before=abc&count=5`
+      )
+    )
+    assert.deepEqual(result.posts, posts)
+  })
+})

--- a/static/js/lib/api/moderation.js
+++ b/static/js/lib/api/moderation.js
@@ -1,0 +1,50 @@
+// @flow
+import { POST, DELETE } from "redux-hammock/constants"
+
+import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./fetch_auth"
+
+import type {
+  ChannelModerators,
+  Moderator,
+  GenericReport,
+  ReportRecord
+} from "../../flow/discussionTypes"
+
+export function getChannelModerators(
+  channelName: string
+): Promise<ChannelModerators> {
+  return fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/moderators/`)
+}
+
+export function addChannelModerator(
+  channelName: string,
+  email: string
+): Promise<Moderator> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/channels/${channelName}/moderators/`,
+    {
+      method: POST,
+      body:   JSON.stringify({ email })
+    }
+  )
+}
+
+export function deleteChannelModerator(
+  channelName: string,
+  username: string
+): Promise<void> {
+  return fetchWithAuthFailure(
+    `/api/v0/channels/${channelName}/moderators/${username}/`,
+    { method: DELETE }
+  )
+}
+
+export function reportContent(payload: GenericReport): Promise<GenericReport> {
+  return fetchJSONWithAuthFailure(`/api/v0/reports/`, {
+    method: POST,
+    body:   JSON.stringify(payload)
+  })
+}
+
+export const getReports = (channelName: string): Promise<Array<ReportRecord>> =>
+  fetchJSONWithAuthFailure(`/api/v0/channels/${channelName}/reports/`)

--- a/static/js/lib/api/moderation_test.js
+++ b/static/js/lib/api/moderation_test.js
@@ -1,0 +1,132 @@
+// @flow
+import sinon from "sinon"
+import R from "ramda"
+import { assert } from "chai"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import { POST, DELETE } from "redux-hammock/constants"
+
+import {
+  getChannelModerators,
+  addChannelModerator,
+  deleteChannelModerator,
+  reportContent,
+  getReports
+} from "./moderation"
+import { makeModerators, makeModerator } from "../../factories/channels"
+import { makeReportRecord } from "../../factories/reports"
+
+import type { CommentReport, PostReport } from "../../flow/discussionTypes"
+
+describe("Moderation API", () => {
+  let fetchJSONStub, fetchStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+    fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("reports a comment", async () => {
+    const payload: CommentReport = {
+      commentId:  "1",
+      reason:     "spam",
+      reportType: "comment"
+    }
+    fetchJSONStub.returns(Promise.resolve())
+
+    await reportContent(payload)
+    assert.ok(
+      fetchJSONStub.calledWith(`/api/v0/reports/`, {
+        method: POST,
+        body:   JSON.stringify(payload)
+      })
+    )
+  })
+
+  it("reports a post", async () => {
+    const payload: PostReport = {
+      postId:     "1",
+      reason:     "spam",
+      reportType: "post"
+    }
+    fetchJSONStub.returns(Promise.resolve())
+
+    await reportContent(payload)
+    assert.ok(
+      fetchJSONStub.calledWith(`/api/v0/reports/`, {
+        method: POST,
+        body:   JSON.stringify(payload)
+      })
+    )
+  })
+
+  it("gets reports", async () => {
+    const reports = R.times(makeReportRecord, 5)
+    fetchJSONStub.returns(Promise.resolve(reports))
+
+    await getReports("channelName")
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/channels/channelName/reports/`))
+  })
+
+  describe("channel moderators", () => {
+    it("gets a list of moderator", async () => {
+      const channelName = "channel_name"
+      const moderators = makeModerators()
+
+      fetchJSONStub.returns(Promise.resolve(moderators))
+
+      assert.deepEqual(moderators, await getChannelModerators(channelName))
+
+      assert.ok(
+        fetchJSONStub.calledWith(`/api/v0/channels/${channelName}/moderators/`)
+      )
+    })
+
+    it("adds a moderator", async () => {
+      const channelName = "channel_name"
+      const moderator = makeModerator()
+
+      fetchJSONStub.returns(Promise.resolve(moderator))
+
+      assert.deepEqual(
+        moderator,
+        // $FlowFixMe: flowt thinks .email can be undefined
+        await addChannelModerator(channelName, moderator.email)
+      )
+
+      assert.ok(
+        fetchJSONStub.calledWith(`/api/v0/channels/${channelName}/moderators/`)
+      )
+      assert.deepEqual(fetchJSONStub.args[0][1], {
+        method: POST,
+        body:   JSON.stringify({
+          email: moderator.email
+        })
+      })
+    })
+
+    it("removes a moderator", async () => {
+      const channelName = "channel_name"
+      const moderator = makeModerator()
+
+      fetchJSONStub.returns(Promise.resolve(moderator))
+
+      await deleteChannelModerator(channelName, moderator.moderator_name)
+
+      assert.ok(
+        fetchStub.calledWith(
+          `/api/v0/channels/${channelName}/moderators/${
+            moderator.moderator_name
+          }/`
+        )
+      )
+      assert.deepEqual(fetchStub.args[0][1], {
+        method: DELETE
+      })
+    })
+  })
+})

--- a/static/js/lib/api/posts.js
+++ b/static/js/lib/api/posts.js
@@ -1,0 +1,61 @@
+// @flow
+import R from "ramda"
+import { PATCH, DELETE } from "redux-hammock/constants"
+
+import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./fetch_auth"
+import { objectToFormData } from "../../lib/forms"
+
+import type { CreatePostPayload, Post } from "../../flow/discussionTypes"
+
+export async function createPost(
+  channelName: string,
+  payload: CreatePostPayload
+): Promise<Post> {
+  const formData = objectToFormData(R.pick(["text", "url", "title"], payload))
+
+  if (payload.article && payload.article.length !== 0) {
+    formData.append("article_content", JSON.stringify(payload.article))
+
+    if (payload.coverImage) {
+      formData.append("cover_image", payload.coverImage)
+    }
+  }
+
+  return JSON.parse(
+    await fetchWithAuthFailure(`/api/v0/channels/${channelName}/posts/`, {
+      method: "POST",
+      body:   formData
+    })
+  )
+}
+
+export function getPost(postId: string): Promise<Post> {
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`)
+}
+
+export function updateUpvote(postId: string, upvoted: boolean): Promise<Post> {
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
+    body:   JSON.stringify({ upvoted })
+  })
+}
+
+export function updateRemoved(postId: string, removed: boolean): Promise<Post> {
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
+    body:   JSON.stringify({ removed })
+  })
+}
+
+export function editPost(postId: string, post: Post): Promise<Post> {
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: PATCH,
+    body:   JSON.stringify(R.dissoc("url", post))
+  })
+}
+
+export function deletePost(postId: string): Promise<Post> {
+  return fetchWithAuthFailure(`/api/v0/posts/${postId}/`, {
+    method: DELETE
+  })
+}

--- a/static/js/lib/api/posts_test.js
+++ b/static/js/lib/api/posts_test.js
@@ -1,0 +1,120 @@
+// @flow
+import R from "ramda"
+import sinon from "sinon"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import { PATCH, POST } from "redux-hammock/constants"
+import { assert } from "chai"
+
+import { makePost } from "../../factories/posts"
+import {
+  createPost,
+  getPost,
+  deletePost,
+  editPost,
+  updateRemoved
+} from "./posts"
+import { objectToFormData } from "../../lib/forms"
+
+describe("Post API", () => {
+  let fetchJSONStub, fetchStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+    fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("creates a post", async () => {
+    const post = makePost()
+    post.score = 1
+    fetchStub.returns(Promise.resolve(JSON.stringify(post)))
+
+    const text = "Text"
+    const title = "Title"
+    const url = "URL"
+    const result = await createPost("channelname", { text, title, url })
+    const body = objectToFormData({ url, text, title })
+    sinon.assert.calledWith(fetchStub, "/api/v0/channels/channelname/posts/", {
+      body,
+      method: POST
+    })
+    assert.deepEqual(result, post)
+  })
+
+  it("creates a post with a coverImage", async () => {
+    const post = makePost()
+    post.score = 1
+    fetchStub.returns(Promise.resolve(JSON.stringify(post)))
+
+    const title = "Title"
+    const article = [{ an: "article" }]
+    const coverImage = new File([], "asdf.jpg")
+    const result = await createPost("channelname", {
+      title,
+      coverImage,
+      article
+    })
+    const body = objectToFormData({ title, coverImage, article })
+    sinon.assert.calledWith(fetchStub, "/api/v0/channels/channelname/posts/", {
+      body,
+      method: POST
+    })
+    assert.deepEqual(result, post)
+  })
+
+  it("gets post", async () => {
+    const post = makePost()
+    fetchJSONStub.returns(Promise.resolve(post))
+
+    const result = await getPost("1")
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/1/`))
+    assert.deepEqual(result, post)
+  })
+
+  it("deletes a post", async () => {
+    const post = makePost()
+    fetchStub.returns(Promise.resolve())
+
+    await deletePost(post.id)
+    assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
+  })
+
+  it("updates a post", async () => {
+    const post = makePost()
+
+    fetchJSONStub.returns(Promise.resolve())
+
+    post.text = "updated!"
+
+    await editPost(post.id, post)
+
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/`))
+    assert.deepEqual(fetchJSONStub.args[0][1], {
+      method: PATCH,
+      body:   JSON.stringify(R.dissoc("url", post))
+    })
+  })
+
+  //
+  ;[true, false].forEach(status => {
+    it(`updates post removed: ${String(status)}`, async () => {
+      const post = makePost()
+
+      fetchJSONStub.returns(Promise.resolve())
+
+      await updateRemoved(post.id, status)
+
+      assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/`))
+      assert.deepEqual(fetchJSONStub.args[0][1], {
+        method: PATCH,
+        body:   JSON.stringify({
+          removed: status
+        })
+      })
+    })
+  })
+})

--- a/static/js/lib/api/util.js
+++ b/static/js/lib/api/util.js
@@ -1,0 +1,16 @@
+// @flow
+import R from "ramda"
+
+import { toQueryString } from "../url"
+import { getPaginationSortParams } from "../posts"
+
+const paramsToQueryString = paramSelector =>
+  R.compose(
+    toQueryString,
+    R.reject(R.isNil),
+    paramSelector
+  )
+
+export const getPaginationSortQS = paramsToQueryString(getPaginationSortParams)
+
+export const getCommentSortQS = paramsToQueryString(R.pickAll(["sort"]))

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -1,6 +1,5 @@
 /* global SETTINGS: false */
 // @flow
-
 import {
   LOGIN_URL,
   LOGIN_PASSWORD_URL,

--- a/static/js/reducers/account_settings.js
+++ b/static/js/reducers/account_settings.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { INITIAL_STATE, GET } from "redux-hammock/constants"
 
 export const accountSettingsEndpoint = {

--- a/static/js/reducers/auth.js
+++ b/static/js/reducers/auth.js
@@ -1,6 +1,6 @@
 // @flow
 import R from "ramda"
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { INITIAL_STATE } from "redux-hammock/constants"
 import { deriveVerbFuncs } from "redux-hammock/hammock"
 

--- a/static/js/reducers/channel_avatar.js
+++ b/static/js/reducers/channel_avatar.js
@@ -1,6 +1,6 @@
 // @flow
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 export const channelAvatarEndpoint = {
   name:         "channelAvatar",

--- a/static/js/reducers/channel_banner.js
+++ b/static/js/reducers/channel_banner.js
@@ -1,6 +1,6 @@
 // @flow
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 export const channelBannerEndpoint = {
   name:         "channelBanner",

--- a/static/js/reducers/channel_contributors.js
+++ b/static/js/reducers/channel_contributors.js
@@ -2,7 +2,7 @@
 import { GET, POST, DELETE, INITIAL_STATE } from "redux-hammock/constants"
 import R from "ramda"
 
-import * as api from "../lib/api"
+import * as channelAPI from "../lib/api/channels"
 
 import type { ChannelContributors, Contributor } from "../flow/discussionTypes"
 
@@ -58,7 +58,7 @@ export const channelContributorsEndpoint = {
   verbs:        [GET, POST, DELETE],
   initialState: { ...INITIAL_STATE, data: new Map() },
   getFunc:      async (channelName: string) => {
-    const response = await api.getChannelContributors(channelName)
+    const response = await channelAPI.getChannelContributors(channelName)
     return { channelName, response }
   },
   getSuccessHandler: (
@@ -70,12 +70,15 @@ export const channelContributorsEndpoint = {
     return update
   },
   postFunc: async (channelName: string, email: string) => {
-    const contributor = await api.addChannelContributor(channelName, email)
+    const contributor = await channelAPI.addChannelContributor(
+      channelName,
+      email
+    )
     return { channelName, contributor }
   },
   postSuccessHandler: addContributor,
   deleteFunc:         async (channelName: string, username: string) => {
-    await api.deleteChannelContributor(channelName, username)
+    await channelAPI.deleteChannelContributor(channelName, username)
     return { channelName, username }
   },
   deleteSuccessHandler: deleteContributor

--- a/static/js/reducers/channel_moderators.js
+++ b/static/js/reducers/channel_moderators.js
@@ -4,7 +4,7 @@ import R from "ramda"
 
 import type { ChannelModerators, Moderator } from "../flow/discussionTypes"
 
-import * as api from "../lib/api"
+import * as moderationAPI from "../lib/api/moderation"
 
 type ChannelModeratorsEndpointResponse = {
   channelName: string,
@@ -56,7 +56,7 @@ export const channelModeratorsEndpoint = {
   verbs:        [GET, POST, DELETE],
   initialState: { ...INITIAL_STATE, data: new Map() },
   getFunc:      async (channelName: string) => {
-    const response = await api.getChannelModerators(channelName)
+    const response = await moderationAPI.getChannelModerators(channelName)
     return { channelName, response }
   },
   getSuccessHandler: (
@@ -68,12 +68,15 @@ export const channelModeratorsEndpoint = {
     return update
   },
   postFunc: async (channelName: string, email: string) => {
-    const moderator = await api.addChannelModerator(channelName, email)
+    const moderator = await moderationAPI.addChannelModerator(
+      channelName,
+      email
+    )
     return { channelName, moderator }
   },
   postSuccessHandler: addModerator,
   deleteFunc:         async (channelName: string, username: string) => {
-    await api.deleteChannelModerator(channelName, username)
+    await moderationAPI.deleteChannelModerator(channelName, username)
     return { channelName, username }
   },
   deleteSuccessHandler: deleteModerator

--- a/static/js/reducers/channel_subscribers.js
+++ b/static/js/reducers/channel_subscribers.js
@@ -1,18 +1,21 @@
 // @flow
 import { GET, POST, DELETE, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api"
+import * as channelAPI from "../lib/api/channels"
 
 export const channelSubscribersEndpoint = {
   name:         "channelSubscribers",
   verbs:        [GET, POST, DELETE],
   initialState: { ...INITIAL_STATE, data: null },
   postFunc:     async (channelName: string, username: string) => {
-    const subscriber = await api.addChannelSubscriber(channelName, username)
+    const subscriber = await channelAPI.addChannelSubscriber(
+      channelName,
+      username
+    )
     return { channelName, subscriber }
   },
   deleteFunc: async (channelName: string, username: string) => {
-    await api.deleteChannelSubscriber(channelName, username)
+    await channelAPI.deleteChannelSubscriber(channelName, username)
     return { channelName, username }
   }
 }

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -4,7 +4,7 @@ import R from "ramda"
 
 import { SET_CHANNEL_DATA, CLEAR_CHANNEL_ERROR } from "../actions/channel"
 import type { Channel } from "../flow/discussionTypes"
-import * as api from "../lib/api"
+import * as channelAPI from "../lib/api/channels"
 
 const updateChannelHandler = (
   payload: Channel,
@@ -19,11 +19,11 @@ export const channelsEndpoint = {
   name:                "channels",
   verbs:               [GET, POST, PATCH],
   initialState:        { ...INITIAL_STATE, data: new Map() },
-  getFunc:             (name: string) => api.getChannel(name),
+  getFunc:             (name: string) => channelAPI.getChannel(name),
   getSuccessHandler:   updateChannelHandler,
-  postFunc:            (channel: Channel) => api.createChannel(channel),
+  postFunc:            (channel: Channel) => channelAPI.createChannel(channel),
   postSuccessHandler:  updateChannelHandler,
-  patchFunc:           (channel: Channel) => api.updateChannel(channel),
+  patchFunc:           (channel: Channel) => channelAPI.updateChannel(channel),
   patchSuccessHandler: updateChannelHandler,
   extraActions:        {
     [SET_CHANNEL_DATA]: (state, action) => {

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -10,7 +10,7 @@ import {
 
 import { CLEAR_COMMENT_ERROR, REPLACE_MORE_COMMENTS } from "../actions/comment"
 import { findComment } from "../lib/comments"
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 import type { Action } from "../flow/reduxTypes"
 import type {

--- a/static/js/reducers/embedly.js
+++ b/static/js/reducers/embedly.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as embedlyAPI from "../lib/api/embedly"
 import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
 export type EmbedlyResponse = {
@@ -12,7 +12,7 @@ type EmbedlyData = Map<string, Object>
 export const embedlyEndpoint = {
   name:              "embedly",
   verbs:             [GET],
-  getFunc:           (url: string) => api.getEmbedly(url),
+  getFunc:           (url: string) => embedlyAPI.getEmbedly(url),
   getSuccessHandler: (
     payload: EmbedlyResponse,
     data: EmbedlyData

--- a/static/js/reducers/frontpage.js
+++ b/static/js/reducers/frontpage.js
@@ -1,7 +1,7 @@
 // @flow
 import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api"
+import * as frontpageAPI from "../lib/api/frontpage"
 import { mapPostListResponse } from "../lib/posts"
 
 import type { PostListPaginationParams } from "../flow/discussionTypes"
@@ -16,6 +16,7 @@ export const frontPageEndpoint = {
       postIds:    []
     }
   },
-  getFunc:           (params: PostListPaginationParams) => api.getFrontpage(params),
+  getFunc: (params: PostListPaginationParams) =>
+    frontpageAPI.getFrontpage(params),
   getSuccessHandler: mapPostListResponse
 }

--- a/static/js/reducers/password_change.js
+++ b/static/js/reducers/password_change.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { INITIAL_STATE, POST } from "redux-hammock/constants"
 
 export const passwordChangeEndpoint = {

--- a/static/js/reducers/password_reset.js
+++ b/static/js/reducers/password_reset.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { INITIAL_STATE } from "redux-hammock/constants"
 import { deriveVerbFuncs } from "redux-hammock/hammock"
 

--- a/static/js/reducers/post_removed.js
+++ b/static/js/reducers/post_removed.js
@@ -1,10 +1,11 @@
 // @flow
-import * as api from "../lib/api"
+import * as postAPI from "../lib/api/posts"
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
 export const postRemovedEndpoint = {
-  name:         "postRemoved",
-  verbs:        [PATCH],
-  patchFunc:    (id: string, removed: boolean) => api.updateRemoved(id, removed),
+  name:      "postRemoved",
+  verbs:     [PATCH],
+  patchFunc: (id: string, removed: boolean) =>
+    postAPI.updateRemoved(id, removed),
   initialState: { ...INITIAL_STATE }
 }

--- a/static/js/reducers/post_upvotes.js
+++ b/static/js/reducers/post_upvotes.js
@@ -1,10 +1,11 @@
 // @flow
-import * as api from "../lib/api"
+import * as postAPI from "../lib/api/posts"
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
 export const postUpvotesEndpoint = {
-  name:         "postUpvotes",
-  verbs:        [PATCH],
-  patchFunc:    (id: string, upvoted: boolean) => api.updateUpvote(id, upvoted),
+  name:      "postUpvotes",
+  verbs:     [PATCH],
+  patchFunc: (id: string, upvoted: boolean) =>
+    postAPI.updateUpvote(id, upvoted),
   initialState: { ...INITIAL_STATE }
 }

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as postAPI from "../lib/api/posts"
 import {
   GET,
   POST,
@@ -36,11 +36,11 @@ const mergeMultiplePosts = (
 export const postsEndpoint = {
   name:     "posts",
   verbs:    [GET, POST, PATCH, DELETE],
-  getFunc:  (id: string) => api.getPost(id),
+  getFunc:  (id: string) => postAPI.getPost(id),
   postFunc: (name: string, payload: CreatePostPayload) =>
-    api.createPost(name, payload),
-  patchFunc:            (id: string, post: Post) => api.editPost(id, post),
-  deleteFunc:           (id: string) => api.deletePost(id),
+    postAPI.createPost(name, payload),
+  patchFunc:            (id: string, post: Post) => postAPI.editPost(id, post),
+  deleteFunc:           (id: string) => postAPI.deletePost(id),
   postSuccessHandler:   mergePostData,
   initialState:         { ...INITIAL_STATE, data: new Map() },
   getSuccessHandler:    mergePostData,

--- a/static/js/reducers/posts_for_channel.js
+++ b/static/js/reducers/posts_for_channel.js
@@ -1,7 +1,7 @@
 // @flow
 import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api"
+import * as channelAPI from "../lib/api/channels"
 import { mapPostListResponse } from "../lib/posts"
 import { EVICT_POSTS_FOR_CHANNEL } from "../actions/posts_for_channel"
 
@@ -20,7 +20,7 @@ export const postsForChannelEndpoint = {
   name:    "postsForChannel",
   verbs:   [GET],
   getFunc: async (channelName: string, params: PostListPaginationParams) => {
-    const response = await api.getPostsForChannel(channelName, params)
+    const response = await channelAPI.getPostsForChannel(channelName, params)
     return { channelName, response }
   },
   initialState:      { ...INITIAL_STATE, data: new Map() },

--- a/static/js/reducers/profile_image.js
+++ b/static/js/reducers/profile_image.js
@@ -1,6 +1,6 @@
 // @flow
 import { PATCH, INITIAL_STATE } from "redux-hammock/constants"
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 export const profileImageEndpoint = {
   name:         "profileImage",

--- a/static/js/reducers/profiles.js
+++ b/static/js/reducers/profiles.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { GET, PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
 import type { Profile, ProfilePayload } from "../flow/discussionTypes"

--- a/static/js/reducers/reports.js
+++ b/static/js/reducers/reports.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as moderationAPI from "../lib/api/moderation"
 import { GET, POST, INITIAL_STATE } from "redux-hammock/constants"
 
 import type {
@@ -24,8 +24,8 @@ const getReportInitialData = (): ReportData => ({
 export const reportsEndpoint = {
   name:         "reports",
   verbs:        [POST, GET],
-  postFunc:     (report: GenericReport) => api.reportContent(report),
-  getFunc:      (channelName: string) => api.getReports(channelName),
+  postFunc:     (report: GenericReport) => moderationAPI.reportContent(report),
+  getFunc:      (channelName: string) => moderationAPI.getReports(channelName),
   initialState: {
     ...INITIAL_STATE,
     data: getReportInitialData()

--- a/static/js/reducers/search.js
+++ b/static/js/reducers/search.js
@@ -1,7 +1,7 @@
 // @flow
 import { POST, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 import type { Result, SearchParams } from "../flow/searchTypes"
 

--- a/static/js/reducers/settings.js
+++ b/static/js/reducers/settings.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { GET, PATCH } from "redux-hammock/constants"
 
 export const FREQUENCY_IMMEDIATE: "immediate" = "immediate"

--- a/static/js/reducers/subscribedChannels.js
+++ b/static/js/reducers/subscribedChannels.js
@@ -2,13 +2,13 @@
 import { GET, INITIAL_STATE } from "redux-hammock/constants"
 
 import type { Channel } from "../flow/discussionTypes"
-import * as api from "../lib/api"
+import * as channelAPI from "../lib/api/channels"
 
 export const subscribedChannelsEndpoint = {
   name:              "subscribedChannels",
   verbs:             [GET],
   initialState:      { ...INITIAL_STATE, data: [] },
-  getFunc:           () => api.getChannels(),
+  getFunc:           () => channelAPI.getChannels(),
   getSuccessHandler: (payload: Array<Channel>): any =>
     payload.map(channel => channel.name)
 }

--- a/static/js/reducers/websites.js
+++ b/static/js/reducers/websites.js
@@ -1,5 +1,5 @@
 // @flow
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 import { POST, DELETE } from "redux-hammock/constants"
 
 export const userWebsitesEndpoint = {

--- a/static/js/reducers/widgets.js
+++ b/static/js/reducers/widgets.js
@@ -1,7 +1,7 @@
 // @flow
 import { GET, PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
 
 import type { WidgetListResponse } from "../flow/widgetTypes"
 

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -10,7 +10,13 @@ import thunk from "redux-thunk"
 
 import Router, { routes } from "../Router"
 
-import * as api from "../lib/api"
+import * as api from "../lib/api/api"
+import * as channelAPI from "../lib/api/channels"
+import * as ckeditorAPI from "../lib/api/ckeditor"
+import * as moderationAPI from "../lib/api/moderation"
+import * as embedlyAPI from "../lib/api/embedly"
+import * as frontpageAPI from "../lib/api/frontpage"
+import * as postAPI from "../lib/api/posts"
 import rootReducer from "../reducers"
 import * as utilFuncs from "../lib/util"
 
@@ -35,14 +41,24 @@ export default class IntegrationTestHelper {
     // stub all the api functions
     // NOTE: due to a regression in sinon 2.x, if you use `callsFake` you must
     //       call `resetBehavior()` on the stub first or the error still raises
-    for (const methodName in api) {
-      if (typeof api[methodName] === "function") {
-        const stubName = `${methodName}Stub`
-        this[stubName] = this.sandbox
-          .stub(api, methodName)
-          .throws(() => new Error(`${stubName} not implemented`))
+    ;[
+      api,
+      channelAPI,
+      ckeditorAPI,
+      moderationAPI,
+      embedlyAPI,
+      frontpageAPI,
+      postAPI
+    ].forEach(apiModule => {
+      for (const methodName in apiModule) {
+        if (typeof apiModule[methodName] === "function") {
+          const stubName = `${methodName}Stub`
+          this[stubName] = this.sandbox
+            .stub(apiModule, methodName)
+            .throws(() => new Error(`${stubName} not implemented`))
+        }
       }
-    }
+    })
 
     this.scrollIntoViewStub = this.sandbox.stub()
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

a start on #1667 

#### What's this PR do?

splits `lib/api.js` into modules grouped by functionality, which live in a new `lib/api/` directory.

#### How should this be manually tested?

No code has been added or removed, functions have just been moved into different modules (and their associated tests split out as well). So everything *should* just work as it did before, but it's definitely good to go around and exercise all of the major functions of the app and make sure everything is working.