### PR TITLE
fix article validation

### DIFF
--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -108,7 +108,7 @@ const isEmptyArticle = (article: Array<Object>): boolean => {
   // sometimes the editor will leave one empty tag in it
   if (article.length === 1) {
     const [obj] = article
-    if (R.equals(obj.attributes, {}) || R.equals(obj.children, [])) {
+    if (R.equals(obj.attributes, {}) && R.equals(obj.children, [])) {
       return true
     }
   }

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -165,18 +165,32 @@ describe("validation library", () => {
       })
     })
 
-    it("should complain about an empty article post", () => {
-      const post = {
-        value: {
-          postType:        LINK_TYPE_ARTICLE,
-          title:           "potato",
-          article_content: []
+    //
+    ;[
+      [[], true],
+      [[{ attributes: {}, children: [] }], true],
+      [[{ attributes: {}, children: [{ hey: "there" }] }], false]
+    ].forEach(([articleContent, shouldGiveError]) => {
+      it(`${shouldIf(shouldGiveError)} if articleContent = ${JSON.stringify(
+        articleContent
+      )}`, () => {
+        const post = {
+          value: {
+            postType:        LINK_TYPE_ARTICLE,
+            title:           "potato",
+            article_content: articleContent
+          }
         }
-      }
-      assert.deepEqual(validatePostCreateForm(post), {
-        value: {
-          article_content: "Article must not be empty"
-        }
+        assert.deepEqual(
+          validatePostCreateForm(post),
+          shouldGiveError
+            ? {
+              value: {
+                article_content: "Article must not be empty"
+              }
+            }
+            : {}
+        )
       })
     })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

fixes a bug in #1852

#### What's this PR do?

I should have `&&`-ed where I should have `||`-ed :woman_facepalming: 

#### How should this be manually tested?

Make sure you can reproduce the issue. 

- open the post creation form and go to create an article. 
- type in just one line of text
- try to submit, you should incorrectly get a validation error saying it's empty

then this branch should fix that issue.