### PR TITLE
add autoFocus prop to password input

### DIFF
--- a/static/js/components/auth/AuthPasswordForm.js
+++ b/static/js/components/auth/AuthPasswordForm.js
@@ -21,6 +21,7 @@ const AuthPasswordForm = ({
         name="password"
         value={form.password}
         onChange={onUpdate}
+        autoFocus
       />
       {validationMessage(validation.password)}
     </div>

--- a/static/js/components/auth/AuthPasswordForm_test.js
+++ b/static/js/components/auth/AuthPasswordForm_test.js
@@ -49,6 +49,7 @@ describe("AuthPasswordForm component", () => {
     assert.equal(wrapper.find(".validation-message").exists(), false)
     assert.equal(wrapper.find("button").props().disabled, false)
     assert.equal(wrapper.find("Link").prop("to"), "/password_reset")
+    assert.isTrue(wrapper.find("input").prop("autoFocus"))
   })
 
   it("should disable the submit button if processing === true", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1665 

#### What's this PR do?

this just sets the `autoFocus` prop on the password page input tag, which causes it to grab focus when it mounts. This makes it so that if you're logging in to the app the password field will be focused automatically after you type in your email and hit enter :tada: 

#### How should this be manually tested?

make sure that the behavior described above works as advertised, and that nothing is weird or broken because of it.