### PR TITLE
Fix flaky test

### DIFF
--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -43,7 +43,7 @@ export const makeWidgetJson = (widgetType: string): ?Object => {
   case "RSS Feed":
     return ({
       title:   casual.title,
-      entries: R.range(1, casual.integer(1, 8)).map(() => ({
+      entries: R.range(1, casual.integer(2, 8)).map(() => ({
         title:       casual.title,
         description: casual.description,
         link:        casual.url,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
The widget factory sometimes creates a RSS feed widget with zero entries. This changes it to have at least one entry so that the tests don't fail.

#### How should this be manually tested?
N/A
