### PR TITLE
round out article cover image UI

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -8,6 +8,7 @@ import Editor, { editorUpdateFormShim } from "./Editor"
 import LoginPopup from "./LoginPopup"
 import ProfileImage, { PROFILE_IMAGE_MICRO } from "../containers/ProfileImage"
 import ArticleEditor from "./ArticleEditor"
+import CoverImageInput from "./CoverImageInput"
 
 import { actions } from "../actions"
 import { clearCommentError } from "../actions/comment"
@@ -443,14 +444,19 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
     onSubmit = async e => {
       const { formKey, forms, patchPost, post } = this.props
       // eslint-disable-next-line camelcase
-      const { text, article_content } = R.prop(formKey, forms).value
+      const { text, article_content, cover_image } = R.prop(
+        formKey,
+        forms
+      ).value
 
       e.preventDefault()
 
       const { id } = post
       this.setState({ patching: true })
       // eslint-disable-next-line camelcase
-      const content = article_content ? { id, article_content } : { id, text }
+      const content = article_content
+        ? { id, article_content, cover_image }
+        : { id, text }
       try {
         await patchPost(content)
       } catch (_) {
@@ -462,6 +468,7 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
       const { forms, formKey, onUpdate, cancelReply } = this.props
       const { patching } = this.state
       const text = R.pathOr("", [formKey, "value", "text"], forms)
+      const image = R.pathOr(null, [formKey, "value", "cover_image"], forms)
       const article = R.pathOr(
         null,
         [formKey, "value", "article_content"],
@@ -471,17 +478,22 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
       const inputType = article ? ArticleInput : WYSIWYGInput
 
       return (
-        <InputFormHelper
-          onSubmit={this.onSubmit}
-          text={text}
-          article={article}
-          onUpdate={onUpdate}
-          cancelReply={cancelReply}
-          isComment={true}
-          disabled={patching}
-          autoFocus={true}
-          inputType={inputType}
-        />
+        <React.Fragment>
+          {article ? (
+            <CoverImageInput image={image} onUpdate={onUpdate} />
+          ) : null}
+          <InputFormHelper
+            onSubmit={this.onSubmit}
+            text={text}
+            article={article}
+            onUpdate={onUpdate}
+            cancelReply={cancelReply}
+            isComment={true}
+            disabled={patching}
+            autoFocus={true}
+            inputType={inputType}
+          />
+        </React.Fragment>
       )
     }
   }

--- a/static/js/components/CommentForms_test.js
+++ b/static/js/components/CommentForms_test.js
@@ -619,10 +619,11 @@ describe("CommentForms", () => {
       assert.isNotOk(wrapper.find("textarea").exists())
     })
 
-    it("should use the ArticleEditor if an article post", () => {
+    it("should use the ArticleEditor and CoverImageInput if an article post", () => {
       post.article = []
       wrapper = renderEditPostForm()
       assert.ok(wrapper.find("ArticleEditor"))
+      assert.ok(wrapper.find("CoverImageInput"))
     })
 
     it("should have the autofocus prop", () => {

--- a/static/js/components/CoverImageInput.js
+++ b/static/js/components/CoverImageInput.js
@@ -1,0 +1,89 @@
+// @flow
+import React from "react"
+import Dropzone from "react-dropzone"
+
+import { editorUpdateFormShim } from "./Editor"
+
+type Props = {
+  image: ?File | string,
+  onUpdate: Function,
+  setPhotoError?: (err: string) => void
+}
+
+export default class CoverImageInput extends React.Component<Props> {
+  node: { current: null | React$ElementRef<typeof HTMLDivElement> }
+
+  constructor(props: Props) {
+    super(props)
+    this.node = React.createRef()
+  }
+
+  setCoverImage = (image: ?File) => {
+    const { onUpdate } = this.props
+    editorUpdateFormShim("cover_image", onUpdate)(image)
+  }
+
+  handleImageDrop = (images: Array<File>) => {
+    const [image] = images
+    this.setCoverImage(image)
+
+    if (this.node.current) {
+      this.node.current.focus()
+    }
+  }
+
+  clearCoverImage = () => {
+    this.setCoverImage(undefined)
+  }
+
+  render() {
+    const { image, setPhotoError } = this.props
+
+    return (
+      <div className="article-banner-image-wrapper" ref={this.node}>
+        <div className="article-banner-image">
+          {image ? (
+            <div className="cover-img-container">
+              <img
+                src={
+                  typeof image === "string" || image instanceof String
+                    ? image
+                    : URL.createObjectURL(image)
+                }
+              />
+              <button
+                className="high-contrast-outlined"
+                type="button"
+                onClick={this.clearCoverImage}
+              >
+                remove image
+              </button>
+            </div>
+          ) : (
+            <Dropzone
+              onDrop={this.handleImageDrop}
+              className="photo-active-item photo-dropzone dashed-border"
+              accept="image/*"
+              onDropRejected={() => {
+                if (setPhotoError) {
+                  setPhotoError("Please select a valid photo")
+                }
+              }}
+            >
+              <div className="desktop-upload-message">
+                Optional: Add a cover image to your post<br />Drag an image here
+                or<br />
+                <button type="button" className="outlined">
+                  Click to select an image
+                </button>
+              </div>
+              <div className="mobile-upload-message">
+                Click to select a photo.
+              </div>
+            </Dropzone>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/static/js/components/CoverImageInput_test.js
+++ b/static/js/components/CoverImageInput_test.js
@@ -1,0 +1,83 @@
+// @flow
+import { assert } from "chai"
+import { configureShallowRenderer } from "../lib/test_utils"
+import sinon from "sinon"
+import Dropzone from "react-dropzone"
+import R from "ramda"
+
+import CoverImageInput from "./CoverImageInput"
+
+import { makeEvent } from "../lib/test_utils"
+
+describe("CoverImageInput", () => {
+  let renderInput, onUpdateStub, setPhotoErrorStub, imageFile, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    onUpdateStub = sandbox.stub()
+    setPhotoErrorStub = sandbox.stub()
+    imageFile = new File([], "foobar.jpg")
+    renderInput = configureShallowRenderer(CoverImageInput, {
+      onUpdate:      onUpdateStub,
+      setPhotoError: setPhotoErrorStub
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should render a dropzone", () => {
+    const wrapper = renderInput()
+    const dropZone = wrapper.find(Dropzone)
+    assert.ok(dropZone.exists())
+    assert.ok(dropZone.find("button").exists())
+    const { className, accept } = dropZone.props()
+    assert.equal(className, "photo-active-item photo-dropzone dashed-border")
+    assert.deepEqual(accept, "image/*")
+  })
+
+  it("should have an onDrop function wired up right on the dropzone", () => {
+    const dropZone = renderInput().find(Dropzone)
+    const { onDrop } = dropZone.props()
+    onDrop([imageFile])
+    const event = R.omit(
+      ["preventDefault"],
+      makeEvent("cover_image", imageFile)
+    )
+    sinon.assert.calledWith(onUpdateStub, event)
+  })
+
+  it("should have an onDropRejected function wired up right on the dropzone", () => {
+    const dropZone = renderInput().find(Dropzone)
+    const { onDropRejected } = dropZone.props()
+    onDropRejected()
+    sinon.assert.calledWith(setPhotoErrorStub, "Please select a valid photo")
+  })
+
+  it("should render an image if the prop is provided", () => {
+    sandbox.stub(URL, "createObjectURL").returns("image!")
+    ;[(imageFile, "http://example.com/foo.jpg")].forEach(image => {
+      const wrapper = renderInput({ image })
+      const img = wrapper.find("img")
+      assert.ok(img.exists())
+      const { src } = img.props()
+      if (typeof image === "string" || image instanceof String) {
+        assert.equal(image, src)
+      } else {
+        assert.equal("image!", src)
+      }
+    })
+  })
+
+  it("should show a button to clear input if an image is present", () => {
+    const wrapper = renderInput({ image: imageFile })
+    const btn = wrapper.find("button")
+    assert.equal(btn.text(), "remove image")
+    btn.props().onClick()
+    sinon.assert.calledWith(
+      onUpdateStub,
+      R.omit(["preventDefault"], makeEvent("cover_image", undefined))
+    )
+  })
+})

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -1,12 +1,12 @@
 /* global SETTINGS: false */
 // @flow
 import React from "react"
-import Dropzone from "react-dropzone"
 
 import Embedly, { EmbedlyLoader } from "./Embedly"
 import Editor, { editorUpdateFormShim } from "./Editor"
 import CloseButton from "./CloseButton"
 import ArticleEditor from "./ArticleEditor"
+import CoverImageInput from "./CoverImageInput"
 
 import {
   isLinkTypeAllowed,
@@ -37,8 +37,6 @@ type Props = {
   openClearPostTypeDialog: Function,
   setPhotoError: Function
 }
-
-const imageUploaderName = "coverImage"
 
 const channelOptions = (channels: Map<string, Channel>) =>
   Array.from(channels)
@@ -116,44 +114,14 @@ export default class CreatePostForm extends React.Component<Props> {
     ) : null
   }
 
-  handleImageDrop = (images: Array<File>) => {
-    const { onUpdate } = this.props
-
-    const [image] = images
-    editorUpdateFormShim(imageUploaderName, onUpdate)(image)
-  }
-
-  articleCoverImageInput = () => {
-    const { postForm, setPhotoError } = this.props
-
-    return postForm && postForm.coverImage ? (
-      <img src={URL.createObjectURL(postForm.coverImage)} />
-    ) : (
-      <Dropzone
-        onDrop={this.handleImageDrop}
-        className="photo-upload-dialog photo-active-item photo-dropzone dashed-border"
-        style={{ height: 150 }}
-        accept="image/*"
-        onDropRejected={() => setPhotoError("Please select a valid photo")}
-      >
-        <div className="desktop-upload-message">
-          Optional: Add a cover image to your post<br />Drag an image here or<br />
-          <button type="button" className="outlined">
-            Click to select an image
-          </button>
-        </div>
-        <div className="mobile-upload-message">Click to select a photo.</div>
-      </Dropzone>
-    )
-  }
-
   postContentInputs = () => {
     const {
       postForm,
       onUpdate,
       validation,
       embedlyInFlight,
-      embedly
+      embedly,
+      setPhotoError
     } = this.props
     if (!postForm) {
       return null
@@ -175,11 +143,11 @@ export default class CreatePostForm extends React.Component<Props> {
     } else if (postType === LINK_TYPE_ARTICLE) {
       return (
         <div className="article row post-content">
-          <div className="article-banner-image-wrapper">
-            <div className="article-banner-image">
-              {this.articleCoverImageInput()}
-            </div>
-          </div>
+          <CoverImageInput
+            image={postForm.cover_image}
+            setPhotoError={setPhotoError}
+            onUpdate={onUpdate}
+          />
           {validationMessage(validation.coverImage)}
           <ArticleEditor onChange={editorUpdateFormShim("article", onUpdate)} />
           {this.clearInputButton()}

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -2,7 +2,6 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import Dropzone from "react-dropzone"
 
 import CreatePostForm from "./CreatePostForm"
 import Embedly, { EmbedlyLoader } from "./Embedly"
@@ -26,7 +25,8 @@ describe("CreatePostForm", () => {
     renderPostForm,
     openClearPostTypeDialogStub,
     updatePostTypeStub,
-    setPhotoErrorStub
+    setPhotoErrorStub,
+    onUpdateStub
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -35,6 +35,7 @@ describe("CreatePostForm", () => {
     openClearPostTypeDialogStub = sandbox.stub()
     updatePostTypeStub = sandbox.stub()
     setPhotoErrorStub = sandbox.stub()
+    onUpdateStub = sandbox.stub()
     renderPostForm = configureShallowRenderer(CreatePostForm, {
       validation:              {},
       channels:                new Map(),
@@ -44,7 +45,7 @@ describe("CreatePostForm", () => {
       embedly:                 {},
       history:                 {},
       onSubmit:                sandbox.stub(),
-      nUpdate:                 sandbox.stub(),
+      onUpdate:                onUpdateStub,
       updatePostType:          updatePostTypeStub,
       processing:              false,
       updateChannelSelection:  sandbox.stub(),
@@ -118,32 +119,25 @@ describe("CreatePostForm", () => {
     const wrapper = renderPostForm({
       postForm
     })
-    const input = wrapper.find(Dropzone)
+    const input = wrapper.find("CoverImageInput")
     assert.ok(input.exists())
-    const { className, onDrop, style, accept, onDropRejected } = input.props()
-    assert.equal(
-      className,
-      "photo-upload-dialog photo-active-item photo-dropzone dashed-border"
-    )
-    assert.equal(onDrop, wrapper.instance().handleImageDrop)
-    assert.deepEqual(style, { height: 150 })
-    assert.deepEqual(accept, "image/*")
-    onDropRejected()
-    sinon.assert.calledWith(setPhotoErrorStub, "Please select a valid photo")
+    const { setPhotoError, onUpdate } = input.props()
+    assert.equal(onUpdate, onUpdateStub)
+    assert.equal(setPhotoError, setPhotoErrorStub)
   })
 
-  it("should display a coverImage, if there is one in the form", () => {
-    const image = new File([], "foobar.jpg")
+  it("should pass down a coverImage, if there is one in the form", () => {
+    const coverImage = new File([], "foobar.jpg")
     const postForm = {
       ...newPostForm(),
-      postType:   LINK_TYPE_ARTICLE,
-      coverImage: image
+      postType:    LINK_TYPE_ARTICLE,
+      cover_image: coverImage
     }
     const wrapper = renderPostForm({
       postForm
     })
-    const img = wrapper.find(".article-banner-image img")
-    assert.ok(img.exists())
+    const { image } = wrapper.find("CoverImageInput").props()
+    assert.equal(image, coverImage)
   })
 
   //

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -21,10 +21,12 @@ import { formatPostTitle } from "../lib/posts"
 import { userIsAnonymous } from "../lib/util"
 import { editPostKey } from "../components/CommentForms"
 import { makeProfile } from "../lib/profile"
-import { postPermalink, profileURL } from "../lib/url"
+import { postPermalink, profileURL, embedlyResizeImage } from "../lib/url"
 
 import type { Post, Channel } from "../flow/discussionTypes"
 import type { FormsState } from "../flow/formTypes"
+
+const COVER_IMAGE_DISPLAY_HEIGHT = 300
 
 type Props = {
   post: Post,
@@ -58,7 +60,19 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
       return post.text ? (
         renderTextContent(post)
       ) : (
-        <ArticleEditor readOnly initialData={post.article_content || []} />
+        <React.Fragment>
+          {post.cover_image ? (
+            <img
+              className="cover-image"
+              src={embedlyResizeImage(
+                SETTINGS.embedlyKey,
+                post.cover_image,
+                COVER_IMAGE_DISPLAY_HEIGHT
+              )}
+            />
+          ) : null}
+          <ArticleEditor readOnly initialData={post.article_content || []} />
+        </React.Fragment>
       )
     }
   }

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -16,7 +16,12 @@ import ProfileImage from "../containers/ProfileImage"
 import SharePopup from "./SharePopup"
 
 import { wait } from "../lib/util"
-import { postPermalink, postDetailURL, profileURL } from "../lib/url"
+import {
+  postPermalink,
+  postDetailURL,
+  profileURL,
+  embedlyResizeImage
+} from "../lib/url"
 import { makePost } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { actions } from "../actions"
@@ -398,8 +403,9 @@ describe("ExpandedPostDisplay", () => {
     assert.isTrue(popup.props().hideSocialButtons)
   })
 
-  it("should use ArticleEditor to display if an article post", () => {
+  it("should use ArticleEditor and embedlyResizeImage to display if an article post", () => {
     post.article_content = []
+    post.cover_image = "/img/image.jpg"
     post.text = null
     const wrapper = shallow(<ExpandedPostDisplay {...postProps()} />)
     assert.ok(wrapper.find("ArticleEditor"))
@@ -407,5 +413,12 @@ describe("ExpandedPostDisplay", () => {
       readOnly:    true,
       initialData: []
     })
+    const img = wrapper.find("img.cover-image")
+    assert.ok(img.exists())
+    const { src } = img.props()
+    assert.equal(
+      src,
+      embedlyResizeImage(SETTINGS.embedlyKey, "/img/image.jpg", 300)
+    )
   })
 })

--- a/static/js/components/admin/EditChannelAppearanceForm_test.js
+++ b/static/js/components/admin/EditChannelAppearanceForm_test.js
@@ -64,6 +64,7 @@ describe("EditChannelAppearanceForm", () => {
 
   describe("callbacks", () => {
     let onSubmit, onUpdate
+
     beforeEach(() => {
       [onSubmit, onUpdate] = [sandbox.stub(), sandbox.stub()]
     })
@@ -86,6 +87,7 @@ describe("EditChannelAppearanceForm", () => {
         wrapper.find(`[name="public_description"]`).simulate("change", event)
         assert.isOk(onUpdate.calledWith(event))
       })
+
       it(`should be called when the title is modified`, () => {
         const wrapper = renderForm(form, { onSubmit, onUpdate })
         const event = { target: { value: "text" } }
@@ -93,6 +95,8 @@ describe("EditChannelAppearanceForm", () => {
         wrapper.find(`[name="title"]`).simulate("change", event)
         assert.isOk(onUpdate.calledWith(event))
       })
+
+      //
       ;["avatar", "banner"].forEach(field => {
         [true, false].forEach(hasEdit => {
           it(`should modify the ${field} when the blob ${
@@ -100,7 +104,7 @@ describe("EditChannelAppearanceForm", () => {
           }`, () => {
             const blobUrl = `blob_url_${field}`
             const onUpdate = "onUpdateFunc"
-            URL.createObjectURL = sandbox.stub().returns(blobUrl)
+            sandbox.stub(URL, "createObjectURL").returns(blobUrl)
 
             form[field] = makeImage(field)
             if (!hasEdit) {

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -66,7 +66,8 @@ const CREATE_POST_PAYLOAD = { formKey: CREATE_POST_KEY }
 const getForm = R.prop(CREATE_POST_KEY)
 
 const createPostPayload = (postForm: PostForm): CreatePostPayload => {
-  const { postType, title, url, text, article, coverImage } = postForm
+  // eslint-disable-next-line camelcase
+  const { postType, title, url, text, article, cover_image } = postForm
 
   switch (postType) {
   case LINK_TYPE_LINK:
@@ -74,7 +75,7 @@ const createPostPayload = (postForm: PostForm): CreatePostPayload => {
   case LINK_TYPE_TEXT:
     return { title, text }
   case LINK_TYPE_ARTICLE:
-    return { title, article, coverImage }
+    return { title, article, cover_image }
   }
 
   // if no postType was selected, we're dealing with a 'title only' post
@@ -206,10 +207,10 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
         ...CREATE_POST_PAYLOAD,
         value: {
           postType,
-          url:        "",
-          text:       "",
-          article:    [],
-          coverImage: null
+          url:         "",
+          text:        "",
+          article:     [],
+          cover_image: null
         }
       })
     )

--- a/static/js/factories/posts.js
+++ b/static/js/factories/posts.js
@@ -38,7 +38,8 @@ export const makePost = (
   thumbnail:       isURLPost ? casual.url : null,
   title:           casual.sentence,
   upvoted:         casual.boolean,
-  url:             isURLPost ? casual.url : null
+  url:             isURLPost ? casual.url : null,
+  cover_image:     casual.url
 })
 
 export const makeChannelPostList = (channelName: string = casual.word) =>

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -44,6 +44,7 @@ export const makeCommentResult = (): CommentResult => ({
 export const makePostResult = (): PostResult => ({
   article_content:     null,
   article_text:        null,
+  post_cover_image:    null,
   author_avatar_small: casual.url,
   author_headline:     casual.text,
   author_id:           casual.username,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -85,7 +85,8 @@ export type Post = AuthoredContent & {
   stickied:        boolean,
   removed:         boolean,
   thumbnail:       ?string,
-  post_type:       ?string
+  post_type:       ?string,
+  cover_image:     ?string
 }
 
 export type PostFormType =
@@ -95,12 +96,12 @@ export type PostFormType =
   | null
 
 export type PostForm = {
-  postType:     PostFormType,
-  text:         string,
-  url:          string,
-  title:        string,
-  article:      Array<Object>,
-  coverImage?:  ?File
+  postType:      PostFormType,
+  text:          string,
+  url:           string,
+  title:         string,
+  article:       Array<Object>,
+  cover_image:   ?File
 }
 
 export type PostValidation = {
@@ -114,11 +115,11 @@ export type PostValidation = {
 }
 
 export type CreatePostPayload = {
-  url?:         string,
-  text?:        string,
-  title:        string,
-  article?:     Array<Object>,
-  coverImage?:  ?File,
+  url?:          string,
+  text?:         string,
+  title:         string,
+  article?:      Array<Object>,
+  cover_image?:  ?File,
 }
 
 export type PostListPagination = {

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -52,6 +52,7 @@ export type PostResult = ResultCommon & {
   removed: boolean,
   score: number,
   text: string,
+  post_cover_image: ?string
 }
 
 export type Result = PostResult | CommentResult | ProfileResult

--- a/static/js/lib/api/posts_test.js
+++ b/static/js/lib/api/posts_test.js
@@ -1,5 +1,4 @@
 // @flow
-import R from "ramda"
 import sinon from "sinon"
 import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
 import { PATCH, POST } from "redux-hammock/constants"
@@ -84,18 +83,18 @@ describe("Post API", () => {
   })
 
   it("updates a post", async () => {
-    const post = makePost()
-
-    fetchJSONStub.returns(Promise.resolve())
-
+    const post = makePost(false)
+    fetchStub.returns(Promise.resolve(JSON.stringify(post)))
     post.text = "updated!"
+    const { title, text } = post
+    const body = objectToFormData({ title, text })
 
     await editPost(post.id, post)
 
-    assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/`))
-    assert.deepEqual(fetchJSONStub.args[0][1], {
+    assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
+    assert.deepEqual(fetchStub.args[0][1], {
       method: PATCH,
-      body:   JSON.stringify(R.dissoc("url", post))
+      body
     })
   })
 

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -15,13 +15,13 @@ import type {
 } from "../flow/discussionTypes"
 
 export const newPostForm = (): PostForm => ({
-  postType:   null,
-  text:       "",
-  url:        "",
-  title:      "",
-  thumbnail:  null,
-  article:    [],
-  coverImage: null
+  postType:    null,
+  text:        "",
+  url:         "",
+  title:       "",
+  thumbnail:   null,
+  article:     [],
+  cover_image: null
 })
 
 export const postFormIsContentless = R.useWith(

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -18,13 +18,13 @@ import { urlHostname } from "./url"
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
     assert.deepEqual(newPostForm(), {
-      postType:   null,
-      text:       "",
-      url:        "",
-      title:      "",
-      article:    [],
-      thumbnail:  null,
-      coverImage: null
+      postType:    null,
+      text:        "",
+      url:         "",
+      title:       "",
+      article:     [],
+      thumbnail:   null,
+      cover_image: null
     })
   })
 

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -58,7 +58,8 @@ export const searchResultToPost = (result: PostResult): Post => ({
   thumbnail:       result.post_link_thumbnail,
   title:           result.post_title,
   upvoted:         false,
-  url:             result.post_link_url
+  url:             result.post_link_url,
+  cover_image:     result.post_cover_image
 })
 
 export const searchResultToProfile = (result: ProfileResult): Profile => ({

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -59,6 +59,7 @@ describe("search functions", () => {
     assert.deepEqual(post, {
       article_content: result.article_content,
       article_text:    result.article_text,
+      cover_image:     null,
       author_id:       result.author_id,
       author_name:     result.author_name,
       author_headline: result.author_headline,

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -44,7 +44,7 @@ export const configureShallowRenderer = (
 ) => (extraProps: Object = {}) =>
   shallow(<Component {...defaultProps} {...extraProps} />)
 
-export const makeEvent = (name: string, value: string) => ({
+export const makeEvent = (name: string, value: any) => ({
   target:         { value, name },
   preventDefault: sinon.stub()
 })

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -34,6 +34,20 @@ button.dark-outlined {
   color: $navy;
 }
 
+button.high-contrast-outlined {
+  background-color: $navy;
+  border: 1px solid $border-grey;
+  color: $border-grey;
+}
+
+button.opaque {
+  opacity: 0.4;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 button.compact {
   font-size: 12px;
   padding: 9px 7px;

--- a/static/scss/cover-image.scss
+++ b/static/scss/cover-image.scss
@@ -1,0 +1,35 @@
+.article-banner-image-wrapper {
+  display: inline-block;
+  width: 100%;
+  background-color: white;
+  border-radius: $std-border-radius;
+
+  .article-banner-image {
+    margin: 10px;
+    min-height: 115px;
+    background-color: $pale-grey;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+
+    .photo-dropzone {
+      height: 150px;
+    }
+
+    .cover-img-container {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      img {
+        max-width: 100%;
+      }
+
+      button {
+        position: absolute;
+        bottom: 0;
+      }
+    }
+  }
+}

--- a/static/scss/create-post.scss
+++ b/static/scss/create-post.scss
@@ -44,31 +44,4 @@
     display: flex;
     justify-content: flex-end;
   }
-
-  .article {
-    .article-banner-image-wrapper {
-      display: inline-block;
-      width: 100%;
-      background-color: white;
-      border-radius: $std-border-radius;
-
-      .article-banner-image {
-        margin: 10px;
-        min-height: 115px;
-        background-color: $pale-grey;
-        display: flex;
-        align-items: center;
-        flex-direction: column;
-
-        .msg {
-          color: $font-grey-light;
-          padding-bottom: 15px;
-        }
-
-        img {
-          max-width: 100%;
-        }
-      }
-    }
-  }
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -57,6 +57,7 @@
 @import "search";
 @import "article";
 @import "widget";
+@import "cover-image";
 
 body {
   font-family: "Source Sans Pro", helvetica, arial, sans-serif !important;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1492 
closes #1664 

#### What's this PR do?

A few things. Basically this adds:

- the ability to remove a cover image you've already added when creating a new post (like if you clicked the wrong picture accidentally or something).
- displaying the cover image on the post detail page, if one has been added for the article post in question
- editing the cover image for an article post that you've already created

#### How should this be manually tested?

I think just make sure that all the functions mentioned above work as they should, and that existing editing / post creation function works correctly for all kinds of posts.

#### Screenshots (if appropriate)

![show_image_on_article](https://user-images.githubusercontent.com/6207644/50986387-b5f70d80-14d4-11e9-82f6-4459b5c3e1dd.png)
![editing_existing_article_pic_added](https://user-images.githubusercontent.com/6207644/50986388-b5f70d80-14d4-11e9-821d-3d9d03a1ee06.png)
![editing_existing_article](https://user-images.githubusercontent.com/6207644/50986389-b5f70d80-14d4-11e9-9598-50c49d437cc7.png)
