### PR TITLE
fix prosemirror-markdown issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prop-types": "^15.6.2",
     "prosemirror-commands": "^1.0.7",
     "prosemirror-example-setup": "^1.0.1",
-    "prosemirror-markdown": "^1.1.1",
+    "prosemirror-markdown": "^1.2.2",
     "prosemirror-model": "^1.6.0",
     "prosemirror-schema-basic": "^1.0.0",
     "prosemirror-schema-list": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7344,9 +7344,9 @@ line-height@^0.1.1:
   dependencies:
     computed-style "~0.1.3"
 
-linkify-it@~1.2.2:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-1.2.4.tgz#0773526c317c8fd13bd534ee1d180ff88abf881a"
+linkify-it@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.1.0.tgz#c4caf38a6cd7ac2212ef3c7d2bde30a91561f9db"
   dependencies:
     uc.micro "^1.0.1"
 
@@ -7646,15 +7646,15 @@ markdown-escapes@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
 
-markdown-it@^6.0.4:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-6.1.1.tgz#ced037f4473ee9f5153ac414f77dc83c91ba927c"
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
   dependencies:
     argparse "^1.0.7"
     entities "~1.1.1"
-    linkify-it "~1.2.2"
-    mdurl "~1.0.1"
-    uc.micro "^1.0.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 material-colors@^1.2.1:
   version "1.2.6"
@@ -7724,7 +7724,7 @@ md5@^2.1.0:
     crypt "~0.0.1"
     is-buffer "~1.1.1"
 
-mdurl@~1.0.1:
+mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
@@ -9384,11 +9384,11 @@ prosemirror-keymap@^1.0.0:
     prosemirror-state "^1.0.0"
     w3c-keyname "^1.1.8"
 
-prosemirror-markdown@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.1.1.tgz#35cdb1a5aff2948b618e79ccd017813cfa5dc329"
+prosemirror-markdown@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.2.2.tgz#e9fcf73c242e5231e61906c5fe33c6bf78a9c517"
   dependencies:
-    markdown-it "^6.0.4"
+    markdown-it "^8.4.2"
     prosemirror-model "^1.0.0"
 
 prosemirror-menu@^1.0.0:
@@ -11781,7 +11781,7 @@ ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
-uc.micro@^1.0.1:
+uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 


### PR DESCRIPTION


#### What are the relevant tickets?

closes #1696 

#### What's this PR do?

upgrades our prosemirror-markdown package.

#### How should this be manually tested?

tests should pass and you shouldn't be able to reproduce the issue on the linked issue.