### PR TITLE
Cache RSS widget feed data

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+release: scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program uwsgi uwsgi.ini
 worker: newrelic-admin run-program celery -A open_discussions.celery:app worker -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker: newrelic-admin run-program celery -A open_discussions.celery:app worker -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --no-input &&
+      python3 manage.py createcachetable &&
       uwsgi uwsgi.ini --honour-stdin'
     tty: true
     ports:

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -560,12 +560,17 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "local-in-memory-cache",
     },
+    "external_assets": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "external_asset_cache",
+    },
     "redis": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": CELERY_BROKER_URL,
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
     },
 }
+
 
 # Elasticsearch
 ELASTICSEARCH_DEFAULT_PAGE_SIZE = get_int("ELASTICSEARCH_DEFAULT_PAGE_SIZE", 5)
@@ -756,3 +761,6 @@ OCW_UPLOAD_IMAGE_ONLY = get_bool("OCW_UPLOAD_IMAGE_ONLY", False)
 OCW_BASE_URL = get_string("OCW_BASE_URL", "http://ocw.mit.edu/")
 MITX_BASE_URL = get_string("MITX_BASE_URL", "https://www.edx.org/course/")
 MITX_ALT_URL = get_string("MITX_ALT_URL", "https://courses.edx.org/courses/")
+
+# Widgets
+WIDGETS_RSS_CACHE_TTL = get_int("WIDGETS_RSS_CACHE_TTL", 15 * 60)

--- a/open_discussions/test_utils.py
+++ b/open_discussions/test_utils.py
@@ -3,6 +3,7 @@ import abc
 import json
 from contextlib import contextmanager
 import traceback
+from unittest.mock import Mock
 
 import pytest
 
@@ -65,3 +66,15 @@ def drf_datetime(dt):
         str: ISO 8601 formatted datetime
     """
     return dt.isoformat().replace("+00:00", "Z")
+
+
+class PickleableMock(Mock):
+    """
+    A Mock that can be passed to pickle.dumps()
+
+    Source: https://github.com/testing-cabal/mock/issues/139#issuecomment-122128815
+    """
+
+    def __reduce__(self):
+        """Required method for being pickleable"""
+        return (Mock, ())

--- a/open_discussions/test_utils_test.py
+++ b/open_discussions/test_utils_test.py
@@ -1,7 +1,14 @@
 """Tests for test utils"""
+import pickle
+
 import pytest
 
-from open_discussions.test_utils import any_instance_of, assert_not_raises, MockResponse
+from open_discussions.test_utils import (
+    any_instance_of,
+    assert_not_raises,
+    MockResponse,
+    PickleableMock,
+)
 
 
 def test_any_instance_of():
@@ -45,3 +52,8 @@ def test_mock_response():
     response = MockResponse(content, 404)
     assert response.status_code == 404
     assert response.content == content
+
+
+def test_pickleable_mock():
+    """Tests that a mock can be pickled"""
+    pickle.dumps(PickleableMock(field_name=dict()))

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ celery==4.2.0
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-bitfield==1.9.3
+django-cache-memoize==0.1.6
 django-redis==4.7.0
 django-guardian==1.4.9
 django-server-status==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 amqp==2.1.4               # via kombu
-appnope==0.1.0            # via ipython
 base36==0.1.1
 beautifulsoup4==4.6.0
 betamax-serializers==0.2.0
@@ -28,6 +27,7 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 django-anymail[mailgun]==3.0
 django-bitfield==1.9.3
+django-cache-memoize==0.1.6
 django-compat==1.0.15
 django-cors-headers==2.1.0
 django-guardian==1.4.9

--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+indent() {
+    RE="s/^/       /"
+    [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
+}
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+# trim "./" from the path
+MANAGE_FILE=${MANAGE_FILE:2}
+
+echo "-----> Generating cache tables"
+python $MANAGE_FILE createcachetable 2>&1 | indent

--- a/widgets/serializers/rss_test.py
+++ b/widgets/serializers/rss_test.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from open_discussions.test_utils import PickleableMock
 from widgets.factories import WidgetInstanceFactory
 from widgets.serializers import rss
 
@@ -23,7 +24,7 @@ def test_url_widget_serialize(mocker, timestamp_key, item_count, display_limit):
         for idx in range(item_count)
     ]
     mock_parse = mocker.patch(
-        "feedparser.parse", return_value=mocker.Mock(entries=entries)
+        "feedparser.parse", return_value=PickleableMock(entries=entries)
     )
     widget_instance = WidgetInstanceFactory.create(type_rss=True)
     widget_instance.configuration["feed_display_limit"] = display_limit


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1749 
Based on RFC #1835 

#### What's this PR do?
This PR adds caching to RSS feed data. It does so on a per-url basis while allowing multiple RSS widget instances with the same URL to utilize the same cache because they may only differ by number of items shown.

#### How should this be manually tested?
- Run the app, ensure the `external_asset_cache` table is created
- Hit a page with an RSS feed, ensure a record shows up in the table for it
- Put a `raise Exception()` in `_fetch_rss_entries` and hit that page again. The exception should not get raised
- Edit the widget and change the rss feed url. Ensure after saving that you see the new feed items.
- Create a new RSS widget and ensure everything works for that too