### PR TITLE
Fixed bug with preview text for posts including a base64-encoded image

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -4,12 +4,12 @@ import React from "react"
 import moment from "moment"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
-import Dotdotdot from "react-dotdotdot"
 
 import Card from "./Card"
 import DropdownMenu from "./DropdownMenu"
 import ReportCount from "./ReportCount"
 import PostUpvoteButton from "./PostUpvoteButton"
+import TruncatedText from "./TruncatedText"
 
 import {
   channelURL,
@@ -137,7 +137,7 @@ export class CompactPostDisplay extends React.Component<Props> {
     const { post, showPinUI } = this.props
 
     const formattedDate = moment(post.created).fromNow()
-    const previewText = getPlainTextContent(post)
+    const plainText = getPlainTextContent(post)
 
     return (
       <Card
@@ -163,11 +163,14 @@ export class CompactPostDisplay extends React.Component<Props> {
                 </div>
               </Link>
             </div>
-            {previewText ? (
+            {plainText ? (
               <div className="row">
-                <Dotdotdot clamp={POST_PREVIEW_LINES} className="preview">
-                  {previewText}
-                </Dotdotdot>
+                <TruncatedText
+                  text={plainText}
+                  lines={POST_PREVIEW_LINES}
+                  estCharsPerLine={130}
+                  className="preview"
+                />
               </div>
             ) : null}
             <div className="row author-row">

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -110,9 +110,13 @@ describe("CompactPostDisplay", () => {
       post_type:  LINK_TYPE_TEXT,
       plain_text: exampleText
     })
-    const truncatableText = renderPostDisplay({ post }).find("Dotdotdot")
-    assert.equal(truncatableText.prop("clamp"), POST_PREVIEW_LINES)
-    assert.equal(truncatableText.prop("children"), exampleText)
+    const truncatableText = renderPostDisplay({ post }).find("TruncatedText")
+    assert.deepEqual(truncatableText.props(), {
+      text:            exampleText,
+      lines:           POST_PREVIEW_LINES,
+      estCharsPerLine: 130,
+      className:       "preview"
+    })
   })
 
   it("should link to the post detail page via post date", () => {

--- a/static/js/components/TruncatedText.js
+++ b/static/js/components/TruncatedText.js
@@ -1,0 +1,25 @@
+import React from "react"
+
+import Dotdotdot from "react-dotdotdot"
+
+type Props = {
+  text: string,
+  lines: number,
+  // Estimated maximum number of characters on a single line of text for the element where this
+  // text will be rendered. Doesn't have to be exact.
+  estCharsPerLine: number,
+  className: ?string
+}
+
+const TruncatedText = ({ text, lines, estCharsPerLine, className }: Props) => {
+  return (
+    <Dotdotdot clamp={lines} className={className}>
+      {// Dotdotdot seems to trip on long, unbroken strings. As a fail-safe, we're limiting
+      // the input string to a number of characters that is greater than the characters that
+      // will be shown, but not so long that it will cause issues with Dotdotdot.
+        text.substring(0, estCharsPerLine * (lines + 2))}
+    </Dotdotdot>
+  )
+}
+
+export default TruncatedText

--- a/static/js/components/TruncatedText_test.js
+++ b/static/js/components/TruncatedText_test.js
@@ -1,0 +1,42 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import _ from "lodash"
+
+import TruncatedText from "./TruncatedText"
+
+describe("TruncatedText", () => {
+  const render = (props = {}) => shallow(<TruncatedText {...props} />)
+
+  it("displays text", () => {
+    const props = {
+      text:            "normal text",
+      lines:           2,
+      estCharsPerLine: 200,
+      className:       "some-class"
+    }
+    const wrapper = render(props)
+    const dotdotdot = wrapper.find("Dotdotdot")
+
+    assert.isTrue(dotdotdot.exists())
+    assert.equal(dotdotdot.prop("clamp"), props.lines)
+    assert.equal(dotdotdot.prop("className"), props.className)
+    assert.equal(dotdotdot.prop("children"), props.text)
+  })
+
+  it("limits text that is passed into Dotdotdot if necessary", () => {
+    const text = _.repeat("1234567890", 10),
+      lines = 1,
+      estCharsPerLine = 5
+    const props = { text, lines, estCharsPerLine }
+    const wrapper = render(props)
+    const dotdotdotText = wrapper.find("Dotdotdot").prop("children")
+
+    assert.isBelow(dotdotdotText.length, text.length)
+    assert.equal(
+      dotdotdotText,
+      text.substring(0, estCharsPerLine * (lines + 2))
+    )
+  })
+})

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -121,13 +121,8 @@ export const postMenuDropdownFuncs = (dispatch: Dispatch<*>, post: Post) => {
   }
 }
 
-export const getPlainTextContent = (post: Post): ?string => {
-  if (isPostContainingText(post)) {
-    // Default to the 'text' value if 'plain_text' is null for any reason
-    return post.plain_text || post.text
-  }
-  return null
-}
+export const getPlainTextContent = (post: Post): ?string =>
+  isPostContainingText(post) ? post.plain_text : null
 
 export const isEditablePostType = (post: Post): boolean =>
   post.post_type === LINK_TYPE_TEXT || post.post_type === LINK_TYPE_ARTICLE

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -172,16 +172,16 @@ describe("Post utils", () => {
   })
 
   describe("getPlainTextContent", () => {
-    const exampleText = "magnets, how do they work?"
+    const txt = "magnets, how do they work?"
     ;[
-      [LINK_TYPE_LINK, {}, null],
-      [LINK_TYPE_ARTICLE, { plain_text: exampleText }, exampleText],
-      [LINK_TYPE_TEXT, { plain_text: exampleText }, exampleText],
-      [LINK_TYPE_TEXT, { text: exampleText }, exampleText]
-    ].forEach(([postType, updatedProperties, expReturnValue]) => {
+      [LINK_TYPE_LINK, {}, null, "link post"],
+      [LINK_TYPE_ARTICLE, { plain_text: txt }, txt, "article post"],
+      [LINK_TYPE_TEXT, { plain_text: txt }, txt, "text post"],
+      [LINK_TYPE_TEXT, { text: txt }, null, "text post w/ empty plain text"]
+    ].forEach(([postType, updatedProperties, expReturnValue, desc]) => {
       it(`${shouldIf(
         !!expReturnValue
-      )} return some text content for ${postType}-type post`, () => {
+      )} return some text content for a ${desc}`, () => {
         const post = {
           ...makePost(postType === LINK_TYPE_LINK),
           ...updatedProperties,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/internal/issues/13

#### What's this PR do?
Fixes bug with preview text for posts including a base64-encoded image.

#### How should this be manually tested?
- Go through the steps to reproduce in the linked issue. The bug behavior should no longer happen on this branch
- Make sure that all of your posts look correct in the post listing views (channel pages, front page, profile page)

#### Screenshots (if appropriate)
![ss 2019-02-05 at 13 46 17](https://user-images.githubusercontent.com/14932219/52296483-7c3aea80-294c-11e9-957a-29a75ea96d03.png)
![ss 2019-02-05 at 13 46 24](https://user-images.githubusercontent.com/14932219/52296488-7e04ae00-294c-11e9-84b8-327d846c847f.png)


