### PR TITLE
add validation to post edit form

### DIFF
--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -158,9 +158,11 @@ export default class CreatePostForm extends React.Component<Props, State> {
             />
           ) : null}
           {validationMessage(validation.coverImage)}
-          <ArticleEditor onChange={editorUpdateFormShim("article", onUpdate)} />
+          <ArticleEditor
+            onChange={editorUpdateFormShim("article_content", onUpdate)}
+          />
           {this.clearInputButton()}
-          {validationMessage(validation.article)}
+          {validationMessage(validation.article_content)}
         </div>
       )
     } else {

--- a/static/js/components/CreatePostForm_test.js
+++ b/static/js/components/CreatePostForm_test.js
@@ -108,7 +108,7 @@ describe("CreatePostForm", () => {
   it("should show article validation message", () => {
     const postForm = { ...newPostForm(), postType: LINK_TYPE_ARTICLE }
     const wrapper = renderPostForm({
-      validation: { article: "WHAT?! NO! OF COURSE NOT!" },
+      validation: { article_content: "WHAT?! NO! OF COURSE NOT!" },
       postForm
     })
     assert.equal(

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -67,7 +67,7 @@ const getForm = R.prop(CREATE_POST_KEY)
 
 const createPostPayload = (postForm: PostForm): CreatePostPayload => {
   // eslint-disable-next-line camelcase
-  const { postType, title, url, text, article, cover_image } = postForm
+  const { postType, title, url, text, article_content, cover_image } = postForm
 
   switch (postType) {
   case LINK_TYPE_LINK:
@@ -75,7 +75,7 @@ const createPostPayload = (postForm: PostForm): CreatePostPayload => {
   case LINK_TYPE_TEXT:
     return { title, text }
   case LINK_TYPE_ARTICLE:
-    return { title, article, cover_image }
+    return { title, article_content, cover_image }
   }
 
   // if no postType was selected, we're dealing with a 'title only' post
@@ -121,7 +121,7 @@ const shouldFormReset = (
     allEmptyOrNil([
       postForm.value.url,
       postForm.value.text,
-      postForm.value.article
+      postForm.value.article_content
     ])
   ) {
     return true
@@ -194,7 +194,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
         url:              "",
         text:             "",
         thumbnail:        null,
-        article:          [],
+        article_content:  [],
         show_cover_image: true
       })
     }
@@ -238,7 +238,7 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
       postType,
       url:              "",
       text:             "",
-      article:          [],
+      article_content:  [],
       cover_image:      null,
       show_cover_image: true
     })

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -584,7 +584,7 @@ describe("CreatePostPage", () => {
                   : toChannelTypes[0],
               url:              "",
               text:             "",
-              article:          [],
+              article_content:  [],
               thumbnail:        null,
               show_cover_image: true
             })
@@ -656,7 +656,8 @@ describe("CreatePostPage", () => {
         const url =
           hasInput && postType === LINK_TYPE_LINK ? "http://foo.edu" : ""
         const text = hasInput && postType === LINK_TYPE_TEXT ? "test text" : ""
-        const article =
+        // eslint-disable-next-line camelcase
+        const article_content =
           hasInput && postType === LINK_TYPE_ARTICLE ? [{ foo: "bar" }] : null
         const props: any = {
           dispatch,
@@ -665,7 +666,7 @@ describe("CreatePostPage", () => {
               postType: postType,
               url,
               text,
-              article
+              article_content
             }
           },
           channel: currentChannel
@@ -685,7 +686,7 @@ describe("CreatePostPage", () => {
             url:              "",
             text:             "",
             thumbnail:        null,
-            article:          [],
+            article_content:  [],
             show_cover_image: true
           })
         } else {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -102,31 +102,32 @@ export type PostFormType =
   | null
 
 export type PostForm = {
-  postType:           PostFormType,
-  text:               string,
-  url:                string,
-  title:              string,
-  article:            Array<Object>,
-  cover_image:        ?File,
-  show_cover_image:   boolean
+  postType:         PostFormType,
+  post_type?:       PostFormType,
+  text:             string,
+  url:              string,
+  title:            string,
+  article_content:  Array<Object>,
+  cover_image:      ?File,
+  show_cover_image: boolean
 }
 
 export type PostValidation = {
-  text?:       string,
-  url?:        string,
-  title?:      string,
-  channel?:    string,
-  post_type?:  string,
-  article?:    string,
-  coverImage?: string,
+  text?:            string,
+  url?:             string,
+  title?:           string,
+  channel?:         string,
+  post_type?:       string,
+  article_content?: string,
+  coverImage?:      string,
 }
 
 export type CreatePostPayload = {
-  url?:          string,
-  text?:         string,
-  title:         string,
-  article?:      Array<Object>,
-  cover_image?:  ?File,
+  url?:             string,
+  text?:            string,
+  title:            string,
+  article_content?: Array<Object>,
+  cover_image?:     ?File,
 }
 
 export type PostListPagination = {

--- a/static/js/lib/api/posts.js
+++ b/static/js/lib/api/posts.js
@@ -14,8 +14,8 @@ export async function createPost(
 ): Promise<Post> {
   const formData = objectToFormData(R.pick(["text", "url", "title"], payload))
 
-  if (!emptyOrNil(payload.article)) {
-    formData.append("article_content", JSON.stringify(payload.article))
+  if (!emptyOrNil(payload.article_content)) {
+    formData.append("article_content", JSON.stringify(payload.article_content))
 
     if (payload.cover_image) {
       formData.append("cover_image", payload.cover_image)

--- a/static/js/lib/posts.js
+++ b/static/js/lib/posts.js
@@ -25,7 +25,7 @@ export const newPostForm = (): PostForm => ({
   url:              "",
   title:            "",
   thumbnail:        null,
-  article:          [],
+  article_content:  [],
   cover_image:      null,
   show_cover_image: true
 })

--- a/static/js/lib/posts_test.js
+++ b/static/js/lib/posts_test.js
@@ -28,7 +28,7 @@ describe("Post utils", () => {
       text:             "",
       url:              "",
       title:            "",
-      article:          [],
+      article_content:  [],
       thumbnail:        null,
       cover_image:      null,
       show_cover_image: true

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -68,7 +68,13 @@ const validateIfPostType = (
   postType: PostFormType,
   validator: Function
 ) => (postForm: { value: PostForm }) => {
-  if (R.isEmpty(postForm) || postForm.value.postType !== postType) {
+  if (R.isEmpty(postForm)) {
+    return S.Nothing
+  }
+
+  const formPostType = postForm.value.postType || postForm.value.post_type
+
+  if (formPostType !== postType) {
     return S.Nothing
   } else {
     return validator(postForm)
@@ -91,12 +97,32 @@ export const postURLValidation = validateIfPostType(
   }
 )
 
+const isEmptyArticle = (article: Array<Object>): boolean => {
+  // unfortunately detecting an empty article is non-trivial :/
+
+  // if it's an empty array that's easy
+  if (R.equals(article, [])) {
+    return true
+  }
+
+  // sometimes the editor will leave one empty tag in it
+  if (article.length === 1) {
+    const [obj] = article
+    if (R.equals(obj.attributes, {}) || R.equals(obj.children, [])) {
+      return true
+    }
+  }
+  return false
+}
+
 export const postArticleValidation = validateIfPostType(
   LINK_TYPE_ARTICLE,
   (postForm: { value: PostForm }) => {
     const { value: post } = postForm
-    if (R.equals(post.article, [])) {
-      return S.Just(formLensSetter("article", "Article must not be empty"))
+    if (isEmptyArticle(post.article_content)) {
+      return S.Just(
+        formLensSetter("article_content", "Article must not be empty")
+      )
     } else {
       return S.Nothing
     }

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -167,21 +167,25 @@ describe("validation library", () => {
 
     it("should complain about an empty article post", () => {
       const post = {
-        value: { postType: LINK_TYPE_ARTICLE, title: "potato", article: [] }
+        value: {
+          postType:        LINK_TYPE_ARTICLE,
+          title:           "potato",
+          article_content: []
+        }
       }
       assert.deepEqual(validatePostCreateForm(post), {
         value: {
-          article: "Article must not be empty"
+          article_content: "Article must not be empty"
         }
       })
     })
 
-    it("should allow an non-empty article post", () => {
+    it("should allow a non-empty article post", () => {
       const post = {
         value: {
-          postType: LINK_TYPE_ARTICLE,
-          title:    "potato",
-          article:  [{ hey: "there" }]
+          postType:        LINK_TYPE_ARTICLE,
+          title:           "potato",
+          article_content: [{ hey: "there" }]
         }
       }
       assert.deepEqual(validatePostCreateForm(post), {})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1682

#### What's this PR do?

This adds validation to the post editing on the post detail page. You should be able to trigger a validation message showing up by either:

- editing an article post to be empty
or
- making a verrrryyy long (more than 40000 characters) post

#### How should this be manually tested?

Editing a post should work as before. Creating posts should work normally and there should be no regressions there. All flows for creating posts should be tested: all post types, switching between post types, switching between channels which disallow different post types, etc.


#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
![artfjfjffj](https://user-images.githubusercontent.com/6207644/52731861-c47d8c80-2f8c-11e9-8d34-4ad3c6e83c4d.png)
![toooooolong](https://user-images.githubusercontent.com/6207644/52731923-eecf4a00-2f8c-11e9-92fb-63dc1f897ac8.png)
