### PR TITLE
populates and indexes new Course field `availability`

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -22,6 +22,17 @@ class ResourceType(Enum):
     ocw_resource = "ocw_resource"
 
 
+class AvailabilityType(Enum):
+    """
+    Enum for Course availability options dictated by edX API values.
+    All OCW courses should be set to "Current"
+    """
+
+    current = "Current"
+    upcoming = "Upcoming"
+    starting_soon = "Starting Soon"
+
+
 MIT_OWNER_KEYS = ["MITx", "MITx_PRO"]
 
 NON_COURSE_DIRECTORIES = [

--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -31,6 +31,7 @@ class AvailabilityType(Enum):
     current = "Current"
     upcoming = "Upcoming"
     starting_soon = "Starting Soon"
+    archived = "Archived"
 
 
 MIT_OWNER_KEYS = ["MITx", "MITx_PRO"]

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -3,7 +3,7 @@ import factory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
-from course_catalog.constants import PlatformType
+from course_catalog.constants import PlatformType, AvailabilityType
 from course_catalog.models import Course, CourseInstructor, CourseTopic, CoursePrice
 
 # pylint: disable=unused-argument
@@ -43,6 +43,13 @@ class CourseFactory(DjangoModelFactory):
 
     course_id = factory.Sequence(lambda n: "COURSE%03d.MIT" % n)
     platform = FuzzyChoice((PlatformType.mitx.value, PlatformType.ocw.value))
+    availability = FuzzyChoice(
+        (
+            AvailabilityType.current.value,
+            AvailabilityType.upcoming.value,
+            AvailabilityType.starting_soon.value,
+        )
+    )
 
     @factory.post_generation
     def instructors(self, create, extracted, **kwargs):

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -48,6 +48,7 @@ class CourseFactory(DjangoModelFactory):
             AvailabilityType.current.value,
             AvailabilityType.upcoming.value,
             AvailabilityType.starting_soon.value,
+            AvailabilityType.archived.value,
         )
     )
 

--- a/course_catalog/task_helpers.py
+++ b/course_catalog/task_helpers.py
@@ -18,6 +18,7 @@ from course_catalog.constants import (
     ocw_edx_mapping,
     NON_COURSE_DIRECTORIES,
     ResourceType,
+    AvailabilityType,
 )
 from course_catalog.models import Course, CourseTopic, CourseInstructor, CoursePrice
 from course_catalog.serializers import CourseSerializer
@@ -117,6 +118,7 @@ def parse_mitx_json_data(course_data, force_overwrite=False):
             "last_modified": max_modified,
             "raw_json": course_data,
             "url": get_course_url(course_run_key, course_data, PlatformType.mitx.value),
+            "availability": course_run.get("availability"),
         }
 
         course_serializer = CourseSerializer(
@@ -264,6 +266,7 @@ def digest_ocw_course(
         "published": is_published,
         "raw_json": master_json,
         "url": get_course_url(course_id, master_json, PlatformType.ocw.value),
+        "availability": AvailabilityType.current.value,
     }
     if "PROD/RES" in course_prefix:
         course_fields["learning_resource_type"] = ResourceType.ocw_resource.value

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -97,6 +97,7 @@ COURSE_OBJECT_TYPE = {
     "price": {"type": "nested"},
     "image_src": {"type": "keyword"},
     "published": {"type": "boolean"},
+    "availability": {"type": "keyword"},
 }
 
 MAPPING = {

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -149,6 +149,7 @@ class ESCourseSerializer(ESModelSerializer):
             "prices",
             "instructors",
             "published",
+            "availability",
         ]
 
         read_only_fields = fields

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -233,6 +233,7 @@ def test_es_course_serializer():
         "topics": list(course.topics.values_list("name", flat=True)),
         "prices": list(course.prices.values("price", "mode")),
         "published": True,
+        "availability": course.availability,
     }
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1898 in conjunction with PR #1900.
Note: this PR merges code into the branch that PR #1900 is asking merging into `master`.
Code is split into two separate PRs on Peter's request.

#### What's this PR do?
Adds content population for newly added `availability` Course field on import and includes the content for Elasticsearch indexing via `ESCourseSerializer`

One question for the reviewer:
Should values for the `Course.availability` field be enforced at the database-level via a "choices" field parameter populated by the values of`course_catalog/constants/AvailabilityType` enum? 
Position of the author: I would typically prefer enforcement from an enum (and thus giving me a guarantee on the range of values I as a developer can expect from the database), but I ultimately opted to not enforce it at the database-level because we don't technically know all the possible values. [The edX documentation](https://course-catalog-api-guide.readthedocs.io/en/latest/course_catalog/catalog.html) doesn't seem to have any mention of availability or possible values returned by the API. Instead, this code trusts the edX API to return consistent values and accepts whatever the edX API returns (which appears to be only three values: `"Current"`, `"Upcoming"`, and `"Starting Soon"`). If the reviewer agrees, no action is needed. (note: the values for the enum are based on what I've seen returned from the API upon manual inspection; the enum exists to serve as a constant for when our code is using it)
 
#### How should this be manually tested?
You may call the sync functions manually to check if the new field is being populated correctly:
```
course_catalog/tasks/sync_and_upload_edx_data()
course_catalog/tasks/digest_ocw_course()
```
You can call the index function to check if the field exists in the ES index:
```
search/task_helpers/index_new_course()
```