### PR TITLE
Limit widget dialog focus to widget type selection

### DIFF
--- a/static/js/components/widgets/WidgetEditDialog.js
+++ b/static/js/components/widgets/WidgetEditDialog.js
@@ -35,9 +35,14 @@ export default class WidgetEditDialog extends React.Component<Props> {
   }
 
   deBlur = () => {
-    const { dialogOpen } = this.props
+    const { dialogData, dialogOpen } = this.props
     const node = document.querySelector(".widget-dialog button.submit")
-    if (dialogOpen && node) {
+    if (
+      dialogOpen &&
+      dialogData &&
+      dialogData.state === WIDGET_TYPE_SELECT &&
+      node
+    ) {
       // deblur radio buttons by putting focus on submit button
       node.focus()
     }

--- a/static/js/components/widgets/WidgetEditDialog_test.js
+++ b/static/js/components/widgets/WidgetEditDialog_test.js
@@ -24,6 +24,7 @@ import {
   WIDGET_TYPE_RSS,
   WIDGET_TYPE_URL
 } from "../../lib/constants"
+import { isIf, shouldIf } from "../../lib/test_utils"
 
 describe("WidgetEditDialog", () => {
   let sandbox,
@@ -185,29 +186,41 @@ describe("WidgetEditDialog", () => {
         dialogData.validation.widget_type
       )
     })
+    ;[
+      [true, WIDGET_TYPE_SELECT, true],
+      [false, WIDGET_TYPE_SELECT, false],
+      [false, WIDGET_CREATE, true],
+      [false, WIDGET_CREATE, false],
+      [false, WIDGET_EDIT, true],
+      [false, WIDGET_EDIT, false]
+    ].forEach(([expected, dialogState, dialogOpen]) => {
+      it.only(`${shouldIf(
+        expected
+      )} shift focus from radio buttons when state=${dialogState} and dialog ${isIf(
+        dialogOpen
+      )} open`, () => {
+        const div = document.createElement("div")
+        // $FlowFixMe: document.body should almost never be null
+        document.body.appendChild(div)
 
-    it("disables automatic focus on radio buttons by focusing on the submit button", () => {
-      const div = document.createElement("div")
-      // $FlowFixMe: document.body should almost never be null
-      document.body.appendChild(div)
-
-      mount(
-        <WidgetEditDialog
-          dialogData={dialogData}
-          dialogOpen={true}
-          setDialogData={setDialogDataStub}
-          setDialogVisibility={setDialogVisibilityStub}
-          specs={specs}
-          updateForm={updateFormStub}
-        />,
-        {
-          attachTo: div
-        }
-      )
-      // $FlowFixMe: if it's null it will fail the test anyway
-      const focusedElement: HTMLElement = document.activeElement
-      assert.equal(focusedElement.tagName, "BUTTON")
-      assert.equal(focusedElement.className, "submit")
+        mount(
+          <WidgetEditDialog
+            dialogData={dialogData}
+            dialogOpen={true}
+            setDialogData={setDialogDataStub}
+            setDialogVisibility={setDialogVisibilityStub}
+            specs={specs}
+            updateForm={updateFormStub}
+          />,
+          {
+            attachTo: div
+          }
+        )
+        // $FlowFixMe: if it's null it will fail the test anyway
+        const focusedElement: HTMLElement = document.activeElement
+        assert.equal(focusedElement.tagName, "BUTTON")
+        assert.equal(focusedElement.className, "submit")
+      })
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes bug from #1848 

#### What's this PR do?
Fixes a bug which removes focus every time the dialog changes state, instead of just during radio button selection.

#### How should this be manually tested?
In master you should notice that you can't type in the widget text field. On this PR that should work fine.

