### PR TITLE
Create ChannelGroupRoles in populate_user_roles function

### DIFF
--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -102,7 +102,7 @@ def populate_user_roles(channel_ids):
     for channel in Channel.objects.filter(id__in=channel_ids):
         try:
             role = ROLE_MODERATORS
-            channel_role, _ = ChannelGroupRole.objects.get_or_create(
+            ChannelGroupRole.objects.get_or_create(
                 channel=channel,
                 role=role,
                 group=Group.objects.get_or_create(name=f"{channel.name}_{role}")[0],
@@ -112,7 +112,7 @@ def populate_user_roles(channel_ids):
                 if user:
                     add_user_role(channel, ROLE_MODERATORS, user)
             role = ROLE_CONTRIBUTORS
-            channel_role, _ = ChannelGroupRole.objects.get_or_create(
+            ChannelGroupRole.objects.get_or_create(
                 channel=channel,
                 role=role,
                 group=Group.objects.get_or_create(name=f"{channel.name}_{role}")[0],

--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -146,7 +146,7 @@ def populate_subscriptions_and_roles(self):
         + [
             populate_user_roles.si(ids)
             for ids in chunks(
-                Channel.objects.values_list("id", flat=True),
+                Channel.objects.order_by("id").values_list("id", flat=True),
                 chunk_size=settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE,
             )
         ]

--- a/channels/tasks_test.py
+++ b/channels/tasks_test.py
@@ -72,6 +72,7 @@ def test_populate_subscriptions_and_roles(
     """
     channels, users = channels_and_users
     users = sorted(users, key=lambda user: user.id)
+    channels = sorted(channels, key=lambda channel: channel.id)
     settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE = 2
     mock_populate_user_subscriptions = mocker.patch(
         "channels.tasks.populate_user_subscriptions"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1670

#### What's this PR do?
Creates `ChannelGroupRole` objects when running the `populate_user_roles` task used by the `backpopulate_subscriptions_roles` command

#### How should this be manually tested?
 Delete any existing `ChannelGroupRole` and `Group` objects in your database.  Run the `backpopulate_subscriptions_roles` command. Your count of `ChannelGroupRole` objects should be 2x your count of `Channel` objects.

