### PR TITLE
Bumped Elasticsearch docker image version to 6.5.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "6379"
 
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
     environment:
       - network.host=0.0.0.0
       - http.cors.enabled=true


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1810 

#### What's this PR do?
Bumps our Elasticsearch docker image version to 6.5.4

#### How should this be manually tested?
- Run the `recreate_index` management command
- Search for some posts/comments on the search page and check that results are as expected
- Perform some index-updating tasks (e.g.: creating a new post), then run a search that will yield the new/updated document(s) and make sure those changes have been reflected in the index

#### Any background context you want to provide?
- The latest version of ES is 6.6, but [there isn't a published docker image for that version yet](https://hub.docker.com/_/elasticsearch)
- @blarghmatey: Merging this will probably require some ops magic on your end
- I'm pretty sure we'll need everyone to run `recreate_index` after this merges
