### PR TITLE
fix post pinning

### DIFF
--- a/static/js/lib/api/posts.js
+++ b/static/js/lib/api/posts.js
@@ -48,8 +48,10 @@ export function updateRemoved(postId: string, removed: boolean): Promise<Post> {
   })
 }
 
-export async function editPost(postId: string, post: Post): Promise<Post> {
-  const formData = objectToFormData(R.pick(["text", "title"], post))
+export async function editPost(postId: string, post: Object): Promise<Post> {
+  const formData = objectToFormData(
+    R.pick(["text", "title", "stickied", "ignore_reports", "subscribed"], post)
+  )
 
   if (!emptyOrNil(post.article_content)) {
     formData.append("article_content", JSON.stringify(post.article_content))

--- a/static/js/lib/api/posts_test.js
+++ b/static/js/lib/api/posts_test.js
@@ -82,19 +82,23 @@ describe("Post API", () => {
     assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
   })
 
-  it("updates a post", async () => {
-    const post = makePost(false)
-    fetchStub.returns(Promise.resolve(JSON.stringify(post)))
-    post.text = "updated!"
-    const { title, text } = post
-    const body = objectToFormData({ title, text })
-
-    await editPost(post.id, post)
-
-    assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
-    assert.deepEqual(fetchStub.args[0][1], {
-      method: PATCH,
-      body
+  //
+  ;[
+    ["text", "text"],
+    ["title", "title"],
+    ["stickied", true],
+    ["ignore_reports", true],
+    ["subscribed", true]
+  ].forEach(([fieldName, val]) => {
+    it(`lets you update the ${fieldName} field on a post`, async () => {
+      const post = makePost(false)
+      fetchStub.returns(Promise.resolve(JSON.stringify(post)))
+      await editPost(post.id, { [fieldName]: val })
+      const bodyExp = objectToFormData({ [fieldName]: val })
+      assert.ok(fetchStub.calledWith(`/api/v0/posts/${post.id}/`))
+      const { method, body } = fetchStub.args[0][1]
+      assert.equal(method, PATCH)
+      assert.deepEqual([...body.entries()], [...bodyExp.entries()])
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1727 

#### What's this PR do?

makes post pinning work again. I goofed when I was working on https://github.com/mitodl/open-discussions/pull/1676. this fixes it.

#### How should this be manually tested?

you should be able to:

- pin a post
- subscribe to a post
- 'ignore reports' on a post