### PR TITLE
update the channel post listing after pinning / unpinning a post

### DIFF
--- a/static/js/hoc/withPostList.js
+++ b/static/js/hoc/withPostList.js
@@ -8,6 +8,7 @@ import PostList from "../components/PostList"
 
 import { toggleUpvote } from "../util/api_actions"
 import { actions } from "../actions"
+import { evictPostsForChannel } from "../actions/posts_for_channel"
 
 import type { Location } from "react-router"
 import type { Dispatch } from "redux"
@@ -28,7 +29,8 @@ type Props = {
   showReportPost: boolean,
   showRemovePost: boolean,
   showTogglePinPost: boolean,
-  showPinUI: boolean
+  showPinUI: boolean,
+  channelName?: string
 }
 
 const withPostList = (WrappedComponent: Class<React.Component<*, *>>) => {
@@ -62,10 +64,12 @@ const withPostList = (WrappedComponent: Class<React.Component<*, *>>) => {
       const {
         dispatch,
         loadPosts,
+        channelName,
         location: { search }
       } = this.props
 
       await dispatch(actions.posts.patch(post.id, { stickied: !post.stickied }))
+      dispatch(evictPostsForChannel(channelName))
       await loadPosts(qs.parse(search))
     }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1841 

#### What's this PR do?

This PR evicts the current post list after the user has made a request to toggle the pinned state of a post. This will force the UI to show the 'true' state of the post list after the pinned state is updated.

There was a difficulty before because of some of the logic relating to the pagination. This sidesteps modifying or changing that logic by just clearing the whole post list, so we use what we get back from the API directly, instead of trying to figure out in which cases we want to merge the new post list into the existing one and in which cases we want to overwrite it.

#### How should this be manually tested?

Pagination and loading on the channel page should work as normal. If you pin a post you should see a spinner for a sec while the post list refreshes, and then you should see that the newly-pinned post is at the top and that the post list now looks the same as if you had refreshed the page (this wasn't the case before - the 'pin' UI would be added to the recently pinned post but its position in the list wouldn't change).

Unpinning the post should have a similar effect.