### PR TITLE
Implement embedly widget

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -46,5 +46,5 @@ export const setAuthUserDetail = createAction(SET_AUTH_USER_DETAIL)
 export const hideDropdownDebounced = createAction(
   HIDE_DROPDOWN,
   i => i,
-  () => ({ debounce: { time: 100 } })
+  () => ({ debounce: { time: 100, key: HIDE_DROPDOWN } })
 )

--- a/static/js/components/widgets/UrlWidget.js
+++ b/static/js/components/widgets/UrlWidget.js
@@ -1,11 +1,14 @@
 // @flow
 import React from "react"
 
+import EmbedlyContainer from "../../containers/EmbedlyContainer"
+
 import type { WidgetComponentProps } from "../../flow/widgetTypes"
 
 const UrlWidget = ({
   widgetInstance: {
     configuration: { url }
   }
-}: WidgetComponentProps) => <iframe src={url} />
+}: // $FlowFixMe: Not sure why flow is complaining but url is the only prop it needs
+WidgetComponentProps) => <EmbedlyContainer url={url} />
 export default UrlWidget

--- a/static/js/components/widgets/UrlWidget_test.js
+++ b/static/js/components/widgets/UrlWidget_test.js
@@ -11,7 +11,7 @@ describe("UrlWidget", () => {
     const widgetInstance = makeWidgetInstance("URL")
     const wrapper = shallow(<UrlWidget widgetInstance={widgetInstance} />)
     assert.equal(
-      wrapper.find("iframe").prop("src"),
+      wrapper.find("Connect(EmbedlyContainer)").prop("url"),
       widgetInstance.configuration.url
     )
   })

--- a/static/js/components/widgets/WidgetField.js
+++ b/static/js/components/widgets/WidgetField.js
@@ -2,8 +2,10 @@
 import React from "react"
 import R from "ramda"
 
-import type { WidgetFieldSpec } from "../../flow/widgetTypes"
 import Editor, { editorUpdateFormShim } from "../../components/Editor"
+import EmbedlyContainer from "../../containers/EmbedlyContainer"
+
+import type { WidgetFieldSpec } from "../../flow/widgetTypes"
 
 type Props = {
   fieldSpec: WidgetFieldSpec,
@@ -42,6 +44,21 @@ const WidgetField = ({ fieldSpec, value, onChange }: Props) => {
           </option>
         ))}
       </select>
