### PR TITLE
Collapse and expand widgets

### DIFF
--- a/static/js/components/widgets/MarkdownWidget.js
+++ b/static/js/components/widgets/MarkdownWidget.js
@@ -2,23 +2,12 @@
 import React from "react"
 
 import { Markdown } from "../Markdown"
-import type { WidgetInstance } from "../../flow/widgetTypes"
+import type { WidgetComponentProps } from "../../flow/widgetTypes"
 
-type Props = {
-  widgetInstance: WidgetInstance
-}
-
-const MarkdownWidget = ({ widgetInstance }: Props) => {
-  const {
-    title,
+const MarkdownWidget = ({
+  widgetInstance: {
     configuration: { source }
-  } = widgetInstance
-  return (
-    <React.Fragment>
-      <span className="title">{title}</span>
-      <Markdown source={source} />
-    </React.Fragment>
-  )
-}
+  }
+}: WidgetComponentProps) => <Markdown source={source} />
 
 export default MarkdownWidget

--- a/static/js/components/widgets/MarkdownWidget_test.js
+++ b/static/js/components/widgets/MarkdownWidget_test.js
@@ -18,7 +18,6 @@ describe("MarkdownWidget", () => {
 
   it("should display the title and markdown", () => {
     const wrapper = renderWidget()
-    assert.equal(wrapper.find(".title").text(), instance.title)
     assert.ok(wrapper.find("Markdown").exists())
     assert.equal(
       wrapper.find("Markdown").prop("source"),

--- a/static/js/components/widgets/RssWidget.js
+++ b/static/js/components/widgets/RssWidget.js
@@ -7,34 +7,25 @@ import { AllHtmlEntities } from "html-entities"
 
 const entities = new AllHtmlEntities()
 
-import type { WidgetInstance } from "../../flow/widgetTypes"
+import type { WidgetComponentProps } from "../../flow/widgetTypes"
 
-type Props = {
-  widgetInstance: WidgetInstance
-}
-
-const RssWidget = ({ widgetInstance: { json, title } }: Props) => {
+const RssWidget = ({ widgetInstance: { json } }: WidgetComponentProps) => {
   const entries = (json && json.entries) || []
 
-  return (
-    <React.Fragment>
-      <span className="title">{title}</span>
-      {entries.map(entry => (
-        <div key={entry.link} className="entry">
-          <div className="entry-title">
-            <a href={entry.link} target="_blank" rel="noopener noreferrer">
-              {entry.title}
-            </a>
-          </div>
-          <Dotdotdot clamp={3} className="description">
-            {entities.decode(striptags(entry.description))}
-          </Dotdotdot>
-          <span className="time">
-            {entry.timestamp ? moment(entry.timestamp).fromNow() : null}
-          </span>
-        </div>
-      ))}
-    </React.Fragment>
-  )
+  return entries.map(entry => (
+    <div key={entry.link} className="entry">
+      <div className="entry-title">
+        <a href={entry.link} target="_blank" rel="noopener noreferrer">
+          {entry.title}
+        </a>
+      </div>
+      <Dotdotdot clamp={3} className="description">
+        {entities.decode(striptags(entry.description))}
+      </Dotdotdot>
+      <span className="time">
+        {entry.timestamp ? moment(entry.timestamp).fromNow() : null}
+      </span>
+    </div>
+  ))
 }
 export default RssWidget

--- a/static/js/components/widgets/RssWidget_test.js
+++ b/static/js/components/widgets/RssWidget_test.js
@@ -10,7 +10,6 @@ describe("RssWidget", () => {
   it("renders a RssWidget", () => {
     const widgetInstance = makeWidgetInstance("RSS Feed")
     const wrapper = shallow(<RssWidget widgetInstance={widgetInstance} />)
-    assert.equal(widgetInstance.title, wrapper.find(".title").text())
     assert.equal(
       widgetInstance.json.entries.length,
       wrapper.find(".entry").length

--- a/static/js/components/widgets/UrlWidget.js
+++ b/static/js/components/widgets/UrlWidget.js
@@ -1,21 +1,11 @@
 // @flow
 import React from "react"
 
-import type { WidgetInstance } from "../../flow/widgetTypes"
-
-type Props = {
-  widgetInstance: WidgetInstance
-}
+import type { WidgetComponentProps } from "../../flow/widgetTypes"
 
 const UrlWidget = ({
   widgetInstance: {
-    title,
     configuration: { url }
   }
-}: Props) => (
-  <React.Fragment>
-    <span className="title">{title}</span>
-    <iframe src={url} />
-  </React.Fragment>
-)
+}: WidgetComponentProps) => <iframe src={url} />
 export default UrlWidget

--- a/static/js/components/widgets/UrlWidget_test.js
+++ b/static/js/components/widgets/UrlWidget_test.js
@@ -14,6 +14,5 @@ describe("UrlWidget", () => {
       wrapper.find("iframe").prop("src"),
       widgetInstance.configuration.url
     )
-    assert.equal(wrapper.find(".title").text(), widgetInstance.title)
   })
 })

--- a/static/js/components/widgets/WidgetInstance.js
+++ b/static/js/components/widgets/WidgetInstance.js
@@ -10,10 +10,12 @@ import type { StatelessFunctionalComponent } from "react"
 import type { WidgetInstance as WidgetInstanceType } from "../../flow/widgetTypes"
 
 type Props = {
+  expanded: boolean,
   deleteInstance: (widgetInstance: WidgetInstanceType) => void,
   startEditInstance: (widgetInstance: WidgetInstanceType) => void,
   widgetInstance: WidgetInstanceType,
-  editing: boolean
+  editing: boolean,
+  setExpanded: (newValue: boolean) => void
 }
 
 const DragHandle = SortableHandle(() => (
@@ -21,11 +23,29 @@ const DragHandle = SortableHandle(() => (
 ))
 
 const SortableWidgetInstance: StatelessFunctionalComponent<Props> = SortableElement(
-  ({ widgetInstance, editing, deleteInstance, startEditInstance }: Props) => {
+  ({
+    expanded,
+    widgetInstance,
+    editing,
+    deleteInstance,
+    setExpanded,
+    startEditInstance
+  }: Props) => {
     const WidgetClass = validWidgetRenderers[widgetInstance.widget_type]
     return (
       <Card className="widget">
-        <WidgetClass widgetInstance={widgetInstance} />
+        <div className="title-row">
+          <span className="title">{widgetInstance.title}</span>
+          {editing ? (
+            <span
+              className="toggle-collapse material-icons"
+              onClick={() => setExpanded(!expanded)}
+            >
+              {expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"}
+            </span>
+          ) : null}
+        </div>
+        {expanded ? <WidgetClass widgetInstance={widgetInstance} /> : null}
         {editing ? (
           <React.Fragment>
             <hr />

--- a/static/js/components/widgets/WidgetInstance.js
+++ b/static/js/components/widgets/WidgetInstance.js
@@ -15,7 +15,7 @@ type Props = {
   startEditInstance: (widgetInstance: WidgetInstanceType) => void,
   widgetInstance: WidgetInstanceType,
   editing: boolean,
-  setExpanded: (newValue: boolean) => void
+  toggleExpanded: () => void
 }
 
 const DragHandle = SortableHandle(() => (
@@ -28,7 +28,7 @@ const SortableWidgetInstance: StatelessFunctionalComponent<Props> = SortableElem
     widgetInstance,
     editing,
     deleteInstance,
-    setExpanded,
+    toggleExpanded,
     startEditInstance
   }: Props) => {
     const WidgetClass = validWidgetRenderers[widgetInstance.widget_type]
@@ -39,7 +39,7 @@ const SortableWidgetInstance: StatelessFunctionalComponent<Props> = SortableElem
           {editing ? (
             <span
               className="toggle-collapse material-icons"
-              onClick={() => setExpanded(!expanded)}
+              onClick={toggleExpanded}
             >
               {expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"}
             </span>

--- a/static/js/components/widgets/WidgetInstance_test.js
+++ b/static/js/components/widgets/WidgetInstance_test.js
@@ -5,16 +5,24 @@ import { assert } from "chai"
 import sinon from "sinon"
 
 import WidgetInstance from "./WidgetInstance"
+
 import { makeWidgetInstance } from "../../factories/widgets"
+import { shouldIf } from "../../lib/test_utils"
+import { validWidgetRenderers } from "../../lib/widgets"
 
 describe("WidgetInstance", () => {
-  let widgetInstance, sandbox, deleteInstanceStub, startEditInstanceStub
+  let widgetInstance,
+    sandbox,
+    deleteInstanceStub,
+    startEditInstanceStub,
+    setExpandedStub
 
   beforeEach(() => {
     widgetInstance = makeWidgetInstance()
     sandbox = sinon.createSandbox()
     deleteInstanceStub = sandbox.stub()
     startEditInstanceStub = sandbox.stub()
+    setExpandedStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -29,9 +37,12 @@ describe("WidgetInstance", () => {
         index={3}
         editing={false}
         startEditInstance={startEditInstanceStub}
+        expanded={true}
+        setExpanded={setExpandedStub}
         {...props}
       />,
       {
+        // for react-sortable-hoc
         context: {
           manager: {
             add:    sandbox.stub(),
@@ -40,6 +51,10 @@ describe("WidgetInstance", () => {
         }
       }
     )
+  it("renders the widget title", () => {
+    const wrapper = render()
+    assert.equal(wrapper.find(".title").text(), widgetInstance.title)
+  })
   ;[
     ["URL", "UrlWidget"],
     ["RSS Feed", "RssWidget"],
@@ -48,11 +63,36 @@ describe("WidgetInstance", () => {
     it(`renders a widget instance for ${widgetClassName} given widget_type=${widgetType}`, () => {
       const instance = makeWidgetInstance(widgetType)
       const wrapper = render({ widgetInstance: instance })
-      assert.isTrue(wrapper.find(widgetClassName).exists())
       assert.equal(
         wrapper.find(widgetClassName).prop("widgetInstance"),
         instance
       )
+    })
+  })
+  ;[true, false].forEach(expanded => {
+    it(`${shouldIf(expanded)} render the widget instance if it is ${
+      expanded ? "" : "not "
+    }expanded`, () => {
+      const wrapper = render({ expanded })
+      const name = validWidgetRenderers[widgetInstance.widget_type].name
+      assert.equal(wrapper.find(name).exists(), expanded)
+    })
+  })
+  ;[
+    [true, true, "keyboard_arrow_up"],
+    [true, false, "keyboard_arrow_down"],
+    [false, true, null],
+    [false, false, null]
+  ].forEach(([editing, expanded, expected]) => {
+    it(`${shouldIf(!!expected)} render the proper arrow for expanded=${String(
+      expanded
+    )} and editing=${String(editing)}`, () => {
+      const wrapper = render({ expanded, editing })
+      if (expected) {
+        assert.equal(wrapper.find(".toggle-collapse").text(), expected)
+      } else {
+        assert.isFalse(wrapper.find(".toggle-collapse").exists())
+      }
     })
   })
 
@@ -72,6 +112,13 @@ describe("WidgetInstance", () => {
     it("has a drag handle", () => {
       const wrapper = render({ editing: true })
       assert.isTrue(wrapper.find(".drag-handle").exists())
+    })
+    ;[true, false].forEach(expanded => {
+      it(expanded ? "collapses" : "expands", () => {
+        const wrapper = render({ editing: true, expanded })
+        wrapper.find(".toggle-collapse").prop("onClick")()
+        sinon.assert.calledWith(setExpandedStub, !expanded)
+      })
     })
   })
 })

--- a/static/js/components/widgets/WidgetInstance_test.js
+++ b/static/js/components/widgets/WidgetInstance_test.js
@@ -15,14 +15,14 @@ describe("WidgetInstance", () => {
     sandbox,
     deleteInstanceStub,
     startEditInstanceStub,
-    setExpandedStub
+    toggleExpandedStub
 
   beforeEach(() => {
     widgetInstance = makeWidgetInstance()
     sandbox = sinon.createSandbox()
     deleteInstanceStub = sandbox.stub()
     startEditInstanceStub = sandbox.stub()
-    setExpandedStub = sandbox.stub()
+    toggleExpandedStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -38,7 +38,7 @@ describe("WidgetInstance", () => {
         editing={false}
         startEditInstance={startEditInstanceStub}
         expanded={true}
-        setExpanded={setExpandedStub}
+        toggleExpanded={toggleExpandedStub}
         {...props}
       />,
       {
@@ -117,7 +117,7 @@ describe("WidgetInstance", () => {
       it(expanded ? "collapses" : "expands", () => {
         const wrapper = render({ editing: true, expanded })
         wrapper.find(".toggle-collapse").prop("onClick")()
-        sinon.assert.calledWith(setExpandedStub, !expanded)
+        sinon.assert.calledWith(toggleExpandedStub)
       })
     })
   })

--- a/static/js/components/widgets/WidgetList.js
+++ b/static/js/components/widgets/WidgetList.js
@@ -13,19 +13,25 @@ type Props = {
   startAddInstance: () => void,
   startEditInstance: (widgetInstance: WidgetInstanceType) => void,
   clearForm: () => void,
+  expanded: { [string]: boolean },
   deleteInstance: (widgetInstance: WidgetInstanceType) => void,
   widgetInstances: Array<WidgetInstanceType>,
+  setExpanded: (widgetInstanceIds: Array<string>, expanded: boolean) => void,
   editing: boolean
 }
 
 const SortableWidgetList: StatelessFunctionalComponent<Props> = SortableContainer(
   ({
     widgetInstances,
-    editing,
+    expanded,
     deleteInstance,
+    editing,
+    setExpanded,
     startAddInstance,
     startEditInstance
   }: Props) => {
+    const widgetKeys = widgetInstances.map(getWidgetKey)
+    const anyCollapsed = widgetKeys.filter(key => !expanded[key]).length > 0
     return (
       <div className="widget-list">
         {editing ? (
@@ -33,18 +39,29 @@ const SortableWidgetList: StatelessFunctionalComponent<Props> = SortableContaine
             <span className="add-widget" onClick={() => startAddInstance()}>
               + Add widget
             </span>
+            <span
+              className="toggle-collapse-all"
+              onClick={() => setExpanded(widgetKeys, anyCollapsed)}
+            >
+              {anyCollapsed ? "Expand" : "Collapse"} all
+            </span>
           </div>
         ) : null}
-        {widgetInstances.map((widgetInstance, i) => (
-          <WidgetInstance
-            startEditInstance={startEditInstance}
-            widgetInstance={widgetInstance}
-            key={getWidgetKey(widgetInstance)}
-            index={i}
-            editing={editing}
-            deleteInstance={deleteInstance}
-          />
-        ))}
+        {widgetInstances.map((widgetInstance, i) => {
+          const key = getWidgetKey(widgetInstance)
+          return (
+            <WidgetInstance
+              startEditInstance={startEditInstance}
+              widgetInstance={widgetInstance}
+              key={key}
+              index={i}
+              editing={editing}
+              deleteInstance={deleteInstance}
+              expanded={!editing || expanded[key]}
+              setExpanded={newValue => setExpanded([key], newValue)}
+            />
+          )
+        })}
       </div>
     )
   }

--- a/static/js/components/widgets/WidgetList.js
+++ b/static/js/components/widgets/WidgetList.js
@@ -49,6 +49,7 @@ const SortableWidgetList: StatelessFunctionalComponent<Props> = SortableContaine
         ) : null}
         {widgetInstances.map((widgetInstance, i) => {
           const key = getWidgetKey(widgetInstance)
+          const instanceIsExpanded = !!expanded[key]
           return (
             <WidgetInstance
               startEditInstance={startEditInstance}
@@ -57,8 +58,8 @@ const SortableWidgetList: StatelessFunctionalComponent<Props> = SortableContaine
               index={i}
               editing={editing}
               deleteInstance={deleteInstance}
-              expanded={!editing || expanded[key]}
-              setExpanded={newValue => setExpanded([key], newValue)}
+              expanded={!editing || instanceIsExpanded}
+              toggleExpanded={() => setExpanded([key], !instanceIsExpanded)}
             />
           )
         })}

--- a/static/js/components/widgets/WidgetList_test.js
+++ b/static/js/components/widgets/WidgetList_test.js
@@ -119,12 +119,9 @@ describe("WidgetList", () => {
       wrapper
         .find(WidgetInstance)
         .at(i)
-        .prop("setExpanded")("abc")
-      sinon.assert.calledWith(
-        setExpandedStub,
-        [getWidgetKey(widgetInstance)],
-        "abc"
-      )
+        .prop("toggleExpanded")()
+      const key = getWidgetKey(widgetInstance)
+      sinon.assert.calledWith(setExpandedStub, [key], !expanded[key])
     })
   })
   ;[true, false].forEach(editing => {

--- a/static/js/components/widgets/WidgetList_test.js
+++ b/static/js/components/widgets/WidgetList_test.js
@@ -1,31 +1,48 @@
 // @flow
 import React from "react"
+import R from "ramda"
 import { mount } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
+import casual from "casual-browserify"
 
-import { makeWidgetListResponse } from "../../factories/widgets"
+import { getWidgetKey } from "../../lib/widgets"
+import {
+  makeWidgetInstance,
+  makeWidgetListResponse
+} from "../../factories/widgets"
 
 import WidgetList from "./WidgetList"
 import WidgetInstance from "./WidgetInstance"
+import { shouldIf } from "../../lib/test_utils"
 
 describe("WidgetList", () => {
   let listResponse,
     sandbox,
+    expanded,
     clearFormStub,
     submitFormStub,
     deleteInstanceStub,
     startEditInstanceStub,
-    startAddInstanceStub
+    startAddInstanceStub,
+    setExpandedStub
 
   beforeEach(() => {
     listResponse = makeWidgetListResponse()
+    expanded = {}
+    listResponse.widgets.forEach((instance, i) => {
+      if (i % 2 === 0) {
+        expanded[getWidgetKey(instance)] = casual.boolean
+      }
+    })
+
     sandbox = sinon.createSandbox()
     clearFormStub = sandbox.stub()
     submitFormStub = sandbox.stub()
     deleteInstanceStub = sandbox.stub()
     startEditInstanceStub = sandbox.stub()
     startAddInstanceStub = sandbox.stub()
+    setExpandedStub = sandbox.stub()
   })
 
   afterEach(() => {
@@ -39,9 +56,11 @@ describe("WidgetList", () => {
         clearForm={clearFormStub}
         submitForm={submitFormStub}
         editing={false}
+        expanded={expanded}
         deleteInstance={deleteInstanceStub}
         startEditInstance={startEditInstanceStub}
         startAddInstance={startAddInstanceStub}
+        setExpanded={setExpandedStub}
         {...props}
       />
     )
@@ -65,18 +84,97 @@ describe("WidgetList", () => {
       assert.equal(props.startEditInstance, startEditInstanceStub)
     })
   })
-  ;[true, false].forEach(hasForm => {
-    it(`${hasForm ? "has" : "doesn't have"} a form`, () => {
-      const wrapper = render({ editing: hasForm })
-      assert.equal(wrapper.find(".manage-widgets").length, hasForm ? 1 : 0)
+  ;[
+    [true, true, true],
+    [true, false, false],
+    [false, true, true],
+    [false, false, true]
+  ].forEach(([editing, isExpanded, expected]) => {
+    it(`has expanded=${String(expected)} when editing=${String(
+      editing
+    )} and expanded[key]=${String(isExpanded)}`, () => {
+      expanded = {}
+      const widgetKeys = listResponse.widgets.map(getWidgetKey)
+      for (const key of widgetKeys) {
+        expanded[key] = isExpanded
+      }
+      const wrapper = render({ editing, expanded })
+
+      listResponse.widgets.forEach((widgetInstance, i) => {
+        assert.equal(
+          wrapper
+            .find(WidgetInstance)
+            .at(i)
+            .prop("expanded"),
+          expected
+        )
+      })
     })
   })
 
-  describe("form", () => {
+  it("sets the expanded value of an instance", () => {
+    const wrapper = render()
+    listResponse.widgets.forEach((widgetInstance, i) => {
+      setExpandedStub.reset()
+      wrapper
+        .find(WidgetInstance)
+        .at(i)
+        .prop("setExpanded")("abc")
+      sinon.assert.calledWith(
+        setExpandedStub,
+        [getWidgetKey(widgetInstance)],
+        "abc"
+      )
+    })
+  })
+  ;[true, false].forEach(editing => {
+    it(`${shouldIf(
+      editing
+    )} show the manage widgets links when editing`, () => {
+      const wrapper = render({ editing })
+      assert.equal(wrapper.find(".manage-widgets").exists(), editing)
+    })
+  })
+
+  describe("editing", () => {
     it("has a link to add new widgets", () => {
       const wrapper = render({ editing: true })
       wrapper.find(".add-widget").prop("onClick")()
       sinon.assert.calledWith(startAddInstanceStub)
+    })
+    ;[true, false].forEach(allExpanded => {
+      it(`has a link to ${allExpanded ? "expand" : "collapse"} widgets`, () => {
+        const widgetKeys = listResponse.widgets.map(getWidgetKey)
+        expanded = {}
+        if (allExpanded) {
+          for (const key of widgetKeys) {
+            expanded[key] = true
+          }
+        }
+
+        const link = render({ editing: true, expanded }).find(
+          ".toggle-collapse-all"
+        )
+        assert.equal(link.text(), allExpanded ? "Collapse all" : "Expand all")
+        link.prop("onClick")()
+        sinon.assert.calledWith(setExpandedStub, widgetKeys, !allExpanded)
+      })
+    })
+
+    it("has a link to expand all widgets if any widgets are collapsed", () => {
+      listResponse.widgets = R.range(0, 5).map(() => makeWidgetInstance())
+      const widgetKeys = listResponse.widgets.map(getWidgetKey)
+      expanded = {
+        [widgetKeys[0]]: true,
+        [widgetKeys[1]]: false
+      }
+
+      const link = render({ editing: true, expanded }).find(
+        ".toggle-collapse-all"
+      )
+      assert.equal(link.text(), "Expand all")
+      link.prop("onClick")()
+      sinon.assert.calledWith(setExpandedStub, widgetKeys, true)
     })
   })
 })

--- a/static/js/containers/widgets/ManageWidgetHeader.js
+++ b/static/js/containers/widgets/ManageWidgetHeader.js
@@ -9,6 +9,7 @@ import { actions } from "../../actions"
 
 import type { Dispatch } from "redux"
 import type {
+  WidgetForm,
   WidgetInstance as WidgetInstanceType,
   WidgetListResponse
 } from "../../flow/widgetTypes"
@@ -22,7 +23,7 @@ type PatchPayload = {
 
 type Props = {
   clearForm: () => void,
-  form: FormValue<Array<WidgetInstanceType>>,
+  form: FormValue<WidgetForm>,
   patchWidgetInstances: (payload: PatchPayload) => Promise<WidgetListResponse>,
   submitForm: () => Promise<void>,
   channel: Channel,
@@ -34,7 +35,7 @@ export class ManageWidgetHeader extends React.Component<Props> {
     const { channel, form, patchWidgetInstances, clearForm } = this.props
     if (form && form.value) {
       await patchWidgetInstances({
-        widgets: form.value,
+        widgets: form.value.instances,
         // $FlowFixMe: if we're at this point we definitely have a widget id
         id:      channel.widget_list_id
       })

--- a/static/js/containers/widgets/ManageWidgetHeader.js
+++ b/static/js/containers/widgets/ManageWidgetHeader.js
@@ -33,7 +33,7 @@ type Props = {
 export class ManageWidgetHeader extends React.Component<Props> {
   submitForm = async () => {
     const { channel, form, patchWidgetInstances, clearForm } = this.props
-    if (form && form.value) {
+    if (form && form.value && form.value.instances) {
       await patchWidgetInstances({
         widgets: form.value.instances,
         // $FlowFixMe: if we're at this point we definitely have a widget id

--- a/static/js/containers/widgets/ManageWidgetHeader_test.js
+++ b/static/js/containers/widgets/ManageWidgetHeader_test.js
@@ -30,7 +30,9 @@ describe("ManageWidgetHeader", () => {
     initialState = {
       forms: {
         [WIDGET_FORM_KEY]: {
-          value: updatedWidgetList
+          value: {
+            instances: updatedWidgetList
+          }
         }
       }
     }
@@ -80,6 +82,21 @@ describe("ManageWidgetHeader", () => {
       forms: {
         [WIDGET_FORM_KEY]: {
           value: null
+        }
+      }
+    })
+    await inner.find(".submit").prop("onClick")()
+    assert.equal(helper.patchWidgetListStub.callCount, 0)
+  })
+
+  it("won't submit the form if there are no instances in the form", async () => {
+    const { inner } = await render({
+      forms: {
+        [WIDGET_FORM_KEY]: {
+          value: {
+            expanded:  { a: "bc" },
+            instances: null
+          }
         }
       }
     })

--- a/static/js/flow/widgetTypes.js
+++ b/static/js/flow/widgetTypes.js
@@ -48,3 +48,12 @@ export type RSSWidgetJson = {
   title: string,
   entries: Array<RSSWidgetEntry>
 }
+
+export type WidgetForm = {
+  instances: Array<WidgetInstance>,
+  expanded: ?{[string]: boolean}
+}
+
+export type WidgetComponentProps = {
+  widgetInstance: WidgetInstance
+}

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -7,6 +7,7 @@ import { MemoryRouter } from "react-router"
 import { Provider } from "react-redux"
 import { createStoreWithMiddleware } from "../store/configureStore"
 import casual from "casual-browserify"
+import { SortableContainer } from "react-sortable-hoc"
 
 import {
   editCommentKey,
@@ -29,6 +30,7 @@ import {
 import { CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC } from "../lib/channels"
 import { dropdownMenuFuncs } from "../lib/ui"
 import { commentPermalink } from "../lib/url"
+import { getWidgetKey } from "../lib/widgets"
 import { createCommentTree } from "../reducers/comments"
 import rootReducer from "../reducers"
 
@@ -51,7 +53,6 @@ import SearchResult from "../components/SearchResult"
 import SearchTextbox from "../components/SearchTextbox"
 import WidgetInstance from "../components/widgets/WidgetInstance"
 import WidgetList from "../components/widgets/WidgetList"
-import { SortableContainer } from "react-sortable-hoc"
 
 // delay import so fonts get applied first
 setTimeout(() => {
@@ -693,7 +694,12 @@ storiesOf("Widgets", module)
   })
   .add("list", () => {
     const editing = boolean("editing")
+    const allCollapsed = boolean("collapsed")
     const list = makeWidgetListResponse().widgets
+    const collapsed = {}
+    for (const widget of list) {
+      collapsed[getWidgetKey(widget)] = allCollapsed
+    }
 
     return (
       <StoryWrapper>
@@ -704,6 +710,8 @@ storiesOf("Widgets", module)
           deleteInstance={action("delete")}
           submitForm={action("submit")}
           widgetInstances={list}
+          collapsed={collapsed}
+          setCollapsed={action("collapse")}
           editing={editing}
         />
       </StoryWrapper>

--- a/static/scss/widget.scss
+++ b/static/scss/widget.scss
@@ -4,10 +4,16 @@
   }
 
   .manage-widgets {
+    display: flex;
     margin-bottom: 5px;
 
-    .add-widget {
+    .add-widget,
+    .toggle-collapse-all {
       cursor: pointer;
+    }
+
+    .toggle-collapse-all {
+      margin-left: auto;
     }
   }
 }
@@ -43,12 +49,21 @@
 .widget {
   font-size: 14px;
 
-  .title {
-    // remove margin applied by Card to .title
-    margin: 0 0 15px 0;
-    font-size: 17px;
-    font-weight: 700;
-    display: inline-block;
+  .title-row {
+    display: flex;
+    margin-bottom: 15px;
+
+    .title {
+      // remove margin applied by Card to .title
+      margin: 0;
+      font-size: 17px;
+      font-weight: 700;
+    }
+
+    .toggle-collapse {
+      cursor: pointer;
+      margin-left: auto;
+    }
   }
 
   &,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1661 

#### What's this PR do?
Implements expanding and collapsing widgets. 

#### How should this be manually tested?
Click 'manage widgets'. All of the widgets should be editable and in a collapsed state. You should be able to delete, reorder, and edit widgets.

Click the 'Expand all' link. You should see all widget instances be expanded. The link should become 'Collapse all'. Click it again and it should collapse all widgets.

Click the downward arrow icon next to a single widget. You should be able to toggle whether that widget instance is collapsed or not, without affecting any of the others.

Click '+ Add Widget'. Add a new widget. It should show up at the bottom in a collapsed state. You should be able to expand and collapse it just like the other widget instances, and the 'Collapse all'/'Expand all' link should also affect it.

Also verify that you can still save widget changes, since the redux store for widgets changed schema slightly.

#### Screenshots
Fully expanded
![screenshot from 2019-01-23 16-01-22](https://user-images.githubusercontent.com/863262/51636965-83173580-1f28-11e9-84f7-249f3156b92a.png)

Partially expanded
![screenshot from 2019-01-23 16-00-53](https://user-images.githubusercontent.com/863262/51636975-890d1680-1f28-11e9-91c6-a45314ceaf62.png)

Fully collapsed
![screenshot from 2019-01-23 16-00-39](https://user-images.githubusercontent.com/863262/51636988-91fde800-1f28-11e9-93be-c75991f8bbb0.png)
