### PR TITLE
remove icons from post type buttons on create post page

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -61,7 +61,6 @@ export default class CreatePostForm extends React.Component<Props> {
               className="write-something dark-outlined compact"
               onClick={() => updatePostType(LINK_TYPE_TEXT)}
             >
-              <i className="material-icons text_fields">text_fields</i>
               Write something
             </button>
           ) : null}
@@ -70,7 +69,6 @@ export default class CreatePostForm extends React.Component<Props> {
               className="share-a-link dark-outlined compact"
               onClick={() => updatePostType(LINK_TYPE_LINK)}
             >
-              <i className="material-icons open_in_new">open_in_new</i>
               Share a link
             </button>
           ) : null}
@@ -80,7 +78,6 @@ export default class CreatePostForm extends React.Component<Props> {
                 className="write-an-article dark-outlined compact"
                 onClick={() => updatePostType(LINK_TYPE_ARTICLE)}
               >
-                <i className="material-icons text_fields">text_fields</i>
               Write an Article
               </button>
             ) : null}

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -35,10 +35,14 @@ button.dark-outlined {
 }
 
 button.compact {
-  font-size: 14px;
-  padding: 9px 20px;
+  font-size: 12px;
+  padding: 9px 7px;
   display: flex;
   align-items: center;
+
+  @include breakpoint(extrawide) {
+    padding: 9px 20px;
+  }
 
   i {
     font-size: 16px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  


#### What are the relevant tickets?

closes #1644 

#### What's this PR do?

This makes a few adjustments to the post type buttons on the post create form to make them fit a little better on mobile (especially when the article UI flag is turned on).

Basically before, with the article post type button, some of the buttons could get squashed too much on a phone, so that the text in them would be forced on to two lines, like this:

![mobilebuttons](https://user-images.githubusercontent.com/6207644/50995911-83f2a500-14ee-11e9-9aaa-4a7570612921.png)

This removes the icons and adjusts the font-size and padding to fix this issue.

#### How should this be manually tested?

The create post page should look nice and be usable at all screen widths, things should always be spaced out nicely and the button text shouldn't be forced on to two lines at any screen width.

#### Screenshots (if appropriate)

![buttonchange_iphone5](https://user-images.githubusercontent.com/6207644/50996176-362a6c80-14ef-11e9-88fb-157de1065afb.png)
![buttonchange_iphone6](https://user-images.githubusercontent.com/6207644/50996177-362a6c80-14ef-11e9-8207-563a33735e98.png)
![buttonchange_desktopnarrow](https://user-images.githubusercontent.com/6207644/50996178-362a6c80-14ef-11e9-8a0d-85f3dd84ab42.png)
![buttonchange_desktop](https://user-images.githubusercontent.com/6207644/50996180-36c30300-14ef-11e9-9508-bebdfa2c5728.png)
