### PR TITLE
Added a few issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,28 @@
+---
+labels: bug
+name: "Bug Report"
+about: "Something isn't quite right"
+---
+### Steps to Reproduce
+
+(List or Description)
+
+### Expected Behavior
+
+(Optional)
+
+### Actual Behavior
+
+(Optional)
+
+### Stacktrace
+
+(Optional)
+
+### Related Issues
+
+(Optional)
+
+### Screenshot or Screencast
+
+(Optional)

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,17 @@
+---
+name: New Feature
+about: "New feature to implement"
+---
+As a X, I'd like to Y
+
+#### Designs and Mockups
+
+
+
+#### Acceptance Criteria:
+
+- [ ] Requirement
+
+#### Out of Scope
+
+- Not going to do

--- a/.github/ISSUE_TEMPLATE/rfc_template.md
+++ b/.github/ISSUE_TEMPLATE/rfc_template.md
@@ -1,0 +1,13 @@
+---
+title: 'RFC: '
+labels: RFC
+name: "Request For Comment"
+about: "About to work on something substantial? Make an RFC!"
+---
+
+
+[Rendered](https://github.com/mitodl/open-discussions/blob/COMMIT_BLOB/docs/rfcs/XXXX-feature-name.md)
+
+#### Relevant Issues
+
+#### Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 #### Pre-Flight checklist
 
 - [ ] Screenshots and design review for any changes that affect layout or styling
-  - [ ] Desktop screenshots 
-  - [ ] Mobile width screenshots 
-  - [ ] tag @ferdi or @pdpinch for review  
+  - [ ] Desktop screenshots
+  - [ ] Mobile width screenshots
+  - [ ] Tag @ferdi or @pdpinch for review
 - [ ] Migrations
   - [ ] Migration is backwards-compatible with current production code
 - [ ] Testing

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,12 @@
+## Title for RFC
+
+#### Abstract
+
+
+##### Architecture Changes
+
+
+#### Security Considerations
+
+
+#### Testing & Rollout


### PR DESCRIPTION

#### What are the relevant tickets?
N/A, but implemented an RFC template (plus a bug and feature on based on how we often write those) based on the writings in this blog post: https://blog.pragmaticengineer.com/scaling-engineering-teams-via-writing-things-down-rfcs/

#### What's this PR do?
Adds some templates for issues and moves the existing PR template into the `.github/` directory to keep clutter down.

#### How should this be manually tested?
N/A
