### PR TITLE
add channel about page frontend

### DIFF
--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -19,42 +19,39 @@ type Props = {
   channel: Channel,
   history: Object,
   isModerator: boolean,
-  navbarItems?: React.Node
+  children?: any
 }
 
-export default class ChannelHeader extends React.Component<Props> {
-  render() {
-    const { channel, history, isModerator, navbarItems } = this.props
-    return (
-      <div className="channel-page-header">
-        <ChannelBanner editable={false} channel={channel} />
-        <Grid className="main-content two-column channel-header">
-          <Cell className="avatar-headline-row" width={12}>
-            <div className="left">
-              <ChannelAvatar
-                editable={false}
-                channel={channel}
-                imageSize={CHANNEL_AVATAR_MEDIUM}
-              />
-              <div className="title-and-headline">
-                <div className="title">
-                  <Link to={channelURL(channel.name)}>{channel.title}</Link>
-                </div>
-                {channel.public_description ? (
-                  <div className="headline">{channel.public_description}</div>
-                ) : null}
-              </div>
+const ChannelHeader = ({ channel, history, isModerator, children }: Props) => (
+  <div className="channel-page-header">
+    <ChannelBanner editable={false} channel={channel} />
+    <Grid className="main-content two-column channel-header">
+      <Cell className="avatar-headline-row" width={12}>
+        <div className="left">
+          <ChannelAvatar
+            editable={false}
+            channel={channel}
+            imageSize={CHANNEL_AVATAR_MEDIUM}
+          />
+          <div className="title-and-headline">
+            <div className="title">
+              <Link to={channelURL(channel.name)}>{channel.title}</Link>
             </div>
-            <div className="right channel-controls">
-              <ChannelFollowControls channel={channel} history={history} />
-              {isModerator ? (
-                <ChannelSettingsLink channel={channel} history={history} />
-              ) : null}
-            </div>
-          </Cell>
-        </Grid>
-        {navbarItems}
-      </div>
-    )
-  }
-}
+            {channel.public_description ? (
+              <div className="headline">{channel.public_description}</div>
+            ) : null}
+          </div>
+        </div>
+        <div className="right channel-controls">
+          <ChannelFollowControls channel={channel} history={history} />
+          {isModerator ? (
+            <ChannelSettingsLink channel={channel} history={history} />
+          ) : null}
+        </div>
+      </Cell>
+    </Grid>
+    {children}
+  </div>
+)
+
+export default ChannelHeader

--- a/static/js/components/ChannelHeader_test.js
+++ b/static/js/components/ChannelHeader_test.js
@@ -7,7 +7,6 @@ import { assert } from "chai"
 import ChannelHeader from "./ChannelHeader"
 
 import { makeChannel } from "../factories/channels"
