### PR TITLE
Fix link menu when editing rich text widget

### DIFF
--- a/static/js/components/Editor.js
+++ b/static/js/components/Editor.js
@@ -330,6 +330,8 @@ export class Editor extends React.Component<Props, State> {
 
   render() {
     const { showLinkMenu } = this.state
+    const { getForm } = this.formHelpers
+    const form = getForm(this.props)
 
     return (
       <div className="editor-wrapper">
@@ -340,7 +342,7 @@ export class Editor extends React.Component<Props, State> {
           ref={this.node}
         />
         {this.renderMenuBar()}
-        {showLinkMenu ? this.renderLinkMenu() : null}
+        {showLinkMenu && form ? this.renderLinkMenu() : null}
       </div>
     )
   }

--- a/static/js/components/Editor_test.js
+++ b/static/js/components/Editor_test.js
@@ -18,6 +18,7 @@ import ConnectedEditor, {
   menuButtonClass
 } from "./Editor"
 
+import { actions } from "../actions"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { shouldIf } from "../lib/test_utils"
 import * as util from "../lib/util"
@@ -365,6 +366,16 @@ describe("Editor component", () => {
       inner.instance().closeLinkMenu()
       wrapper.update()
       assert.isNotOk(wrapper.find(AddLinkMenu).exists())
+    })
+
+    it("should not render <AddLinkMenu /> if the form doesn't exist", () => {
+      const { wrapper, inner } = renderConnectedEditor()
+      inner.instance().openLinkMenu()
+      helper.store.dispatch(
+        actions.forms.formEndEdit({ formKey: inner.instance().uuid })
+      )
+      wrapper.update()
+      assert.isFalse(wrapper.find(AddLinkMenu).exists())
     })
 
     it("should pass the right props to <AddLinkMenu />", () => {

--- a/static/scss/add-link-menu.scss
+++ b/static/scss/add-link-menu.scss
@@ -28,4 +28,8 @@
     white-space: nowrap;
     margin: 0 5px;
   }
+
+  input {
+    width: inherit;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1805 

#### What's this PR do?
It seems like there's a race condition between the `setState` and the creating of the form via redux. To workaround this the visibility check is updated to make sure the form exists before rendering it.

#### How should this be manually tested?
Start managing widgets. Add a new rich text widget. In the interface add a link. On master this will cause an exception but it should work fine on this PR.

#### Any background context you want to provide?
There's a CSS change I needed to make so that all the items in the link dialog fit within it on Firefox. There are some changes with the width of the text fields, see the screenshots below.

#### Screenshots (if appropriate)
Chrome + PR + create post
![chrome_pr_createpost](https://user-images.githubusercontent.com/863262/52292029-c66a9e80-2941-11e9-96fb-b9e865414b57.png)


Chrome + PR + widget edit
![chrome_pr_widget](https://user-images.githubusercontent.com/863262/52292033-ca96bc00-2941-11e9-881c-e130cfd339df.png)


Firefox + PR + create post
![firefox_pr_createpost](https://user-images.githubusercontent.com/863262/52292043-ce2a4300-2941-11e9-9a0d-807ffabf5be0.png)

Firefox + PR + widget edit
![firefox_pr_widget](https://user-images.githubusercontent.com/863262/52292046-d1253380-2941-11e9-9c99-0dc7db3e3800.png)

Chrome + master + create post
![chrome_master_createpost](https://user-images.githubusercontent.com/863262/52292056-d5515100-2941-11e9-8a2b-33ac2497a720.png)

Chrome + master + widget edit
Broken

Firefox + master + create post
![firefox_master_createpost](https://user-images.githubusercontent.com/863262/52292072-dd10f580-2941-11e9-9e5b-19f949dfa05b.png)


Firefox + master + widget edit
Broken