### PR TITLE
Fixed URL patterns to match post slugs with special characters

### DIFF
--- a/open_discussions/urls_test.py
+++ b/open_discussions/urls_test.py
@@ -1,35 +1,56 @@
 """Tests for URLs"""
+from urllib.parse import quote_plus
+import pytest
 
-from unittest import TestCase
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 
-class URLTests(TestCase):
-    """URL tests"""
+def test_index():
+    """Test that the index URL is set correctly"""
+    assert reverse("open_discussions-index") == "/"
 
-    def test_urls(self):
-        """Make sure URLs match with resolved names"""
-        assert reverse("open_discussions-index") == "/"
-        assert (
-            reverse(
-                "channel-post",
-                kwargs={
-                    "channel_name": "channel1",
-                    "post_id": "1n",
-                    "post_slug": "a_slug",
-                },
-            )
-            == "/c/channel1/1n/a_slug/"
+
+@pytest.mark.parametrize(
+    "post_slug",
+    ["dash-slug", "underscore_slug" "CAP-SLUG", "12345", "ünícôdę-chärâctêrs_123"],
+)
+def test_post_slug_match(post_slug):
+    """Test that our post slug regex correctly matches valid values"""
+    assert reverse(
+        "channel-post",
+        kwargs={"channel_name": "channel1", "post_id": "1n", "post_slug": post_slug},
+    ) == "/c/channel1/1n/{}/".format(quote_plus(post_slug))
+    assert reverse(
+        "channel-post-comment",
+        kwargs={
+            "channel_name": "channel1",
+            "post_id": "1n",
+            "post_slug": post_slug,
+            "comment_id": "b4",
+        },
+    ) == "/c/channel1/1n/{}/comment/b4/".format(quote_plus(post_slug))
+
+
+@pytest.mark.parametrize("post_slug", ["spaced slug", "non-alphanum-$"])
+def test_post_slug_match_fail(post_slug):
+    """Test that our post slug regex does not match invalid values"""
+    with pytest.raises(NoReverseMatch):
+        reverse(
+            "channel-post",
+            kwargs={
+                "channel_name": "channel1",
+                "post_id": "1n",
+                "post_slug": post_slug,
+            },
         )
-        assert (
-            reverse(
-                "channel-post-comment",
-                kwargs={
-                    "channel_name": "channel1",
-                    "post_id": "1n",
-                    "post_slug": "a_slug",
-                    "comment_id": "b4",
-                },
-            )
-            == "/c/channel1/1n/a_slug/comment/b4/"
+    with pytest.raises(NoReverseMatch):
+        reverse(
+            "channel-post-comment",
+            kwargs={
+                "channel_name": "channel1",
+                "post_id": "1n",
+                "post_slug": post_slug,
+                "comment_id": "b4",
+            },
         )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1683

#### What's this PR do?
Fixes our post slug URL pattern to accept unicode characters

#### How should this be manually tested?
The test cases that were added should be sufficient

#### Any background context you want to provide?
The alternation in the regex (`|`) makes the match slower, but I don't think it should have any real performance impact. I used `timeit` to compare the new regex with the old. The results for 100,000 runs were ~0.5 and ~0.2 respectively
