### PR TITLE
scroll validations errors into view on post create page

### DIFF
--- a/static/js/components/ScrollToTop_test.js
+++ b/static/js/components/ScrollToTop_test.js
@@ -14,8 +14,8 @@ describe("ScrollToTop", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     scrollStub = sandbox.stub()
-    window.scrollTo = scrollStub
     browserHistory = createMemoryHistory()
+    scrollStub = sandbox.stub(window, "scrollTo")
   })
 
   afterEach(() => {
@@ -34,7 +34,7 @@ describe("ScrollToTop", () => {
   it("should scroll to top when visiting a new link", () => {
     renderComponent()
     browserHistory.push("/foo")
-    sinon.assert.calledWith(window.scrollTo, 0, 0)
+    sinon.assert.calledWith(scrollStub, 0, 0)
   })
 
   it("should not scroll to top when user clicks forward or back", () => {
@@ -43,7 +43,7 @@ describe("ScrollToTop", () => {
     renderComponent()
     browserHistory.goBack()
     browserHistory.goForward()
-    sinon.assert.notCalled(window.scrollTo)
+    sinon.assert.notCalled(scrollStub)
   })
 
   it("should render children", () => {

--- a/static/js/containers/CreatePostPage.js
+++ b/static/js/containers/CreatePostPage.js
@@ -306,6 +306,13 @@ class CreatePostPage extends React.Component<CreatePostPageProps> {
 
     if (!postForm || !R.isEmpty(validation)) {
       this.setValidationErrors(validation.value)
+
+      if (validation.value.title || validation.value.channel) {
+        window.scrollTo({
+          top:      0,
+          behavior: "smooth"
+        })
+      }
     } else {
       const channelName = channel.name
       const data = createPostPayload(postForm.value)

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -45,7 +45,8 @@ describe("CreatePostPage", () => {
     commentsResponse,
     article,
     twitterEmbedStub,
-    sandbox
+    sandbox,
+    scrollToStub
 
   const setTitle = (wrapper, title) =>
     wrapper
@@ -96,6 +97,7 @@ describe("CreatePostPage", () => {
     window.twttr = {
       widgets: { load: helper.sandbox.stub() }
     }
+    scrollToStub = helper.sandbox.stub(window, "scrollTo")
   })
 
   afterEach(() => {
@@ -281,6 +283,10 @@ describe("CreatePostPage", () => {
     setLinkPost(wrapper)
     submitPost(wrapper)
     assert.lengthOf(wrapper.find(".titlefield .validation-message"), 0)
+    sinon.assert.calledWith(scrollToStub, {
+      top:      0,
+      behavior: "smooth"
+    })
   })
 
   it("should show validation errors when the url post is empty", async () => {
@@ -307,6 +313,10 @@ describe("CreatePostPage", () => {
     select.simulate("change", { target: { value: channels[6].name } })
     submitPost(wrapper)
     assert.lengthOf(wrapper.find(".channel-select .validation-message"), 0)
+    sinon.assert.calledWith(scrollToStub, {
+      top:      0,
+      behavior: "smooth"
+    })
   })
 
   it("should let us set a validation error for invalid cover image", async () => {

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -36,7 +36,7 @@ describe("EditChannelBasicPage", () => {
     helper.getWidgetListStub.returns(Promise.resolve(makeWidgetListResponse(0)))
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
-    window.scrollTo = helper.sandbox.stub()
+    helper.sandbox.stub(window, "scrollTo")
   })
 
   afterEach(() => {

--- a/static/js/containers/admin/EditChannelContributorsPage_test.js
+++ b/static/js/containers/admin/EditChannelContributorsPage_test.js
@@ -84,7 +84,7 @@ describe("EditChannelContributorsPage", () => {
       })
     )
     helper.getProfileStub.returns(Promise.resolve(""))
-    window.scrollTo = helper.sandbox.stub()
+    helper.sandbox.stub(window, "scrollTo")
   })
 
   afterEach(() => {

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -90,7 +90,7 @@ describe("EditChannelModeratorsPage", () => {
     )
     helper.getProfileStub.returns(Promise.resolve(""))
     helper.getWidgetListStub.returns(Promise.resolve(makeWidgetListResponse(0)))
-    window.scrollTo = helper.sandbox.stub()
+    helper.sandbox.stub(window, "scrollTo")
   })
 
   afterEach(() => {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1796

#### What's this PR do?

This adds a little bit of scrolling to the create post page. Basically the issue is that, if you're editing a very long post or you're working on a short screen, you can scroll down so that the title or channel validation errors are not visible. It won't be clear to the user in that case why the post isn't going through.

What I decided to do to fix the issue is to check when the user submits the post if there is a `title` or `channel` validation error and, if so, do a smooth scroll to the top. This should only be minimally disruptive in cases where you can already see the validation message.

#### How should this be manually tested?

Basically go to the create post page and mess around with very long text and article posts. If you leave the title off, make a very long post, and try to submit it, it should scroll you up to the top of the page so that the validation error is visible. Same thing for not having a channel selected.

But if you trigger another validation error, for instance by making your text post really really long, it shouldn't scroll you.

@ferdi and @pdpinch y'all might want to try this one out and make sure it feels like it should.