### PR TITLE
Fixed anonymous create post page bug

### DIFF
--- a/static/js/components/auth/PrivateRoute.js
+++ b/static/js/components/auth/PrivateRoute.js
@@ -1,0 +1,25 @@
+// @flow
+import React from "react"
+
+import { userIsAnonymous } from "../../lib/util"
+import { generateLoginRedirectUrl } from "../../lib/auth"
+
+import { Route, Redirect } from "react-router-dom"
+
+export default function PrivateRoute({
+  component: Component,
+  ...routeProps
+}: Object) {
+  return (
+    <Route
+      {...routeProps}
+      render={props => {
+        return userIsAnonymous() ? (
+          <Redirect to={generateLoginRedirectUrl()} />
+        ) : (
+          <Component {...props} />
+        )
+      }}
+    />
+  )
+}

--- a/static/js/components/auth/PrivateRoute_test.js
+++ b/static/js/components/auth/PrivateRoute_test.js
@@ -1,0 +1,53 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import { Redirect } from "react-router-dom"
+
+import PrivateRoute from "./PrivateRoute"
+import * as util from "../../lib/util"
+import { isIf } from "../../lib/test_utils"
+import * as authHelpers from "../../lib/auth"
+
+describe("PrivateRoute", () => {
+  const fakePath = "somepath",
+    fakeRedirectUrl = "/login"
+  let sandbox, userIsAnonymousStub, loginRedirectUrlStub, FakeComponent
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    userIsAnonymousStub = sandbox.stub(util, "userIsAnonymous")
+    loginRedirectUrlStub = sandbox
+      .stub(authHelpers, "generateLoginRedirectUrl")
+      .returns(fakeRedirectUrl)
+    FakeComponent = sandbox.fake()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+  ;[[false, "load the route"], [true, "redirect to the login page"]].forEach(
+    ([isAnonymous, desc]) => {
+      it(`should ${desc} if user ${isIf(isAnonymous)} anonymous`, () => {
+        userIsAnonymousStub.returns(isAnonymous)
+        const wrapper = shallow(
+          <PrivateRoute path={fakePath} component={FakeComponent} />
+        )
+        const routeComponent = wrapper.find("Route")
+        assert.isTrue(routeComponent.exists())
+        const { path, render } = routeComponent.props()
+        assert.equal(path, fakePath)
+        const renderResult = render()
+        if (isAnonymous) {
+          assert.equal(renderResult.type, Redirect)
+          assert.equal(renderResult.props.to, fakeRedirectUrl)
+          sinon.assert.calledOnce(loginRedirectUrlStub)
+        } else {
+          assert.equal(renderResult.type, FakeComponent)
+        }
+      })
+    }
+  )
+})

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -31,6 +31,7 @@ import PasswordResetPage from "./auth/PasswordResetPage"
 import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
 import ChannelRouter from "./ChannelRouter"
 
+import PrivateRoute from "../components/auth/PrivateRoute"
 import Snackbar from "../components/material/Snackbar"
 import Banner from "../components/material/Banner"
 import Drawer from "../containers/Drawer"
@@ -192,7 +193,7 @@ class App extends React.Component<AppProps> {
             component={ChannelRouter}
           />
           <Route path={`${match.url}manage/`} component={AdminPage} />
-          <Route
+          <PrivateRoute
             path={`${match.url}create_post/:channelName?`}
             component={CreatePostPage}
           />

--- a/static/js/lib/api/fetch_auth.js
+++ b/static/js/lib/api/fetch_auth.js
@@ -6,19 +6,18 @@ import {
   fetchJSONWithCSRF,
   fetchWithCSRF
 } from "redux-hammock/django_csrf_fetch"
-import qs from "query-string"
 
 import { LOGIN_URL } from "../url"
+import { generateLoginRedirectUrl } from "../../lib/auth"
 import { isNotAuthenticatedErrorType } from "../../util/rest"
 
 const redirectAndReject = async () => {
   // redirect to the authenticating app
-  const { pathname, search, hash } = window.location
+  const { pathname } = window.location
 
   // ensure that we don't end up in a redirect loop
   if (pathname !== LOGIN_URL) {
-    const next = `${pathname}${search}${hash}`
-    window.location = `${LOGIN_URL}?${qs.stringify({ next })}`
+    window.location = generateLoginRedirectUrl()
   }
 
   return Promise.reject("You were logged out, please login again")

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -1,5 +1,7 @@
 /* global SETTINGS: false */
 // @flow
+import qs from "query-string"
+
 import {
   LOGIN_URL,
   LOGIN_PASSWORD_URL,
@@ -25,6 +27,13 @@ import {
 } from "../reducers/auth"
 
 import type { AuthResponse } from "../flow/authTypes"
+
+export const generateLoginRedirectUrl = () => {
+  const { pathname, search, hash } = window.location
+
+  const next = `${pathname}${search}${hash}`
+  return `${LOGIN_URL}?${qs.stringify({ next })}`
+}
 
 export const processAuthResponse = (
   history: Object,

--- a/static/js/lib/auth_test.js
+++ b/static/js/lib/auth_test.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import { assert } from "chai"
 import sinon from "sinon"
+import qs from "query-string"
 
 import {
   LOGIN_URL,
@@ -30,6 +31,7 @@ import {
 } from "../reducers/auth"
 
 import {
+  generateLoginRedirectUrl,
   processAuthResponse,
   isAnonAccessiblePath,
   needsAuthedSite,
@@ -55,6 +57,18 @@ describe("auth lib", () => {
 
   afterEach(() => {
     sandbox.restore()
+  })
+
+  describe("generateLoginRedirectUrl", () => {
+    it("generates a URL for the login page with a 'next' param", () => {
+      const next = "/path/to/resource?param=value#anchor"
+      window.location = next
+
+      assert.equal(
+        generateLoginRedirectUrl(),
+        `${LOGIN_URL}?${qs.stringify({ next })}`
+      )
+    })
   })
 
   describe("processAuthResponse", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1710 

#### What's this PR do?
- Fixes bug where anonymous users could access the create post page
- Adds a new `Route` component that auto-redirects if a user is not logged in (`PrivateRoute`)

#### How should this be manually tested?
As an anonymous user, try to navigate to `/create_post/` and `/create_post/<some_channel_name>`. Both should redirect you to the login page with the right `next` param

#### Any background context you want to provide?
- `PrivateRoute` implementation inspired by [this example](https://reacttraining.com/react-router/web/example/auth-workflow)
- `/create_post/<some_channel_name>` already redirected before this PR, but `/create_post/` didn't. That was kind of by accident. If a channel name existed in the URL, you would get redirected to login since the API call to fetch channel info is implemented with `fetchJSONWithAuthFailure`. If you didn't have the channel name in the URL, that fetch wouldn't be attempted, so the route wasn't protected