### PR TITLE
Fixed contributor delete permissions and changed logic for showing leave channel option

### DIFF
--- a/open_discussions/permissions.py
+++ b/open_discussions/permissions.py
@@ -169,12 +169,17 @@ class ContributorPermissions(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        return channel_exists(view) and (
-            is_staff_user(request)
-            or (
-                (channel_is_mod_editable(view) or is_readonly(request))
-                and is_moderator(request, view)
-            )
+        if not channel_exists(view):
+            return False
+        # Allow self-delete
+        if (
+            request.method == "DELETE"
+            and view.kwargs.get("contributor_name", None) == request.user.username
+        ):
+            return True
+        return is_staff_user(request) or (
+            (channel_is_mod_editable(view) or is_readonly(request))
+            and is_moderator(request, view)
         )
 
 

--- a/open_discussions/permissions_test.py
+++ b/open_discussions/permissions_test.py
@@ -264,6 +264,20 @@ def test_is_own_subscription_permission(
     )
 
 
+def test_contributor_permission_self_delete(mocker):
+    """
+    Test that users can delete their own contributor status
+    """
+    mocker.patch("open_discussions.permissions.is_staff_user", return_value=False)
+    mocker.patch("open_discussions.permissions.is_moderator", return_value=False)
+    username = "user1"
+    request, view = mocker.Mock(), mocker.Mock()
+    request.method = "DELETE"
+    request.user.username = username
+    view.kwargs = {"contributor_name": username}
+    assert ContributorPermissions().has_permission(request, view) is True
+
+
 # This is essentially is_staff or (moderator and (mod_editable or readonly))
 @pytest.mark.parametrize(
     "is_staff, moderator, mod_editable, readonly, expected",

--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -46,7 +46,7 @@ export default class ChannelHeader extends React.Component<Props> {
               </div>
             </div>
             <div className="right channel-controls">
-              <ChannelFollowControls channel={channel} />
+              <ChannelFollowControls channel={channel} history={history} />
               {isModerator ? (
                 <ChannelSettingsLink channel={channel} history={history} />
               ) : null}

--- a/static/js/components/ChannelHeader_test.js
+++ b/static/js/components/ChannelHeader_test.js
@@ -42,7 +42,10 @@ describe("ChannelHeader", () => {
     const wrapper = render()
     const followControls = wrapper.find("Connect(ChannelFollowControls)")
     assert.isTrue(followControls.exists())
-    assert.deepEqual(followControls.prop("channel"), channel)
+    assert.deepEqual(followControls.props(), {
+      history,
+      channel
+    })
   })
   ;[true, false].forEach(hasNavbar => {
     it(`${shouldIf(hasNavbar)} navbar items`, () => {

--- a/static/js/containers/ChannelFollowControls.js
+++ b/static/js/containers/ChannelFollowControls.js
@@ -11,6 +11,7 @@ import { actions } from "../actions"
 import { hideDropdown, showDropdown } from "../actions/ui"
 import { leaveChannel } from "../util/api_actions"
 import { getOwnProfile } from "../lib/redux_selectors"
+import { FRONTPAGE_URL } from "../lib/url"
 import { CHANNEL_TYPE_PUBLIC } from "../lib/channels"
 
 import type { Dispatch } from "redux"
@@ -20,6 +21,7 @@ export const CHANNEL_FOLLOW_DROPDOWN = "CHANNEL_FOLLOW_DROPDOWN"
 
 type Props = {
   channel: Channel,
+  history: Object,
   username: string,
   isDropdownOpen: boolean,
   showDropdown: () => void,
@@ -49,10 +51,10 @@ export class ChannelFollowControls extends React.Component<Props> {
   }
 
   handleLeaveChannelClick = async () => {
-    const { leaveChannel, loadChannel, loadChannels, username } = this.props
+    const { leaveChannel, history, loadChannels, username } = this.props
 
     await leaveChannel(username)
-    await loadChannel()
+    history.push(FRONTPAGE_URL)
     await loadChannels()
   }
 
@@ -87,7 +89,7 @@ export class ChannelFollowControls extends React.Component<Props> {
             </li>
             {channel.channel_type !== CHANNEL_TYPE_PUBLIC &&
             channel.user_is_contributor &&
-            channel.user_is_moderator ? (
+            !channel.user_is_moderator ? (
                 <li>
                   <a onClick={this.handleLeaveChannelClick}>Leave channel</a>
                 </li>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1769 

#### What's this PR do?
- Changes permissions so non-mod users can remove themselves as channel contributors
- Changes the logic for showing the channel "Leave" button so that it shows up only for non-moderators

#### How should this be manually tested?
- With a non-mod user, go to a channel detail page where the user is a contributor and click the "Leave Channel" option in the "Following" dropdown. You should no longer be a contributor and you should be sent back to the home page.
- With a mod user, make sure the "Leave" option isn't available

#### Any background context you want to provide?
Reddit doesn't seem to like the idea of a contributor being removed by a non-moderator, even if it's the user doing it on their own behalf. That's the reason for the admin API usage. The fact that reddit doesn't allow this makes me wonder if we need to think about this a little more...
