### PR TITLE
Updated post summary card styling

### DIFF
--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -146,8 +146,8 @@ describe("CompactPostDisplay", () => {
     const post = makePost(true)
     const wrapper = renderPostDisplay({ post })
     const { href, target } = wrapper
-      .find("a")
-      .at(3)
+      .find(".external-link a")
+      .at(0)
       .props()
     assert.equal(href, post.url)
     assert.equal(target, "_blank")

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -7,6 +7,7 @@ import { NotFound, NotAuthorized } from "../components/ErrorPages"
 import Card from "./Card"
 import { Cell, Grid } from "./Grid"
 import { contentLoaderSpeed } from "../lib/constants"
+import { EMBEDLY_THUMB_HEIGHT } from "../lib/posts"
 
 type LoadingProps = {
   loaded: boolean,
@@ -35,22 +36,26 @@ const AnimatedEmptyPost = (i: number) => {
   return (
     <div className="post-content-loader" key={`loader-${i}`}>
       <Card className="compact-post-summary">
-        <div className="post-toprow">
-          <ContentLoader
-            speed={contentLoaderSpeed}
-            style={{ width: "100%", height: "137px" }}
-            width={1000}
-            height={137}
-            preserveAspectRatio="none"
-          >
-            <rect x="0" y="0" rx="5" ry="5" width="70%" height="20" />
-            <rect x="0" y="40" rx="5" ry="5" width="70%" height="16" />
-            <rect x="0" y="58" rx="5" ry="5" width="70%" height="16" />
-            <rect x="0" y="113" rx="5" ry="5" width="70" height="24" />
-            <rect x="75%" y="0" rx="5" ry="5" width="25%" height="103" />
-            <rect x="89%" y="113" rx="5" ry="5" width="11%" height="24" />
-          </ContentLoader>
-        </div>
+        <ContentLoader
+          speed={contentLoaderSpeed}
+          style={{ width: "100%", height: "137px" }}
+          width={1000}
+          height={137}
+          preserveAspectRatio="none"
+        >
+          <rect x="0" y="0" rx="5" ry="5" width="60%" height="20" />
+          <rect x="0" y="40" rx="5" ry="5" width="60%" height="16" />
+          <rect x="0" y="58" rx="5" ry="5" width="60%" height="16" />
+          <rect x="0" y="113" rx="5" ry="5" width="170" height="24" />
+          <rect
+            x="66%"
+            y="0"
+            rx="5"
+            ry="5"
+            width="34%"
+            height={EMBEDLY_THUMB_HEIGHT}
+          />
+        </ContentLoader>
       </Card>
     </div>
   )

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -16,6 +16,8 @@ import type {
 } from "../flow/discussionTypes"
 
 export const POST_PREVIEW_LINES = 2
+export const EMBEDLY_THUMB_HEIGHT = 123
+export const EMBEDLY_THUMB_WIDTH = 240
 
 export const newPostForm = (): PostForm => ({
   postType:         null,

--- a/static/scss/post-list.scss
+++ b/static/scss/post-list.scss
@@ -18,49 +18,6 @@
   }
 }
 
-.post-toprow {
-  height: auto;
-  margin-bottom: 10px;
-  word-break: break-word;
-
-  .column1 {
-    word-break: break-word;
-  }
-
-  .column2 {
-    position: relative;
-    overflow: hidden;
-    min-width: 24px;
-    width: 24px;
-    margin-left: 5px;
-    display: flex;
-    justify-content: flex-end;
-    height: 103px;
-
-    .top-right {
-      position: absolute;
-      top: 0px;
-      right: 0px;
-
-      img {
-        width: 201px;
-        height: 103px;
-      }
-    }
-  }
-
-  .link-thumbnail {
-    min-width: 25%;
-    width: 25%;
-    overflow: hidden;
-    border-radius: 5px;
-
-    img {
-      border-radius: 5px;
-    }
-  }
-}
-
 .overlay-icon {
   color: $navy;
   background-color: $pale-grey;

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -53,26 +53,6 @@
   font-size: $submission-font-size;
 }
 
-.comments-and-menu,
-.post-actions {
-  // to make the user-menu live in it correctly
-  position: relative;
-  display: flex;
-  align-items: center;
-
-  > * {
-    color: $font-grey-light;
-  }
-
-  i {
-    cursor: pointer;
-  }
-
-  .dropdown-menu {
-    top: 22px;
-  }
-}
-
 .authored-by {
   display: flex;
   flex-direction: column;
@@ -94,10 +74,81 @@
   }
 }
 
+.post-content-loader .compact-post-summary .card-contents {
+  // Prevent flexbox styling for post loading animation
+  display: block;
+}
+
 .compact-post-summary {
   $child-vert-spacing: 10px;
 
   font-size: $modest-font-size;
+
+  .card-contents {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: auto;
+    word-break: break-word;
+
+    .column1 {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      word-break: break-word;
+    }
+
+    .column2 {
+      position: relative;
+      overflow: hidden;
+      min-width: 24px;
+      width: 24px;
+      margin-left: 10px;
+      display: flex;
+      justify-content: flex-end;
+
+      &.link-thumbnail {
+        min-width: 34%;
+        width: 34%;
+        overflow: hidden;
+        border-radius: 5px;
+        height: 103px;
+
+        &.external-link {
+          height: 123px;
+        }
+
+        img {
+          border-radius: 5px;
+        }
+      }
+
+      .top-right {
+        position: absolute;
+        top: 0px;
+        right: 0px;
+
+        img {
+          width: 201px;
+          height: 103px;
+        }
+      }
+    }
+  }
+
+  .row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .title-row {
+    margin: 0 0 $child-vert-spacing;
+
+    i {
+      color: $font-grey-light;
+    }
+  }
 
   .preview {
     color: $font-grey-mid;
@@ -105,15 +156,6 @@
 
   .author-row {
     margin-top: $child-vert-spacing;
-  }
-
-  .upvote-report-count {
-    display: flex;
-    align-items: center;
-
-    .report-count {
-      margin-left: 10px;
-    }
   }
 
   span.post-title {
@@ -135,21 +177,36 @@
     }
   }
 
-  .title-row {
-    margin: 0 0 $child-vert-spacing;
-
-    i {
-      color: $font-grey-light;
+  @include breakpoint(phone) {
+    .report-count {
+      padding-left: 8px;
+      padding-right: 8px;
     }
   }
 
-  .row {
+  .preview-footer {
+    position: relative;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: flex-start;
+    align-items: center;
+    flex-wrap: wrap;
 
-    .upvotes {
-      margin-top: 5px;
+    > * {
+      margin: $child-vert-spacing 7px 0 0;
+    }
+
+    i {
+      cursor: pointer;
+    }
+
+    .dropdown-menu {
+      top: 22px;
+      right: inherit;
+      // HACK: This puts the menu dropdown underneath the three-dot menu icon.
+      // Fix this when we establish a way to position dropdown menus and other
+      // click-to-reveal elements near the element that was clicked to reveal them.
+      left: 50px;
     }
   }
 }
@@ -374,10 +431,6 @@
     margin: 0 6px;
     line-height: 18.7px;
   }
-}
-
-.comment-link {
-  margin-right: 5px;
 }
 
 .upvote-button,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review 
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1733 

#### What's this PR do?
Updates post summary card styling (see issue for details)

#### How should this be manually tested?
- Load a post listing page (channel page, front page, profile post feed)
- Check that the buttons and report count appear on the left side with no styling weirdness
- Check that the card looks good at various screen widths

#### Any background context you want to provide?
Uploaded cover images for articles have hardcoded dimensions of 201px x 103 px, so they cannot expand vertically to fill the space. We decided to increase the size of link thumbnails from embedly in such a way that they appear larger with the same aspect ratio (and thus occupy more vertical space) and just increase the displayed width of user thumbnails. For that reason, the two different types of thumbnails will have different heights, but should have the same width

#### Screenshots (if appropriate)
<img width="652" alt="ss 2019-01-17 at 15 08 48" src="https://user-images.githubusercontent.com/14932219/51345792-dd685000-1a69-11e9-885c-912f61f98d10.png">
<img width="556" alt="ss 2019-01-17 at 13 44 48" src="https://user-images.githubusercontent.com/14932219/51345636-8498b780-1a69-11e9-91e1-4a051447ba1c.png">
<img width="252" alt="ss 2019-01-17 at 14 37 53" src="https://user-images.githubusercontent.com/14932219/51345579-659a2580-1a69-11e9-86d8-00877aa73ba9.png">

