### PR TITLE
fix dropdown menu click targets

### DIFF
--- a/static/scss/dropdown-menu.scss
+++ b/static/scss/dropdown-menu.scss
@@ -13,6 +13,8 @@ ul.dropdown-menu {
     text-decoration: none;
     color: $navy;
     white-space: nowrap;
+    display: inline-block;
+    width: 100%;
   }
 
   li {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1728 

#### What's this PR do?

a little CSS tweak to make sure that the click areas for the dropdown menus are not so small.

#### How should this be manually tested?

you should be able to more comfortably click the elements in the dropdown menus. The menu that shows this the most clearly is the post menu, which includes the pin option (which is quite narrow).

before the click target where you could actually trigger the action was only the text itself. now it's sort of that whole row (read the issue for details).
