### PR TITLE
Added button to follow/unfollow channel

### DIFF
--- a/channels/serializers/channels.py
+++ b/channels/serializers/channels.py
@@ -31,6 +31,7 @@ class ChannelSerializer(serializers.Serializer):
     allowed_post_types = WriteableSerializerMethodField()
     user_is_contributor = serializers.SerializerMethodField()
     user_is_moderator = serializers.SerializerMethodField()
+    user_is_subscriber = serializers.SerializerMethodField()
     widget_list_id = serializers.IntegerField(
         required=False, allow_null=True, read_only=True
     )
@@ -54,6 +55,13 @@ class ChannelSerializer(serializers.Serializer):
         For some reason reddit returns None instead of False so an explicit conversion is done here.
         """
         return bool(channel.user_is_moderator)
+
+    def get_user_is_subscriber(self, channel):
+        """
+        Get user_is_subscriber from reddit object.
+        For some reason reddit returns None instead of False so an explicit conversion is done here.
+        """
+        return bool(channel.user_is_subscriber)
 
     def get_avatar(self, channel):
         """Get the avatar image URL"""

--- a/channels/serializers/channels_test.py
+++ b/channels/serializers/channels_test.py
@@ -59,6 +59,7 @@ def test_serialize_channel(
         "public_description": "public_description",
         "user_is_moderator": True,
         "user_is_contributor": True,
+        "user_is_subscriber": True,
         "membership_is_managed": membership_is_managed,
         "avatar": channel.avatar.url if has_avatar else None,
         "avatar_small": channel.avatar_small.url if has_avatar else None,

--- a/channels/views/channels_test.py
+++ b/channels/views/channels_test.py
@@ -204,6 +204,7 @@ def test_get_channel_anonymous(client, public_channel, settings, allow_anonymous
         assert resp.json() == {
             **default_channel_response_data(public_channel),
             "user_is_contributor": False,
+            "user_is_subscriber": False,
         }
     else:
         assert resp.status_code in (

--- a/channels/views/test_utils.py
+++ b/channels/views/test_utils.py
@@ -19,6 +19,7 @@ def default_channel_response_data(channel):
         "public_description": channel.public_description,
         "channel_type": channel.channel_type,
         "user_is_contributor": True,
+        "user_is_subscriber": True,
         "user_is_moderator": False,
         "link_type": channel.link_type,
         "membership_is_managed": False,

--- a/static/js/components/Arrow.js
+++ b/static/js/components/Arrow.js
@@ -1,0 +1,9 @@
+import React from "react"
+
+export const DropDownArrow = () => (
+  <i className="material-icons arrow_drop_down">arrow_drop_down</i>
+)
+
+export const DropUpArrow = () => (
+  <i className="material-icons arrow_drop_up">arrow_drop_up</i>
+)

--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -9,6 +9,7 @@ import ChannelAvatar, {
   CHANNEL_AVATAR_MEDIUM
 } from "../containers/ChannelAvatar"
 import ChannelSettingsLink from "../containers/ChannelSettingsLink"
+import ChannelFollowControls from "../containers/ChannelFollowControls"
 
 import { channelURL } from "../lib/url"
 
@@ -44,7 +45,8 @@ export default class ChannelHeader extends React.Component<Props> {
                 ) : null}
               </div>
             </div>
-            <div className="right">
+            <div className="right channel-controls">
+              <ChannelFollowControls channel={channel} />
               {isModerator ? (
                 <ChannelSettingsLink channel={channel} history={history} />
               ) : null}

--- a/static/js/components/ChannelHeader_test.js
+++ b/static/js/components/ChannelHeader_test.js
@@ -38,6 +38,12 @@ describe("ChannelHeader", () => {
     assert.equal(linkProps.to, channelURL(channel.name))
     assert.equal(linkProps.children, channel.title)
   })
+  it("renders options for a user to follow/unfollow the channel", () => {
+    const wrapper = render()
+    const followControls = wrapper.find("Connect(ChannelFollowControls)")
+    assert.isTrue(followControls.exists())
+    assert.deepEqual(followControls.prop("channel"), channel)
+  })
   ;[true, false].forEach(hasNavbar => {
     it(`${shouldIf(hasNavbar)} navbar items`, () => {
       const navbarItems = "navbarItems"

--- a/static/js/components/Picker.js
+++ b/static/js/components/Picker.js
@@ -3,7 +3,7 @@ import React from "react"
 import R from "ramda"
 import { Menu, MenuItem, MenuAnchor } from "rmwc/Menu"
 
-import { DropDownArrow, DropUpArrow } from "./UserMenu"
+import { DropDownArrow, DropUpArrow } from "./Arrow"
 
 import {
   VALID_POST_SORT_LABELS,

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 
 import DropdownMenu from "./DropdownMenu"
 import ProfileImage, { PROFILE_IMAGE_SMALL } from "../containers/ProfileImage"
+import { DropUpArrow, DropDownArrow } from "./Arrow"
 
 import { isProfileComplete } from "../lib/util"
 import { profileURL, SETTINGS_URL, LOGIN_URL, REGISTER_URL } from "../lib/url"
@@ -21,14 +22,6 @@ type DropdownMenuProps = {
   closeMenu: Function,
   className?: string
 }
-
-export const DropDownArrow = () => (
-  <i className="material-icons arrow_drop_down">arrow_drop_down</i>
-)
-
-export const DropUpArrow = () => (
-  <i className="material-icons arrow_drop_up">arrow_drop_up</i>
-)
 
 export const LoggedInMenu = (props: DropdownMenuProps) => (
   <DropdownMenu {...props}>

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -6,12 +6,8 @@ import sinon from "sinon"
 import { shallow } from "enzyme"
 import { Link } from "react-router-dom"
 
-import UserMenu, {
-  DropDownArrow,
-  DropUpArrow,
-  LoggedInMenu,
-  LoggedOutMenu
-} from "./UserMenu"
+import UserMenu, { LoggedInMenu, LoggedOutMenu } from "./UserMenu"
+import { DropDownArrow, DropUpArrow } from "./Arrow"
 
 import { profileURL, SETTINGS_URL, LOGIN_URL, REGISTER_URL } from "../lib/url"
 import * as utilFuncs from "../lib/util"

--- a/static/js/containers/ChannelFollowControls.js
+++ b/static/js/containers/ChannelFollowControls.js
@@ -1,0 +1,137 @@
+/* global SETTINGS: false */
+// @flow
+import React from "react"
+import R from "ramda"
+import { connect } from "react-redux"
+
+import DropdownMenu from "../components/DropdownMenu"
+import { DropUpArrow, DropDownArrow } from "../components/Arrow"
+
+import { actions } from "../actions"
+import { hideDropdown, showDropdown } from "../actions/ui"
+import { leaveChannel } from "../util/api_actions"
+import { getOwnProfile } from "../lib/redux_selectors"
+import { CHANNEL_TYPE_PUBLIC } from "../lib/channels"
+
+import type { Dispatch } from "redux"
+import type { Channel } from "../flow/discussionTypes"
+
+export const CHANNEL_FOLLOW_DROPDOWN = "CHANNEL_FOLLOW_DROPDOWN"
+
+type Props = {
+  channel: Channel,
+  username: string,
+  isDropdownOpen: boolean,
+  showDropdown: () => void,
+  hideDropdown: () => void,
+  followChannel: (username: string) => void,
+  unfollowChannel: (username: string) => void,
+  leaveChannel: (username: string) => void,
+  loadChannel: () => void,
+  loadChannels: () => void
+}
+
+export class ChannelFollowControls extends React.Component<Props> {
+  handleFollowClick = async () => {
+    const { followChannel, loadChannel, loadChannels, username } = this.props
+
+    await followChannel(username)
+    await loadChannel()
+    await loadChannels()
+  }
+
+  handleUnfollowClick = async () => {
+    const { unfollowChannel, loadChannel, loadChannels, username } = this.props
+
+    await unfollowChannel(username)
+    await loadChannel()
+    await loadChannels()
+  }
+
+  handleLeaveChannelClick = async () => {
+    const { leaveChannel, loadChannel, loadChannels, username } = this.props
+
+    await leaveChannel(username)
+    await loadChannel()
+    await loadChannels()
+  }
+
+  render() {
+    const {
+      channel,
+      showDropdown,
+      hideDropdown,
+      isDropdownOpen,
+      username
+    } = this.props
+
+    // Follow/unfollow controls should not be shown if the user is anonymous or if the channel
+    // has membership managed externally.
+    if (R.isEmpty(username) || channel.membership_is_managed) {
+      return null
+    }
+
+    return channel.user_is_subscriber ? (
+      <React.Fragment>
+        <a className="follow-button dropdown-button" onClick={showDropdown}>
+          <span>Following</span>
+          {isDropdownOpen ? <DropUpArrow /> : <DropDownArrow />}
+        </a>
+        {isDropdownOpen ? (
+          <DropdownMenu
+            closeMenu={hideDropdown}
+            className="channel-follow-dropdown"
+          >
+            <li>
+              <a onClick={this.handleUnfollowClick}>Unfollow channel</a>
+            </li>
+            {channel.channel_type !== CHANNEL_TYPE_PUBLIC &&
+            channel.user_is_contributor &&
+            channel.user_is_moderator ? (
+                <li>
+                  <a onClick={this.handleLeaveChannelClick}>Leave channel</a>
+                </li>
+              ) : null}
+          </DropdownMenu>
+        ) : null}
+      </React.Fragment>
+    ) : (
+      <button className="follow-button" onClick={this.handleFollowClick}>
+        Follow
+      </button>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  const {
+    ui: { dropdownMenus }
+  } = state
+
+  const profile = getOwnProfile(state)
+  const isDropdownOpen = dropdownMenus.has(CHANNEL_FOLLOW_DROPDOWN)
+  return {
+    isDropdownOpen,
+    username: profile ? profile.username : ""
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<any>, { channel }: Props) => ({
+  showDropdown:  () => dispatch(showDropdown(CHANNEL_FOLLOW_DROPDOWN)),
+  hideDropdown:  () => dispatch(hideDropdown(CHANNEL_FOLLOW_DROPDOWN)),
+  followChannel: (username: string) =>
+    dispatch(actions.channelSubscribers.post(channel.name, username)),
+  unfollowChannel: (username: string) =>
+    dispatch(actions.channelSubscribers.delete(channel.name, username)),
+  leaveChannel: (username: string) =>
+    leaveChannel(dispatch, channel.name, username),
+  loadChannel:  () => dispatch(actions.channels.get(channel.name)),
+  loadChannels: () => dispatch(actions.subscribedChannels.get())
+})
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
+)(ChannelFollowControls)

--- a/static/js/containers/ChannelFollowControls_test.js
+++ b/static/js/containers/ChannelFollowControls_test.js
@@ -1,0 +1,193 @@
+/* global SETTINGS */
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { actions } from "../actions"
+import { SHOW_DROPDOWN, HIDE_DROPDOWN } from "../actions/ui"
+import { makeChannel } from "../factories/channels"
+import { makeProfile } from "../factories/profiles"
+import * as apiActions from "../util/api_actions"
+import * as reduxSelectors from "../lib/redux_selectors"
+import ChannelFollowControls, {
+  CHANNEL_FOLLOW_DROPDOWN,
+  ChannelFollowControls as InnerChannelFollowControls
+} from "./ChannelFollowControls"
+import { CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC } from "../lib/channels"
+import { shouldIf } from "../lib/test_utils"
+
+describe("ChannelFollowControls", () => {
+  let helper, render, channel, profile, dropdownMenus, getOwnProfileStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    dropdownMenus = new Set()
+    channel = {
+      ...makeChannel(),
+      membership_is_managed: false,
+      channel_type:          CHANNEL_TYPE_PRIVATE,
+      user_is_contributor:   true
+    }
+    profile = makeProfile()
+
+    getOwnProfileStub = helper.sandbox
+      .stub(reduxSelectors, "getOwnProfile")
+      .returns(profile)
+    helper.getChannelStub.returns(Promise.resolve(channel))
+    helper.getChannelsStub.returns(Promise.resolve([channel]))
+    helper.addChannelSubscriberStub.returns(Promise.resolve())
+    helper.deleteChannelSubscriberStub.returns(Promise.resolve())
+    helper.deleteChannelContributorStub.returns(Promise.resolve())
+
+    render = helper.configureHOCRenderer(
+      ChannelFollowControls,
+      InnerChannelFollowControls,
+      {
+        ui: {
+          dropdownMenus
+        }
+      },
+      {
+        channel
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("shows nothing if the user is logged out", async () => {
+    getOwnProfileStub.returns(null)
+    const { inner } = await render()
+    assert.isNull(inner.html())
+  })
+
+  it("shows nothing if the channel has managed membership", async () => {
+    const props = { channel: { ...channel, membership_is_managed: true } }
+    const { inner } = await render({}, props)
+    assert.isNull(inner.html())
+  })
+
+  it("shows a 'follow' button when the user is not subscribed", async () => {
+    const props = { channel: { ...channel, user_is_subscriber: false } }
+    const { inner, store } = await render({}, props)
+    const button = inner.find("button")
+    assert.equal(button.text(), "Follow")
+    await button.prop("onClick")()
+    assert.equal(
+      store.getActions()[0].type,
+      actions.channelSubscribers.post.requestType
+    )
+    sinon.assert.calledWithExactly(
+      helper.addChannelSubscriberStub,
+      props.channel.name,
+      profile.username
+    )
+    sinon.assert.calledOnce(helper.getChannelsStub)
+  })
+
+  describe("when subscribed", () => {
+    let props = {}
+
+    beforeEach(() => {
+      props = {
+        channel: {
+          ...channel,
+          user_is_subscriber: true
+        }
+      }
+    })
+
+    it("shows a 'following' button that reveals a menu", async () => {
+      const { inner, store } = await render({}, props)
+      const button = inner.find("a.dropdown-button")
+      assert.include(button.text(), "Following")
+      button.prop("onClick")()
+      assert.equal(store.getActions()[0].type, SHOW_DROPDOWN)
+    })
+    ;[true, false].forEach(isOpen => {
+      it(`${shouldIf(
+        isOpen
+      )} include a visible dropdown menu when indicated by state`, async () => {
+        if (isOpen) {
+          dropdownMenus.add(CHANNEL_FOLLOW_DROPDOWN)
+        }
+        const { inner, store } = await render({}, props)
+        const menu = inner.find(".channel-follow-dropdown")
+        assert.equal(menu.exists(), isOpen)
+        if (isOpen) {
+          menu.prop("closeMenu")()
+          assert.equal(store.getActions()[0].type, HIDE_DROPDOWN)
+        }
+      })
+    })
+
+    describe("has a dropdown menu", () => {
+      const menuItemsSelector = ".channel-follow-dropdown li a",
+        unfollowText = "Unfollow channel",
+        leaveText = "Leave channel"
+      let leaveChannelstub
+
+      beforeEach(async () => {
+        leaveChannelstub = helper.sandbox.stub(apiActions, "leaveChannel")
+        dropdownMenus.add(CHANNEL_FOLLOW_DROPDOWN)
+      })
+
+      it("with the correct options", async () => {
+        props.channel.user_is_moderator = true
+        const { inner } = await render({}, props)
+        const menuItems = inner.find(menuItemsSelector)
+        assert.equal(menuItems.at(0).text(), unfollowText)
+        assert.equal(menuItems.at(1).text(), leaveText)
+      })
+
+      it("with an 'unfollow' button that removes the user's subscription", async () => {
+        const { inner, store } = await render({}, props)
+        const menuItems = inner.find(menuItemsSelector)
+        await menuItems.at(0).prop("onClick")()
+        const actionsObserved = store.getActions()
+        assert.equal(
+          actionsObserved[0].type,
+          actions.channelSubscribers.delete.requestType
+        )
+        sinon.assert.calledWithExactly(
+          helper.deleteChannelSubscriberStub,
+          props.channel.name,
+          profile.username
+        )
+        sinon.assert.calledOnce(helper.getChannelsStub)
+      })
+
+      it("with a 'leave' button that removes the user from the channel", async () => {
+        props.channel.user_is_moderator = true
+        const { inner } = await render({}, props)
+        const menuItems = inner.find(menuItemsSelector)
+        await menuItems.at(1).prop("onClick")()
+        sinon.assert.calledOnce(leaveChannelstub)
+        const args = leaveChannelstub.firstCall.args
+        assert.equal(args[1], props.channel.name)
+        assert.equal(args[2], profile.username)
+        sinon.assert.calledOnce(helper.getChannelsStub)
+      })
+
+      it("without a 'leave' button if the channel is public", async () => {
+        props.channel.channel_type = CHANNEL_TYPE_PUBLIC
+        const { inner } = await render({}, props)
+        const menuItems = inner.find(menuItemsSelector)
+        assert.equal(menuItems.at(0).text(), unfollowText)
+        assert.lengthOf(menuItems, 1)
+      })
+
+      it("without a 'leave' button if the user isn't a contributor and moderator", async () => {
+        props.channel.user_is_contributor = false
+        props.channel.user_is_moderator = false
+        const { inner } = await render({}, props)
+        const menuItems = inner.find(menuItemsSelector)
+        assert.equal(menuItems.at(0).text(), unfollowText)
+        assert.lengthOf(menuItems, 1)
+      })
+    })
+  })
+})

--- a/static/js/containers/ChannelSettingsLink.js
+++ b/static/js/containers/ChannelSettingsLink.js
@@ -41,7 +41,7 @@ export class ChannelSettingsLink extends React.Component<Props> {
     }
   }
 
-  renderContent = () => {
+  render = () => {
     const { channel, isOpen, hideDropdown } = this.props
 
     if (!SETTINGS.allow_widgets_ui) {
@@ -74,10 +74,6 @@ export class ChannelSettingsLink extends React.Component<Props> {
         ) : null}
       </React.Fragment>
     )
-  }
-
-  render() {
-    return <div className="settings-menu">{this.renderContent()}</div>
   }
 }
 

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -32,6 +32,7 @@ export const makeChannel = (privateChannel: boolean = false): Channel => {
     public_description:    casual.description,
     num_users:             casual.integer(0, 500),
     user_is_contributor:   casual.coin_flip,
+    user_is_subscriber:    casual.coin_flip,
     user_is_moderator:     casual.coin_flip,
     membership_is_managed: casual.coin_flip,
     allow_widgets_ui:      casual.coin_flip,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -22,6 +22,7 @@ export type Channel = {
   num_users:             number,
   user_is_contributor:   boolean,
   user_is_moderator:     boolean,
+  user_is_subscriber:    boolean,
   membership_is_managed: boolean,
   ga_tracking_id:        ?string,
   avatar:                string|null,

--- a/static/js/util/api_actions.js
+++ b/static/js/util/api_actions.js
@@ -72,3 +72,12 @@ export const toggleFollowComment = R.curry(
     return dispatch(setSnackbarMessage({ message }))
   }
 )
+
+export const leaveChannel = async (
+  dispatch: Dispatch<*>,
+  channelName: string,
+  username: string
+) => {
+  await dispatch(actions.channelSubscribers.delete(channelName, username))
+  await dispatch(actions.channelContributors.delete(channelName, username))
+}

--- a/static/js/util/api_actions_test.js
+++ b/static/js/util/api_actions_test.js
@@ -1,5 +1,6 @@
 import R from "ramda"
 import { assert } from "chai"
+import sinon from "sinon"
 
 import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
@@ -11,7 +12,8 @@ import {
   approveComment,
   removeComment,
   toggleFollowComment,
-  toggleFollowPost
+  toggleFollowPost,
+  leaveChannel
 } from "../util/api_actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
@@ -223,6 +225,40 @@ describe("api_actions util", () => {
         helper.updateCommentStub.calledWith(comment.id, { removed: true })
       )
       assert.equal(resultComment.removed, true)
+    })
+  })
+
+  describe("leaveChannel", () => {
+    const channelName = "some_channel_name",
+      username = "someuser"
+
+    beforeEach(() => {
+      helper.deleteChannelSubscriberStub.returns(Promise.resolve())
+      helper.deleteChannelContributorStub.returns(Promise.resolve())
+    })
+
+    it("should make requests to remove the user as a subscriber and contributor", async () => {
+      await helper.listenForActions(
+        [
+          actions.channelSubscribers.delete.requestType,
+          actions.channelSubscribers.delete.successType,
+          actions.channelContributors.delete.requestType,
+          actions.channelContributors.delete.successType
+        ],
+        async () => {
+          await leaveChannel(helper.store.dispatch, channelName, username)
+        }
+      )
+      sinon.assert.calledWithExactly(
+        helper.deleteChannelSubscriberStub,
+        channelName,
+        username
+      )
+      sinon.assert.calledWithExactly(
+        helper.deleteChannelContributorStub,
+        channelName,
+        username
+      )
     })
   })
 })

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -44,6 +44,7 @@ $channel-banner-height: 200px;
 $submission-font-size: 16px;
 $tooltip-font-size: 14px;
 $modest-font-size: 14px;
+$button-vert-padding: 9px;
 
 // Spacing values for items that appear on the left side of the drawer and toolbar
 $icon-padding-left: 19px;

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -1,7 +1,8 @@
 button,
 input[type="submit"],
 .mdc-button,
-a.link-button {
+a.link-button,
+.dropdown-button {
   background-color: $rouge;
   color: white;
   margin: 0 10px 5px 0;

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -86,9 +86,14 @@
   align-items: center;
   justify-content: space-between;
 
-  .left {
+  .left,
+  .right {
     display: flex;
     align-items: center;
+  }
+
+  .left {
+    padding-right: 5px;
   }
 
   .avatar-image,
@@ -120,15 +125,77 @@
     color: white;
   }
 
-  .settings-menu {
+  .channel-controls {
     position: relative;
+    flex-grow: 0.5;
+    justify-content: flex-end;
+    min-height: 38px;
+
+    a {
+      cursor: pointer;
+    }
+
+    button {
+      font-family: inherit;
+    }
+
+    .follow-button,
+    .edit-button {
+      margin-right: 0;
+      margin-left: 10px;
+    }
+
+    .follow-button {
+      flex-grow: 1;
+      padding: $button-vert-padding 0;
+      min-width: 110px;
+      max-width: 145px;
+      text-align: center;
+    }
+
+    .dropdown-button {
+      position: relative;
+
+      span {
+        display: inline-block;
+        padding-right: 10px;
+      }
+
+      i.material-icons {
+        position: absolute;
+        right: 5px;
+        top: 50%;
+        margin-top: -12px;
+      }
+    }
+
+    .edit-button {
+      z-index: 20;
+    }
+
+    .dropdown-menu {
+      &.settings-menu-dropdown {
+        right: 0;
+        top: 30px;
+      }
+
+      &.channel-follow-dropdown {
+        right: 34px;
+        top: 39px;
+
+        // HACK: If there is no channel settings icon, this should be the last child, so
+        // the menu should float all the way right. We need to get menus showing up relative
+        // to the clicked item.
+        &:last-child {
+          right: 0;
+        }
+      }
+    }
+  }
+
+  .settings-menu {
     cursor: pointer;
     z-index: 20;
-
-    .settings-menu-dropdown {
-      top: 31px;
-      right: 0;
-    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1663

#### What's this PR do?
Adds button to follow channel and controls to unfollow or leave channel to the channel header

#### How should this be manually tested?
Try the follow button and both "following" menu options, and test the UI at different screen widths

#### Any background context you want to provide?
The [design](https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5bd9df8815d2791b648ee414) shows a "Following" button that looks like it has white text with a transparent background, but I was concerned that depending on the channel header image it wouldn't be visible. I kept the same styling as the "Follow" button [here](https://app.zeplin.io/project/5b181d3bf71408ae4d406b94/screen/5ba4e7e0a4dc98a7608ee6b5)

#### Screenshots (if appropriate)
<img width="378" alt="ss 2019-01-22 at 14 30 23" src="https://user-images.githubusercontent.com/14932219/51571521-59023c80-1e70-11e9-81d1-436af2a0130e.png">
<img width="375" alt="ss 2019-01-22 at 14 30 15" src="https://user-images.githubusercontent.com/14932219/51571522-59023c80-1e70-11e9-8670-831ffc36f4bd.png">
<img width="382" alt="ss 2019-01-22 at 14 30 08" src="https://user-images.githubusercontent.com/14932219/51571523-59023c80-1e70-11e9-8d07-3be0354a5702.png">
<img width="910" alt="ss 2019-01-22 at 14 29 53" src="https://user-images.githubusercontent.com/14932219/51571524-59023c80-1e70-11e9-9ebc-a7f7093d13ff.png">
<img width="920" alt="ss 2019-01-22 at 14 29 42" src="https://user-images.githubusercontent.com/14932219/51571525-59023c80-1e70-11e9-91d3-9709c336a663.png">
<img width="918" alt="ss 2019-01-22 at 14 29 34" src="https://user-images.githubusercontent.com/14932219/51571526-59023c80-1e70-11e9-9a06-3745c62c8db8.png">

