### PR TITLE
Backpopulate all posts and comments

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -509,6 +509,10 @@ def create_channel_groups_and_roles(channel):
 class Api:
     """Channel API"""
 
+    # help Mock() spec this object correctly
+    reddit = None
+    user = None
+
     def __init__(self, user):
         """Constructor"""
         if user is None:

--- a/channels/backpopulate_api.py
+++ b/channels/backpopulate_api.py
@@ -91,6 +91,7 @@ def backpopulate_comments(submission):
         comment.author.name for comment in submission.comments if comment.author
     }
     authors_by_username = User.objects.in_bulk(author_usernames, field_name="username")
+    update_count = 0
 
     for comment in submission.comments:
         author = (
@@ -101,6 +102,8 @@ def backpopulate_comments(submission):
         # we may see a comment in reddit before it's created in the database
         # but it should have correct values in that case
         # so this update may affect zero rows, but that's ok
-        Comment.objects.filter(comment_id=comment.id).update(
+        update_count += Comment.objects.filter(comment_id=comment.id).update(
             author=author, **comment_values
         )
+
+    return update_count

--- a/channels/backpopulate_api_test.py
+++ b/channels/backpopulate_api_test.py
@@ -183,7 +183,9 @@ def test_backpopulate_comments(mocker):
         ),
     ]
 
-    backpopulate_api.backpopulate_comments(submission)
+    result = backpopulate_api.backpopulate_comments(submission)
+
+    assert result == len(comments)
 
     submission.comments.replace_more.assert_called_once_with(limit=None)
 

--- a/channels/management/commands/backpopulate_posts.py
+++ b/channels/management/commands/backpopulate_posts.py
@@ -1,0 +1,56 @@
+"""Management command for populating posts and comments from reddit"""
+import sys
+
+import base36
+from django.core.management import BaseCommand
+
+from channels import tasks
+
+
+class Command(BaseCommand):
+    """Populate posts and comments from reddit"""
+
+    help = "Populate posts and comments from reddit"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--post", nargs="?", action="append")
+
+    def handle(self, *args, **options):
+        """Populate posts and comments from reddit"""
+
+        if options["post"]:
+            task = tasks.populate_posts_and_comments.delay(
+                [base36.loads(post_id) for post_id in options["post"]]
+            )
+        else:
+            task = tasks.populate_all_posts_and_comments.delay()
+
+        self.stdout.write(
+            "Started celery task {task} to backpopulate posts and comments".format(
+                task=task
+            )
+        )
+        self.stdout.write("Waiting on task...")
+        results = task.get()
+        # Results will look like this:
+        # results = {
+        #     'posts': 1734,
+        #     'comments': 3547,
+        #     "failures": [
+        #         {"thing_type": "comment", "thing_id": "c4", "reason": "errors happen"},
+        #         {"thing_type": "post", "thing_id": "b9i", "reason": "more than you want them to"}
+        #     ]
+        # }
+        self.stdout.write("Successes:")
+        self.stdout.write(f"Posts:       {results['posts']}")
+        self.stdout.write(f"Comments:    {results['comments']}")
+        failures = results["failures"]
+        if failures:
+            self.stdout.write("")
+            self.stdout.write("Failures:")
+            self.stdout.write("thing_type   thing_id   reason")
+            for failure in results["failures"]:
+                self.stdout.write(
+                    f"{failure['thing_type']:<12} {failure['thing_id']:<10} {failure['reason']}"
+                )
+            sys.exit(1)

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -15,6 +15,7 @@ from urllib3.exceptions import InsecureRequestWarning
 import channels.api
 import channels.factories
 import channels.serializers
+from open_discussions.factories import UserFactory
 
 
 @pytest.fixture(autouse=True)
@@ -148,3 +149,11 @@ def mocked_celery(mocker):
 def disable_search_tasks(mocker):
     """Patch search tasks so they no-op"""
     return mocker.patch("search.task_helpers")
+
+
+@pytest.fixture
+def indexing_user(settings):
+    """Sets and returns the indexing user"""
+    user = UserFactory.create()
+    settings.INDEXING_API_USERNAME = user.username
+    return user


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1756 

#### What's this PR do?
Adds a command that walks all posts and comments and populates them based on values in reddit. It is intended that this operation is fairly idempotent, although there are probably some unavoidable race conditions around certain operations like voting where we don't have strict guarantees of atomicity across all our storage mediums.

Note: the script ignores posts in channels that aren't in the DB.

#### How should this be manually tested?
Run `./manage.py backpopulate_posts` and ensure the resulting data and reported numbers in the output match what you'd expect based on your local environment.
