### PR TITLE
Fixed exception with lazy submissions

### DIFF
--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -250,9 +250,12 @@ def populate_posts_and_comments(post_ids):
     submissions = []
     for post_id in post_ids:
         try:
-            submissions.append(admin_api.get_submission(base36.dumps(post_id)))
+            submission = admin_api.get_submission(base36.dumps(post_id))
+            # force a fetch so any loading errors get caught now
+            submission._fetch()  # pylint: disable=protected-access
+            submissions.append(submission)
         except:  # pylint: disable=bare-except
-            log.exception("Could not find submission '%s'", post_id)
+            log.warning("Could not find submission '%s'", post_id)
 
     channels_by_name = Channel.objects.in_bulk(
         [submission.subreddit.display_name for submission in submissions],


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1807 

#### What's this PR do?
Forces a fetch so nonexistent submissions don't fail the whole task

#### How should this be manually tested?
Run the backpopulate for a post that doesn't exist (use a high value id). Example that will probably work for your local: `./manage.py backpopulate_posts --post "zzzzzz"`

It should break the task on master, but only log a warning in this branch. 