### PR TITLE
Fixed subscriber permission to allow self-editing of channel subs

### DIFF
--- a/channels/views/subscribers.py
+++ b/channels/views/subscribers.py
@@ -10,10 +10,7 @@ from rest_framework.views import APIView
 from channels.api import Api
 from channels.models import Channel, ChannelSubscription
 from channels.serializers.subscribers import SubscriberSerializer
-from open_discussions.permissions import (
-    IsStaffOrReadonlyPermission,
-    IsStaffModeratorOrReadonlyPermission,
-)
+from open_discussions.permissions import IsOwnSubscriptionOrAdminPermission
 
 
 class SubscriberListView(ListCreateAPIView):
@@ -21,7 +18,7 @@ class SubscriberListView(ListCreateAPIView):
     View to add subscribers in channels
     """
 
-    permission_classes = (IsAuthenticated, IsStaffModeratorOrReadonlyPermission)
+    permission_classes = (IsAuthenticated, IsOwnSubscriptionOrAdminPermission)
     serializer_class = SubscriberSerializer
 
     def get_serializer_context(self):
@@ -44,7 +41,7 @@ class SubscriberDetailView(APIView):
     View to retrieve and remove subscribers in channels
     """
 
-    permission_classes = (IsAuthenticated, IsStaffOrReadonlyPermission)
+    permission_classes = (IsAuthenticated, IsOwnSubscriptionOrAdminPermission)
 
     def get_serializer_context(self):
         """Context for the request and view"""

--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -136,6 +136,33 @@ class IsStaffModeratorOrReadonlyPermission(permissions.BasePermission):
         )
 
 
+class IsOwnSubscriptionOrAdminPermission(permissions.BasePermission):
+    """
+    Checks that the user is (1) staff/moderator, (2) editing their own subscription, or (3) making
+    a readonly request
+    """
+
+    @staticmethod
+    def is_own_resource_request(request, view):
+        """Returns True if the request is on the user's own behalf"""
+        resource_owner_username = view.kwargs.get(
+            "subscriber_name", None
+        ) or request.data.get("subscriber_name", None)
+        return resource_owner_username == request.user.username
+
+    def has_permission(self, request, view):
+        """
+        Returns True if user is (1) staff/moderator, (2) editing their own subscription, or (3) making
+        a readonly request
+        """
+        return (
+            is_readonly(request)
+            or self.is_own_resource_request(request, view)
+            or is_staff_user(request)
+            or is_moderator(request, view)
+        )
+
+
 class ContributorPermissions(permissions.BasePermission):
     """
     Only staff and moderators should be able to see and edit the list of contributors


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket - fixes bug w/ #1754 

#### What's this PR do?
Changes subscriber permission to allow users to add/remove their own channel subscriptions

#### How should this be manually tested?
Log in as a non-staff, non-mod user and try to follow/unfollow a public channel on the channel detail page. Also try this with a mod user
