### PR TITLE
fix the thing

### DIFF
--- a/static/scss/close-button.scss
+++ b/static/scss/close-button.scss
@@ -9,7 +9,7 @@
   width: 24px;
   display: flex;
   cursor: pointer;
-  z-index: 10;
+  z-index: 4;
 
   i {
     font-size: 21px;


### PR DESCRIPTION
#### What are the relevant tickets?

closes #1777

#### What's this PR do?

this adjusts the z-index on the `CloseButton` component so that it doesn't appear to be spookily floating above the dialog box any longer.

#### How should this be manually tested?

Make sure you can reproduce the problem described in the linked issue, then confirm that this fixes it.
