### PR TITLE
Fix comment dialog dialog bug and refactor PostPage_test

### DIFF
--- a/static/js/containers/PostPage.js
+++ b/static/js/containers/PostPage.js
@@ -134,7 +134,7 @@ const shouldLoadData = R.complement(
   ])
 )
 
-class PostPage extends React.Component<PostPageProps> {
+export class PostPage extends React.Component<PostPageProps> {
   componentDidMount() {
     this.loadData()
 
@@ -150,7 +150,7 @@ class PostPage extends React.Component<PostPageProps> {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: PostPageProps) {
     if (shouldLoadData(prevProps, this.props)) {
       this.loadData()
     }
@@ -459,7 +459,10 @@ class PostPage extends React.Component<PostPageProps> {
         <Dialog
           open={commentDeleteDialogVisible}
           hideDialog={this.hideCommentDialog(DELETE_COMMENT_DIALOG)}
-          onAccept={this.deleteComment}
+          onAccept={async () => {
+            await this.deleteComment()
+            this.hideCommentDialog(DELETE_COMMENT_DIALOG)()
+          }}
           title="Delete Comment"
           submitText="Yes, Delete"
         >
@@ -468,8 +471,8 @@ class PostPage extends React.Component<PostPageProps> {
         <Dialog
           open={postDeleteDialogVisible}
           hideDialog={hidePostDialog}
-          onAccept={() => {
-            this.deletePost(post)
+          onAccept={async () => {
+            await this.deletePost(post)
             hidePostDialog()
           }}
           title="Delete Post"

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -348,14 +348,11 @@ describe("PostPage", function() {
     helper.getMoreCommentsStub.returns(Promise.resolve(newComments))
     await commentTreeProps.loadMoreComments(moreComments)
     const actionsList = store.getActions()
-    assert.deepEqual(
-      actionsList.slice(actionsList.length - 3).map(action => action.type),
-      [
-        actions.morecomments.get.requestType,
-        actions.morecomments.get.successType,
-        REPLACE_MORE_COMMENTS
-      ]
-    )
+    assert.includeMembers(R.pluck("type")(actionsList), [
+      actions.morecomments.get.requestType,
+      actions.morecomments.get.successType,
+      REPLACE_MORE_COMMENTS
+    ])
 
     sinon.assert.calledWith(
       helper.getMoreCommentsStub,
@@ -394,8 +391,7 @@ describe("PostPage", function() {
       assert.equal(props.title, "Delete Post")
       await props.onAccept()
       sinon.assert.calledWith(helper.deletePostStub, post.id)
-      const actionsList = store.getActions()
-      assert.deepEqual(actionsList.slice(actionsList.length - 4), [
+      assert.includeDeepMembers(store.getActions(), [
         {
           type:    actions.posts.delete.requestType,
           payload: post.id
@@ -426,8 +422,7 @@ describe("PostPage", function() {
       const comment = comments[0]
 
       inner.find("CommentTree").prop("deleteComment")(comment)
-      const actionsList = store.getActions()
-      assert.deepEqual(actionsList.slice(actionsList.length - 2), [
+      assert.includeDeepMembers(store.getActions(), [
         {
           type:    SET_FOCUSED_COMMENT,
           payload: comment
@@ -456,9 +451,8 @@ describe("PostPage", function() {
       assert.equal(dialogProps.title, "Delete Comment")
       await dialogProps.onAccept()
 
-      const actionsList = store.getActions()
       sinon.assert.calledWith(helper.deleteCommentStub, comment.id)
-      assert.deepEqual(actionsList.slice(actionsList.length - 5), [
+      assert.includeDeepMembers(store.getActions(), [
         {
           type:    actions.comments.delete.requestType,
           payload: post.id
@@ -497,8 +491,7 @@ describe("PostPage", function() {
           const { inner, store } = await render()
 
           await inner.find("ExpandedPostDisplay").prop("removePost")(post)
-          const actionsList = store.getActions()
-          assert.deepEqual(actionsList.slice(actionsList.length - 2), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    SET_FOCUSED_POST,
               payload: post
@@ -531,8 +524,7 @@ describe("PostPage", function() {
           assert.equal(dialogProps.title, "Remove Post")
           await dialogProps.onAccept({ preventDefault: helper.sandbox.stub() })
 
-          const actionsList = store.getActions()
-          assert.deepEqual(actionsList.slice(actionsList.length - 6), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    actions.postRemoved.patch.requestType,
               payload: post.id
@@ -573,9 +565,8 @@ describe("PostPage", function() {
           helper.updateRemovedStub.returns(Promise.resolve(expected))
 
           await inner.find("ExpandedPostDisplay").prop("approvePost")(post)
-          const actionsList = store.getActions()
 
-          assert.deepEqual(actionsList.slice(actionsList.length - 1), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    SET_SNACKBAR_MESSAGE,
               payload: {
@@ -598,8 +589,7 @@ describe("PostPage", function() {
 
           inner.find("CommentTree").prop("remove")(comment)
 
-          const actionsList = store.getActions()
-          assert.deepEqual(actionsList.slice(actionsList.length - 2), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    SET_FOCUSED_COMMENT,
               payload: comment
@@ -632,9 +622,8 @@ describe("PostPage", function() {
 
           assert.equal(dialogProps.title, "Remove Comment")
           await dialogProps.onAccept({ preventDefault: helper.sandbox.stub() })
-          const actionsList = store.getActions()
 
-          assert.deepEqual(actionsList.slice(actionsList.length - 5), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    actions.comments.patch.requestType,
               payload: comment.id
@@ -670,9 +659,8 @@ describe("PostPage", function() {
           const { inner, store } = await render()
 
           await inner.find("CommentTree").prop("approve")(comment)
-          const actionsList = store.getActions()
 
-          assert.deepEqual(actionsList.slice(actionsList.length - 3), [
+          assert.includeDeepMembers(store.getActions(), [
             {
               type:    actions.comments.patch.requestType,
               payload: comment.id
@@ -710,8 +698,7 @@ describe("PostPage", function() {
 
         await inner.find("CommentTree").prop("reportComment")(comment)
 
-        const actionsList = store.getActions()
-        assert.deepEqual(actionsList.slice(actionsList.length - 3), [
+        assert.includeDeepMembers(store.getActions(), [
           {
             type:    FORM_BEGIN_EDIT,
             payload: {
@@ -799,8 +786,7 @@ describe("PostPage", function() {
           reason:     reason
         })
 
-        const actionsList = store.getActions()
-        assert.deepEqual(actionsList.slice(actionsList.length - 6), [
+        assert.includeDeepMembers(store.getActions(), [
           {
             type:    actions.reports.post.requestType,
             payload: {
@@ -844,8 +830,7 @@ describe("PostPage", function() {
         })
         assert.ok(preventDefaultStub.called)
 
-        const actionsList = store.getActions()
-        assert.deepEqual(actionsList.slice(actionsList.length - 3), [
+        assert.includeDeepMembers(store.getActions(), [
           {
             type:    SET_FOCUSED_POST,
             payload: post
@@ -927,8 +912,7 @@ describe("PostPage", function() {
           reason:  reason
         })
 
-        const actionsList = store.getActions()
-        assert.deepEqual(actionsList.slice(actionsList.length - 6), [
+        assert.includeDeepMembers(store.getActions(), [
           {
             type:    actions.reports.post.requestType,
             payload: {

--- a/static/js/containers/PostPage_test.js
+++ b/static/js/containers/PostPage_test.js
@@ -367,7 +367,7 @@ describe("PostPage", function() {
       const { inner, store } = await render()
       inner.find("ExpandedPostDisplay").prop("showPostDeleteDialog")()
       const actionsList = store.getActions()
-      assert.deepEqual(actionsList[actionsList.length - 1], {
+      assert.deepEqual(R.last(actionsList), {
         type:    SHOW_DIALOG,
         payload: "DELETE_POST_DIALOG"
       })
@@ -749,7 +749,7 @@ describe("PostPage", function() {
         })
 
         const actionsList = store.getActions()
-        assert.deepEqual(actionsList[actionsList.length - 1], {
+        assert.deepEqual(R.last(actionsList), {
           type:    FORM_UPDATE,
           payload: {
             formKey: REPORT_FORM_KEY,
@@ -874,7 +874,7 @@ describe("PostPage", function() {
         })
 
         const actionsList = store.getActions()
-        assert.deepEqual(actionsList[actionsList.length - 1], {
+        assert.deepEqual(R.last(actionsList), {
           type:    FORM_UPDATE,
           payload: {
             formKey: REPORT_FORM_KEY,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1765 
Fixes #706 

#### What's this PR do?
Fixes the dialog not closing bug and also refactors tests on PostPage. There should be new tests for the bug and other related functionality.

#### How should this be manually tested?
Delete a comment. Click the accept button on the confirmation dialog. The comment should be deleted and the dialog should disappear.

