### PR TITLE
Adds functionality to export edx courses into json format and upload it to s3

### DIFF
--- a/course_catalog/management/commands/backpopulate_edx_data.py
+++ b/course_catalog/management/commands/backpopulate_edx_data.py
@@ -1,7 +1,7 @@
 """Management command for populating edx course data"""
 from django.core.management import BaseCommand
 
-from course_catalog.tasks import get_edx_data
+from course_catalog.tasks import sync_and_upload_edx_data
 from open_discussions.utils import now_in_utc
 
 
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Run Populate edx courses"""
-        task = get_edx_data.delay()
+        task = sync_and_upload_edx_data.delay()
         self.stdout.write(
             "Started celery task {task} to get edx course data".format(task=task)
         )

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -71,7 +71,7 @@ def get_edx_data(force_overwrite=False):
         aws_access_key_id=settings.OCW_CONTENT_ACCESS_KEY,
         aws_secret_access_key=settings.OCW_CONTENT_SECRET_ACCESS_KEY,
     ).Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
-    raw_data_bucket.put_object(Key="edx_courses.json", Body=json.dumps(edx_data), ACL="public-read")
+    raw_data_bucket.put_object(Key="edx_courses.json", Body=json.dumps(edx_data))
 
 
 @app.task

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -66,7 +66,7 @@ def sync_and_upload_edx_data(force_overwrite=False):
 
         url = response.json()["next"]
 
-    if error_occurred:
+    if not error_occurred:
         edx_data["count"] = len(edx_data["results"])
         raw_data_bucket = boto3.resource(
             "s3",

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -46,8 +46,8 @@ def get_edx_data(force_overwrite=False):
     access_token = get_access_token()
 
     edx_data = {
-        "count": 0,
-        "catalog_url": "",
+        "count": None,
+        "catalog_url": settings.EDX_API_URL,
         "results": [],
     }
 

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -45,11 +45,7 @@ def get_edx_data(force_overwrite=False):
     url = settings.EDX_API_URL
     access_token = get_access_token()
 
-    edx_data = {
-        "count": None,
-        "catalog_url": settings.EDX_API_URL,
-        "results": [],
-    }
+    edx_data = {"count": None, "catalog_url": settings.EDX_API_URL, "results": []}
 
     while url:
         response = requests.get(url, headers={"Authorization": "JWT " + access_token})

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -48,8 +48,8 @@ def sync_and_upload_edx_data(force_overwrite=False):
 
     edx_data = {"count": 0, "catalog_url": settings.EDX_API_URL, "results": []}
 
+    log.info("Syncing edX data...")
     while url:
-        log.info("Syncing edX data...")
         response = requests.get(url, headers={"Authorization": "JWT " + access_token})
         if response.status_code == 200:
             for course_data in response.json()["results"]:

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 @app.task
-def get_edx_data(force_overwrite=False):
+def sync_and_upload_edx_data(force_overwrite=False):
     """
     Task to sync mitx data with the database
     Args:
@@ -40,7 +40,7 @@ def get_edx_data(force_overwrite=False):
         and settings.OCW_LEARNING_COURSE_ACCESS_KEY
         and settings.OCW_LEARNING_COURSE_SECRET_ACCESS_KEY
     ):