-import { shouldIf } from "../lib/test_utils"
 import { channelURL } from "../lib/url"
 
 describe("ChannelHeader", () => {
@@ -38,6 +37,7 @@ describe("ChannelHeader", () => {
     assert.equal(linkProps.to, channelURL(channel.name))
     assert.equal(linkProps.children, channel.title)
   })
+
   it("renders options for a user to follow/unfollow the channel", () => {
     const wrapper = render()
     const followControls = wrapper.find("Connect(ChannelFollowControls)")
@@ -47,15 +47,17 @@ describe("ChannelHeader", () => {
       channel
     })
   })
-  ;[true, false].forEach(hasNavbar => {
-    it(`${shouldIf(hasNavbar)} navbar items`, () => {
-      const navbarItems = "navbarItems"
-      const wrapper = render({
-        navbarItems: hasNavbar ? navbarItems : null
-      })
-      assert.equal(wrapper.text().includes(navbarItems), hasNavbar)
-    })
+
+  it("should render children", () => {
+    const wrapper = shallow(
+      <ChannelHeader channel={channel} isModerator={false} history={history}>
+        <div className="im-a-child" />
+      </ChannelHeader>
+    )
+    assert.ok(wrapper.find(".im-a-child").exists())
   })
+
+  //
   ;[true, false].forEach(hasHeadline => {
     it(`${
       hasHeadline ? "shows" : "doesn't show"
@@ -69,6 +71,8 @@ describe("ChannelHeader", () => {
       }
     })
   })
+
+  //
   ;[true, false].forEach(isModerator => {
     it(`${
       isModerator ? "shows" : "doesn't show"

--- a/static/js/components/ChannelNavbar.js
+++ b/static/js/components/ChannelNavbar.js
@@ -1,12 +1,13 @@
 // @flow
 /* global SETTINGS: false */
 import * as React from "react"
+import R from "ramda"
 import { NavLink } from "react-router-dom"
 
 import { Cell, Grid } from "./Grid"
 import IntraPageNav from "./IntraPageNav"
 
-import { channelSearchURL, channelURL } from "../lib/url"
+import { channelSearchURL, channelURL, channelAboutURL } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
@@ -28,9 +29,20 @@ export default class ChannelNavbar extends React.Component<Props> {
                 exact
                 to={channelURL(channel.name)}
                 activeClassName="active"
+                className="home-link"
               >
                 Home
               </NavLink>
+              {!R.isNil(channel.about) || channel.user_is_moderator ? (
+                <NavLink
+                  exact
+                  to={channelAboutURL(channel.name)}
+                  activeClassName="active"
+                  className="about-link"
+                >
+                  About
+                </NavLink>
+              ) : null}
               {SETTINGS.allow_search ? (
                 <NavLink
                   exact

--- a/static/js/components/ChannelNavbar_test.js
+++ b/static/js/components/ChannelNavbar_test.js
@@ -6,6 +6,7 @@ import { shallow } from "enzyme"
 
 import ChannelNavbar from "./ChannelNavbar"
 
+import { shouldIf, isIf } from "../lib/test_utils"
 import { channelURL } from "../lib/url"
 import { makeChannel } from "../factories/channels"
 
@@ -28,9 +29,8 @@ describe("ChannelNavbar", () => {
   it("renders a navbar", () => {
     const children = "some children"
     const wrapper = render({ children })
-    const links = wrapper.find("IntraPageNav NavLink")
-    assert.equal(links.length, 1)
-    const props = links.props()
+    const homeLink = wrapper.find(".home-link")
+    const props = homeLink.props()
     assert.equal(props.to, channelURL(channel.name))
     assert.isTrue(
       wrapper
@@ -40,13 +40,34 @@ describe("ChannelNavbar", () => {
         .includes(children)
     )
   })
+
+  //
   ;[true, false].forEach(allowSearch => {
     it(`${
       allowSearch ? "shows" : "doesn't show"
     } the search button depending on if it's allowed`, () => {
       SETTINGS.allow_search = allowSearch
       const wrapper = render()
-      assert.equal(wrapper.find(".search-link").length, allowSearch ? 1 : 0)
+      assert.equal(wrapper.find(".search-link").exists(), allowSearch)
+    })
+  })
+
+  //
+  ;[
+    [false, undefined, false],
+    [true, undefined, true],
+    [false, [{ foo: "bar" }], true],
+    [true, [{ foo: "bar" }], true]
+  ].forEach(([userIsModerator, channelAbout, shouldShowAboutLink]) => {
+    it(`${shouldIf(
+      shouldShowAboutLink
+    )} render about page link when user ${ifIf(
+      userIsModerator
+    )} moderator and channelabout = ${json.stringify(channelabout)}`, () => {
+      channel.about = channelabout
+      channel.user_is_moderator = userismoderator
+      const wrapper = render()
+      assert.equal(shouldShowAboutLink, wrapper.find(".about-link").exists())
     })
   })
 })

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -7,8 +7,6 @@ import { MetaTags } from "react-meta-tags"
 import qs from "query-string"
 
 import HomePage from "./HomePage"
-import ChannelPage from "./ChannelPage"
-import PostPage from "./PostPage"
 import SearchPage from "./SearchPage"
 import ContentPolicyPage from "./policies/ContentPolicyPage"
 import PrivacyPolicyPage from "./policies/PrivacyPolicyPage"
@@ -30,6 +28,7 @@ import RegisterDetailsPage from "./auth/RegisterDetailsPage"
 import InactiveUserPage from "./auth/InactiveUserPage"
 import PasswordResetPage from "./auth/PasswordResetPage"
 import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
+import ChannelRouter from "./ChannelRouter"
 
 import Snackbar from "../components/material/Snackbar"
 import Banner from "../components/material/Banner"
@@ -51,6 +50,7 @@ import { isAnonAccessiblePath, needsAuthedSite } from "../lib/auth"
 import { isMobileWidth, preventDefaultAndInvoke } from "../lib/util"
 import { getOwnProfile } from "../lib/redux_selectors"
 import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
+import { channelIndexRoute } from "../lib/routing"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -187,29 +187,8 @@ class App extends React.Component<AppProps> {
         <div className="content">
           <Route exact path={match.url} component={HomePage} />
           <Route
-            exact
-            path={`${match.url}c/:channelName`}
-            component={ChannelPage}
-          />
-          <Switch>
-            {SETTINGS.allow_search ? (
-              <Route
-                path={`${match.url}c/:channelName/search/`}
-                component={SearchPage}
-              />
-            ) : null}
-            <Route
-              exact
-              path={`${match.url}c/:channelName/:postID/:postSlug?`}
-              component={PostPage}
-            />
-          </Switch>
-          <Route
-            exact
-            path={`${
-              match.url
-            }c/:channelName/:postID/:postSlug?/comment/:commentID`}
-            component={PostPage}
+            path={channelIndexRoute(match.url)}
+            component={ChannelRouter}
           />
           <Route path={`${match.url}manage/`} component={AdminPage} />
           <Route

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -26,6 +26,7 @@ describe("App", () => {
     postList = makeChannelPostList()
     helper = new IntegrationTestHelper()
     helper.getChannelsStub.returns(Promise.resolve(channels))
+    helper.getChannelStub.returns(Promise.resolve(channels[0]))
     helper.getSettingsStub.returns(
       Promise.resolve([makeFrontpageSetting(), makeCommentSetting()])
     )

--- a/static/js/containers/ChannelAboutPage.js
+++ b/static/js/containers/ChannelAboutPage.js
@@ -1,0 +1,106 @@
+// @flow
+import React from "react"
+import R from "ramda"
+import { connect } from "react-redux"
+
+import ArticleEditor from "../components/ArticleEditor"
+
+import withSingleColumn from "../hoc/withSingleColumn"
+
+import { editorUpdateFormShim } from "../components/Editor"
+import { actions } from "../actions"
+import { getChannelForm } from "../lib/channels"
+import { channelFormDispatchToProps } from "../util/form_actions"
+
+import type { Channel, ChannelForm } from "../flow/discussionTypes"
+import type { FormValue } from "../flow/formTypes"
+import type { Dispatch } from "redux"
+
+type Props = {
+  channel: Channel,
+  dispatch: Dispatch<*>,
+  channelForm: FormValue<ChannelForm>,
+  channelName: string,
+  beginChannelFormEdit: Function,
+  endChannelFormEdit: Function,
+  patchChannel: Function,
+  updateChannelForm: Function
+}
+
+export class ChannelAboutPage extends React.Component<Props> {
+  renderAboutContent = () => {
+    const { channel, updateChannelForm, channelForm } = this.props
+
+    // key props are necessary here to force react to render
+    // a new ArticleEditor when we switch from viewing to editing
+    // instead of passing new props to the existing component
+    //
+    // this is because the ArticleEditor relies on DOM manipulation
+    // to render itself correctly, so it breaks some of React's
+    // assumptions
+    return channelForm ? (
+      <ArticleEditor
+        key="edit"
+        initialData={channel.about || []}
+        onChange={editorUpdateFormShim("about", updateChannelForm)}
+      />
+    ) : (
+      <ArticleEditor key="view" readOnly initialData={channel.about || []} />
+    )
+  }
+
+  saveChannelAbout = async () => {
+    const { channelForm, patchChannel, endChannelFormEdit } = this.props
+
+    const patchValue = R.pickAll(["name", "about"], channelForm.value)
+    await patchChannel(patchValue)
+    endChannelFormEdit()
+  }
+
+  renderChannelEditUI = () => {
+    const { beginChannelFormEdit, channelForm, channel } = this.props
+
+    return channelForm ? (
+      <button className="save-button" onClick={this.saveChannelAbout}>
+        Save
+      </button>
+    ) : (
+      <button
+        className="edit-button"
+        onClick={() => beginChannelFormEdit(channel)}
+      >
+        Edit
+      </button>
+    )
+  }
+
+  render() {
+    const { channel } = this.props
+
+    return (
+      <React.Fragment>
+        {channel ? this.renderAboutContent() : null}
+        {channel && channel.user_is_moderator
+          ? this.renderChannelEditUI()
+          : null}
+      </React.Fragment>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  channelForm: getChannelForm(state.forms)
+})
+
+const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
+  patchChannel: channelData => dispatch(actions.channels.patch(channelData)),
+  ...channelFormDispatchToProps(dispatch)
+})
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  withSingleColumn("home-page")
+)(ChannelAboutPage)

--- a/static/js/containers/ChannelAboutPage_test.js
+++ b/static/js/containers/ChannelAboutPage_test.js
@@ -1,0 +1,86 @@
+// @flow
+/* global SETTINGS */
+import { assert } from "chai"
+import sinon from "sinon"
+
+import ChannelAboutPage, {
+  ChannelAboutPage as InnerChannelAboutPage
+} from "./ChannelAboutPage"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeChannel } from "../factories/channels"
+import { shouldIf } from "../lib/test_utils"
+import { actions } from "../actions"
+import { editChannelForm, EDIT_CHANNEL_KEY } from "../lib/channels"
+
+describe("ChannelAboutPage", () => {
+  let helper, render, channel
+
+  beforeEach(() => {
+    channel = makeChannel()
+    helper = new IntegrationTestHelper()
+    helper.updateChannelStub.returns(Promise.resolve())
+    render = helper.configureHOCRenderer(
+      ChannelAboutPage,
+      InnerChannelAboutPage,
+      {
+        forms: {}
+      },
+      { channel }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render about content, if present", async () => {
+    channel.about = [{ foo: "bar" }]
+    const { inner } = await render()
+    const { readOnly, initialData } = inner.find("ArticleEditor").props()
+    assert.isTrue(readOnly)
+    assert.deepEqual(initialData, channel.about)
+  })
+
+  //
+  ;[true, false].forEach(userIsModerator => {
+    it(`${shouldIf(
+      userIsModerator
+    )} render editing UI if user is moderator`, async () => {
+      channel.user_is_moderator = userIsModerator
+      const { inner } = await render()
+      assert.equal(userIsModerator, inner.find(".edit-button").exists())
+    })
+  })
+
+  it("should call beginChannelFormEdit when user clicks edit", async () => {
+    channel.user_is_moderator = true
+    const { inner, store } = await render()
+    inner.find(".edit-button").simulate("click")
+    const { type, payload } = store.getLastAction()
+    assert.equal(type, actions.forms.FORM_BEGIN_EDIT)
+    assert.equal(payload.formKey, EDIT_CHANNEL_KEY)
+    assert.deepEqual(payload.value, editChannelForm(channel))
+  })
+
+  it("should render an editing UI when there is a form present", async () => {
+    channel.user_is_moderator = true
+    const patchStub = helper.sandbox.stub()
+    const { inner, store } = await render(
+      {
+        forms: {
+          [EDIT_CHANNEL_KEY]: { value: { field: "Value" } }
+        }
+      },
+      { patchChannel: patchStub }
+    )
+    const { onChange } = inner.find("ArticleEditor").props()
+    onChange("wowowowow")
+    const { type, payload } = store.getLastAction()
+    assert.equal(type, actions.forms.FORM_UPDATE)
+    assert.deepEqual(payload.value, { about: "wowowowow" })
+    const { onClick } = inner.find(".save-button").props()
+    onClick()
+    sinon.assert.called(helper.updateChannelStub)
+  })
+})

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -7,15 +7,12 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 
 import CanonicalLink from "../components/CanonicalLink"
-import ChannelNavbar from "../components/ChannelNavbar"
 import { PostLoading, withLoading } from "../components/Loading"
 import { PostSortPicker } from "../components/Picker"
-import ManageWidgetHeader from "./widgets/ManageWidgetHeader"
 import {
   withPostModeration,
   postModerationSelector
 } from "../hoc/withPostModeration"
-import withChannelHeader from "../hoc/withChannelHeader"
 import { withChannelSidebar } from "../hoc/withSidebar"
 import withPostList from "../hoc/withPostList"
 import { withChannelTracker } from "../hoc/withChannelTracker"
@@ -23,7 +20,6 @@ import { withChannelTracker } from "../hoc/withChannelTracker"
 import { actions } from "../actions"
 import { setPostData, clearPostError } from "../actions/post"
 import { safeBulkGet } from "../lib/maps"
-import { getChannelName } from "../lib/util"
 import { getPostIds } from "../lib/posts"
 import { anyErrorExcept404 } from "../util/rest"
 import { getSubscribedChannels } from "../lib/redux_selectors"
@@ -91,7 +87,6 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
       dispatch,
       errored,
       notFound,
-      channelName,
       loadPosts,
       location: { search }
     } = this.props
@@ -101,7 +96,6 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
     }
 
     try {
-      await dispatch(actions.channels.get(channelName))
       await loadPosts(qs.parse(search))
     } catch (_) {} // eslint-disable-line no-empty
   }
@@ -140,7 +134,7 @@ export class ChannelPage extends React.Component<ChannelPageProps> {
 
 const mapStateToProps = (state, ownProps) => {
   const { channels } = state
-  const channelName = getChannelName(ownProps)
+  const { channelName } = ownProps
   const postsForChannel = state.postsForChannel.data.get(channelName) || {}
   const channel = channels.data.get(channelName)
   const postIds = getPostIds(postsForChannel)
@@ -159,8 +153,8 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     ...postModerationSelector(state, ownProps),
-    channelName,
     channel,
+    channelName,
     loaded,
     canLoadMore:        !state.postsForChannel.processing,
     notFound,
@@ -178,12 +172,7 @@ const mapStateToProps = (state, ownProps) => {
       channels,
       state.posts,
       state.subscribedChannels
-    ]),
-    navbarItems: (
-      <ChannelNavbar channel={channel}>
-        <ManageWidgetHeader channel={channel} />
-      </ChannelNavbar>
-    )
+    ])
   }
 }
 
@@ -192,7 +181,7 @@ const mapDispatchToProps = (
   ownProps: ChannelPageProps
 ) => ({
   loadPosts: async (search: Object) => {
-    const channelName = getChannelName(ownProps)
+    const { channelName } = ownProps
 
     const response = await dispatch(
       actions.postsForChannel.get(channelName, search)
@@ -207,7 +196,6 @@ export default R.compose(
     mapStateToProps,
     mapDispatchToProps
   ),
-  withChannelHeader,
   withPostModeration,
   withChannelTracker,
   withPostList,

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -74,12 +74,8 @@ describe("ChannelPage", () => {
         forms: {}
       },
       {
-        match: {
-          params: {
-            channelName: currentChannel.name
-          }
-        },
-        location: {
+        channelName: currentChannel.name,
+        location:    {
           search:   {},
           pathname: channelURL(currentChannel.name)
         },
@@ -187,12 +183,8 @@ describe("ChannelPage", () => {
     const { inner } = await render(
       {},
       {
-        match: {
-          params: {
-            channelName:
-              "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
-          }
-        }
+        channelName:
+          "somenamethatshouldnevercollidebecauseitsaridiculouslylongvalue"
       }
     )
     assert.lengthOf(inner.find("PostLoading"), 1)
@@ -245,6 +237,8 @@ describe("ChannelPage", () => {
     assert.isFalse(inner.find(NotFound).exists())
     assert.include(inner.find(".errored").text(), "Error loading page")
   })
+
+  //
   ;[true, false].forEach(loaded => {
     it(`sets canLoadMore=${String(loaded)} when loaded=${String(
       loaded

--- a/static/js/containers/ChannelRouter.js
+++ b/static/js/containers/ChannelRouter.js
@@ -1,0 +1,149 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { connect } from "react-redux"
+import { Route, Switch } from "react-router-dom"
+import R from "ramda"
+
+import ChannelPage from "./ChannelPage"
+import SearchPage from "./SearchPage"
+import PostPage from "./PostPage"
+import ManageWidgetHeader from "./widgets/ManageWidgetHeader"
+import ChannelAboutPage from "./ChannelAboutPage"
+
+import ChannelHeader from "../components/ChannelHeader"
+import ChannelNavbar from "../components/ChannelNavbar"
+
+import { actions } from "../actions"
+import { getChannelName } from "../lib/util"
+import { searchRoute } from "../lib/routing"
+
+import type { Channel } from "../flow/discussionTypes"
+import type { Match } from "react-router"
+
+type Props = {
+  getChannel: (channelName: string) => Promise<*>,
+  channelName: string,
+  channel: Channel,
+  history: Object,
+  match: Match
+}
+
+class ChannelRouter extends React.Component<Props> {
+  componentDidMount() {
+    this.loadData()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!R.eqProps("channelName", prevProps, this.props)) {
+      this.loadData()
+    }
+  }
+
+  loadData = async () => {
+    const { getChannel, channelName } = this.props
+
+    getChannel(channelName)
+  }
+
+  renderChannelIndexPage = routeProps => {
+    const { channelName } = this.props
+    return <ChannelPage channelName={channelName} {...routeProps} />
+  }
+
+  renderSearchPage = routeProps => {
+    const { channelName } = this.props
+    return <SearchPage channelName={channelName} {...routeProps} />
+  }
+
+  renderPostPage = routeProps => {
+    const { channelName } = this.props
+    return <PostPage channelName={channelName} {...routeProps} />
+  }
+
+  renderAboutPage = () => {
+    const { channel } = this.props
+    return <ChannelAboutPage channel={channel} />
+  }
+
+  renderChannelNavbar = (withWidgetHeader: boolean) => {
+    const { channel } = this.props
+    return (
+      <ChannelNavbar channel={channel}>
+        {withWidgetHeader ? <ManageWidgetHeader channel={channel} /> : null}
+      </ChannelNavbar>
+    )
+  }
+
+  render() {
+    const { channel, match, history } = this.props
+
+    return (
+      <div className="channel-page-wrapper">
+        {channel ? (
+          <ChannelHeader
+            channel={channel}
+            history={history}
+            isModerator={channel.user_is_moderator}
+          >
+            <Route
+              exact
+              path={match.url}
+              render={() => this.renderChannelNavbar(true)}
+            />
+            <Route
+              path={`${match.url}/about/`}
+              render={() => this.renderChannelNavbar(true)}
+            />
+            {SETTINGS.allow_search ? (
+              <Route
+                path={searchRoute(match.url)}
+                render={() => this.renderChannelNavbar(false)}
+              />
+            ) : null}
+          </ChannelHeader>
+        ) : null}
+        <Route exact path={match.url} render={this.renderChannelIndexPage} />
+        <Switch>
+          {SETTINGS.allow_search ? (
+            <Route
+              path={`${match.url}/search/`}
+              render={this.renderSearchPage}
+            />
+          ) : null}
+          <Route path={`${match.url}/about/`} render={this.renderAboutPage} />
+          ) : null}
+          <Route
+            exact
+            path={`${match.url}/:postID/:postSlug?`}
+            render={this.renderPostPage}
+          />
+          <Route
+            exact
+            path={`${match.url}/:postID/:postSlug?/comment/:commentID`}
+            component={this.renderPostPage}
+          />
+        </Switch>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { channels } = state
+  const channelName = getChannelName(ownProps)
+  const channel = channels.data.get(channelName)
+
+  return { channel, channelName }
+}
+
+const mapDispatchToProps = {
+  getChannel: actions.channels.get
+}
+
+export default R.compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
+)(ChannelRouter)

--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -15,7 +15,6 @@ import ReportForm from "../components/ReportForm"
 import { ReplyToPostForm } from "../components/CommentForms"
 import withSingleColumn from "../hoc/withSingleColumn"
 import { withPostDetailSidebar } from "../hoc/withSidebar"
-import withChannelHeader from "../hoc/withChannelHeader"
 import {
   withPostModeration,
   postModerationSelector
@@ -45,7 +44,7 @@ import {
   toggleFollowPost,
   toggleFollowComment
 } from "../util/api_actions"
-import { getChannelName, getPostID, getCommentID, truncate } from "../lib/util"
+import { getPostID, getCommentID, truncate } from "../lib/util"
 import {
   anyErrorExcept404,
   anyErrorExcept404or410,
@@ -163,7 +162,6 @@ class PostPage extends React.Component<PostPageProps> {
       channelName,
       postID,
       commentID,
-      channel,
       location: { search }
     } = this.props
     if (!postID || !channelName) {
@@ -180,10 +178,6 @@ class PostPage extends React.Component<PostPageProps> {
       if (post.url) {
         const embedlyResponse = await dispatch(actions.embedly.get(post.url))
         handleTwitterWidgets(embedlyResponse)
-      }
-
-      if (!channel) {
-        dispatch(actions.channels.get(channelName))
       }
     } catch (_) {} // eslint-disable-line no-empty
   }
@@ -511,7 +505,7 @@ class PostPage extends React.Component<PostPageProps> {
 const mapStateToProps = (state, ownProps) => {
   const { posts, channels, comments, forms, ui, embedly } = state
   const postID = getPostID(ownProps)
-  const channelName = getChannelName(ownProps)
+  const { channelName } = ownProps
   const commentID = getCommentID(ownProps)
   const post = posts.data.get(postID)
   const channel = channels.data.get(channelName)
@@ -567,7 +561,6 @@ const mapStateToProps = (state, ownProps) => {
 
 export default R.compose(
   connect(mapStateToProps),
-  withChannelHeader,
   withPostModeration,
   withCommentModeration,
   SETTINGS.allow_related_posts_ui

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -152,6 +152,8 @@ describe("PostPage", function() {
     const wrapper = await renderPage()
     assert.deepEqual(wrapper.find(CommentTree).props().comments, comments)
   })
+
+  //
   ;[
     [true, true, "should upvote a comment"],
     [true, false, "should clear an upvote"],
@@ -273,15 +275,8 @@ describe("PostPage", function() {
     it(`should show a ReplyToPostForm when userIsAnonymous() === ${userIsAnon}`, async () => {
       const anonStub = helper.sandbox.stub(utilFuncs, "userIsAnonymous")
       anonStub.returns(userIsAnon)
-
-      const [wrapper] = await renderComponent(
-        postDetailURL(channel.name, post.id),
-        userIsAnon
-          ? basicPostPageActions
-          : basicPostPageActions.concat(FORM_BEGIN_EDIT)
-      )
+      const wrapper = await renderPage()
       wrapper.update()
-
       assert.ok(wrapper.find(ReplyToPostForm).exists())
     })
   })
@@ -348,8 +343,6 @@ describe("PostPage", function() {
       [
         actions.posts["delete"].requestType,
         actions.posts["delete"].successType,
-        actions.channels.get.requestType,
-        actions.channels.get.successType,
         actions.widgets.get.requestType,
         actions.widgets.get.successType,
         actions.postsForChannel.get.requestType,
@@ -658,6 +651,8 @@ describe("PostPage", function() {
         actions.comments.get.successType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
         SET_CHANNEL_DATA
       ]
     )
@@ -676,6 +671,8 @@ describe("PostPage", function() {
         actions.posts.get.failureType,
         actions.comments.get.requestType,
         actions.comments.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
         SET_CHANNEL_DATA
@@ -696,6 +693,8 @@ describe("PostPage", function() {
         actions.comments.get.failureType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
         SET_CHANNEL_DATA
       ]
     )
@@ -715,6 +714,8 @@ describe("PostPage", function() {
         actions.comments.get.failureType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
         SET_CHANNEL_DATA
       ]
     )
@@ -732,6 +733,8 @@ describe("PostPage", function() {
         actions.comments.get.successType,
         actions.subscribedChannels.get.requestType,
         actions.subscribedChannels.get.successType,
+        actions.channels.get.requestType,
+        actions.channels.get.successType,
         SET_CHANNEL_DATA
       ]
     )

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -54,12 +54,8 @@ describe("SearchPage", () => {
       }
     }
     initialProps = {
-      match: {
-        params: {
-          channelName: channel.name
-        }
-      },
-      location: {
+      channelName: channel.name,
+      location:    {
         search: "q=text"
       },
       history: helper.browserHistory
@@ -108,6 +104,8 @@ describe("SearchPage", () => {
       )
     })
   })
+
+  //
   ;["", "a"].forEach(query => {
     it(`doesn't run a search if initial search text is '${query}'`, async () => {
       await renderPage(
@@ -138,6 +136,8 @@ describe("SearchPage", () => {
     // from is 5, plus 5 is 10 which is == numHits so no more results
     assert.isFalse(inner.find("InfiniteScroll").prop("hasMore"))
   })
+
+  //
   ;[0, 5].forEach(from => {
     it(`InfiniteScroll initialLoad ${shouldIf(
       from > 0
@@ -148,25 +148,8 @@ describe("SearchPage", () => {
       assert.equal(infiniteScroll.prop("initialLoad"), from === 0)
     })
   })
-  ;[true, false].forEach(hasChannel => {
-    it(`${hasChannel ? "loads" : "doesn't load"} a channel`, async () => {
-      await renderPage(
-        {},
-        {
-          match: {
-            params: {
-              channelName: hasChannel ? channel.name : null
-            }
-          }
-        }
-      )
-      if (hasChannel) {
-        sinon.assert.calledWith(helper.getChannelStub, channel.name)
-      } else {
-        sinon.assert.notCalled(helper.getChannelStub)
-      }
-    })
-  })
+
+  //
   ;[
     [true, false, false],
     [false, true, false],
@@ -265,30 +248,6 @@ describe("SearchPage", () => {
       error:         null
     })
   })
-  ;[true, false].forEach(hasChannel => {
-    it(`${
-      hasChannel ? "shows" : "doesn't show"
-    } the ChannelHeader`, async () => {
-      const renderPageWithHeader = helper.configureHOCRenderer(
-        ConnectedSearchPage,
-        "withChannelHeader(WithLoading)",
-        initialState,
-        initialProps
-      )
-
-      const { inner } = await renderPageWithHeader(
-        {},
-        {
-          match: {
-            params: {
-              channelName: hasChannel ? channel.name : ""
-            }
-          }
-        }
-      )
-      assert.equal(inner.find("ChannelHeader").length, hasChannel ? 1 : 0)
-    })
-  })
 
   it("populates the type from the query parameter", async () => {
     const type = "post"
@@ -378,6 +337,8 @@ describe("SearchPage", () => {
     inner.find("SearchTextbox").prop("onClear")()
     assert.equal(inner.state().text, "")
   })
+
+  //
   ;[
     [true, true, true, true],
     [true, true, false, true],
@@ -408,11 +369,7 @@ describe("SearchPage", () => {
           }
         },
         {
-          match: {
-            params: {
-              channelName: hasChannel ? channel.name : null
-            }
-          }
+          channelName: hasChannel ? channel.name : null
         }
       )
       assert.equal(wrapper.props().loaded, loaded)

--- a/static/js/containers/admin/EditChannelAppearancePage_test.js
+++ b/static/js/containers/admin/EditChannelAppearancePage_test.js
@@ -4,7 +4,6 @@ import { assert } from "chai"
 import sinon from "sinon"
 
 import EditChannelAppearancePage, {
-  EDIT_CHANNEL_KEY,
   EditChannelAppearancePage as InnerEditChannelAppearancePage
 } from "./EditChannelAppearancePage"
 
@@ -15,6 +14,7 @@ import { channelURL } from "../../lib/url"
 import * as validationFuncs from "../../lib/validation"
 import { shouldIf, isIf } from "../../lib/test_utils"
 import IntegrationTestHelper from "../../util/integration_test_helper"
+import { EDIT_CHANNEL_KEY } from "../../lib/channels"
 
 describe("EditChannelAppearancePage", () => {
   let helper, render, channel, initialState, initialProps

--- a/static/js/factories/channels.js
+++ b/static/js/factories/channels.js
@@ -40,7 +40,8 @@ export const makeChannel = (privateChannel: boolean = false): Channel => {
     avatar_medium:         hasAvatar ? "http://avatar.medium.url" : null,
     banner:                casual.coin_flip ? "http://banner.url" : null,
     widget_list_id:        casual.integer(4, 99),
-    allowed_post_types:    [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_ARTICLE]
+    allowed_post_types:    [LINK_TYPE_TEXT, LINK_TYPE_LINK, LINK_TYPE_ARTICLE],
+    about:                 null
   }
 }
 

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -30,6 +30,7 @@ export type Channel = {
   banner:                string|null,
   widget_list_id:        ?number,
   allowed_post_types:    Array<LinkType>,
+  about:                 ?Array<Object>,
 }
 
 export type ChannelForm = {

--- a/static/js/hoc/withChannelHeader.js
+++ b/static/js/hoc/withChannelHeader.js
@@ -10,7 +10,7 @@ const withChannelHeader = R.curry(
       static WrappedComponent: Class<React.Component<*, *>>
 
       render() {
-        const { channel, history, navbarItems } = this.props
+        const { channel, history } = this.props
 
         return (
           <div className="channel-page-wrapper">
@@ -19,7 +19,6 @@ const withChannelHeader = R.curry(
                 channel={channel}
                 history={history}
                 isModerator={channel.user_is_moderator}
-                navbarItems={navbarItems}
               />
             ) : null}
             <WrappedComponent {...this.props} />

--- a/static/js/hoc/withCommentModeration.js
+++ b/static/js/hoc/withCommentModeration.js
@@ -119,10 +119,11 @@ export const withCommentModeration = (
 
 export const commentModerationSelector = (state: Object, ownProps: Object) => {
   const { ui, focus } = state
+  const channelName = ownProps.channelName || getChannelName(ownProps)
 
   return {
     showRemoveCommentDialog: ui.dialogs.has(DIALOG_REMOVE_COMMENT),
     focusedComment:          focus.comment,
-    channelName:             getChannelName(ownProps)
+    channelName
   }
 }

--- a/static/js/hoc/withPostModeration.js
+++ b/static/js/hoc/withPostModeration.js
@@ -203,7 +203,7 @@ export const withPostModeration = (
 
 export const postModerationSelector = (state: Object, ownProps: Object) => {
   const { channels, reports, ui, focus, forms } = state
-  const channelName = getChannelName(ownProps)
+  const channelName = ownProps.channelName || getChannelName(ownProps)
   const channel = channels.data.get(channelName)
 
   const userIsModerator = channel && channel.user_is_moderator

--- a/static/js/lib/api/channels.js
+++ b/static/js/lib/api/channels.js
@@ -45,7 +45,13 @@ export function updateChannel(channel: Channel): Promise<Channel> {
     method: PATCH,
     body:   JSON.stringify(
       R.pickAll(
-        ["title", "public_description", "channel_type", "allowed_post_types"],
+        [
+          "title",
+          "public_description",
+          "channel_type",
+          "allowed_post_types",
+          "about"
+        ],
         channel
       )
     )

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -54,6 +54,12 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
     channel
   )
 
+export const EDIT_CHANNEL_KEY = "channel:edit"
+
+export const EDIT_CHANNEL_PAYLOAD = { formKey: EDIT_CHANNEL_KEY }
+
+export const getChannelForm = R.prop(EDIT_CHANNEL_KEY)
+
 export const newMemberForm = (): AddMemberForm => ({
   email: ""
 })

--- a/static/js/lib/routing.js
+++ b/static/js/lib/routing.js
@@ -1,0 +1,5 @@
+// @flow
+
+export const channelIndexRoute = (baseURL: string) => `${baseURL}c/:channelName`
+
+export const searchRoute = (baseURL: string) => `${baseURL}/search`

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -6,6 +6,9 @@ import type { Post } from "../flow/discussionTypes"
 
 export const channelURL = (channelName: string) => `/c/${channelName}`
 
+export const channelAboutURL = (channelName: string) =>
+  `/c/${channelName}/about`
+
 export const channelModerationURL = (channelName: string) =>
   `/manage/c/edit/${channelName}/moderation/`
 

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -3,10 +3,10 @@
 import R from "ramda"
 import _ from "lodash"
 import qs from "query-string"
+import isURL from "validator/lib/isURL"
 
 import type { Match } from "react-router"
 import type { Profile } from "../flow/discussionTypes"
-import isURL from "validator/lib/isURL"
 
 export const getChannelName = (props: { match: Match }): string =>
   props.match.params.channelName || ""

--- a/static/js/util/form_actions.js
+++ b/static/js/util/form_actions.js
@@ -1,0 +1,37 @@
+// @flow
+import R from "ramda"
+
+import { actions } from "../actions"
+import { editChannelForm, EDIT_CHANNEL_PAYLOAD } from "../lib/channels"
+
+import type { Dispatch } from "redux"
+import type { Channel } from "../flow/discussionTypes"
+
+export const beginChannelFormEdit = (channel: Channel) =>
+  actions.forms.formBeginEdit(
+    R.merge(EDIT_CHANNEL_PAYLOAD, {
+      value: editChannelForm(channel)
+    })
+  )
+
+export const updateChannelForm = (e: Object) =>
+  actions.forms.formUpdate(
+    R.merge(EDIT_CHANNEL_PAYLOAD, {
+      value: {
+        [e.target.name]: e.target.value
+      }
+    })
+  )
+
+export const channelFormDispatchToProps = (dispatch: Dispatch<*>) => ({
+  beginChannelFormEdit: (channel: Channel) =>
+    dispatch(beginChannelFormEdit(channel)),
+  updateChannelForm:  (e: Object) => dispatch(updateChannelForm(e)),
+  endChannelFormEdit: () =>
+    dispatch(
+      actions.forms.formEndEdit({
+        ...EDIT_CHANNEL_PAYLOAD
+      })
+    ),
+  dispatch
+})

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -148,6 +148,12 @@ export default class IntegrationTestHelper {
         />
       )
 
+      // just a little convenience method
+      store.getLastAction = function() {
+        const actions = this.getActions()
+        return actions[actions.length - 1]
+      }
+
       // dive through layers of HOCs until we reach the desired inner component
       let inner = wrapper
       while (!inner.is(InnerComponent)) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1778 
closes #1623

#### What's this PR do?

This provides the frontend portion of the channel about page. That includes a new page, facilities to edit an save the about field on the channel, and a refactor of the channel routing logic to facilitate both adding a new page and removing some redundancy.


#### How should this be manually tested?

Make sure that all routes under `/c/channelName` work correctly and there are no regressions anywhere (I did some pretty extensive testing but there is a chance I missed something).

Ensure that, if you're a moderator user, you see an 'about' thing in the channel-level navbar.

if you go there you should be able to edit your channel's about document.

If you're not a moderator user you shouldn't see the link for the moderator page on channels which do not have the document saved, and you should see it on those that do. For non-moderator users the channel document should display nicely.

#### Screenshots (if appropriate)

'about' button shows up in nav always for moderators:

![aboutbutton](https://user-images.githubusercontent.com/6207644/52592191-bce6a800-2e13-11e9-8527-6a93e76be6ac.png)
![aboutbuttonmod2](https://user-images.githubusercontent.com/6207644/52592209-c8d26a00-2e13-11e9-9e23-cd82a7f5a7af.png)

(first channel has an about document saved, second does not, but the about link still shows up on the second one b/c my user is a mod)

for anonymous or non-moderator users it will only show up if the channel has a saved about document:

![aboutbuttonmod23](https://user-images.githubusercontent.com/6207644/52592270-f4555480-2e13-11e9-943c-c2d3adfec45c.png)

vs

![aboutbuttonmod23fffdfdf](https://user-images.githubusercontent.com/6207644/52592274-f8817200-2e13-11e9-936a-ef56bf94956e.png)

the page itself looks like this for mods:

![aboutbuttonmod](https://user-images.githubusercontent.com/6207644/52592287-02a37080-2e14-11e9-9f72-94c2e7391b72.png)

with some minimal UI for editing and saving, and like this for non-mods:

![aboutbuttonmod23ff](https://user-images.githubusercontent.com/6207644/52592296-0cc56f00-2e14-11e9-8a50-1db745b20206.png)

mob:

![aboutbuttonmod23fffdfdfmobfff](https://user-images.githubusercontent.com/6207644/52592458-6af25200-2e14-11e9-8759-98f3c3f5da03.png)
![aboutbuttonmod23fffdfdfmob](https://user-images.githubusercontent.com/6207644/52592459-6af25200-2e14-11e9-9f40-bd646044c4ed.png)

