### PR TITLE
Created docker container config for running the app in a Jupyter notebook

### DIFF
--- a/Dockerfile-nb
+++ b/Dockerfile-nb
@@ -1,0 +1,10 @@
+FROM open_discussions_python
+
+USER root
+
+WORKDIR /tmp
+
+RUN pip install --force-reinstall jupyter
+
+USER mitodl
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -198,6 +198,44 @@ MAILGUN_KEY
 Additionally, you'll need to set `MAILGUN_RECIPIENT_OVERRIDE` to your own email address so
 any emails sent from the app will be delivered to you.
 
+### Running the app in a notebook
+
+This repo includes a config for running a [Jupyter notebook](https://jupyter.org/) in a
+Docker container. This enables you to do in a Jupyter notebook anything you might 
+otherwise do in a Django shell. To get started:
+
+- Copy the example file
+    ```bash
+    # Choose any name for the resulting .ipynb file
+    cp app.ipynb.example app.ipynb
+    ```
+- Build the `notebook` container _(for first time use, or when requirements change)_
+    ```bash
+    docker-compose -f docker-compose-notebook.yml build
+    ```
+- Run all the standard containers (`docker-compose up`)
+- In another terminal window, run the `notebook` container
+    ```bash
+    docker-compose -f docker-compose-notebook.yml up
+    ```
+- Visit the running notebook server in your browser. You'll need to do
+  some copy/paste from the `notebook` container log output. You should
+  see some log line that look like this:
+    ```
+    notebook_1  |     To access the notebook, open this file in a browser:
+    notebook_1  |         file:///home/mitodl/.local/share/jupyter/runtime/nbserver-8-open.html
+    notebook_1  |     Or copy and paste one of these URLs:
+    notebook_1  |         http://(2c19429d04d0 or 127.0.0.1):8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea
+    ```
+  Copy the URL at the bottom and paste it into a browser window, replacing the parenthetical with
+  the normal local site URL. The example above would turn into `http://od.odl.local:8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea`
+- Click the `.ipynb` file that you created to run the notebook
+- Execute the first block to confirm it's working properly (click inside the block
+  and press Shift+Enter)
+  
+From there, you should be able to run code snippets with a live Django app just like you 
+would in a Django shell.
+
 ### Integration with MicroMasters
 
 The following steps assume that you've added `/etc/hosts` aliases for MicroMasters

--- a/app.ipynb.example
+++ b/app.ipynb.example
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import django\n",
+    "from django.contrib.auth import get_user_model\n",
+    "\n",
+    "BASE_DJANGO_APP_NAME = os.environ.get(\"BASE_DJANGO_APP_NAME\")\n",
+    "os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{}.settings'.format(BASE_DJANGO_APP_NAME))\n",
+    "django.setup()\n",
+    "\n",
+    "User = get_user_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -1,0 +1,19 @@
+version: '2.1'
+services:
+  notebook:
+    build:
+      context: .
+      dockerfile: Dockerfile-nb
+    extends:
+      file: docker-compose.yml
+      service: python
+    volumes:
+      - .:/src
+    environment:
+      BASE_DJANGO_APP_NAME: open_discussions
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      jupyter notebook --no-browser --ip=0.0.0.0 --port=8080'
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
#### Pre-Flight checklist
Checklist isn't relevant for this PR

#### What are the relevant tickets?
No ticket

#### What's this PR do?
What the title says. Now you can run the app in a Jupyter notebook!

#### How should this be manually tested?
- Go through the steps in the README to run a notebook
- Try to fetch a post via `channels.api.Api#get_post`
- Try to create a post via `channels.api.Api#create_post`

#### Any background context you want to provide?
- Not crazy about adding another top-level file but I couldn't think of another place to put it
- `.ipynb` files are already gitignore'd
- It will be possible to get around the annoying step of copying the notebook server URL from the docker container logs. Figured that could be done separately

#### Screenshots (if appropriate)
![ss 2019-02-13 at 16 59 23](https://user-images.githubusercontent.com/14932219/52747206-4089cb80-2fb1-11e9-87c7-93a801a4b6a4.png)

