### PR TITLE
Add validation to widget configuration inputs, fix URL validation

### DIFF
--- a/static/js/components/EmbedlyCard.js
+++ b/static/js/components/EmbedlyCard.js
@@ -1,9 +1,9 @@
 /* global SETTINGS: false */
 // @flow
 import React from "react"
-import isURL from "validator/lib/isURL"
 
 import { loadEmbedlyPlatform, renderEmbedlyCard } from "../lib/embed"
+import { isValidUrl } from "../lib/util"
 
 type Props = {
   url: string
@@ -16,7 +16,7 @@ export default class EmbedlyCard extends React.Component<Props> {
   render() {
     const { url } = this.props
 
-    if (!isURL(url, { allow_underscores: true })) {
+    if (!isValidUrl(url)) {
       return null
     }
 

--- a/static/js/components/EmbedlyCard_test.js
+++ b/static/js/components/EmbedlyCard_test.js
@@ -35,8 +35,8 @@ describe("EmbedlyCard", () => {
     sinon.assert.calledWith(renderEmbedlyCardStub, url)
   })
 
-  it("does not render when the url is invalid", () => {
-    url = "not_a_url"
+  it("does not render when the url is missing the protocol prefix", () => {
+    url = "mit.edu"
     const wrapper = render()
     assert.equal(wrapper.text(), "")
     sinon.assert.calledWith(loadEmbedlyPlatformStub)

--- a/static/js/components/widgets/MarkdownWidget_test.js
+++ b/static/js/components/widgets/MarkdownWidget_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 
 import MarkdownWidget from "./MarkdownWidget"
 
+import { WIDGET_TYPE_MARKDOWN } from "../../lib/constants"
 import { configureShallowRenderer } from "../../lib/test_utils"
 import { makeWidgetInstance } from "../../factories/widgets"
 
@@ -10,7 +11,7 @@ describe("MarkdownWidget", () => {
   let renderWidget, instance
 
   beforeEach(() => {
-    instance = makeWidgetInstance("Markdown")
+    instance = makeWidgetInstance(WIDGET_TYPE_MARKDOWN)
     renderWidget = configureShallowRenderer(MarkdownWidget, {
       widgetInstance: instance
     })

--- a/static/js/components/widgets/RssWidget_test.js
+++ b/static/js/components/widgets/RssWidget_test.js
@@ -4,11 +4,13 @@ import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import RssWidget from "./RssWidget"
+
+import { WIDGET_TYPE_RSS } from "../../lib/constants"
 import { makeWidgetInstance } from "../../factories/widgets"
 
 describe("RssWidget", () => {
   it("renders a RssWidget", () => {
-    const widgetInstance = makeWidgetInstance("RSS Feed")
+    const widgetInstance = makeWidgetInstance(WIDGET_TYPE_RSS)
     const wrapper = shallow(<RssWidget widgetInstance={widgetInstance} />)
     assert.equal(
       widgetInstance.json.entries.length,
@@ -31,7 +33,7 @@ describe("RssWidget", () => {
   })
 
   it("renders a RssWidget with a missing timestamp", () => {
-    const widgetInstance = makeWidgetInstance("RSS Feed")
+    const widgetInstance = makeWidgetInstance(WIDGET_TYPE_RSS)
     widgetInstance.json.entries[0].timestamp = null
     const wrapper = shallow(<RssWidget widgetInstance={widgetInstance} />)
     const entryWrapper = wrapper.find(".entry").at(0)

--- a/static/js/components/widgets/UrlWidget_test.js
+++ b/static/js/components/widgets/UrlWidget_test.js
@@ -4,11 +4,13 @@ import { shallow } from "enzyme"
 import { assert } from "chai"
 
 import UrlWidget from "./UrlWidget"
+
+import { WIDGET_TYPE_URL } from "../../lib/constants"
 import { makeWidgetInstance } from "../../factories/widgets"
 
 describe("UrlWidget", () => {
   it("renders a UrlWidget", () => {
-    const widgetInstance = makeWidgetInstance("URL")
+    const widgetInstance = makeWidgetInstance(WIDGET_TYPE_URL)
     const wrapper = shallow(<UrlWidget widgetInstance={widgetInstance} />)
     assert.equal(
       wrapper.find("EmbedlyCard").prop("url"),

--- a/static/js/components/widgets/WidgetEditDialog.js
+++ b/static/js/components/widgets/WidgetEditDialog.js
@@ -98,6 +98,7 @@ export default class WidgetEditDialog extends React.Component<Props> {
                 onChange={this.updateValue(lens)}
                 fieldSpec={fieldSpec}
               />
+              {validationMessage(R.view(lens, validation))}
             </label>
           )
         })}

--- a/static/js/components/widgets/WidgetEditDialog_test.js
+++ b/static/js/components/widgets/WidgetEditDialog_test.js
@@ -4,6 +4,7 @@ import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 import casual from "casual-browserify"
+import R from "ramda"
 
 import WidgetEditDialog, {
   WIDGET_CREATE,
@@ -19,6 +20,11 @@ import {
   makeWidgetSpec,
   validFieldSpecTypes
 } from "../../factories/widgets"
+import {
+  WIDGET_TYPE_MARKDOWN,
+  WIDGET_TYPE_RSS,
+  WIDGET_TYPE_URL
+} from "../../lib/constants"
 
 describe("WidgetEditDialog", () => {
   let sandbox,
@@ -208,20 +214,38 @@ describe("WidgetEditDialog", () => {
         }
       })
     })
-
-    it("renders validation for the widget title field", () => {
-      dialogData = {
-        ...dialogData,
-        validation: {
-          title: "Missing field"
+    ;[
+      [
+        "widget title",
+        WIDGET_TYPE_MARKDOWN,
+        { title: "Missing field" },
+        "Missing field"
+      ],
+      [
+        "embed url",
+        WIDGET_TYPE_URL,
+        { configuration: { url: "URL is not valid" } },
+        "URL is not valid"
+      ],
+      [
+        "rss url",
+        WIDGET_TYPE_RSS,
+        { configuration: { url: "URL is not valid" } },
+        "URL is not valid"
+      ]
+    ].forEach(([description, widgetType, validation, expectedMessage]) => {
+      it(`renders validation for ${description}`, () => {
+        dialogData = {
+          ...dialogData,
+          instance: makeWidgetInstance(widgetType),
+          validation
         }
-      }
-      const wrapper = render()
-      assert.equal(
-        wrapper.find(".validation-message").text(),
-        // $FlowFixMe
-        dialogData.validation.title
-      )
+        const wrapper = render()
+        assert.equal(
+          wrapper.find(".validation-message").text(),
+          expectedMessage
+        )
+      })
     })
 
     it("renders fields for a widget configuration", () => {

--- a/static/js/components/widgets/WidgetEditDialog_test.js
+++ b/static/js/components/widgets/WidgetEditDialog_test.js
@@ -4,7 +4,6 @@ import { shallow } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 import casual from "casual-browserify"
-import R from "ramda"
 
 import WidgetEditDialog, {
   WIDGET_CREATE,

--- a/static/js/components/widgets/WidgetField.js
+++ b/static/js/components/widgets/WidgetField.js
@@ -7,6 +7,12 @@ import Editor, { editorUpdateFormShim } from "../Editor"
 import EmbedlyCard from "../EmbedlyCard"
 
 import type { WidgetFieldSpec } from "../../flow/widgetTypes"
+import {
+  WIDGET_FIELD_TYPE_MARKDOWN,
+  WIDGET_FIELD_TYPE_NUMBER,
+  WIDGET_FIELD_TYPE_TEXTAREA,
+  WIDGET_FIELD_TYPE_URL
+} from "../../lib/constants"
 
 type Props = {
   fieldSpec: WidgetFieldSpec,
@@ -17,7 +23,7 @@ type Props = {
 const WidgetField = ({ fieldSpec, value, onChange }: Props) => {
   const valueOrDefault = R.defaultTo(fieldSpec.default || "", value)
   switch (fieldSpec.input_type) {
-  case "markdown_wysiwyg":
+  case WIDGET_FIELD_TYPE_MARKDOWN:
     return (
       <Editor
         initialValue={valueOrDefault}
@@ -25,7 +31,7 @@ const WidgetField = ({ fieldSpec, value, onChange }: Props) => {
         placeHolder=""
       />
     )
-  case "textarea":
+  case WIDGET_FIELD_TYPE_TEXTAREA:
     return (
       <textarea
         value={valueOrDefault}
@@ -36,7 +42,7 @@ const WidgetField = ({ fieldSpec, value, onChange }: Props) => {
         placeholder={fieldSpec.props.placeholder}
       />
     )
-  case "number":
+  case WIDGET_FIELD_TYPE_NUMBER:
     return (
       <select className="field" value={valueOrDefault} onChange={onChange}>
         {R.range(fieldSpec.props.min, fieldSpec.props.max + 1).map(index => (
@@ -46,7 +52,7 @@ const WidgetField = ({ fieldSpec, value, onChange }: Props) => {
         ))}
       </select>
     )
-  case "url":
+  case WIDGET_FIELD_TYPE_URL:
     return (
       <React.Fragment>
         <input

--- a/static/js/components/widgets/WidgetField_test.js
+++ b/static/js/components/widgets/WidgetField_test.js
@@ -8,6 +8,13 @@ import { assert } from "chai"
 import WidgetField from "./WidgetField"
 
 import { makeFieldSpec } from "../../factories/widgets"
+import {
+  WIDGET_FIELD_TYPE_MARKDOWN,
+  WIDGET_FIELD_TYPE_NUMBER,
+  WIDGET_FIELD_TYPE_TEXT,
+  WIDGET_FIELD_TYPE_TEXTAREA,
+  WIDGET_FIELD_TYPE_URL
+} from "../../lib/constants"
 
 describe("WidgetField", () => {
   let sandbox, onChangeStub, value, fieldSpec
@@ -33,7 +40,12 @@ describe("WidgetField", () => {
       />
     )
   }
-  ;["text", "textarea", "number", "url"].forEach(fieldType => {
+  ;[
+    WIDGET_FIELD_TYPE_TEXT,
+    WIDGET_FIELD_TYPE_TEXTAREA,
+    WIDGET_FIELD_TYPE_NUMBER,
+    WIDGET_FIELD_TYPE_URL
+  ].forEach(fieldType => {
     describe(`${fieldType} field`, () => {
       it("uses an empty string for a default value if there is none in the spec", () => {
         fieldSpec = makeFieldSpec(fieldType)
@@ -64,7 +76,11 @@ describe("WidgetField", () => {
       })
     })
   })
-  ;["text", "textarea", "url"].forEach(fieldType => {
+  ;[
+    WIDGET_FIELD_TYPE_TEXT,
+    WIDGET_FIELD_TYPE_TEXTAREA,
+    WIDGET_FIELD_TYPE_URL
+  ].forEach(fieldType => {
     it(`renders a ${fieldType} input field`, () => {
       fieldSpec = makeFieldSpec(fieldType)
       const wrapper = render()
@@ -84,7 +100,7 @@ describe("WidgetField", () => {
   })
 
   it("renders a number field with number options between the min and max", () => {
-    fieldSpec = makeFieldSpec("number")
+    fieldSpec = makeFieldSpec(WIDGET_FIELD_TYPE_NUMBER)
     const wrapper = render()
 
     const options = wrapper.find(".field option")
@@ -99,7 +115,7 @@ describe("WidgetField", () => {
   })
 
   it("renders a wysiwyg markdown field", () => {
-    fieldSpec = makeFieldSpec("markdown_wysiwyg")
+    fieldSpec = makeFieldSpec(WIDGET_FIELD_TYPE_MARKDOWN)
     const value = "some *text*"
     const wrapper = render({ value })
 
@@ -120,7 +136,7 @@ describe("WidgetField", () => {
   })
 
   it("renders an embedly component", () => {
-    fieldSpec = makeFieldSpec("url")
+    fieldSpec = makeFieldSpec(WIDGET_FIELD_TYPE_URL)
     fieldSpec.props.show_embed = true
     const wrapper = render()
     const embedlyCard = wrapper.find("EmbedlyCard")
@@ -129,7 +145,7 @@ describe("WidgetField", () => {
   })
 
   it("doesn't render an embedly component when show_embed is false", () => {
-    fieldSpec = makeFieldSpec("url")
+    fieldSpec = makeFieldSpec(WIDGET_FIELD_TYPE_URL)
     fieldSpec.props.show_embed = false
     const wrapper = render()
     const embedlyCard = wrapper.find("EmbedlyCard")

--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -2,6 +2,14 @@
 import R from "ramda"
 import casual from "casual-browserify"
 
+import {
+  WIDGET_FIELD_TYPE_MARKDOWN,
+  WIDGET_FIELD_TYPE_NUMBER,
+  WIDGET_FIELD_TYPE_URL,
+  WIDGET_TYPE_MARKDOWN,
+  WIDGET_TYPE_RSS,
+  WIDGET_TYPE_URL
+} from "../lib/constants"
 import { incrementer } from "../lib/util"
 import { validWidgetRenderers } from "../lib/widgets"
 
@@ -20,11 +28,11 @@ const listIncr = incrementer()
 
 export const makeWidgetConfiguration = (widgetType: string): Object => {
   switch (widgetType) {
-  case "Markdown":
+  case WIDGET_TYPE_MARKDOWN:
     return { source: `**${casual.word}**` }
-  case "URL":
+  case WIDGET_TYPE_URL:
     return { url: casual.url }
-  case "RSS Feed":
+  case WIDGET_TYPE_RSS:
     return {
       url:                casual.url,
       feed_display_limit: casual.integer(0, 15)
@@ -36,11 +44,11 @@ export const makeWidgetConfiguration = (widgetType: string): Object => {
 
 export const makeWidgetJson = (widgetType: string): ?Object => {
   switch (widgetType) {
-  case "Markdown":
+  case WIDGET_TYPE_MARKDOWN:
     return null
-  case "URL":
+  case WIDGET_TYPE_URL:
     return null
-  case "RSS Feed":
+  case WIDGET_TYPE_RSS:
     return ({
       title:   casual.title,
       entries: R.range(1, casual.integer(2, 8)).map(() => ({
@@ -74,14 +82,14 @@ export const makeWidgetInstance = (
 
 export const makeFieldSpec = (
   specType: ?string = null,
-  suffix: string = ""
+  name: string
 ): WidgetFieldSpec => {
   if (!specType) {
     specType = casual.random_element(validFieldSpecTypes)
   }
   const common = {
-    field_name: `field_${suffix}`,
-    label:      `Field ${suffix}`,
+    field_name: name,
+    label:      `Field ${name}`,
     input_type: specType
   }
 
@@ -115,10 +123,24 @@ export const makeWidgetSpec = (widgetType: ?string = null): WidgetSpec => {
     widgetType = casual.random_element(Object.keys(validWidgetRenderers))
   }
 
+  let fieldSpecs
+  if (widgetType === WIDGET_TYPE_URL) {
+    fieldSpecs = [makeFieldSpec(WIDGET_FIELD_TYPE_URL, "url")]
+  } else if (widgetType === WIDGET_TYPE_MARKDOWN) {
+    fieldSpecs = [makeFieldSpec(WIDGET_FIELD_TYPE_MARKDOWN, "source")]
+  } else if (widgetType === WIDGET_TYPE_RSS) {
+    fieldSpecs = [
+      makeFieldSpec(WIDGET_FIELD_TYPE_URL, "url"),
+      makeFieldSpec(WIDGET_FIELD_TYPE_NUMBER, "feed_display_limit")
+    ]
+  } else {
+    throw new Error(`Unhandled case ${widgetType}, update factory code`)
+  }
+
   return {
     widget_type: widgetType,
     description: casual.word,
-    form_spec:   R.range(1, 5).map(i => makeFieldSpec(null, i))
+    form_spec:   fieldSpecs
   }
 }
 

--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -81,11 +81,14 @@ export const makeWidgetInstance = (
 }
 
 export const makeFieldSpec = (
-  specType: ?string = null,
-  name: string
+  specType?: string,
+  name?: string
 ): WidgetFieldSpec => {
   if (!specType) {
     specType = casual.random_element(validFieldSpecTypes)
+  }
+  if (!name) {
+    name = casual.name
   }
   const common = {
     field_name: name,

--- a/static/js/factories/widgets_test.js
+++ b/static/js/factories/widgets_test.js
@@ -17,8 +17,8 @@ describe("widget factories", () => {
   })
 
   it("makes a widget spec", () => {
-    const spec = makeWidgetSpec("widget_type")
-    assert.deepEqual(spec.widget_type, "widget_type")
+    const spec = makeWidgetSpec()
+    assert.isString(spec.widget_type)
     assert.isArray(spec.form_spec)
     const firstSpec = spec.form_spec[0]
     assert.isString(firstSpec.field_name)

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -5,3 +5,13 @@ export const SOCIAL_SITE_TYPE = "social"
 
 export const POSTS_OBJECT_TYPE = "posts"
 export const COMMENTS_OBJECT_TYPE = "comments"
+
+export const WIDGET_TYPE_MARKDOWN = "Markdown"
+export const WIDGET_TYPE_RSS = "RSS Feed"
+export const WIDGET_TYPE_URL = "URL"
+
+export const WIDGET_FIELD_TYPE_NUMBER = "number"
+export const WIDGET_FIELD_TYPE_TEXT = "text"
+export const WIDGET_FIELD_TYPE_TEXTAREA = "textarea"
+export const WIDGET_FIELD_TYPE_URL = "url"
+export const WIDGET_FIELD_TYPE_MARKDOWN = "markdown_wysiwyg"

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -3,8 +3,9 @@
 import R from "ramda"
 import React from "react"
 
-import type { EmbedlyResponse } from "../reducers/embedly"
 import ReactDOMServer from "react-dom/server"
+
+import type { EmbedlyResponse } from "../reducers/embedly"
 
 export const ensureTwitterEmbedJS = () => {
   if (!window.twttr) {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -6,6 +6,7 @@ import qs from "query-string"
 
 import type { Match } from "react-router"
 import type { Profile } from "../flow/discussionTypes"
+import isURL from "validator/lib/isURL"
 
 export const getChannelName = (props: { match: Match }): string =>
   props.match.params.channelName || ""
@@ -123,3 +124,6 @@ export function* incrementer(): Generator<number, *, *> {
     yield int++
   }
 }
+
+export const isValidUrl = (url: string): boolean =>
+  isURL(url, { allow_underscores: true, require_protocol: true })

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -15,7 +15,8 @@ import {
   getTokenFromUrl,
   defaultProfileImageUrl,
   makeUUID,
-  spaceSeparated
+  spaceSeparated,
+  isValidUrl
 } from "./util"
 
 describe("utility functions", () => {
@@ -180,6 +181,13 @@ describe("utility functions", () => {
       ].forEach(([inputArr, expectedStr]) => {
         assert.deepEqual(spaceSeparated(inputArr), expectedStr)
       })
+    })
+  })
+
+  describe("isValidUrl", () => {
+    it("should assert that a URL allows underscores and requires a protocol prefix", () => {
+      assert.isFalse(isValidUrl("mit.edu"))
+      assert.isTrue(isValidUrl("http://mit.edu/a_url_here"))
     })
   })
 })

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -20,8 +20,16 @@ import {
   validatePasswordChangeForm,
   PASSWORD_LENGTH_MINIMUM,
   validNotMIT,
-  validateSearchQuery
+  validateSearchQuery,
+  validateWidgetDialog
 } from "./validation"
+import {
+  WIDGET_CREATE,
+  WIDGET_EDIT,
+  WIDGET_TYPE_SELECT
+} from "../components/widgets/WidgetEditDialog"
+import { makeWidgetInstance } from "../factories/widgets"
+import { WIDGET_TYPE_RSS, WIDGET_TYPE_URL } from "./constants"
 
 describe("validation library", () => {
   describe("validation", () => {
@@ -431,6 +439,47 @@ describe("validation library", () => {
     ].forEach(([query, isValid]) => {
       it(`a query of '${String(query)}' ${shouldIf(isValid)} be valid`, () => {
         assert.equal(validateSearchQuery(query) === null, isValid)
+      })
+    })
+  })
+
+  describe("validateWidgetDialog", () => {
+    it("should require that a widget type is selected", () => {
+      const data = {
+        state:    WIDGET_TYPE_SELECT,
+        instance: makeWidgetInstance()
+      }
+      assert.deepEqual(validateWidgetDialog(data), {})
+      data.instance.widget_type = null
+      assert.deepEqual(validateWidgetDialog(data), {
+        widget_type: "Widget type is required"
+      })
+    })
+
+    it("should require a widget title", () => {
+      const data = {
+        state:    WIDGET_EDIT,
+        instance: makeWidgetInstance()
+      }
+      assert.deepEqual(validateWidgetDialog(data), {})
+      data.instance.title = null
+      assert.deepEqual(validateWidgetDialog(data), {
+        title: "Widget title is required"
+      })
+    })
+    ;[WIDGET_TYPE_RSS, WIDGET_TYPE_URL].forEach(widgetType => {
+      it(`should require a valid URL for widget type ${widgetType}`, () => {
+        const data = {
+          state:    WIDGET_CREATE,
+          instance: makeWidgetInstance(widgetType)
+        }
+        assert.deepEqual(validateWidgetDialog(data), {})
+        data.instance.configuration.url = "url.without.protocol.prefix.edu"
+        assert.deepEqual(validateWidgetDialog(data), {
+          configuration: {
+            url: "URL is not valid"
+          }
+        })
       })
     })
   })

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -446,10 +446,12 @@ describe("validation library", () => {
   describe("validateWidgetDialog", () => {
     it("should require that a widget type is selected", () => {
       const data = {
-        state:    WIDGET_TYPE_SELECT,
-        instance: makeWidgetInstance()
+        state:      WIDGET_TYPE_SELECT,
+        instance:   makeWidgetInstance(),
+        validation: {}
       }
       assert.deepEqual(validateWidgetDialog(data), {})
+      // $FlowFixMe
       data.instance.widget_type = null
       assert.deepEqual(validateWidgetDialog(data), {
         widget_type: "Widget type is required"
@@ -458,10 +460,12 @@ describe("validation library", () => {
 
     it("should require a widget title", () => {
       const data = {
-        state:    WIDGET_EDIT,
-        instance: makeWidgetInstance()
+        state:      WIDGET_EDIT,
+        instance:   makeWidgetInstance(),
+        validation: {}
       }
       assert.deepEqual(validateWidgetDialog(data), {})
+      // $FlowFixMe
       data.instance.title = null
       assert.deepEqual(validateWidgetDialog(data), {
         title: "Widget title is required"
@@ -470,8 +474,9 @@ describe("validation library", () => {
     ;[WIDGET_TYPE_RSS, WIDGET_TYPE_URL].forEach(widgetType => {
       it(`should require a valid URL for widget type ${widgetType}`, () => {
         const data = {
-          state:    WIDGET_CREATE,
-          instance: makeWidgetInstance(widgetType)
+          state:      WIDGET_CREATE,
+          instance:   makeWidgetInstance(widgetType),
+          validation: {}
         }
         assert.deepEqual(validateWidgetDialog(data), {})
         data.instance.configuration.url = "url.without.protocol.prefix.edu"

--- a/static/js/lib/widgets.js
+++ b/static/js/lib/widgets.js
@@ -3,6 +3,11 @@ import MarkdownWidget from "../components/widgets/MarkdownWidget"
 import RssWidget from "../components/widgets/RssWidget"
 import UrlWidget from "../components/widgets/UrlWidget"
 
+import {
+  WIDGET_TYPE_MARKDOWN,
+  WIDGET_TYPE_RSS,
+  WIDGET_TYPE_URL
+} from "./constants"
 import { incrementer } from "./util"
 
 import type { WidgetInstancePatchable } from "../flow/widgetTypes"
@@ -10,9 +15,9 @@ import type { WidgetInstancePatchable } from "../flow/widgetTypes"
 export const WIDGET_FORM_KEY = "widgets:edit"
 
 export const validWidgetRenderers = {
-  Markdown:   MarkdownWidget,
-  "RSS Feed": RssWidget,
-  URL:        UrlWidget
+  [WIDGET_TYPE_MARKDOWN]: MarkdownWidget,
+  [WIDGET_TYPE_RSS]:      RssWidget,
+  [WIDGET_TYPE_URL]:      UrlWidget
 }
 
 const newWidgetIncr = incrementer()

--- a/static/js/lib/widgets_test.js
+++ b/static/js/lib/widgets_test.js
@@ -6,6 +6,11 @@ import RssWidget from "../components/widgets/RssWidget"
 import UrlWidget from "../components/widgets/UrlWidget"
 
 import {
+  WIDGET_TYPE_URL,
+  WIDGET_TYPE_RSS,
+  WIDGET_TYPE_MARKDOWN
+} from "./constants"
+import {
   validWidgetRenderers,
   getWidgetKey,
   newWidgetInstance
@@ -15,15 +20,15 @@ import { makeWidgetInstance } from "../factories/widgets"
 describe("widget library functions", () => {
   describe("valid widget renderers", () => {
     it("renders with MarkdownWidget", () => {
-      assert.equal(validWidgetRenderers.Markdown, MarkdownWidget)
+      assert.equal(validWidgetRenderers[WIDGET_TYPE_MARKDOWN], MarkdownWidget)
     })
 
     it("renders with RssWidget", () => {
-      assert.equal(validWidgetRenderers["RSS Feed"], RssWidget)
+      assert.equal(validWidgetRenderers[WIDGET_TYPE_RSS], RssWidget)
     })
 
     it("renders with UrlWidget", () => {
-      assert.equal(validWidgetRenderers.URL, UrlWidget)
+      assert.equal(validWidgetRenderers[WIDGET_TYPE_URL], UrlWidget)
     })
   })
 

--- a/static/js/storybook/index.js
+++ b/static/js/storybook/index.js
@@ -28,6 +28,11 @@ import {
   makeWidgetListResponse
 } from "../factories/widgets"
 import { CHANNEL_TYPE_PRIVATE, CHANNEL_TYPE_PUBLIC } from "../lib/channels"
+import {
+  WIDGET_TYPE_MARKDOWN,
+  WIDGET_TYPE_RSS,
+  WIDGET_TYPE_URL
+} from "../lib/constants"
 import { dropdownMenuFuncs } from "../lib/ui"
 import { commentPermalink } from "../lib/url"
 import { getWidgetKey } from "../lib/widgets"
@@ -629,7 +634,7 @@ storiesOf("Widgets", module)
   .addDecorator(withKnobs)
   .add("markdown", () => {
     const editing = boolean("editing")
-    const instance = makeWidgetInstance("Markdown")
+    const instance = makeWidgetInstance(WIDGET_TYPE_MARKDOWN)
     instance.title = text("title", "Markdown widget title")
     instance.configuration.source = text("markdown", "Markdown **body**")
 
@@ -650,7 +655,7 @@ storiesOf("Widgets", module)
   })
   .add("rss", () => {
     const editing = boolean("editing")
-    const instance = makeWidgetInstance("RSS Feed")
+    const instance = makeWidgetInstance(WIDGET_TYPE_RSS)
     instance.title = text("title", "Default widget title")
 
     const SortableWidgetInstance = SortableContainer(props => (
@@ -670,7 +675,7 @@ storiesOf("Widgets", module)
   })
   .add("url", () => {
     const editing = boolean("editing")
-    const instance = makeWidgetInstance("URL")
+    const instance = makeWidgetInstance(WIDGET_TYPE_URL)
     instance.title = text("title", "URL widget title")
     instance.configuration = {
       url:

--- a/widgets/factories.py
+++ b/widgets/factories.py
@@ -6,14 +6,15 @@ from widgets.models import WidgetList, WidgetInstance
 
 
 class WidgetListFactory(DjangoModelFactory):
-    "Factory for widget lists"
+    """Factory for widget lists"""
 
     class Meta:
         model = WidgetList
 
 
 class WidgetInstanceFactory(DjangoModelFactory):
-    "Factory for widget lists"
+    """Factory for widget lists"""
+
     widget_list = factory.SubFactory(WidgetListFactory)
     widget_type = "Text"
     position = factory.LazyAttribute(lambda inst: inst.widget_list.widgets.count() + 1)

--- a/widgets/serializers/widget_list.py
+++ b/widgets/serializers/widget_list.py
@@ -27,9 +27,11 @@ class WidgetListSerializer(serializers.ModelSerializer):
 
     def get_widgets(self, instance):
         """Returns the list of widgets"""
+        widget_map = get_widget_type_mapping()
         return [
             _serializer_for_widget_type(widget.widget_type)(widget).data
             for widget in instance.widgets.all()
+            if widget.widget_type in widget_map
         ]
 
     def get_available_widgets(self, instance):  # pylint: disable=unused-argument

--- a/widgets/serializers/widget_list_test.py
+++ b/widgets/serializers/widget_list_test.py
@@ -1,0 +1,20 @@
+"""Tests for widget list serializer"""
+import pytest
+
+from widgets.factories import WidgetInstanceFactory, WidgetListFactory
+from widgets.serializers.widget_list import WidgetListSerializer
+from widgets.views_test import EXPECTED_AVAILABLE_WIDGETS
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_missing_widget_type():
+    """If a widget type is in the database but not in the serializer map, it should be ignored"""
+    widget_list = WidgetListFactory.create()
+    WidgetInstanceFactory.create(widget_list=widget_list, widget_type="not_A_real_type")
+    assert WidgetListSerializer(widget_list).data == {
+        "available_widgets": EXPECTED_AVAILABLE_WIDGETS,
+        "widgets": [],
+        "id": widget_list.id,
+    }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots 
  - [x] tag @ferdi or @pdpinch for review  
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1791

#### What's this PR do?
Adds front-end validation for URL for the RSS URL field and the Embedly URL field. Also updates the URL validation to require the protocol prefix so that the Django URLField will not fail validation.

#### How should this be manually tested?
Try to add or edit an embedly widget to have "mit.edu" as the URL, without any "http" part. You should not see any embedly rendering for that, and you should see a validation error saying the URL is invalid.

Change the URL to a different one with the "http" prefix. You should now see some embedly rendering. Save the dialog, then click "Done". The changes should persist correctly.


#### Screenshots (if appropriate)
![screenshot from 2019-02-01 12-19-28](https://user-images.githubusercontent.com/863262/52139507-577a0680-261e-11e9-9c70-94a86785e49c.png)

