### PR TITLE
Disable non-widget UI while widgets are edited

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -50,6 +50,7 @@ import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
 import { isAnonAccessiblePath, needsAuthedSite } from "../lib/auth"
 import { isMobileWidth, preventDefaultAndInvoke } from "../lib/util"
 import { getOwnProfile } from "../lib/redux_selectors"
+import { WIDGET_FORM_KEY } from "../lib/widgets"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -67,6 +68,7 @@ type AppProps = {
   banner: BannerState,
   dispatch: Dispatch<*>,
   showUserMenu: boolean,
+  editingWidgets: boolean,
   profile: ?Profile
 }
 
@@ -159,6 +161,7 @@ class App extends React.Component<AppProps> {
       snackbar,
       banner,
       showUserMenu,
+      editingWidgets,
       profile
     } = this.props
 
@@ -183,6 +186,7 @@ class App extends React.Component<AppProps> {
           banner={banner}
           hide={preventDefaultAndInvoke(this.hideBanner)}
         />
+        {editingWidgets ? <div className="opaque-overlay" /> : null}
         <div className="content">
           <Route exact path={match.url} component={HomePage} />
           <Route
@@ -317,6 +321,7 @@ export default connect(state => {
   } = state
 
   const showUserMenu = dropdownMenus.has(USER_MENU_DROPDOWN)
+  const editingWidgets = state.forms[WIDGET_FORM_KEY]
 
   return {
     showDrawerMobile,
@@ -324,6 +329,7 @@ export default connect(state => {
     snackbar,
     banner,
     showUserMenu,
+    editingWidgets,
     profile: getOwnProfile(state)
   }
 })(App)

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -14,6 +14,7 @@ import * as authUtils from "../lib/auth"
 import { makeFrontpageSetting, makeCommentSetting } from "../factories/settings"
 import { makeChannelPostList } from "../factories/posts"
 import { shouldIf, shouldIfGt0 } from "../lib/test_utils"
+import { WIDGET_FORM_KEY } from "../lib/widgets"
 
 describe("App", () => {
   let helper, renderComponent, channels, postList
@@ -125,6 +126,22 @@ describe("App", () => {
           history.push({ pathname: "/" })
         }
       )
+    })
+  })
+  ;[true, false].forEach(editingWidgets => {
+    it(`${
+      editingWidgets ? "shows" : "doesn't show"
+    } the an overlay disabling parts of the UI`, async () => {
+      if (editingWidgets) {
+        helper.store.dispatch(
+          actions.forms.formBeginEdit({
+            formKey: WIDGET_FORM_KEY,
+            value:   null
+          })
+        )
+      }
+      const [wrapper] = await renderComponent("/", [])
+      assert.equal(wrapper.find(".opaque-overlay").exists(), editingWidgets)
     })
   })
 })

--- a/static/js/containers/widgets/ManageWidgetHeader.js
+++ b/static/js/containers/widgets/ManageWidgetHeader.js
@@ -51,7 +51,7 @@ export class ManageWidgetHeader extends React.Component<Props> {
     }
 
     return (
-      <React.Fragment>
+      <span className="manage-widgets-navbar">
         <span className="manage-title">Manage widgets</span>
         <button className="cancel" onClick={clearForm}>
           Cancel
@@ -59,7 +59,7 @@ export class ManageWidgetHeader extends React.Component<Props> {
         <button className="submit" onClick={this.submitForm}>
           Done
         </button>
-      </React.Fragment>
+      </span>
     )
   }
 }

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -50,7 +50,6 @@
     display: flex;
     flex-direction: row;
     margin-bottom: 0;
-    justify-content: flex-end;
     align-items: center;
 
     .manage-title {

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -16,6 +16,7 @@ $footer-height: 152px;
   height: calc(100vh - #{$toolbar-height-desktop});
   top: $toolbar-height-desktop;
   width: $drawer-width;
+  z-index: 45;
 
   .mdc-drawer__drawer {
     position: absolute;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -129,4 +129,12 @@ body {
       }
     }
   }
+
+  .opaque-overlay {
+    z-index: 21;
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.4);
+  }
 }

--- a/static/scss/sidebar.scss
+++ b/static/scss/sidebar.scss
@@ -1,4 +1,8 @@
 .sidebar {
+  // this ensures the sidebar is visible when opaque-overlay covers the screen
+  z-index: 22;
+  position: relative;
+
   .user-count {
     color: $font-grey;
   }

--- a/static/scss/widget.scss
+++ b/static/scss/widget.scss
@@ -50,3 +50,7 @@
     }
   }
 }
+
+.manage-widgets-navbar {
+  z-index: 22;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1747  

#### What's this PR do?
Adds an overlay which will disable most of the rest of the UI. The drawer, toolbar and the manage widget interface should still be editable. If the user saves the widgets or cancels the UI should go back to normal.

#### How should this be manually tested?
For a channel you moderate, click the channel gear icon then 'manage widgets'. You should see other parts of the UI become more opaque than before. You should not be able to click anywhere within the other parts of the UI. The drawer and toolbar should remain unaffected.

Note that the zeplin mockup in the issue differs slightly from the one linked under the checkbox for this item. @pdpinch Any thoughts on if the screenshot below looks good?

#### Screenshots
![screenshot from 2019-01-15 12-08-11](https://user-images.githubusercontent.com/863262/51196958-401ce880-18be-11e9-9e2d-85bc9f081ee4.png)

