### PR TITLE
Bumped ocw-data-parser version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,7 @@ html5lib==0.999999999
 ipython
 markdown2
 newrelic
-ocw-data-parser==0.2.3
+ocw-data-parser==0.2.4
 Pillow==3.4.2
 psycopg2==2.7
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ lxml==4.1.1               # via xmlsec
 markdown2==2.3.7
 newrelic==4.2.0.100
 oauthlib==2.0.7           # via requests-oauthlib, social-auth-core
-ocw-data-parser==0.2.3
+ocw-data-parser==0.2.4
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==3.4.2


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR upgrades the `ocw-data-parser` dependency to pick up the logging fix [here](https://github.com/zagaran/ocw-data-parser/pull/8).

#### How should this be manually tested?

- Run `./manage.py backpopulate_ocw_data` and it should function the same as master.
