### PR TITLE
Add description for widget instances

### DIFF
--- a/widgets/serializers/markdown.py
+++ b/widgets/serializers/markdown.py
@@ -9,7 +9,7 @@ from widgets.serializers.react_fields import ReactMarkdownWysiwygField
 class MarkdownWidgetSerializerConfigSerializer(WidgetConfigSerializer):
     """Serializer for MarkdownWidgetSerializer config"""
 
-    source = ReactMarkdownWysiwygField(help_text="Enter widget text")
+    source = ReactMarkdownWysiwygField(help_text="Enter widget text", label="Text")
 
 
 class MarkdownWidgetSerializer(WidgetInstanceSerializer):
@@ -18,6 +18,7 @@ class MarkdownWidgetSerializer(WidgetInstanceSerializer):
     configuration_serializer_class = MarkdownWidgetSerializerConfigSerializer
 
     name = "Markdown"
+    description = "Rich Text"
 
     @classmethod
     def get_react_renderer(cls, *args):

--- a/widgets/serializers/rss.py
+++ b/widgets/serializers/rss.py
@@ -17,7 +17,7 @@ TIMESTAMP_FORMAT = "%m/%d %I:%M%p"
 class RssFeedWidgetConfigSerializer(WidgetConfigSerializer):
     """Serializer for RssFeedWidget config"""
 
-    url = ReactURLField(help_text="Enter RSS Feed URL")
+    url = ReactURLField(help_text="Enter RSS Feed URL", label="URL")
     feed_display_limit = ReactIntegerField(
         min_value=0, max_value=MAX_FEED_ITEMS, default=3
     )
@@ -29,6 +29,7 @@ class RssFeedWidgetSerializer(WidgetInstanceSerializer):
     configuration_serializer_class = RssFeedWidgetConfigSerializer
 
     name = "RSS Feed"
+    description = "RSS Feed"
 
     def get_html(self, instance):
         """Renders the widget to html based on configuration"""

--- a/widgets/serializers/url.py
+++ b/widgets/serializers/url.py
@@ -11,7 +11,7 @@ from widgets.serializers.react_fields import ReactURLField
 class URLWidgetConfigSerializer(WidgetConfigSerializer):
     """Serializer for URLWidget config"""
 
-    url = ReactURLField(help_text="Enter URL")
+    url = ReactURLField(help_text="Enter URL", label="URL")
 
 
 class URLWidgetSerializer(WidgetInstanceSerializer):
@@ -20,6 +20,7 @@ class URLWidgetSerializer(WidgetInstanceSerializer):
     configuration_serializer_class = URLWidgetConfigSerializer
 
     name = "URL"
+    description = "Embedded URL"
 
     def get_html(self, instance):
         """Renders the widget to html based on configuration"""

--- a/widgets/serializers/utils.py
+++ b/widgets/serializers/utils.py
@@ -14,7 +14,7 @@ def get_widget_classes():
     from widgets.serializers.rss import RssFeedWidgetSerializer
     from widgets.serializers.url import URLWidgetSerializer
 
-    return [URLWidgetSerializer, RssFeedWidgetSerializer, MarkdownWidgetSerializer]
+    return [MarkdownWidgetSerializer, URLWidgetSerializer, RssFeedWidgetSerializer]
 
 
 def get_widget_type_mapping():

--- a/widgets/serializers/widget_instance.py
+++ b/widgets/serializers/widget_instance.py
@@ -39,6 +39,7 @@ class WidgetInstanceSerializer(serializers.ModelSerializer):
         """Returns a specification for building/editing a widget"""
         return {
             "widget_type": cls.name,
+            "description": cls.description,
             "react_renderer": cls.get_react_renderer(),
             "form_spec": cls.configuration_serializer_class().get_form_spec(),
         }

--- a/widgets/views_test.py
+++ b/widgets/views_test.py
@@ -14,9 +14,23 @@ EXPECTED_AVAILABLE_WIDGETS = [
     {
         "form_spec": [
             {
+                "field_name": "source",
+                "input_type": "markdown_wysiwyg",
+                "label": "Text",
+                "props": {"placeholder": "Enter widget text"},
+                "default": "",
+            }
+        ],
+        "react_renderer": "markdown",
+        "widget_type": "Markdown",
+        "description": "Rich Text",
+    },
+    {
+        "form_spec": [
+            {
                 "field_name": "url",
                 "input_type": "text",
-                "label": "Url",
+                "label": "URL",
                 "props": {
                     "max_length": "",
                     "min_length": "",
@@ -27,13 +41,14 @@ EXPECTED_AVAILABLE_WIDGETS = [
         ],
         "widget_type": "URL",
         "react_renderer": "default",
+        "description": "Embedded URL",
     },
     {
         "form_spec": [
             {
                 "field_name": "url",
                 "input_type": "text",
-                "label": "Url",
+                "label": "URL",
                 "props": {
                     "max_length": "",
                     "min_length": "",
@@ -51,19 +66,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
         ],
         "react_renderer": "default",
         "widget_type": "RSS Feed",
-    },
-    {
-        "form_spec": [
-            {
-                "field_name": "source",
-                "input_type": "markdown_wysiwyg",
-                "label": "Source",
-                "props": {"placeholder": "Enter widget text"},
-                "default": "",
-            }
-        ],
-        "react_renderer": "markdown",
-        "widget_type": "Markdown",
+        "description": "RSS Feed",
     },
 ]
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1592 

#### What's this PR do?
Adds a description field to the widget types. Some labels are adjusted too. No frontend changes are made in this PR, that will be handled in #1654 

#### How should this be manually tested?
View a channel page. Widgets should load correctly. Open the network tab and look at the `/api/v0/widget_lists/...` and look at the response. You should see a `description` field in the `available_widgets` for each item in the list.
