### PR TITLE
Added reporting of validation errors to sentry

### DIFF
--- a/open_discussions/exceptions.py
+++ b/open_discussions/exceptions.py
@@ -1,4 +1,6 @@
 """Exceptions for open discussions"""
+from raven.contrib.django.raven_compat.models import client
+from rest_framework.exceptions import ValidationError
 from rest_framework.views import exception_handler
 
 
@@ -9,6 +11,10 @@ def api_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
     response = exception_handler(exc, context)
+
+    if isinstance(exc, ValidationError):
+        # validation errors should get sent to Sentry
+        client.captureException()
 
     # now add the error type to the response
     # sometimes this is a list() if such an api was called

--- a/open_discussions/exceptions_test.py
+++ b/open_discussions/exceptions_test.py
@@ -1,0 +1,39 @@
+"""Tests for exceptions"""
+import pytest
+from django.template import RequestContext
+from rest_framework.exceptions import ValidationError
+
+from open_discussions import exceptions
+
+
+@pytest.mark.parametrize("data", [{}, None, "data"])
+@pytest.mark.parametrize(
+    "exception, sentry_called",
+    [(Exception(), False), (ValidationError("field is invalid"), True)],
+)
+def test_api_exception_handler(mocker, rf, data, exception, sentry_called):
+    """
+    Test a standard exception not handled by default by the rest framework
+    """
+    mock_sentry = mocker.patch(
+        "raven.contrib.django.raven_compat.models.client.captureException",
+        autospec=True,
+    )
+    mock_default_handler = mocker.patch(
+        "open_discussions.exceptions.exception_handler",
+        return_value=mocker.Mock(data=data),
+    )
+
+    context = RequestContext(rf.get("/"))
+
+    resp = exceptions.api_exception_handler(exception, context)
+
+    mock_default_handler.assert_called_once_with(exception, context)
+    if sentry_called:
+        mock_sentry.assert_called_once_with()
+    else:
+        mock_sentry.assert_not_called()
+
+    assert resp == mock_default_handler.return_value
+    if isinstance(data, dict):
+        assert resp.data["error_type"] == exception.__class__.__name__


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1793 

#### What's this PR do?
Logs api validation errors to sentry

#### How should this be manually tested?
You could configure sentry locally and try to submit an invalid API request (e.g. create a post with an empty payload). Or this is simple enough and you can see a test one I triggered in sentry here: https://sentry.io/mit-office-of-digital-learning/discussions/issues/874913945/?query=is%3Aunresolved
