### PR TITLE
fix issue with post dialog staying open

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -385,6 +385,7 @@ class PostPage extends React.Component<PostPageProps> {
 
     const reportForm = getReportForm(forms)
     const showPermalinkUI = R.not(R.isNil(commentID))
+    const hidePostDialog = this.hidePostDialog(DELETE_POST_DIALOG)
 
     return (
       <div>
@@ -410,8 +411,11 @@ class PostPage extends React.Component<PostPageProps> {
         </Dialog>
         <Dialog
           open={postDeleteDialogVisible}
-          hideDialog={this.hidePostDialog(DELETE_POST_DIALOG)}
-          onAccept={() => this.deletePost(post)}
+          hideDialog={hidePostDialog}
+          onAccept={() => {
+            this.deletePost(post)
+            hidePostDialog()
+          }}
           title="Delete Post"
           submitText="Yes, Delete"
         >

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -349,7 +349,8 @@ describe("PostPage", function() {
         actions.channels.get.requestType,
         actions.channels.get.successType,
         actions.postsForChannel.get.requestType,
-        SET_SNACKBAR_MESSAGE
+        SET_SNACKBAR_MESSAGE,
+        HIDE_DIALOG
       ],
       () => {
         wrapper


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #1686

#### What's this PR do?

This fixes an issue where we were not closing the post delete dialog on the post page when we should have been.

#### How should this be manually tested?

confirm you can reproduce the problem described on the linked issue on master, then confirm that this branch fixes it.