### PR TITLE
loading width fix for search pages

### DIFF
--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -5,6 +5,7 @@ import ContentLoader from "react-content-loader"
 
 import { NotFound, NotAuthorized } from "../components/ErrorPages"
 import Card from "./Card"
+import { Cell, Grid } from "./Grid"
 import { contentLoaderSpeed } from "../lib/constants"
 
 type LoadingProps = {
@@ -72,6 +73,12 @@ export const PostLoading = () => (
   </div>
 )
 
+export const SearchLoading = () => (
+  <Grid className="main-content two-column search-page">
+    <Cell width={8}>{PostLoading()}</Cell>
+  </Grid>
+)
+
 export const renderDeferredLoading = ({
   LoadingComponent,
   loaded,
@@ -132,3 +139,4 @@ export const withLoading = R.curry(
 
 export const withSpinnerLoading = withLoading(Loading)
 export const withPostLoading = withLoading(PostLoading)
+export const withSearchLoading = withLoading(SearchLoading)

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -7,7 +7,7 @@ import InfiniteScroll from "react-infinite-scroller"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
-import { Loading, PostLoading, withLoading } from "../components/Loading"
+import { Loading, PostLoading, withSearchLoading } from "../components/Loading"
 import SearchTextbox from "../components/SearchTextbox"
 import ChannelNavbar from "../components/ChannelNavbar"
 import CanonicalLink from "../components/CanonicalLink"
@@ -354,5 +354,5 @@ export default R.compose(
     mapDispatchToProps
   ),
   withChannelHeader,
-  withLoading(PostLoading)
+  withSearchLoading
 )(SearchPage)

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -382,7 +382,7 @@ describe("SearchPage", () => {
     )} and searchLoaded=${String(searchLoaded)} and it ${
       hasChannel ? "has" : "doesn't have"
     } a channel`, async () => {
-      const { inner } = await renderPage(
+      const { wrapper } = await renderPage(
         {
           channels: {
             loaded:     channelLoaded,
@@ -390,7 +390,10 @@ describe("SearchPage", () => {
           },
           search: {
             loaded:     searchLoaded,
-            processing: !searchLoaded
+            processing: !searchLoaded,
+            data:       {
+              initialLoad: true
+            }
           }
         },
         {
@@ -401,7 +404,7 @@ describe("SearchPage", () => {
           }
         }
       )
-      assert.equal(inner.find("PostLoading").exists(), !loaded)
+      assert.equal(wrapper.props().loaded, loaded)
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1552

#### What's this PR do?
Uses a new `SearchLoading` function to ensure the loader displays correctly on initial load of channel search pages.

#### How should this be manually tested?
Go to the search page for a channel.  The loader should briefly appear and not take up the full width of the page.  Perform a search, the loader should appear again and still not take up the full width of the page.  
