### PR TITLE
Added truncated post content preview to post summary card

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-content-loader": "^3.1.2",
     "react-cropper": "^1.0.1",
     "react-dom": "^16.5.2",
+    "react-dotdotdot": "^1.2.3",
     "react-dropzone": "^4.2.5",
     "react-ga": "^2.5.3",
     "react-google-recaptcha": "^1.0.2",

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -4,6 +4,7 @@ import React from "react"
 import moment from "moment"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
+import Dotdotdot from "react-dotdotdot"
 
 import Card from "./Card"
 import DropdownMenu from "./DropdownMenu"
@@ -19,7 +20,9 @@ import {
 import {
   PostTitleAndHostname,
   getPostDropdownMenuKey,
-  postMenuDropdownFuncs
+  postMenuDropdownFuncs,
+  getTextContent,
+  POST_PREVIEW_LINES
 } from "../lib/posts"
 import { userIsAnonymous } from "../lib/util"
 
@@ -70,8 +73,10 @@ export class CompactPostDisplay extends React.Component<Props> {
       useSearchPageUI,
       dispatch
     } = this.props
+
     const formattedDate = moment(post.created).fromNow()
     const { showPostMenu, hidePostMenu } = postMenuDropdownFuncs(dispatch, post)
+    const previewText = getTextContent(post)
 
     return (
       <Card
@@ -97,7 +102,14 @@ export class CompactPostDisplay extends React.Component<Props> {
                 </div>
               </Link>
             </div>
-            <div className="row">
+            {previewText ? (
+              <div className="row">
+                <Dotdotdot clamp={POST_PREVIEW_LINES} className="preview">
+                  {previewText}
+                </Dotdotdot>
+              </div>
+            ) : null}
+            <div className="row author-row">
               <div className="authored-by">
                 <div>
                   <Link to={profileURL(post.author_id)} className="navy">

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -1,6 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
+import R from "ramda"
 import { assert } from "chai"
 import { mount } from "enzyme"
 import { Link } from "react-router-dom"
@@ -12,11 +13,16 @@ import DropdownMenu from "./DropdownMenu"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { wait } from "../lib/util"
 import { channelURL, postDetailURL, urlHostname, profileURL } from "../lib/url"
-import { PostTitleAndHostname, getPostDropdownMenuKey } from "../lib/posts"
+import {
+  PostTitleAndHostname,
+  getPostDropdownMenuKey,
+  POST_PREVIEW_LINES
+} from "../lib/posts"
 import { makePost } from "../factories/posts"
 import { showDropdown } from "../actions/ui"
 import * as utilFuncs from "../lib/util"
 import { shouldIf } from "../lib/test_utils"
+import { LINK_TYPE_TEXT } from "../lib/channels"
 
 describe("CompactPostDisplay", () => {
   let helper, post, openMenu
@@ -96,6 +102,17 @@ describe("CompactPostDisplay", () => {
       .at(0)
     assert.equal(link.text(), post.author_name)
     assert.equal(link.props().to, profileURL(post.author_id))
+  })
+
+  it("should show preview text", () => {
+    const exampleText = "lorem ipsum"
+    post = R.merge(post, {
+      post_type: LINK_TYPE_TEXT,
+      text:      exampleText
+    })
+    const truncatableText = renderPostDisplay({ post }).find("Dotdotdot")
+    assert.equal(truncatableText.prop("clamp"), POST_PREVIEW_LINES)
+    assert.equal(truncatableText.prop("children"), exampleText)
   })
 
   it("should link to the post detail page via post date", () => {

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 
 import { postDetailURL, urlHostname } from "./url"
 import { showDropdown, hideDropdownDebounced } from "../actions/ui"
+import { LINK_TYPE_TEXT, LINK_TYPE_ARTICLE } from "./channels"
 
 import type { Dispatch } from "redux"
 import type {
@@ -13,6 +14,8 @@ import type {
   PostListData,
   PostListResponse
 } from "../flow/discussionTypes"
+
+export const POST_PREVIEW_LINES = 2
 
 export const newPostForm = (): PostForm => ({
   postType:    null,
@@ -110,4 +113,13 @@ export const postMenuDropdownFuncs = (dispatch: Dispatch<*>, post: Post) => {
     showPostMenu: () => dispatch(showDropdown(postMenuKey)),
     hidePostMenu: () => dispatch(hideDropdownDebounced(postMenuKey))
   }
+}
+
+export const getTextContent = (post: Post): ?string => {
+  if (post.post_type === LINK_TYPE_TEXT) {
+    return post.text
+  } else if (post.post_type === LINK_TYPE_ARTICLE) {
+    return post.article_text
+  }
+  return null
 }

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -10,10 +10,12 @@ import {
   PostTitleAndHostname,
   formatPostTitle,
   mapPostListResponse,
-  postFormIsContentless
+  postFormIsContentless,
+  getTextContent
 } from "./posts"
 import { makeChannelPostList, makePost } from "../factories/posts"
 import { urlHostname } from "./url"
+import { LINK_TYPE_ARTICLE, LINK_TYPE_LINK, LINK_TYPE_TEXT } from "./channels"
 
 describe("Post utils", () => {
   it("should return a new post with empty values", () => {
@@ -153,6 +155,30 @@ describe("Post utils", () => {
           sort: "hot"
         }
       })
+    })
+  })
+
+  describe("getTextContent", () => {
+    it("gets a post's text content (or null if it has no text content)", () => {
+      const exampleText = "magnets, how do they work?"
+      let textPost = makePost()
+      textPost = R.merge(textPost, {
+        post_type: LINK_TYPE_TEXT,
+        text:      exampleText
+      })
+      let articlePost = makePost()
+      articlePost = R.merge(articlePost, {
+        post_type:    LINK_TYPE_ARTICLE,
+        article_text: exampleText
+      })
+      let linkPost = makePost()
+      linkPost = R.merge(linkPost, {
+        post_type: LINK_TYPE_LINK
+      })
+
+      assert.equal(getTextContent(textPost), exampleText)
+      assert.equal(getTextContent(articlePost), exampleText)
+      assert.isNull(getTextContent(linkPost))
     })
   })
 })

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -5,6 +5,7 @@ $button-blue: #0085df;
 $footer-button-blue: #3a6080;
 $font-black: rgba(0, 0, 0, 0.87);
 $font-grey: #888;
+$font-grey-mid: #8a8b8c;
 $font-grey-light: #b0b0b0;
 $font-darkgrey: #666;
 $border-grey: #d3d3d3;
@@ -40,9 +41,9 @@ $banner-slide-trans: top 300ms $banner-slide-timing;
 $banner-slide-content-trans: padding-top 300ms $banner-slide-timing;
 $material-icon-size: 24px;
 $channel-banner-height: 200px;
-$author-font-size: 16px;
 $submission-font-size: 16px;
 $tooltip-font-size: 14px;
+$modest-font-size: 14px;
 
 // Spacing values for items that appear on the left side of the drawer and toolbar
 $icon-padding-left: 19px;

--- a/static/scss/comment.scss
+++ b/static/scss/comment.scss
@@ -173,7 +173,7 @@ $replyPaddingLeftPhone: 10px;
         display: inline;
         padding-right: 6px;
         font-weight: 500;
-        font-size: $author-font-size;
+        font-size: 16px;
         color: $navy;
       }
 

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -76,7 +76,6 @@
 .authored-by {
   display: flex;
   flex-direction: column;
-  font-size: $author-font-size;
 
   div {
     padding-bottom: 2px;
@@ -96,6 +95,18 @@
 }
 
 .compact-post-summary {
+  $child-vert-spacing: 10px;
+
+  font-size: $modest-font-size;
+
+  .preview {
+    color: $font-grey-mid;
+  }
+
+  .author-row {
+    margin-top: $child-vert-spacing;
+  }
+
   .upvote-report-count {
     display: flex;
     align-items: center;
@@ -105,11 +116,10 @@
     }
   }
 
-  .post-title {
+  span.post-title {
     font-size: 18px;
     font-weight: bold;
     color: $navy;
-    margin: 0 0 10px;
   }
 
   &.sticky {
@@ -126,6 +136,8 @@
   }
 
   .title-row {
+    margin: 0 0 $child-vert-spacing;
+
     i {
       color: $font-grey-light;
     }
@@ -295,7 +307,7 @@
     justify-content: space-between;
     display: flex;
     margin-top: 10px;
-    font-size: 14px;
+    font-size: $modest-font-size;
 
     a {
       margin: 0 5px;
@@ -335,7 +347,7 @@
   .provider-name {
     text-transform: uppercase;
     padding-bottom: 10px;
-    font-size: 14px;
+    font-size: $modest-font-size;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9711,6 +9711,12 @@ react-dom@^16.5.2:
     prop-types "^15.6.2"
     schedule "^0.5.0"
 
+react-dotdotdot@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz#45bb264153cee73471f55c51c8d1542f4880a34f"
+  dependencies:
+    object.pick "^1.3.0"
+
 react-dropzone@^4.2.5:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.2.11.tgz#c20ff6a62634c5803bed5f292ef1bd4b3e1f90c3"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [ ] tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Partially addresses #1426

#### What's this PR do?
Adds a preview for post/article text content to the post summary card, and truncates it with an ellipsis if it has more than 2 lines of text.

#### How should this be manually tested?
- Check that a post/article with a lot of text is truncated in the post summary card
- Check that a post/article less than 2 lines of text is not truncated
- Check that a link post renders as normal

#### Any background context you want to provide?
Design reference: https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5ba4e6e6c699e4552e267660

#### Screenshots (if appropriate)
![ss 2019-01-15 at 17 45 10](https://user-images.githubusercontent.com/14932219/51215356-b20d2600-18ee-11e9-8854-426de86ef67e.png)
![ss 2019-01-15 at 17 44 50](https://user-images.githubusercontent.com/14932219/51215357-b20d2600-18ee-11e9-8b24-f99afe676db0.png)
