### PR TITLE
use the `post_type` field for post-type specific UI

### DIFF
--- a/static/js/components/CommentForms.js
+++ b/static/js/components/CommentForms.js
@@ -19,6 +19,7 @@ import {
   userIsAnonymous,
   preventDefaultAndInvoke
 } from "../lib/util"
+import { LINK_TYPE_ARTICLE } from "../lib/channels"
 
 import type {
   CommentForm,
@@ -454,9 +455,10 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
       const { id } = post
       this.setState({ patching: true })
       // eslint-disable-next-line camelcase
-      const content = article_content
-        ? { id, article_content, cover_image }
-        : { id, text }
+      const content =
+        post.post_type === LINK_TYPE_ARTICLE
+          ? { id, article_content, cover_image }
+          : { id, text }
       try {
         await patchPost(content)
       } catch (_) {
@@ -465,7 +467,7 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
     }
 
     render() {
-      const { forms, formKey, onUpdate, cancelReply } = this.props
+      const { forms, formKey, onUpdate, cancelReply, post } = this.props
       const { patching } = this.state
       const text = R.pathOr("", [formKey, "value", "text"], forms)
       const image = R.pathOr(null, [formKey, "value", "cover_image"], forms)
@@ -475,7 +477,8 @@ export const EditPostForm: Class<React$Component<*, *>> = connect(
         forms
       )
 
-      const inputType = article ? ArticleInput : WYSIWYGInput
+      const inputType =
+        post.post_type === LINK_TYPE_ARTICLE ? ArticleInput : WYSIWYGInput
 
       return (
         <React.Fragment>

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -25,6 +25,7 @@ import {
   POST_PREVIEW_LINES
 } from "../lib/posts"
 import { userIsAnonymous } from "../lib/util"
+import { LINK_TYPE_LINK } from "../lib/channels"
 
 import type { Dispatch } from "redux"
 import type { Post } from "../flow/discussionTypes"
@@ -134,11 +135,11 @@ export class CompactPostDisplay extends React.Component<Props> {
               </div>
             </div>
           </div>
-          {post.url || post.thumbnail ? (
+          {post.post_type === LINK_TYPE_LINK || post.thumbnail ? (
             <div
               className={`column2 ${post.thumbnail ? "link-thumbnail" : ""}`}
             >
-              {post.url ? (
+              {post.post_type === LINK_TYPE_LINK ? (
                 <React.Fragment>
                   <div className="top-right">
                     <a
@@ -168,9 +169,9 @@ export class CompactPostDisplay extends React.Component<Props> {
                     </a>
                   ) : null}
                 </React.Fragment>
-              ) : post.thumbnail ? (
+              ) : (
                 <img src={post.thumbnail} />
-              ) : null}
+              )}
             </div>
           ) : null}
         </div>

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -29,6 +29,7 @@ import { editPostKey } from "../components/CommentForms"
 import * as utilFuncs from "../lib/util"
 import { makeChannel } from "../factories/channels"
 import { shouldIf } from "../lib/test_utils"
+import { LINK_TYPE_ARTICLE } from "../lib/channels"
 
 describe("ExpandedPostDisplay", () => {
   let helper,
@@ -404,6 +405,7 @@ describe("ExpandedPostDisplay", () => {
   })
 
   it("should use ArticleEditor and embedlyResizeImage to display if an article post", () => {
+    post.post_type = LINK_TYPE_ARTICLE
     post.article_content = []
     post.cover_image = "/img/image.jpg"
     post.text = null

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -41,6 +41,7 @@ import * as utilFuncs from "../lib/util"
 import * as embedUtil from "../lib/embed"
 import { removeTrailingSlash, truncate } from "../lib/util"
 import { NOT_AUTHORIZED_ERROR_TYPE } from "../util/rest"
+import { LINK_TYPE_LINK } from "../lib/channels"
 
 describe("PostPage", function() {
   let helper,
@@ -213,6 +214,7 @@ describe("PostPage", function() {
   it("should call window.twttr.widgets.load() if a twitter embed", async () => {
     post.url = "http://foo.bar.example.com/baz"
     post.text = null
+    post.post_type = LINK_TYPE_LINK
     helper.getEmbedlyStub.returns(Promise.resolve({ response: makeTweet() }))
 
     window.twttr = {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -73,6 +73,12 @@ export type AuthoredContent = {
   subscribed:      boolean
 }
 
+export type PostType =
+  | typeof LINK_TYPE_LINK
+  | typeof LINK_TYPE_TEXT
+  | typeof LINK_TYPE_ARTICLE
+
+
 export type Post = AuthoredContent & {
   title:           string,
   url:             ?string,
@@ -86,7 +92,7 @@ export type Post = AuthoredContent & {
   stickied:        boolean,
   removed:         boolean,
   thumbnail:       ?string,
-  post_type:       ?string,
+  post_type:       PostType,
   cover_image:     ?string
 }
 

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -1,72 +1,74 @@
 // @flow
+import type { PostType } from './discussionTypes'
+
 type ResultCommon = {
   author_avatar_small: string,
-  author_headline: ?string,
-  author_id: string,
-  author_name: string,
+  author_headline:     ?string,
+  author_id:           string,
+  author_name:         string,
 }
 
 type RESULT_TYPE_PROFILE = "profile"
 
 export type ProfileResult = ResultCommon & {
-  object_type: RESULT_TYPE_PROFILE,
-  author_bio: ?string,
+  object_type:          RESULT_TYPE_PROFILE,
+  author_bio:           ?string,
   author_avatar_medium: string,
 }
 
 type RESULT_TYPE_COMMENT = "comment"
 
 export type CommentResult = ResultCommon & {
-  channel_name: string,
-  channel_title: string,
-  comment_id: string,
-  created: string,
-  deleted: boolean,
-  object_type: RESULT_TYPE_COMMENT,
+  channel_name:      string,
+  channel_title:     string,
+  comment_id:        string,
+  created:           string,
+  deleted:           boolean,
+  object_type:       RESULT_TYPE_COMMENT,
   parent_comment_id: ?string,
-  post_id: string,
-  post_slug: string,
-  post_title: string,
-  removed: boolean,
-  score: number,
-  text: string,
+  post_id:           string,
+  post_slug:         string,
+  post_title:        string,
+  removed:           boolean,
+  score:             number,
+  text:              string,
 }
 
 type RESULT_TYPE_POST = "post"
 
 export type PostResult = ResultCommon & {
-  article_content: ?Array<Object>,
-  article_text: ?string,
-  channel_name: string,
-  channel_title: string,
-  created: string,
-  deleted: boolean,
-  object_type: RESULT_TYPE_POST,
-  num_comments: number,
-  post_id: string,
-  post_link_url: ?string,
+  article_content:     ?Array<Object>,
+  article_text:        ?string,
+  channel_name:        string,
+  channel_title:       string,
+  created:             string,
+  deleted:             boolean,
+  object_type:         RESULT_TYPE_POST,
+  num_comments:        number,
+  post_id:             string,
+  post_link_url:       ?string,
   post_link_thumbnail: ?string,
-  post_slug: string,
-  post_title: string,
-  post_type: string,
-  removed: boolean,
-  score: number,
-  text: string,
-  post_cover_image: ?string
+  post_slug:           string,
+  post_title:          string,
+  post_type:           PostType,
+  removed:             boolean,
+  score:               number,
+  text:                string,
+  post_cover_image:    ?string
 }
 
 export type Result = PostResult | CommentResult | ProfileResult
 
 export type SearchInputs = {
-  text?: string,
-  type?: string,
+  text?:       string,
+  type?:       string,
   incremental: boolean
 }
 
 export type SearchParams = {
-  type: ?string,
-  text: ?string,
-  from: number,
-  size: number,
+  type:        ?string,
+  text:        ?string,
+  from:        number,
+  size:        number,
   channelName: ?string,
 }

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom"
 
 import { postDetailURL, urlHostname } from "./url"
 import { showDropdown, hideDropdownDebounced } from "../actions/ui"
-import { LINK_TYPE_TEXT, LINK_TYPE_ARTICLE } from "./channels"
+import { LINK_TYPE_LINK, LINK_TYPE_TEXT, LINK_TYPE_ARTICLE } from "./channels"
 
 import type { Dispatch } from "redux"
 import type {
@@ -68,7 +68,7 @@ export const getPaginationSortParams = R.pickAll([
 export const PostTitleAndHostname = ({ post }: { post: Post }) => (
   <React.Fragment>
     <span className="post-title">{post.title}</span>
-    {post.url ? (
+    {post.post_type === LINK_TYPE_LINK ? (
       <span className="url-hostname">{`(${urlHostname(post.url)})`}</span>
     ) : null}
   </React.Fragment>
@@ -77,7 +77,7 @@ export const PostTitleAndHostname = ({ post }: { post: Post }) => (
 export const getPostDropdownMenuKey = (post: Post) => `POST_DROPDOWN_${post.id}`
 
 export const formatPostTitle = (post: Post) =>
-  post.url ? (
+  post.post_type === LINK_TYPE_LINK ? (
     <div>
       <a
         className="post-title navy"
@@ -123,3 +123,6 @@ export const getTextContent = (post: Post): ?string => {
   }
   return null
 }
+
+export const isEditablePostType = (post: Post): boolean =>
+  post.post_type === LINK_TYPE_TEXT || post.post_type === LINK_TYPE_ARTICLE

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -11,7 +11,8 @@ import {
   formatPostTitle,
   mapPostListResponse,
   postFormIsContentless,
-  getTextContent
+  getTextContent,
+  isEditablePostType
 } from "./posts"
 import { makeChannelPostList, makePost } from "../factories/posts"
 import { urlHostname } from "./url"
@@ -179,6 +180,22 @@ describe("Post utils", () => {
       assert.equal(getTextContent(textPost), exampleText)
       assert.equal(getTextContent(articlePost), exampleText)
       assert.isNull(getTextContent(linkPost))
+    })
+  })
+
+  //
+  ;[
+    [LINK_TYPE_LINK, false],
+    [LINK_TYPE_TEXT, true],
+    [LINK_TYPE_ARTICLE, true]
+  ].forEach(([postType, expectation]) => {
+    it(`isEditablePostType should return ${String(
+      expectation
+    )} when ${postType}`, () => {
+      assert.equal(
+        isEditablePostType({ ...makePost(), post_type: postType }),
+        expectation
+      )
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1652 

#### What's this PR do?

Basically this just uses the relatively-new `post_type` value to decide what UI to show or which logic to use in a few places where we need to do different things based on the post type. I went through and changed everywhere that I could think of, but if I missed somewhere where it would make sense to do this refactor as well plz point it out.

#### How should this be manually tested?

Everything should be working as it was before.

Additionally, 'title only' posts (essentially empty text posts) should now be editable, whereas before they were not (because we used the value of `post.text` to figure out if a post should be editable or not).
