### PR TITLE
Fix search loading height issue

### DIFF
--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -209,7 +209,7 @@ export class SearchPage extends React.Component<Props, State> {
         // TODO: fix
         hasMore={from + SETTINGS.search_page_size < total}
         loadMore={this.loadMore}
-        initialLoad={false}
+        initialLoad={from === 0}
         loader={<Loading className="infinite" key="loader" />}
       >
         {results.map((result, i) => (

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -11,6 +11,7 @@ import { makePostResult, makeSearchResponse } from "../factories/search"
 import { makeChannel } from "../factories/channels"
 import { makePost } from "../factories/posts"
 import { makeComment } from "../factories/comments"
+import { shouldIf } from "../lib/test_utils"
 
 describe("SearchPage", () => {
   let helper,
@@ -136,6 +137,16 @@ describe("SearchPage", () => {
     })
     // from is 5, plus 5 is 10 which is == numHits so no more results
     assert.isFalse(inner.find("InfiniteScroll").prop("hasMore"))
+  })
+  ;[0, 5].forEach(from => {
+    it(`InfiniteScroll initialLoad ${shouldIf(
+      from > 0
+    )} be false when from is ${from}`, async () => {
+      const { inner } = await renderPage()
+      inner.setState({ from })
+      const infiniteScroll = inner.find("InfiniteScroll")
+      assert.equal(infiniteScroll.prop("initialLoad"), from === 0)
+    })
   })
   ;[true, false].forEach(hasChannel => {
     it(`${hasChannel ? "loads" : "doesn't load"} a channel`, async () => {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1505

#### What's this PR do?
Sets the `initialLoad` setting of the `InfiniteScroller` component to `true` if `from` === 0

#### How should this be manually tested?
- Make your browser window as tall as possible.  Then run a search that you know will return a decent number of results.  On the master branch, the `Loading` component will display until you move the page.  On this branch, it should appear only very briefly before loading the next set of results.

- Make your browser too short to display the initial results, and open the network tab.  Reload the page.  The search API should only be called once.  