### PR TITLE
Remove automatic focus from dialog radio buttons

### DIFF
--- a/static/js/components/widgets/WidgetEditDialog.js
+++ b/static/js/components/widgets/WidgetEditDialog.js
@@ -26,6 +26,23 @@ export const WIDGET_EDIT = "WIDGET_EDIT"
 export const WIDGET_CREATE = "WIDGET_CREATE"
 
 export default class WidgetEditDialog extends React.Component<Props> {
+  componentDidMount() {
+    this.deBlur()
+  }
+
+  componentDidUpdate() {
+    this.deBlur()
+  }
+
+  deBlur = () => {
+    const { dialogOpen } = this.props
+    const node = document.querySelector(".widget-dialog button.submit")
+    if (dialogOpen && node) {
+      // deblur radio buttons by putting focus on submit button
+      node.focus()
+    }
+  }
+
   updateValue = R.curry((lens: any, event: any) => {
     const { setDialogData, dialogData } = this.props
     if (!dialogData) {

--- a/static/js/components/widgets/WidgetEditDialog_test.js
+++ b/static/js/components/widgets/WidgetEditDialog_test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { shallow } from "enzyme"
+import { shallow, mount } from "enzyme"
 import { assert } from "chai"
 import sinon from "sinon"
 import casual from "casual-browserify"
@@ -184,6 +184,30 @@ describe("WidgetEditDialog", () => {
         // $FlowFixMe
         dialogData.validation.widget_type
       )
+    })
+
+    it("disables automatic focus on radio buttons by focusing on the submit button", () => {
+      const div = document.createElement("div")
+      // $FlowFixMe: document.body should almost never be null
+      document.body.appendChild(div)
+
+      mount(
+        <WidgetEditDialog
+          dialogData={dialogData}
+          dialogOpen={true}
+          setDialogData={setDialogDataStub}
+          setDialogVisibility={setDialogVisibilityStub}
+          specs={specs}
+          updateForm={updateFormStub}
+        />,
+        {
+          attachTo: div
+        }
+      )
+      // $FlowFixMe: if it's null it will fail the test anyway
+      const focusedElement: HTMLElement = document.activeElement
+      assert.equal(focusedElement.tagName, "BUTTON")
+      assert.equal(focusedElement.className, "submit")
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1814 

#### What's this PR do?
Sets focus to the submit button so that the default focus is not on the radio button.

#### How should this be manually tested?
Start managing widgets and then click '+ Add Widget'. You should not see any radio buttons highlighted at all.
