### PR TITLE
Hide embedly title for embedly widgets

### DIFF
--- a/static/js/components/EmbedlyCard.js
+++ b/static/js/components/EmbedlyCard.js
@@ -6,7 +6,8 @@ import { loadEmbedlyPlatform, renderEmbedlyCard } from "../lib/embed"
 import { isValidUrl } from "../lib/util"
 
 type Props = {
-  url: string
+  url: string,
+  className?: string
 }
 export default class EmbedlyCard extends React.Component<Props> {
   componentDidMount() {
@@ -14,12 +15,17 @@ export default class EmbedlyCard extends React.Component<Props> {
   }
 
   render() {
-    const { url } = this.props
+    const { className, url } = this.props
 
     if (!isValidUrl(url)) {
       return null
     }
 
-    return <div dangerouslySetInnerHTML={{ __html: renderEmbedlyCard(url) }} />
+    return (
+      <div
+        className={className}
+        dangerouslySetInnerHTML={{ __html: renderEmbedlyCard(url) }}
+      />
+    )
   }
 }

--- a/static/js/components/widgets/UrlWidget.js
+++ b/static/js/components/widgets/UrlWidget.js
@@ -9,5 +9,7 @@ const UrlWidget = ({
   widgetInstance: {
     configuration: { url }
   }
-}: WidgetComponentProps) => <EmbedlyCard url={url} />
+}: WidgetComponentProps) => (
+  <EmbedlyCard url={url} className="no-embedly-title" />
+)
 export default UrlWidget

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -60,8 +60,7 @@ export const loadEmbedlyPlatform = () => {
     // $FlowFixMe
     script.parentNode.insertBefore(el, script)
 
-    // $FlowFixMe
-    embedly("on", "card.rendered", function(iframe) {
+    window.embedly("on", "card.rendered", function(iframe) {
       // IE does not provide Element.closest, but it's not essential functionality
       if (iframe.closest && iframe.closest(".no-embedly-title")) {
         const head = iframe.contentDocument.head

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -40,6 +40,22 @@ export const hasIframe = R.memoizeWith(R.identity, (html: string) => {
   return !!div.querySelector("iframe")
 })
 
+export const onCardRendered = (iframe: HTMLIFrameElement): void => {
+  // IE does not provide Element.closest, but it's not essential functionality
+  if (iframe.closest && iframe.closest(".no-embedly-title")) {
+    const head = iframe.contentDocument.head
+    const style = iframe.contentDocument.createElement("style")
+    style.setAttribute("type", "text/css")
+    // hide the title
+    style.innerText = ".hdr { display: none; }"
+
+    if (head) {
+      // for flow
+      head.appendChild(style)
+    }
+  }
+}
+
 export const loadEmbedlyPlatform = () => {
   const id = "embedly-platform"
 
@@ -60,17 +76,7 @@ export const loadEmbedlyPlatform = () => {
     // $FlowFixMe
     script.parentNode.insertBefore(el, script)
 
-    window.embedly("on", "card.rendered", function(iframe) {
-      // IE does not provide Element.closest, but it's not essential functionality
-      if (iframe.closest && iframe.closest(".no-embedly-title")) {
-        const head = iframe.contentDocument.head
-        const style = iframe.contentDocument.createElement("style")
-        style.setAttribute("type", "text/css")
-        // hide the title
-        style.innerText = ".hdr { display: none; }"
-        head.appendChild(style)
-      }
-    })
+    window.embedly("on", "card.rendered", onCardRendered)
   }
 }
 

--- a/static/js/lib/embed.js
+++ b/static/js/lib/embed.js
@@ -1,4 +1,4 @@
-/* global SETTINGS: false */
+/* globals SETTINGS: false, embedly: false */
 // @flow
 import R from "ramda"
 import React from "react"
@@ -59,6 +59,19 @@ export const loadEmbedlyPlatform = () => {
     const script = document.getElementsByTagName("script")[0]
     // $FlowFixMe
     script.parentNode.insertBefore(el, script)
+
+    // $FlowFixMe
+    embedly("on", "card.rendered", function(iframe) {
+      // IE does not provide Element.closest, but it's not essential functionality
+      if (iframe.closest && iframe.closest(".no-embedly-title")) {
+        const head = iframe.contentDocument.head
+        const style = iframe.contentDocument.createElement("style")
+        style.setAttribute("type", "text/css")
+        // hide the title
+        style.innerText = ".hdr { display: none; }"
+        head.appendChild(style)
+      }
+    })
   }
 }
 

--- a/static/js/lib/embed_test.js
+++ b/static/js/lib/embed_test.js
@@ -83,6 +83,8 @@ describe("embed utils", () => {
         "http://cdn.embedly.com/widgets/platform.js"
       )
     })
+
+    //
     ;[true, false].forEach(hidesTitle => {
       it(`${
         hidesTitle ? "adds" : "doesn't add"

--- a/static/js/lib/embed_test.js
+++ b/static/js/lib/embed_test.js
@@ -6,6 +6,7 @@ import {
   handleTwitterWidgets,
   hasIframe,
   loadEmbedlyPlatform,
+  onCardRendered,
   renderEmbedlyCard
 } from "./embed"
 
@@ -82,6 +83,9 @@ describe("embed utils", () => {
         firstScript.getAttribute("src"),
         "http://cdn.embedly.com/widgets/platform.js"
       )
+
+      const callback = embedlyStub.firstCall.args[2]
+      assert.equal(callback, onCardRendered)
     })
 
     //
@@ -89,8 +93,6 @@ describe("embed utils", () => {
       it(`${
         hidesTitle ? "adds" : "doesn't add"
       } a style element to hide the title`, () => {
-        loadEmbedlyPlatform()
-
         const container = document.createElement("div")
         document.body.append(container)
         if (hidesTitle) {
@@ -99,8 +101,7 @@ describe("embed utils", () => {
         const iframe = document.createElement("iframe")
         container.appendChild(iframe)
 
-        const callback = embedlyStub.firstCall.args[2]
-        callback(iframe)
+        onCardRendered(iframe)
         if (hidesTitle) {
           assert.equal(
             iframe.contentDocument.querySelector("style").innerText,

--- a/static/js/lib/embed_test.js
+++ b/static/js/lib/embed_test.js
@@ -68,7 +68,7 @@ describe("embed utils", () => {
 
       // this expects at least one script element to already exist
       embedlyStub = sandbox.stub()
-      global.embedly = embedlyStub
+      window.embedly = embedlyStub
 
       const script = document.createElement("script")
       document.head.appendChild(script)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1856 

#### What's this PR do?
Adds an embedly hook to add CSS to hide a title for embedly card iframes in widgets

#### How should this be manually tested?
Add an embedly widget. You should not see the title (see images below)

#### Screenshot
Before:
![screenshot from 2019-02-21 16-29-17](https://user-images.githubusercontent.com/863262/53202982-e498f580-35f5-11e9-8294-1bf3e8ea83b2.png)

After:
![screenshot from 2019-02-21 16-28-33](https://user-images.githubusercontent.com/863262/53202988-e82c7c80-35f5-11e9-81a8-127b79342d4c.png)