-        log.warning("Required settings missing for get_edx_data")
+        log.warning("Required settings missing for sync_and_upload_edx_data")
         return
     url = settings.EDX_API_URL
     access_token = get_access_token()

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -128,7 +128,16 @@ def test_get_mitx_data_saves_json(
     """
     setup_s3(settings)
     get_edx_data()
-    # todo: patch boto3.resource.Bucket.put_objects and check "edx_courses.json" is passed as argument
+    conn = boto3.client(
+        "s3",
+        aws_access_key_id=settings.OCW_LEARNING_COURSE_BUCKET_NAME,
+        aws_secret_access_key=settings.OCW_LEARNING_COURSE_ACCESS_KEY,
+    )
+    json_is_uploaded = conn.list_objects(
+        Bucket=settings.OCW_LEARNING_COURSE_BUCKET_NAME, Prefix="edx_courses.json"
+    )
+    # check that pub_object call to create edx_courses.json succeeded
+    assert json_is_uploaded
 
 
 @mock_s3

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -11,7 +11,7 @@ import pytest
 from moto import mock_s3
 
 from course_catalog.models import Course, CoursePrice, CourseInstructor, CourseTopic
-from course_catalog.tasks import get_edx_data, get_ocw_data
+from course_catalog.tasks import sync_and_upload_edx_data, get_ocw_data
 
 pytestmark = pytest.mark.django_db
 # pylint:disable=redefined-outer-name,unused-argument
@@ -112,7 +112,7 @@ def test_get_mitx_data_valid(
     Test that mitx sync task successfully creates database objects
     """
     setup_s3(settings)
-    get_edx_data()
+    sync_and_upload_edx_data()
     assert Course.objects.count() == 1
     assert CoursePrice.objects.count() == 2
     assert CourseInstructor.objects.count() == 2
@@ -127,7 +127,7 @@ def test_get_mitx_data_saves_json(
     Test that mitx sync task successfully saves edx API response results in S3
     """
     setup_s3(settings)
-    get_edx_data()
+    sync_and_upload_edx_data()
     s3 = boto3.resource(
         "s3",
         aws_access_key_id=settings.OCW_LEARNING_COURSE_BUCKET_NAME,
@@ -150,7 +150,7 @@ def test_get_mitx_data_status_error(settings, mocker, access_token, mitx_data):
     )
     settings.EDX_API_URL = "fake_url"
     setup_s3(settings)
-    get_edx_data()
+    sync_and_upload_edx_data()
     assert Course.objects.count() == 0
 
 
@@ -164,7 +164,7 @@ def test_get_mitx_data_unexpected_error(settings, mocker, access_token, get_test
     )
     settings.EDX_API_URL = "fake_url"
     setup_s3(settings)
-    get_edx_data()
+    sync_and_upload_edx_data()
     assert Course.objects.count() == 0
 
 
@@ -172,7 +172,7 @@ def test_get_mitx_data_no_settings():
     """
     No data should be imported if MITx settings are missing
     """
-    get_edx_data()
+    sync_and_upload_edx_data()
     assert Course.objects.count() == 0
 
 

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -128,16 +128,15 @@ def test_get_mitx_data_saves_json(
     """
     setup_s3(settings)
     get_edx_data()
-    conn = boto3.client(
+    s3 = boto3.resource(
         "s3",
         aws_access_key_id=settings.OCW_LEARNING_COURSE_BUCKET_NAME,
         aws_secret_access_key=settings.OCW_LEARNING_COURSE_ACCESS_KEY,
     )
-    json_is_uploaded = conn.list_objects(
-        Bucket=settings.OCW_LEARNING_COURSE_BUCKET_NAME, Prefix="edx_courses.json"
-    )
+    obj = s3.Object(settings.OCW_LEARNING_COURSE_BUCKET_NAME, "edx_courses.json")
     # check that pub_object call to create edx_courses.json succeeded
-    assert json_is_uploaded
+    contents = json.loads(obj.get()["Body"].read())
+    assert "results" in contents
 
 
 @mock_s3

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -539,7 +539,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=0, hour=14, day_of_week=2),  # 10am EST on tuesdays
     },
     "update_edx-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_edx_data",
+        "task": "course_catalog.tasks.sync_and_upload_edx_data",
         "schedule": crontab(minute=0, hour=4),  # 12am EST
     },
     "update_ocw-courses-every-1-days": {


### PR DESCRIPTION
#### What are the relevant tickets?
Addresses this issue ["export edX discovery API response to S3"](https://github.com/mitodl/course-catalog/issues/51)

#### What's this PR do?
Adds functionality to export edx courses into json format and upload it to s3

#### Where should the reviewer start?
`course_catalog/tasks.py`