+    )
+  case "url":
+    return (
+      <React.Fragment>
+        <input
+          type="text"
+          className="field"
+          value={valueOrDefault}
+          onChange={onChange}
+          minLength={fieldSpec.props.min_length}
+          maxLength={fieldSpec.props.max_length}
+          placeholder={fieldSpec.props.placeholder}
+        />
+        <EmbedlyContainer url={valueOrDefault} debounceKey="widget-field" />
+      </React.Fragment>
     )
   default:
     return (

--- a/static/js/components/widgets/WidgetField_test.js
+++ b/static/js/components/widgets/WidgetField_test.js
@@ -33,7 +33,7 @@ describe("WidgetField", () => {
       />
     )
   }
-  ;["text", "textarea", "number"].forEach(fieldType => {
+  ;["text", "textarea", "number", "url"].forEach(fieldType => {
     describe(`${fieldType} field`, () => {
       it("uses an empty string for a default value if there is none in the spec", () => {
         fieldSpec = makeFieldSpec(fieldType)
@@ -64,7 +64,7 @@ describe("WidgetField", () => {
       })
     })
   })
-  ;["text", "textarea"].forEach(fieldType => {
+  ;["text", "textarea", "url"].forEach(fieldType => {
     it(`renders a ${fieldType} input field`, () => {
       fieldSpec = makeFieldSpec(fieldType)
       const wrapper = render()
@@ -117,5 +117,13 @@ describe("WidgetField", () => {
         value: newValue
       }
     })
+  })
+
+  it("renders an embedly component", () => {
+    fieldSpec = makeFieldSpec("url")
+    const wrapper = render()
+    const embedlyContainer = wrapper.find("Connect(EmbedlyContainer)")
+    assert.isTrue(embedlyContainer.exists())
+    assert.equal(embedlyContainer.prop("url"), value)
   })
 })

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -219,7 +219,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       embedlyGetFunc.meta = {
         debounce: {
           time: 1000,
-          key:  actions.embedly.get.requestType
+          key:  "create-post"
         }
       }
       // $FlowFixMe

--- a/static/js/containers/EmbedlyContainer.js
+++ b/static/js/containers/EmbedlyContainer.js
@@ -1,0 +1,74 @@
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import isURL from "validator/lib/isURL"
+
+import Embedly from "../components/Embedly"
+
+import { actions } from "../actions"
+import { ensureTwitterEmbedJS, handleTwitterWidgets } from "../lib/embed"
+
+import type { Dispatch } from "redux"
+
+const isValidEmbedlyUrl = (url: string): boolean =>
+  isURL(url, { allow_underscores: true })
+
+type Props = {
+  embedly: Object,
+  fetch: () => Promise<*>,
+  url: string,
+  debounceKey?: string
+}
+export class EmbedlyContainer extends React.Component<Props> {
+  componentDidMount() {
+    const { fetch } = this.props
+    fetch()
+
+    ensureTwitterEmbedJS()
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.url !== this.props.url) {
+      this.props.fetch()
+    }
+  }
+
+  render() {
+    const { embedly, url } = this.props
+    return isValidEmbedlyUrl(url) ? (
+      <div className="embedly-preview">
+        <Embedly embedly={embedly} />
+      </div>
+    ) : null
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  embedly: state.embedly.data.get(ownProps.url)
+})
+
+const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) => ({
+  fetch: async () => {
+    const { url, debounceKey } = ownProps
+    if (isValidEmbedlyUrl(url)) {
+      const embedlyGetFunc = actions.embedly.get(url)
+      if (debounceKey) {
+        embedlyGetFunc.meta = {
+          debounce: {
+            time: 1000,
+            key:  debounceKey
+          }
+        }
+      }
+
+      // $FlowFixMe
+      const embedlyResponse = await dispatch(embedlyGetFunc)
+      handleTwitterWidgets(embedlyResponse)
+    }
+  }
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EmbedlyContainer)

--- a/static/js/containers/EmbedlyContainer_test.js
+++ b/static/js/containers/EmbedlyContainer_test.js
@@ -1,0 +1,96 @@
+// @flow
+import sinon from "sinon"
+import { assert } from "chai"
+
+import EmbedlyContainer, {
+  EmbedlyContainer as InnerEmbedlyContainer
+} from "./EmbedlyContainer"
+
+import { makeTweet } from "../factories/embedly"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import * as embedUtil from "../lib/embed"
+import { wait } from "../lib/util"
+
+describe("EmbedlyContainer", () => {
+  let helper,
+    render,
+    url,
+    embedlyResponse,
+    ensureTwitterEmbedJSStub,
+    handleTwitterWidgetsStub
+  beforeEach(() => {
+    url = "https://example.com"
+    embedlyResponse = {
+      response: makeTweet()
+    }
+    helper = new IntegrationTestHelper()
+    ensureTwitterEmbedJSStub = helper.sandbox.stub(
+      embedUtil,
+      "ensureTwitterEmbedJS"
+    )
+    handleTwitterWidgetsStub = helper.sandbox.stub(
+      embedUtil,
+      "handleTwitterWidgets"
+    )
+    helper.getEmbedlyStub.returns(Promise.resolve(embedlyResponse))
+    render = helper.configureHOCRenderer(
+      EmbedlyContainer,
+      InnerEmbedlyContainer,
+      {
+        embedly: {
+          data: new Map([[url, embedlyResponse.response]])
+        }
+      },
+      {
+        url
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders, calling the proper initialization function", async () => {
+    const { inner } = await render()
+    assert.isTrue(inner.find("Embedly").exists())
+    assert.deepEqual(
+      inner.find("Embedly").prop("embedly"),
+      embedlyResponse.response
+    )
+    sinon.assert.calledWith(ensureTwitterEmbedJSStub)
+  })
+
+  it("fetches on load and on url change", async () => {
+    await render()
+    // let getEmbedlyStub resolve and fetch continue execution
+    await wait(0)
+    sinon.assert.calledWith(helper.getEmbedlyStub, url)
+    sinon.assert.calledWith(handleTwitterWidgetsStub, embedlyResponse)
+  })
+
+  it("fetches on url change", async () => {
+    const prevUrl = "http://example.com/previous_url"
+    const { inner } = await render(
+      {},
+      {
+        url: prevUrl
+      }
+    )
+    helper.getEmbedlyStub.reset()
+    helper.getEmbedlyStub.returns(Promise.resolve(embedlyResponse))
+
+    inner.instance().componentDidUpdate({ url })
+    // let getEmbedlyStub resolve and fetch continue execution
+    await wait(0)
+    sinon.assert.calledWith(helper.getEmbedlyStub, prevUrl)
+  })
+
+  it("does not fetch if the url is invalid and it won't render anything", async () => {
+    url = "invalid"
+    const { inner } = await render({}, { url })
+    assert.isFalse(inner.find("Embedly").exists())
+    assert.equal(helper.getEmbedlyStub.callCount, 0)
+    sinon.assert.calledWith(ensureTwitterEmbedJSStub)
+  })
+})

--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -13,7 +13,7 @@ import type {
   RSSWidgetJson
 } from "../flow/widgetTypes"
 
-export const validFieldSpecTypes = ["text", "textarea", "number"]
+export const validFieldSpecTypes = ["text", "textarea", "number", "url"]
 
 const instanceIncr = incrementer()
 const listIncr = incrementer()

--- a/widgets/serializers/react_fields.py
+++ b/widgets/serializers/react_fields.py
@@ -18,7 +18,7 @@ class ReactField:
 
     def _get_input_type(self):
         """Returns the field's input type"""
-        return "text"
+        raise NotImplementedError()
 
     def get_field_spec(self):
         """
@@ -74,12 +74,25 @@ class ReactIntegerField(serializers.IntegerField, ReactField):
 class ReactURLField(serializers.URLField, ReactField):
     """ReactField extension of DRF UrlField"""
 
+    def __init__(self, **kwargs):
+        if "show_embed" in kwargs:
+            self.show_embed = kwargs.pop("show_embed")
+        else:
+            self.show_embed = False
+
+        super().__init__(**kwargs)
+
+    def _get_input_type(self):
+        """Returns the field's input type"""
+        return "url"
+
     def _get_props(self):
         """Returns the field properties"""
         return {
             **super()._get_props(),
             "max_length": self.max_length or "",
             "min_length": self.min_length or "",
+            "show_embed": self.show_embed,
         }
 
 

--- a/widgets/serializers/url.py
+++ b/widgets/serializers/url.py
@@ -9,7 +9,7 @@ from widgets.serializers.react_fields import ReactURLField
 class URLWidgetConfigSerializer(WidgetConfigSerializer):
     """Serializer for URLWidget config"""
 
-    url = ReactURLField(help_text="Enter URL", label="URL")
+    url = ReactURLField(help_text="Enter URL", label="URL", show_embed=True)
 
 
 class URLWidgetSerializer(WidgetInstanceSerializer):

--- a/widgets/views_test.py
+++ b/widgets/views_test.py
@@ -28,12 +28,13 @@ EXPECTED_AVAILABLE_WIDGETS = [
         "form_spec": [
             {
                 "field_name": "url",
-                "input_type": "text",
+                "input_type": "url",
                 "label": "URL",
                 "props": {
                     "max_length": "",
                     "min_length": "",
                     "placeholder": "Enter URL",
+                    "show_embed": True,
                 },
                 "default": "",
             }
@@ -45,12 +46,13 @@ EXPECTED_AVAILABLE_WIDGETS = [
         "form_spec": [
             {
                 "field_name": "url",
-                "input_type": "text",
+                "input_type": "url",
                 "label": "URL",
                 "props": {
                     "max_length": "",
                     "min_length": "",
                     "placeholder": "RSS feed URL",
+                    "show_embed": False,
                 },
                 "default": "",
             },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1510 

#### What's this PR do?
Adds `EmbedlyContainer` which handles some embedly lifecycle, handles debounce, handles the embedly loader while the url is processing, and doesn't render for clearly invalid URLs.

This PR only handles youtube URLs, not other embedly sources. Do we need to @pdpinch @Ferdi?

#### How should this be manually tested?
Edit the widget and add a youtube URL. 

#### Screenshots (if appropriate)
In sidebar:
![screenshot from 2019-01-30 10-29-15](https://user-images.githubusercontent.com/863262/51992426-fd8d0b80-247a-11e9-8817-09ca47ebe90b.png)

In dialog editor:
![screenshot from 2019-01-30 10-29-32](https://user-images.githubusercontent.com/863262/51992455-067ddd00-247b-11e9-8b7b-ad840cb18b19.png)
