### PR TITLE
fix JS flakeyness

### DIFF
--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -194,6 +194,7 @@ describe("api", function() {
 
     it("creates a post", async () => {
       const post = makePost()
+      post.score = 1
       fetchStub.returns(Promise.resolve(JSON.stringify(post)))
 
       const text = "Text"
@@ -214,6 +215,7 @@ describe("api", function() {
 
     it("creates a post with a coverImage", async () => {
       const post = makePost()
+      post.score = 1
       fetchStub.returns(Promise.resolve(JSON.stringify(post)))
 
       const title = "Title"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested


#### What are the relevant tickets?

none

#### What's this PR do?

fixes a flakey thing in a JS test. basically when there is a value of -0 `JSON.stringify` will turn that into just 0, which is sensible. However, it seems that sometimes our post factories set a value of -0 for a score. this was causing a flaky test on something I changed for #1660 (see this test failure for an example: https://travis-ci.org/mitodl/open-discussions/jobs/477491161#L2383).

#### How should this be manually tested?

tests should pass and changes should look legit. If you want check out the branch and run the test a few hundred times to assure yourself it isn't flakey any longer.