### PR TITLE
small adjustment to cover image styling

### DIFF
--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -165,6 +165,10 @@
   font-size: $submission-font-size;
   line-height: 1.3;
 
+  img.cover-image {
+    width: 100%;
+  }
+
   .post-upvote-button,
   .post-action {
     font-size: 14px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  

#### What are the relevant tickets?

none

#### What's this PR do?

small tweak to cover image CSS (just setting `width: 100%`).

#### How should this be manually tested?

make sure that article posts with cover images added them display consistently at all widths, with images of all different sizes, on the post detail page. it should basically always constraint the image width to the width of the post, and the image should retain it's natural aspect ratio (not get squished at all) at any width.

#### Screenshots (if appropriate)

![chihuahuamob](https://user-images.githubusercontent.com/6207644/51139322-8b2cf200-1811-11e9-8592-4b85c6504cf4.png)
![tallimage_mob](https://user-images.githubusercontent.com/6207644/51139323-8b2cf200-1811-11e9-9ac9-97cdb49536df.png)
![tallimage_desk](https://user-images.githubusercontent.com/6207644/51139325-8bc58880-1811-11e9-91f3-0d5db65d0a3a.png)
![shortimageupfdfd](https://user-images.githubusercontent.com/6207644/51139326-8bc58880-1811-11e9-9221-d362a20ee792.png)
![shortimageup](https://user-images.githubusercontent.com/6207644/51139327-8bc58880-1811-11e9-9f89-c795f06b7137.png)
