### PR TITLE
Switch backpopulate over to the list() api

### DIFF
--- a/channels/backpopulate_api.py
+++ b/channels/backpopulate_api.py
@@ -70,13 +70,14 @@ def backpopulate_comments(*, post, submission):
         int: number of comments backpopulated
     """
     submission.comments.replace_more(limit=None)
+    all_comments = submission.comments.list()
     author_usernames = {
-        comment.author.name for comment in submission.comments if comment.author
+        comment.author.name for comment in all_comments if comment.author
     }
     authors_by_username = User.objects.in_bulk(author_usernames, field_name="username")
     update_count = 0
 
-    for comment in submission.comments:
+    for comment in all_comments:
         author = (
             authors_by_username.get(comment.author.name) if comment.author else None
         )

--- a/channels/backpopulate_api_test.py
+++ b/channels/backpopulate_api_test.py
@@ -183,7 +183,7 @@ def test_backpopulate_comments(mocker):
             created=CREATED_TIMESTAMP,
         ),
     ]
-    submission.comments.__iter__.return_value = comments
+    submission.comments.list.return_value = comments
 
     result = backpopulate_api.backpopulate_comments(post=post, submission=submission)
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1812 

#### What's this PR do?
Backpopulate was previously only walking top-level comments

#### How should this be manually tested?
- Delete all comments for a post that has nested comments
- Run `./manage.py backpopulate_posts` and ensure you see all the records reappear