### PR TITLE
add embedly support to the Article editor

### DIFF
--- a/static/js/components/ArticleEditor_test.js
+++ b/static/js/components/ArticleEditor_test.js
@@ -10,14 +10,16 @@ import ArticleEditor from "./ArticleEditor"
 
 import { wait } from "../lib/util"
 import { getCKEditorJWT } from "../lib/api/ckeditor"
+import * as embedUtil from "../lib/embed"
 
 describe("ArticleEditor", () => {
-  let sandbox, fetchStub
+  let sandbox, fetchStub, embedlyPlatformStub
 
   beforeEach(() => {
     SETTINGS.ckeditor_upload_url = "/upload/token"
     sandbox = sinon.createSandbox()
     fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+    embedlyPlatformStub = sandbox.stub(embedUtil, "loadEmbedlyPlatform")
   })
 
   afterEach(() => {
@@ -33,6 +35,11 @@ describe("ArticleEditor", () => {
       uploadUrl: SETTINGS.ckeditor_upload_url,
       tokenUrl:  getCKEditorJWT
     })
+  })
+
+  it("should load the embedly platform", () => {
+    mount(<ArticleEditor initialData={[]} />)
+    sinon.assert.called(embedlyPlatformStub)
   })
 
   it("should set the readOnly property, if passed", async () => {

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -35,3 +35,25 @@ export const hasIframe = R.memoizeWith(R.identity, (html: string) => {
   div.innerHTML = html
   return !!div.querySelector("iframe")
 })
+
+export const loadEmbedlyPlatform = () => {
+  const id = "embedly-platform"
+
+  if (!document.getElementById(id)) {
+    window.embedly =
+      window.embedly ||
+      function() {
+        (window.embedly.q = window.embedly.q || []).push(arguments)
+      }
+    const el = document.createElement("script")
+    el.id = id
+    // $FlowFixMe
+    el.async = 1
+    el.src = `${
+      "https:" === document.location.protocol ? "https" : "http"
+    }://cdn.embedly.com/widgets/platform.js`
+    const script = document.getElementsByTagName("script")[0]
+    // $FlowFixMe
+    script.parentNode.insertBefore(el, script)
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] Mobile width screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1457

#### What's this PR do?

This adds support for using embedly to display media embeds instead of CKEditor's built-in support (which supports only a very limited number of sites, like youtube and so on).

Basically now any site that is supported by embedly should work just fine. You can either add media embeds to the editor by using the button in the paragraph menu, or you can just paste in a link.

#### How should this be manually tested?

Make sure that if you are making an article you can add media to it. it should show up as an embedly card.

Make sure everything works equally well on the create post page, the post detail page, and editing an existing post.

#### Screenshots (if appropriate)

![allowembedsfdfedit](https://user-images.githubusercontent.com/6207644/51629501-bc927580-1f15-11e9-9899-95fb15c7665e.png)
![allowembedsfdf](https://user-images.githubusercontent.com/6207644/51629502-bd2b0c00-1f15-11e9-9c51-375eb45335e7.png)
![allowembedsfdfeditmob](https://user-images.githubusercontent.com/6207644/51629549-e481d900-1f15-11e9-9356-7b095ece1616.png)
