### PR TITLE
split comments API functions off of `lib/api/api.js`

### DIFF
--- a/static/js/lib/api/api.js
+++ b/static/js/lib/api/api.js
@@ -1,8 +1,6 @@
 // @flow
 /* global SETTINGS:false, fetch: false */
 // For mocking purposes we need to use "fetch" defined as a global instead of importing as a local.
-import R from "ramda"
-import qs from "query-string"
 import { PATCH, POST, DELETE } from "redux-hammock/constants"
 import { fetchJSONWithCSRF } from "redux-hammock/django_csrf_fetch"
 
@@ -12,13 +10,10 @@ import {
   fetchWithAuthFailure,
   fetchJSONWithToken
 } from "./fetch_auth"
-import { getCommentSortQS, getPaginationSortQS } from "./util"
+import { getPaginationSortQS } from "./util"
 
 import type { AuthResponse, AuthFlow } from "../../flow/authTypes"
 import type {
-  GenericComment,
-  CommentFromAPI,
-  MoreCommentsFromAPI,
   UserFeedComment,
   Post,
   Profile,
@@ -37,68 +32,6 @@ export function search(params: SearchParams): Promise<*> {
     method: POST,
     body:   JSON.stringify(body)
   })
-}
-
-export function getComments(
-  postID: string,
-  params: Object
-): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> {
-  return fetchJSONWithAuthFailure(
-    `/api/v0/posts/${postID}/comments/${getCommentSortQS(params)}`
-  )
-}
-
-export const getComment = (
-  commentID: string
-): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> =>
-  fetchJSONWithAuthFailure(`/api/v0/comments/${commentID}`)
-
-export const createComment = (
-  postId: string,
-  text: string,
-  commentId: ?string
-): Promise<CommentFromAPI> => {
-  const body =
-    commentId === undefined ? { text } : { text, comment_id: commentId }
-
-  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/comments/`, {
-    method: POST,
-    body:   JSON.stringify(body)
-  })
-}
-
-export function updateComment(
-  commentId: string,
-  commentPayload: Object
-): Promise<GenericComment> {
-  return fetchJSONWithAuthFailure(`/api/v0/comments/${commentId}/`, {
-    method: PATCH,
-    body:   JSON.stringify(commentPayload)
-  })
-}
-
-export function deleteComment(commentId: string): Promise<GenericComment> {
-  return fetchWithAuthFailure(`/api/v0/comments/${commentId}/`, {
-    method: DELETE
-  })
-}
-
-export function getMoreComments(
-  postId: string,
-  parentId: string | null,
-  children: Array<string>
-): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> {
-  const payload = {
-    post_id:  postId,
-    children: children
-  }
-  if (!R.isNil(parentId)) {
-    // $FlowFixMe: Flow doesn't know that we're still constructing payload
-    payload.parent_id = parentId
-  }
-  return fetchJSONWithAuthFailure(
-    `/api/v0/morecomments/?${qs.stringify(payload)}`
-  )
 }
 
 export function getUserPosts(

--- a/static/js/lib/api/comments.js
+++ b/static/js/lib/api/comments.js
@@ -1,0 +1,75 @@
+// @flow
+import R from "ramda"
+import qs from "query-string"
+import { PATCH, POST, DELETE } from "redux-hammock/constants"
+
+import { fetchJSONWithAuthFailure, fetchWithAuthFailure } from "./fetch_auth"
+import { getCommentSortQS } from "./util"
+
+import type {
+  GenericComment,
+  CommentFromAPI,
+  MoreCommentsFromAPI
+} from "../../flow/discussionTypes"
+
+export function getComments(
+  postID: string,
+  params: Object
+): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> {
+  return fetchJSONWithAuthFailure(
+    `/api/v0/posts/${postID}/comments/${getCommentSortQS(params)}`
+  )
+}
+
+export const getComment = (
+  commentID: string
+): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> =>
+  fetchJSONWithAuthFailure(`/api/v0/comments/${commentID}`)
+
+export const createComment = (
+  postId: string,
+  text: string,
+  commentId: ?string
+): Promise<CommentFromAPI> => {
+  const body =
+    commentId === undefined ? { text } : { text, comment_id: commentId }
+
+  return fetchJSONWithAuthFailure(`/api/v0/posts/${postId}/comments/`, {
+    method: POST,
+    body:   JSON.stringify(body)
+  })
+}
+
+export function updateComment(
+  commentId: string,
+  commentPayload: Object
+): Promise<GenericComment> {
+  return fetchJSONWithAuthFailure(`/api/v0/comments/${commentId}/`, {
+    method: PATCH,
+    body:   JSON.stringify(commentPayload)
+  })
+}
+
+export function deleteComment(commentId: string): Promise<GenericComment> {
+  return fetchWithAuthFailure(`/api/v0/comments/${commentId}/`, {
+    method: DELETE
+  })
+}
+
+export function getMoreComments(
+  postId: string,
+  parentId: string | null,
+  children: Array<string>
+): Promise<Array<CommentFromAPI | MoreCommentsFromAPI>> {
+  const payload = {
+    post_id:  postId,
+    children: children
+  }
+  if (!R.isNil(parentId)) {
+    // $FlowFixMe: Flow doesn't know that we're still constructing payload
+    payload.parent_id = parentId
+  }
+  return fetchJSONWithAuthFailure(
+    `/api/v0/morecomments/?${qs.stringify(payload)}`
+  )
+}

--- a/static/js/lib/api/comments_test.js
+++ b/static/js/lib/api/comments_test.js
@@ -1,0 +1,173 @@
+import sinon from "sinon"
+import { assert } from "chai"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+import { PATCH, POST, DELETE } from "redux-hammock/constants"
+import R from "ramda"
+import qs from "query-string"
+
+import {
+  getComments,
+  getComment,
+  createComment,
+  updateComment,
+  getMoreComments,
+  deleteComment
+} from "./comments"
+import { makePost } from "../../factories/posts"
+import {
+  makeCommentsResponse,
+  makeMoreCommentsResponse
+} from "../../factories/comments"
+import { COMMENT_SORT_NEW } from "../picker"
+
+describe("Channels API", () => {
+  let fetchJSONStub, fetchStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+    fetchStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe("getComments", () => {
+    let post, response
+
+    beforeEach(() => {
+      post = makePost()
+      response = makeCommentsResponse(post)
+      fetchJSONStub.returns(Promise.resolve(response))
+    })
+
+    it("gets comments for a post", async () => {
+      const resp = await getComments(post.id, {})
+      assert.deepEqual(resp, response)
+    })
+
+    it("includes the sort parameter when getting comments", async () => {
+      const resp = await getComments(post.id, { sort: COMMENT_SORT_NEW })
+      assert.deepEqual(resp, response)
+      assert.ok(
+        fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/comments/?sort=new`)
+      )
+    })
+  })
+
+  it("gets a single comment", async () => {
+    const post = makePost()
+    const response = R.slice(0, 1, makeCommentsResponse(post))
+    fetchJSONStub.returns(response)
+
+    const resp = await getComment(post.id)
+    assert.deepEqual(resp, response)
+  })
+
+  it("creates comments for a post", async () => {
+    const post = makePost()
+    fetchJSONStub.returns(Promise.resolve())
+
+    await createComment(post.id, "my new comment")
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/comments/`))
+    assert.deepEqual(fetchJSONStub.args[0][1], {
+      method: POST,
+      body:   JSON.stringify({ text: "my new comment" })
+    })
+  })
+
+  it("creates comments replying to comments", async () => {
+    const post = makePost()
+    const tree = makeCommentsResponse(post)
+    fetchJSONStub.returns(Promise.resolve())
+
+    await createComment(post.id, "my new comment", tree[0].id)
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/posts/${post.id}/comments/`))
+    assert.deepEqual(fetchJSONStub.args[0][1], {
+      method: POST,
+      body:   JSON.stringify({
+        text:       "my new comment",
+        comment_id: tree[0].id
+      })
+    })
+  })
+
+  it("updates a comment", async () => {
+    const post = makePost()
+    const tree = makeCommentsResponse(post)
+    const comment = tree[0]
+    const commentResponse = { ...comment, replies: undefined, text: "edited" }
+
+    fetchJSONStub.returns(Promise.resolve(commentResponse))
+
+    const payload = {
+      text:      "edited",
+      downvoted: true
+    }
+    const updated = await updateComment(comment.id, payload)
+    assert.ok(fetchJSONStub.calledWith(`/api/v0/comments/${comment.id}/`))
+    assert.deepEqual(updated, commentResponse)
+    assert.deepEqual(fetchJSONStub.args[0][1], {
+      method: PATCH,
+      body:   JSON.stringify(payload)
+    })
+  })
+
+  it("deletes a comment", async () => {
+    const comment = makeCommentsResponse(makePost())[0]
+    fetchStub.returns(Promise.resolve())
+
+    await deleteComment(comment.id)
+    assert.ok(
+      fetchStub.calledWith(`/api/v0/comments/${comment.id}/`, {
+        method: DELETE
+      })
+    )
+  })
+
+  describe("retrieves more comments", () => {
+    it("at the root level", async () => {
+      const post = makePost()
+      const moreComments = makeMoreCommentsResponse(post)
+      const children = ["some", "child", "ren"]
+
+      fetchJSONStub.returns(Promise.resolve(moreComments))
+
+      const response = await getMoreComments(post.id, null, children)
+      const payload = {
+        post_id:  post.id,
+        children: children
+      }
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/morecomments/?${qs.stringify(payload)}`
+        )
+      )
+      assert.deepEqual(response, moreComments)
+    })
+
+    it("replying to a parent", async () => {
+      const post = makePost()
+      const commentsResponse = makeCommentsResponse(post)
+      const parent = commentsResponse[0]
+      const moreComments = makeMoreCommentsResponse(post, parent.id)
+      const children = ["some", "child", "ren"]
+
+      fetchJSONStub.returns(Promise.resolve(moreComments))
+
+      const response = await getMoreComments(post.id, parent.id, children)
+      const payload = {
+        post_id:   post.id,
+        parent_id: parent.id,
+        children:  children
+      }
+      assert.ok(
+        fetchJSONStub.calledWith(
+          `/api/v0/morecomments/?${qs.stringify(payload)}`
+        )
+      )
+      assert.deepEqual(response, moreComments)
+    })
+  })
+})

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -10,7 +10,7 @@ import {
 
 import { CLEAR_COMMENT_ERROR, REPLACE_MORE_COMMENTS } from "../actions/comment"
 import { findComment } from "../lib/comments"
-import * as api from "../lib/api/api"
+import * as commentsAPI from "../lib/api/comments"
 
 import type { Action } from "../flow/reduxTypes"
 import type {
@@ -220,8 +220,8 @@ export const commentsEndpoint = {
     params?: Object
   ): Promise<GetCommentsPayload> => {
     const comments = commentId
-      ? await api.getComment(commentId)
-      : await api.getComments(postId, params || {})
+      ? await commentsAPI.getComment(commentId)
+      : await commentsAPI.getComments(postId, params || {})
 
     return {
       postId:   postId,
@@ -229,7 +229,7 @@ export const commentsEndpoint = {
     }
   },
   deleteFunc: async (postId: string, commentId: string): Promise<*> => {
-    await api.deleteComment(commentId)
+    await commentsAPI.deleteComment(commentId)
     return { postId, commentId }
   },
   deleteSuccessHandler: (
@@ -257,7 +257,7 @@ export const commentsEndpoint = {
     text: string,
     commentId: ?string
   ): Promise<CreateCommentPayload> => {
-    const comment = await api.createComment(postId, text, commentId)
+    const comment = await commentsAPI.createComment(postId, text, commentId)
     return { postId, commentId, comment }
   },
   postSuccessHandler: (
@@ -275,7 +275,7 @@ export const commentsEndpoint = {
     return update
   },
   patchFunc: (commentId: string, payload: Object) =>
-    api.updateComment(commentId, payload),
+    commentsAPI.updateComment(commentId, payload),
   patchSuccessHandler: (
     response: CommentFromAPI,
     data: CommentData
@@ -312,7 +312,7 @@ export const moreCommentsEndpoint = {
   name:    "morecomments",
   verbs:   [GET],
   getFunc: (postId: string, parentId: string | null, children: Array<string>) =>
-    api.getMoreComments(postId, parentId, children),
+    commentsAPI.getMoreComments(postId, parentId, children),
   initialState:      { ...INITIAL_STATE },
   getSuccessHandler: (
     response: Array<CommentFromAPI | MoreCommentsFromAPI>,

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -17,6 +17,7 @@ import * as moderationAPI from "../lib/api/moderation"
 import * as embedlyAPI from "../lib/api/embedly"
 import * as frontpageAPI from "../lib/api/frontpage"
 import * as postAPI from "../lib/api/posts"
+import * as commentAPI from "../lib/api/comments"
 import rootReducer from "../reducers"
 import * as utilFuncs from "../lib/util"
 
@@ -48,7 +49,8 @@ export default class IntegrationTestHelper {
       moderationAPI,
       embedlyAPI,
       frontpageAPI,
-      postAPI
+      postAPI,
+      commentAPI
     ].forEach(apiModule => {
       for (const methodName in apiModule) {
         if (typeof apiModule[methodName] === "function") {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #1667 

#### What's this PR do?

just moves some code around, moving the comment-related functions out into a separate API module.

#### How should this be manually tested?

I think just make sure that you can do all of the comment actions that should be supported, like creating, deleting, editing, etc.