### PR TITLE
upgrade flow to @latest

### DIFF
--- a/flow-typed/npm/express_v4.16.x.js
+++ b/flow-typed/npm/express_v4.16.x.js
@@ -1,8 +1,8 @@
-// flow-typed signature: 45384ed25d019e0595020cc30e78b80f
-// flow-typed version: d11eab7bb5/express_v4.x.x/flow_>=v0.32.x
+// flow-typed signature: 164dcf1c9105e51cb17a374a807146a7
+// flow-typed version: c7f4cf7a4d/express_v4.16.x/flow_>=v0.93.x
 
-import type { Server } from 'http';
-import type { Socket } from 'net';
+import * as http from "http";
+import type { Socket } from "net";
 
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
@@ -17,12 +17,12 @@ declare class express$RequestResponseBase {
 
 declare type express$RequestParams = {
   [param: string]: string
-}
+};
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;
-  cookies: {[cookie: string]: string};
+  cookies: { [cookie: string]: string };
   connection: Socket;
   fresh: boolean;
   hostname: string;
@@ -32,11 +32,11 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   originalUrl: string;
   params: express$RequestParams;
   path: string;
-  protocol: 'https' | 'http';
-  query: {[name: string]: string | Array<string>};
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
   route: string;
   secure: boolean;
-  signedCookies: {[signedCookie: string]: string};
+  signedCookies: { [signedCookie: string]: string };
   stale: boolean;
   subdomains: Array<string>;
   xhr: boolean;
@@ -63,53 +63,80 @@ declare type express$CookieOptions = {
 
 declare type express$Path = string | RegExp;
 
-declare type express$RenderCallback = (err: Error | null, html?: string) => mixed;
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
 
 declare type express$SendFileOptions = {
   maxAge?: number,
   root?: string,
   lastModified?: boolean,
-  headers?: {[name: string]: string},
-  dotfiles?: 'allow' | 'deny' | 'ignore'
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
 };
 
 declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
   headersSent: boolean;
-  locals: {[name: string]: mixed};
+  locals: { [name: string]: mixed };
   append(field: string, value?: string): this;
   attachment(filename?: string): this;
   cookie(name: string, value: string, options?: express$CookieOptions): this;
   clearCookie(name: string, options?: express$CookieOptions): this;
-  download(path: string, filename?: string, callback?: (err?: ?Error) => void): this;
-  format(typesObject: {[type: string]: Function}): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
   json(body?: mixed): this;
   jsonp(body?: mixed): this;
-  links(links: {[name: string]: string}): this;
+  links(links: { [name: string]: string }): this;
   location(path: string): this;
   redirect(url: string, ...args: Array<void>): this;
   redirect(status: number, url: string, ...args: Array<void>): this;
-  render(view: string, locals?: {[name: string]: mixed}, callback?: express$RenderCallback): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
   send(body?: mixed): this;
-  sendFile(path: string, options?: express$SendFileOptions, callback?: (err?: ?Error) => mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
   sendStatus(statusCode: number): this;
   header(field: string, value?: string): this;
-  header(headers: {[name: string]: string}): this;
-  set(field: string, value?: string|string[]): this;
-  set(headers: {[name: string]: string}): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
   status(statusCode: number): this;
   type(type: string): this;
   vary(field: string): this;
   req: express$Request;
 }
 
-declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
 declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
+  | ((
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed);
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
-  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
+  (
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): T;
 }
 declare class express$Route {
   all: express$RouteMethodType<this>;
@@ -149,9 +176,16 @@ declare class express$Router extends express$Route {
   static (options?: express$RouterOptions): express$Router;
   use(middleware: express$Middleware): this;
   use(...middleware: Array<express$Middleware>): this;
-  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
+  use(
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): this;
   use(path: string, router: express$Router): this;
-  handle(req: http$IncomingMessage, res: http$ServerResponse, next: express$NextFunction): void;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
   param(
     param: string,
     callback: (
@@ -161,18 +195,39 @@ declare class express$Router extends express$Route {
       id: string
     ) => mixed
   ): void;
-  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
 }
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
 
 declare class express$Application extends express$Router mixins events$EventEmitter {
   constructor(): void;
-  locals: {[name: string]: mixed};
+  locals: { [name: string]: mixed };
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;
@@ -183,13 +238,53 @@ declare class express$Application extends express$Router mixins events$EventEmit
    */
   //   get(name: string): mixed;
   set(name: string, value: mixed): mixed;
-  render(name: string, optionsOrFunction: {[name: string]: mixed}, callback: express$RenderCallback): void;
-  handle(req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
   // callable signature is not inherited
-  (req: http$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
 }
 
-declare module 'express' {
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
+declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
   declare export type Middleware = express$Middleware;
@@ -201,7 +296,9 @@ declare module 'express' {
 
   declare module.exports: {
     (): express$Application, // If you try to call like a function, it will use this signature
+    json: (opts: ?JsonOptions) => express$Middleware,
     static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
     Router: typeof express$Router, // `Router` property on the function
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
   };
 }

--- a/flow-typed/npm/history_v4.x.x.js
+++ b/flow-typed/npm/history_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: eb8bd974b677b08dfca89de9ac05b60b
-// flow-typed version: 43b30482ac/history_v4.x.x/flow_>=v0.25.x
+// flow-typed signature: 540e42745f797051f3bf17a6af1ccf06
+// flow-typed version: 6a3fe49a8b/history_v4.x.x/flow_>=v0.25.x
 
 declare module "history/createBrowserHistory" {
   declare function Unblock(): void;
@@ -11,25 +11,27 @@ declare module "history/createBrowserHistory" {
     search: string,
     hash: string,
     // Browser and Memory specific
-    state: string,
+    state: {},
     key: string,
   };
 
-  declare export type BrowserHistory = {
+  declare interface IBrowserHistory {
     length: number,
     location: BrowserLocation,
     action: Action,
-    push: (path: string, Array<mixed>) => void,
-    replace: (path: string, Array<mixed>) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<BrowserLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<BrowserLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: BrowserLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-    replace: (path: string) => void,
-  };
+    block(message: string): typeof Unblock,
+    block((location: BrowserLocation, action: Action) => string): typeof Unblock,
+  }
+
+  declare export type BrowserHistory = IBrowserHistory;
 
   declare type HistoryOpts = {
     basename?: string,
@@ -53,28 +55,31 @@ declare module "history/createMemoryHistory" {
     search: string,
     hash: string,
     // Browser and Memory specific
-    state: string,
+    state: {},
     key: string,
   };
 
-  declare export type MemoryHistory = {
+  declare interface IMemoryHistory {
     length: number,
     location: MemoryLocation,
     action: Action,
     index: number,
     entries: Array<string>,
-    push: (path: string, Array<mixed>) => void,
-    replace: (path: string, Array<mixed>) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<MemoryLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<MemoryLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     // Memory only
-    canGo: (n: number) => boolean,
+    canGo(n: number): boolean,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: MemoryLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-  };
+    block(message: string): typeof Unblock,
+    block((location: MemoryLocation, action: Action) => string): typeof Unblock,
+  }
+
+  declare export type MemoryHistory = IMemoryHistory;
 
   declare type HistoryOpts = {
     initialEntries?: Array<string>,
@@ -100,20 +105,24 @@ declare module "history/createHashHistory" {
     hash: string,
   };
 
-  declare export type HashHistory = {
+  declare interface IHashHistory {
     length: number,
     location: HashLocation,
     action: Action,
-    push: (path: string, Array<mixed>) => void,
-    replace: (path: string, Array<mixed>) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<HashLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<HashLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: HashLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-  };
+    block(message: string): typeof Unblock,
+    block((location: HashLocation, action: Action) => string): typeof Unblock,
+    push(path: string): void,
+  }
+
+  declare export type HashHistory = IHashHistory;
 
   declare type HistoryOpts = {
     basename?: string,

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,205 +1,276 @@
-// flow-typed signature: 0fe76887d4f9795dc7679f4f8b63dbe3
-// flow-typed version: c5d8a135ce/react-redux_v5.x.x/flow_>=v0.63.0
+// flow-typed signature: f06f00c3ad0cfedb90c0c6de04b219f3
+// flow-typed version: 3a6d556e4b/react-redux_v5.x.x/flow_>=v0.89.x
 
-import type { Dispatch, Store } from "redux";
+/**
+The order of type arguments for connect() is as follows:
 
-declare module "react-redux" {
-  import type { ComponentType, ElementConfig } from 'react';
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
 
-  declare export class Provider<S, A> extends React$Component<{
-    store: Store<S, A>,
-    children?: any
-  }> {}
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
 
-  declare export function createProvider(
-    storeKey?: string,
-    subKey?: string
-  ): Provider<*, *>;
+connect<Props, OwnProps, _, _, _, _>(…)
 
-  /*
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
 
+Decrypting the abbreviations:
+  WC = Component being wrapped
   S = State
-  A = Action
+  D = Dispatch
   OP = OwnProps
   SP = StateProps
   DP = DispatchProps
   MP = Merge props
-  MDP = Map dispatch to props object
   RSP = Returned state props
   RDP = Returned dispatch props
   RMP = Returned merge props
   CP = Props for returned component
   Com = React Component
   ST = Static properties of Com
-  */
+  EFO = Extra factory options (used only in connectAdvanced)
+*/
 
-  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+declare module "react-redux" {
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
 
-  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
-
-  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
-    stateProps: SP,
-    dispatchProps: DP,
-    ownProps: MP
-  ) => RMP;
-
-  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
+  declare export type Options<S, OP, SP, MP> = {|
     pure?: boolean,
     withRef?: boolean,
     areStatesEqual?: (next: S, prev: S) => boolean,
     areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
-    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
-    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
-    storeKey?: string
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
   |};
 
-  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
 
-  declare export function connect<
-    Com: ComponentType<*>,
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
+
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
+
+  declare class ConnectedComponent<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponent<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP,
+  ) => P;
+
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
+
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string,
+  ): Class<Provider<*>>;
+
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    withRef?: boolean,
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    withRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+  };
+
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
+
+  declare type SelectorFactory<
+    Com: React$ComponentType<*>,
+    Dispatch,
     S: Object,
-    SP: Object,
-    RSP: Object,
-    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
-    ST: {[_: $Keys<Com>]: any}
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<CP & SP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    ST: {[_: $Keys<Com>]: any}
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
-  ): (component: Com) => ComponentType<CP & SP & DP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
     OP: Object,
-    DP: Object,
-    PR: Object,
-    CP: $Diff<ElementConfig<Com>, DP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
-  ): (Com) => ComponentType<CP & OP>;
+    EFO: Object,
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
 
-  declare export function connect<
-    Com: ComponentType<*>,
-    MDP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps: MDP
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
+  declare export function connectAdvanced<
+    Com: React$ComponentType<*>,
+    D,
     S: Object,
-    SP: Object,
-    RSP: Object,
-    MDP: Object,
-    CP: $Diff<ElementConfig<Com>, RSP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToPRops: MDP
-  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MP: Object,
-    RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MDP: Object,
-    MP: Object,
-    RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MDP,
-    mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MP: Object,
-    RMP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
-    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MDP: Object,
-    MP: Object,
-    RMP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: MDP,
-    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: { [_: $Keys<Com>]: any },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
 
   declare export default {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
     connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
   };
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "^7.10.0",
     "express": "^4.16.3",
     "fetch-mock": "^6.4.4",
-    "flow-bin": "^0.75.0",
+    "flow-bin": "^0.94.0",
     "flow-typed": "^2.4.0",
     "history": "^4.7.2",
     "html-entities": "^1.2.1",

--- a/static/js/actions/channel.js
+++ b/static/js/actions/channel.js
@@ -2,7 +2,7 @@
 import { createAction } from "redux-actions"
 
 export const SET_CHANNEL_DATA = "SET_CHANNEL_DATA"
-export const setChannelData = createAction(SET_CHANNEL_DATA)
+export const setChannelData = createAction<string, *>(SET_CHANNEL_DATA)
 
 export const CLEAR_CHANNEL_ERROR = "CLEAR_CHANNEL_ERROR"
-export const clearChannelError = createAction(CLEAR_CHANNEL_ERROR)
+export const clearChannelError = createAction<string, *>(CLEAR_CHANNEL_ERROR)

--- a/static/js/actions/comment.js
+++ b/static/js/actions/comment.js
@@ -2,7 +2,9 @@
 import { createAction } from "redux-actions"
 
 export const REPLACE_MORE_COMMENTS = "REPLACE_MORE_COMMENTS"
-export const replaceMoreComments = createAction(REPLACE_MORE_COMMENTS)
+export const replaceMoreComments = createAction<string, *>(
+  REPLACE_MORE_COMMENTS
+)
 
 export const CLEAR_COMMENT_ERROR = "CLEAR_COMMENT_ERROR"
-export const clearCommentError = createAction(CLEAR_COMMENT_ERROR)
+export const clearCommentError = createAction<string, *>(CLEAR_COMMENT_ERROR)

--- a/static/js/actions/focus.js
+++ b/static/js/actions/focus.js
@@ -2,13 +2,15 @@
 import { createAction } from "redux-actions"
 
 export const SET_FOCUSED_COMMENT = "SET_FOCUSED_COMMENT"
-export const setFocusedComment = createAction(SET_FOCUSED_COMMENT)
+export const setFocusedComment = createAction<string, *>(SET_FOCUSED_COMMENT)
 
 export const CLEAR_FOCUSED_COMMENT = "CLEAR_FOCUSED_COMMENT"
-export const clearFocusedComment = createAction(CLEAR_FOCUSED_COMMENT)
+export const clearFocusedComment = createAction<string, *>(
+  CLEAR_FOCUSED_COMMENT
+)
 
 export const SET_FOCUSED_POST = "SET_FOCUSED_POST"
-export const setFocusedPost = createAction(SET_FOCUSED_POST)
+export const setFocusedPost = createAction<string, *>(SET_FOCUSED_POST)
 
 export const CLEAR_FOCUSED_POST = "CLEAR_FOCUSED_POST"
-export const clearFocusedPost = createAction(CLEAR_FOCUSED_POST)
+export const clearFocusedPost = createAction<string, *>(CLEAR_FOCUSED_POST)

--- a/static/js/actions/forms.js
+++ b/static/js/actions/forms.js
@@ -1,15 +1,14 @@
 // @flow
-
 import { createAction } from "redux-actions"
 
 export const FORM_BEGIN_EDIT = "FORM_BEGIN_EDIT"
-export const formBeginEdit = createAction(FORM_BEGIN_EDIT)
+export const formBeginEdit = createAction<string, *>(FORM_BEGIN_EDIT)
 
 export const FORM_UPDATE = "FORM_UPDATE"
-export const formUpdate = createAction(FORM_UPDATE)
+export const formUpdate = createAction<string, *>(FORM_UPDATE)
 
 export const FORM_VALIDATE = "FORM_VALIDATE"
-export const formValidate = createAction(FORM_VALIDATE)
+export const formValidate = createAction<string, *>(FORM_VALIDATE)
 
 export const FORM_END_EDIT = "FORM_END_EDIT"
-export const formEndEdit = createAction(FORM_END_EDIT)
+export const formEndEdit = createAction<string, *>(FORM_END_EDIT)

--- a/static/js/actions/post.js
+++ b/static/js/actions/post.js
@@ -2,7 +2,7 @@
 import { createAction } from "redux-actions"
 
 export const SET_POST_DATA = "SET_POST_DATA"
-export const setPostData = createAction(SET_POST_DATA)
+export const setPostData = createAction<string, *>(SET_POST_DATA)
 
 export const CLEAR_POST_ERROR = "CLEAR_POST_ERROR"
-export const clearPostError = createAction(CLEAR_POST_ERROR)
+export const clearPostError = createAction<string, *>(CLEAR_POST_ERROR)

--- a/static/js/actions/posts_for_channel.js
+++ b/static/js/actions/posts_for_channel.js
@@ -2,4 +2,6 @@
 import { createAction } from "redux-actions"
 
 export const EVICT_POSTS_FOR_CHANNEL = "EVICT_POSTS_FOR_CHANNEL"
-export const evictPostsForChannel = createAction(EVICT_POSTS_FOR_CHANNEL)
+export const evictPostsForChannel = createAction<string, *>(
+  EVICT_POSTS_FOR_CHANNEL
+)

--- a/static/js/actions/search.js
+++ b/static/js/actions/search.js
@@ -2,7 +2,9 @@
 import { createAction } from "redux-actions"
 
 export const CLEAR_SEARCH = "CLEAR_SEARCH"
-export const clearSearch = createAction(CLEAR_SEARCH)
+export const clearSearch = createAction<string, *>(CLEAR_SEARCH)
 
 export const SET_SEARCH_INCREMENTAL = "SET_SEARCH_INCREMENTAL"
-export const setSearchIncremental = createAction(SET_SEARCH_INCREMENTAL)
+export const setSearchIncremental = createAction<string, *>(
+  SET_SEARCH_INCREMENTAL
+)

--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -8,45 +8,51 @@ export const DIALOG_CLEAR_POST_TYPE = "DIALOG_CLEAR_POST_TYPE"
 export const DIALOG_EDIT_WIDGET = "DIALOG_EDIT_WIDGET"
 
 export const SET_SHOW_DRAWER_DESKTOP = "SET_SHOW_DRAWER_DESKTOP"
-export const setShowDrawerDesktop = createAction(SET_SHOW_DRAWER_DESKTOP)
+export const setShowDrawerDesktop = createAction<string, *>(
+  SET_SHOW_DRAWER_DESKTOP
+)
 
 export const SET_SHOW_DRAWER_MOBILE = "SET_SHOW_DRAWER_MOBILE"
-export const setShowDrawerMobile = createAction(SET_SHOW_DRAWER_MOBILE)
+export const setShowDrawerMobile = createAction<string, *>(
+  SET_SHOW_DRAWER_MOBILE
+)
 
 export const SET_SHOW_COURSE_DRAWER = "SET_SHOW_COURSE_DRAWER"
-export const setShowCourseDrawer = createAction(SET_SHOW_COURSE_DRAWER)
+export const setShowCourseDrawer = createAction<string, *>(
+  SET_SHOW_COURSE_DRAWER
+)
 
 export const SET_SNACKBAR_MESSAGE = "SET_SNACKBAR_MESSAGE"
-export const setSnackbarMessage = createAction(SET_SNACKBAR_MESSAGE)
+export const setSnackbarMessage = createAction<string, *>(SET_SNACKBAR_MESSAGE)
 
 export const SET_BANNER_MESSAGE = "SET_BANNER_MESSAGE"
-export const setBannerMessage = createAction(SET_BANNER_MESSAGE)
+export const setBannerMessage = createAction<string, *>(SET_BANNER_MESSAGE)
 
 export const HIDE_BANNER = "HIDE_BANNER"
-export const hideBanner = createAction(HIDE_BANNER)
+export const hideBanner = createAction<string, *>(HIDE_BANNER)
 
 export const SHOW_DIALOG = "SHOW_DIALOG"
-export const showDialog = createAction(SHOW_DIALOG)
+export const showDialog = createAction<string, *>(SHOW_DIALOG)
 
 export const HIDE_DIALOG = "HIDE_DIALOG"
-export const hideDialog = createAction(HIDE_DIALOG)
+export const hideDialog = createAction<string, *>(HIDE_DIALOG)
 
 export const SET_DIALOG_DATA = "SET_DIALOG_DATA"
-export const setDialogData = createAction(SET_DIALOG_DATA)
+export const setDialogData = createAction<string, *>(SET_DIALOG_DATA)
 
 export const SHOW_DROPDOWN = "SHOW_DROPDOWN"
-export const showDropdown = createAction(SHOW_DROPDOWN)
+export const showDropdown = createAction<string, *>(SHOW_DROPDOWN)
 
 export const HIDE_DROPDOWN = "HIDE_DROPDOWN"
-export const hideDropdown = createAction(HIDE_DROPDOWN)
+export const hideDropdown = createAction<string, *>(HIDE_DROPDOWN)
 
 export const SET_AUTH_USER_DETAIL = "SET_AUTH_USER_DETAIL"
-export const setAuthUserDetail = createAction(SET_AUTH_USER_DETAIL)
+export const setAuthUserDetail = createAction<string, *>(SET_AUTH_USER_DETAIL)
 
 // this is a hack :/
 // needed to debounce just a little bit to get around a race
 // condition with the post dropdown menu
-export const hideDropdownDebounced = createAction(
+export const hideDropdownDebounced = createAction<string, *, *, *>(
   HIDE_DROPDOWN,
   i => i,
   () => ({ debounce: { time: 100 } })

--- a/static/js/components/AddLinkMenu.js
+++ b/static/js/components/AddLinkMenu.js
@@ -3,13 +3,13 @@ import React from "react"
 
 import CloseButton from "./CloseButton"
 
-type Props = {
+type Props = {|
   onSubmit: Function,
   onChange: Function,
   closeMenu: Function,
   text: string,
   url: string
-}
+|}
 
 const AddLinkMenu = ({ onSubmit, onChange, closeMenu, text, url }: Props) => (
   <div className="add-link-menu">

--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -6,11 +6,11 @@ import CustomEditor from "@mitodl/ckeditor-custom-build"
 import { getCKEditorJWT } from "../lib/api/ckeditor"
 import { loadEmbedlyPlatform, renderEmbedlyCard } from "../lib/embed"
 
-type Props = {
+type Props = {|
   initialData?: Array<Object>,
   readOnly?: boolean,
   onChange?: Function
-}
+|}
 
 const editorClassName = (readOnly?: boolean): string =>
   `ck-editor ${readOnly ? "read-only" : ""}`.trim()

--- a/static/js/components/BackButton.js
+++ b/static/js/components/BackButton.js
@@ -1,10 +1,10 @@
 // @flow
 import React from "react"
 
-type BackButtonProps = {
+type BackButtonProps = {|
   onClick: Function,
   className?: string
-}
+|}
 
 const BackButton = ({ onClick, className }: BackButtonProps) => (
   <a

--- a/static/js/components/Button.js
+++ b/static/js/components/Button.js
@@ -1,11 +1,11 @@
 // @flow
 import React from "react"
 
-type ButtonProps = {
+type ButtonProps = {|
   children: React$Element<*>,
   onClick: Function,
   className?: string
-}
+|}
 
 const Button = ({ children, onClick, className }: ButtonProps) => (
   <button className={`mdc-button ${className || ""}`} onClick={onClick}>

--- a/static/js/components/CanonicalLink.js
+++ b/static/js/components/CanonicalLink.js
@@ -6,10 +6,10 @@ import { removeTrailingSlash } from "../lib/util"
 
 import type { Match } from "react-router"
 
-type Props = {
+type Props = {|
   relativeUrl?: ?string,
   match?: ?Match
-}
+|}
 
 const CanonicalLink = ({ relativeUrl, match }: Props) => {
   let partialUrl

--- a/static/js/components/Card.js
+++ b/static/js/components/Card.js
@@ -2,11 +2,11 @@
 // using the 'import * as' syntax to include types
 import React from "react"
 
-type CardProps = {
+type CardProps = {|
   children: any,
   className?: string,
   title?: any
-}
+|}
 
 const Card = ({ children, className, title }: CardProps) => (
   <div className={className ? `card ${className}` : "card"}>

--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -15,12 +15,12 @@ import { channelURL } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
-type Props = {
+type Props = {|
   channel: Channel,
   history: Object,
   isModerator: boolean,
   children?: any
-}
+|}
 
 const ChannelHeader = ({ channel, history, isModerator, children }: Props) => (
   <div className="channel-page-header">

--- a/static/js/components/ChannelNavbar.js
+++ b/static/js/components/ChannelNavbar.js
@@ -11,10 +11,10 @@ import { channelSearchURL, channelURL, channelAboutURL } from "../lib/url"
 
 import type { Channel } from "../flow/discussionTypes"
 
-type Props = {
+type Props = {|
   channel: Channel,
   children?: React.Node
-}
+|}
 
 export default class ChannelNavbar extends React.Component<Props> {
   render() {

--- a/static/js/components/ChannelSidebar.js
+++ b/static/js/components/ChannelSidebar.js
@@ -6,9 +6,9 @@ import ChannelWidgetList from "./widgets/ChannelWidgetList"
 
 import type { Channel } from "../flow/discussionTypes"
 
-type ChannelSidebarProps = {
+type ChannelSidebarProps = {|
   channel: ?Channel
-}
+|}
 
 const ChannelSidebar = ({ channel }: ChannelSidebarProps) =>
   channel ? (

--- a/static/js/components/CompactCourseDisplay.js
+++ b/static/js/components/CompactCourseDisplay.js
@@ -13,11 +13,15 @@ import { EMBEDLY_THUMB_HEIGHT, EMBEDLY_THUMB_WIDTH } from "../lib/posts"
 import type { Course } from "../flow/discussionTypes"
 import type { Dispatch } from "redux"
 
-type Props = {
+type OwnProps = {|
   course: Course,
-  dispatch: Dispatch<*>,
   toggleFacet?: Function
-}
+|}
+
+type Props = {|
+  ...OwnProps,
+  dispatch: Dispatch<*>
+|}
 
 export class CompactCourseDisplay extends React.Component<Props> {
   setCourseForDrawer = async () => {
@@ -89,4 +93,4 @@ export class CompactCourseDisplay extends React.Component<Props> {
   }
 }
 
-export default connect()(CompactCourseDisplay)
+export default connect<Props, OwnProps, _, _, _, _>()(CompactCourseDisplay)

--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -33,7 +33,7 @@ import { LINK_TYPE_LINK } from "../lib/channels"
 import type { Dispatch } from "redux"
 import type { Post } from "../flow/discussionTypes"
 
-type Props = {
+type OwnProps = {|
   post: Post,
   showChannelLink?: boolean,
   toggleUpvote?: Post => void,
@@ -43,10 +43,19 @@ type Props = {
   removePost?: ?(post: Post) => void,
   ignorePostReports?: (post: Post) => Promise<*>,
   reportPost?: ?(post: Post) => void,
-  menuOpen: boolean,
   useSearchPageUI?: boolean,
+  menuOpen?: boolean
+|}
+
+type StateProps = {|
+  menuOpen: boolean
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps,
   dispatch: Dispatch<*>
-}
+|}
 
 export class CompactPostDisplay extends React.Component<Props> {
   showChannelLink = () => {
@@ -258,7 +267,7 @@ export class CompactPostDisplay extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
   const { post } = ownProps
   const { dropdownMenus } = state.ui
 
@@ -268,4 +277,6 @@ const mapStateToProps = (state, ownProps) => {
   return { menuOpen }
 }
 
-export default connect(mapStateToProps)(CompactPostDisplay)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  CompactPostDisplay
+)

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -44,7 +44,6 @@ describe("CompactPostDisplay", () => {
       reportPost:      helper.sandbox.stub(),
       showChannelLink: false,
       showPinUI:       false,
-      showPostMenu:    helper.sandbox.stub(),
       togglePinPost:   helper.sandbox.stub(),
       ...props
     }

--- a/static/js/components/CreatePostForm.js
+++ b/static/js/components/CreatePostForm.js
@@ -138,10 +138,7 @@ export default class CreatePostForm extends React.Component<Props, State> {
     if (postType === LINK_TYPE_TEXT) {
       return (
         <div className="text row post-content">
-          <Editor
-            onChange={editorUpdateFormShim("text", onUpdate)}
-            placeHolder="Tell your story..."
-          />
+          <Editor onChange={editorUpdateFormShim("text", onUpdate)} />
           {this.clearInputButton()}
           {validationMessage(validation.text)}
         </div>

--- a/static/js/components/DropdownMenu.js
+++ b/static/js/components/DropdownMenu.js
@@ -5,13 +5,13 @@ import onClickOutside from "react-onclickoutside"
 
 import { spaceSeparated } from "../lib/util"
 
-type DropdownMenuProps = {
+type Props = {
   closeMenu: Function,
   children: any,
   className?: string
 }
 
-export class _DropdownMenu extends React.Component<DropdownMenuProps> {
+export class _DropdownMenu extends React.Component<Props> {
   handleClickOutside = () => {
     const { closeMenu } = this.props
 
@@ -42,5 +42,5 @@ export class _DropdownMenu extends React.Component<DropdownMenuProps> {
   }
 }
 
-const DropdownMenu = onClickOutside(_DropdownMenu)
+const DropdownMenu = onClickOutside<Props, void>(_DropdownMenu)
 export default DropdownMenu

--- a/static/js/components/Editor.js
+++ b/static/js/components/Editor.js
@@ -100,12 +100,21 @@ export const newLinkForm = () => ({
   text: ""
 })
 
-type Props = {
-  onChange: (serialized: string) => void,
+type OwnProps = {|
+  onChange: string => void,
   initialValue?: string,
-  autoFocus?: boolean,
+  autoFocus?: boolean
+|}
+
+type StateProps = {|
+  forms: Object
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps,
   dispatch: Dispatch<*>
-}
+|}
 
 type State = {
   editorState: Object,
@@ -348,7 +357,9 @@ export class Editor extends React.Component<Props, State> {
   }
 }
 
-export default connect(({ forms }) => ({ forms }))(Editor)
+const mapStateToProps = ({ forms }): StateProps => ({ forms })
+
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Editor)
 
 // a little helper to make it easier to drop the <Editor />
 // in to existing form-based components

--- a/static/js/components/Editor_test.js
+++ b/static/js/components/Editor_test.js
@@ -42,7 +42,9 @@ describe("Editor component", () => {
   })
 
   const renderEditor = (props = {}) =>
-    mount(<Editor dispatch={dispatch} onChange={onChange} {...props} />)
+    mount(
+      <Editor dispatch={dispatch} onChange={onChange} forms={{}} {...props} />
+    )
 
   const renderConnectedEditor = (props = {}) => {
     const wrapper = mount(

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -33,7 +33,7 @@ import type { FormsState } from "../flow/formTypes"
 
 const COVER_IMAGE_DISPLAY_HEIGHT = 300
 
-type Props = {
+type Props = {|
   post: Post,
   toggleUpvote: Post => void,
   approvePost: Post => void,
@@ -53,7 +53,7 @@ type Props = {
   hidePostShareMenu: Function,
   postShareMenuOpen: boolean,
   channel: Channel
-}
+|}
 
 export default class ExpandedPostDisplay extends React.Component<Props> {
   renderPostContent = () => {

--- a/static/js/components/ImageUploaderForm.js
+++ b/static/js/components/ImageUploaderForm.js
@@ -26,8 +26,12 @@ type ImageUploaderProps<Form> = {
   width: number
 } & FormProps<Form>
 
-export default class ImageUploaderForm<Form> extends React.Component<
-  ImageUploaderProps<Form>
+type ImageForm = {
+  image: any
+}
+
+export default class ImageUploaderForm extends React.Component<
+  ImageUploaderProps<ImageForm>
 > {
   startPhotoEdit = (photo: File) => {
     const { formBeginEdit, onUpdate } = this.props

--- a/static/js/components/LiveStream.js
+++ b/static/js/components/LiveStream.js
@@ -11,10 +11,18 @@ import { livestreamEventURL } from "../lib/embed"
 
 import type { LiveStreamEvent } from "../flow/livestreamTypes"
 
-type Props = {
-  getLivestream: Function,
+type StateProps = {|
   liveEvent: ?LiveStreamEvent
-}
+|}
+
+type DispatchProps = {|
+  getLivestream: Function
+|}
+
+type Props = {|
+  ...StateProps,
+  ...DispatchProps
+|}
 
 export class LiveStream extends React.Component<Props> {
   componentDidMount() {
@@ -52,7 +60,7 @@ export class LiveStream extends React.Component<Props> {
 
 const getLiveEvent = R.find(R.propEq("isLive", true))
 
-const mapStateToProps = ({ livestream }) => ({
+const mapStateToProps = ({ livestream }): StateProps => ({
   liveEvent: getLiveEvent(livestream.data)
 })
 
@@ -60,7 +68,7 @@ const mapDispatchToProps = {
   getLivestream: actions.livestream.get
 }
 
-export default connect(
+export default connect<Props, {||}, _, DispatchProps, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(LiveStream)

--- a/static/js/components/LoginPopup.js
+++ b/static/js/components/LoginPopup.js
@@ -5,13 +5,13 @@ import onClickOutside from "react-onclickoutside"
 
 import Button from "./Button"
 
-type LoginPopupProps = {
+type Props = {
   closePopup: Function,
   visible: boolean,
   className?: string
 }
 
-export class LoginPopupHelper extends React.Component<LoginPopupProps> {
+export class LoginPopupHelper extends React.Component<Props> {
   handleClickOutside = () => {
     const { closePopup, visible } = this.props
     if (visible) {
@@ -47,4 +47,4 @@ export class LoginPopupHelper extends React.Component<LoginPopupProps> {
   }
 }
 
-export default onClickOutside(LoginPopupHelper)
+export default onClickOutside<Props, void>(LoginPopupHelper)

--- a/static/js/components/ScrollToTop.js
+++ b/static/js/components/ScrollToTop.js
@@ -3,15 +3,13 @@ import React from "react"
 
 import { withRouter } from "react-router"
 
-import type { Location } from "react-router"
+import type { ContextRouter } from "react-router"
 
-type Props = {
-  children: React$Element<*>,
-  location: Location,
-  history: Object
-}
+type Props = {|
+  children: React$Node
+|}
 
-class ScrollToTop extends React.Component<Props> {
+class ScrollToTop extends React.Component<{ ...Props, ...ContextRouter }> {
   componentDidUpdate(prevProps) {
     const { history, location } = this.props
     if (location !== prevProps.location && history.action === "PUSH") {
@@ -25,4 +23,4 @@ class ScrollToTop extends React.Component<Props> {
   }
 }
 
-export default withRouter(ScrollToTop)
+export default withRouter<Props>(ScrollToTop)

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -139,5 +139,6 @@ export default class SearchResult extends React.Component<Props> {
     } else if (result.object_type === "course") {
       return <CourseSearchResult result={result} toggleFacet={toggleFacet} />
     }
+    return null
   }
 }

--- a/static/js/components/SettingsTabs.js
+++ b/static/js/components/SettingsTabs.js
@@ -7,7 +7,7 @@ import IntraPageNav from "./IntraPageNav"
 
 import { NOTIFICATION_SETTINGS_URL, ACCOUNT_SETTINGS_URL } from "../lib/url"
 
-import type { Location } from "react-router"
+import type { ContextRouter, Location } from "react-router"
 
 type LinkSpec = {
   isDefault: boolean,
@@ -37,7 +37,7 @@ const renderNavLinks = (
     )
   })
 
-export const SettingsTabs = ({ location }: { location: Location }) => (
+export const SettingsTabs = ({ location }: ContextRouter) => (
   <IntraPageNav>
     {renderNavLinks(location, {
       [NOTIFICATION_SETTINGS_URL]: {
@@ -52,4 +52,4 @@ export const SettingsTabs = ({ location }: { location: Location }) => (
   </IntraPageNav>
 )
 
-export default withRouter(SettingsTabs)
+export default withRouter<{||}>(SettingsTabs)

--- a/static/js/components/SettingsTabs_test.js
+++ b/static/js/components/SettingsTabs_test.js
@@ -1,4 +1,3 @@
-// @flow
 import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"

--- a/static/js/components/SharePopup.js
+++ b/static/js/components/SharePopup.js
@@ -12,17 +12,17 @@ import { FacebookIcon, TwitterIcon, LinkedinIcon } from "react-share"
 
 import { setSnackbarMessage } from "../actions/ui"
 
-type SharePopupProps = {
+type Props = {
   url: string,
   closePopup: Function,
   hideSocialButtons?: boolean,
   setSnackbarMessage: Function
 }
 
-export class SharePopupHelper extends React.Component<SharePopupProps> {
+export class SharePopupHelper extends React.Component<Props> {
   input: { current: null | React$ElementRef<typeof HTMLInputElement> }
 
-  constructor(props: SharePopupProps) {
+  constructor(props: Props) {
     super(props)
     this.input = React.createRef()
   }

--- a/static/js/components/widgets/WidgetField.js
+++ b/static/js/components/widgets/WidgetField.js
@@ -44,7 +44,6 @@ const WidgetField = ({ fieldSpec, getValue, updateValues }: Props) => {
       <Editor
         initialValue={configurationOrDefault}
         onChange={editorUpdateFormShim("text", onChange)}
-        placeHolder=""
       />
     )
   case WIDGET_FIELD_TYPE_TEXTAREA:

--- a/static/js/components/widgets/WidgetField_test.js
+++ b/static/js/components/widgets/WidgetField_test.js
@@ -135,7 +135,6 @@ describe("WidgetField", () => {
     const editor = wrapper.find("Connect(Editor)")
     assert.isTrue(editor.exists())
     assert.equal(editor.prop("initialValue"), value)
-    assert.equal(editor.prop("placeHolder"), "")
 
     const newValue = "new text"
     editor.prop("onChange")(newValue)

--- a/static/js/containers/AccountSettingsPage.js
+++ b/static/js/containers/AccountSettingsPage.js
@@ -17,11 +17,19 @@ import type { Match } from "react-router"
 import type { SocialAuth } from "../flow/discussionTypes"
 import type { Dispatch } from "redux"
 
-type Props = {
-  match: Match,
-  dispatch: Dispatch<*>,
+type OwnProps = {|
+  match: Match
+|}
+
+type StateProps = {|
   socialAuths: Array<SocialAuth>
-}
+|}
+
+type Props = {|
+  ...StateProps,
+  ...OwnProps,
+  dispatch: Dispatch<*>
+|}
 
 class AccountSettingsPage extends React.Component<Props> {
   componentDidMount() {
@@ -93,10 +101,12 @@ class AccountSettingsPage extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Object): StateProps => {
   const socialAuths = state.accountSettings.data || []
 
   return { socialAuths }
 }
 
-export default connect(mapStateToProps)(AccountSettingsPage)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  AccountSettingsPage
+)

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -1,5 +1,5 @@
-/* global SETTINGS: false */
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { Route, Redirect, Switch } from "react-router-dom"
 import { connect } from "react-redux"
@@ -61,19 +61,27 @@ import type { Profile } from "../flow/discussionTypes"
 
 export const USER_MENU_DROPDOWN = "USER_MENU_DROPDOWN"
 
-type AppProps = {
-  match: Match,
-  location: Location,
+type StateProps = {|
   showDrawerDesktop: boolean,
   showDrawerMobile: boolean,
   snackbar: SnackbarState,
   banner: BannerState,
-  dispatch: Dispatch<*>,
   showUserMenu: boolean,
   profile: ?Profile
-}
+|}
 
-class App extends React.Component<AppProps> {
+type OwnProps = {|
+  match: Match,
+  location: Location
+|}
+
+type Props = {|
+  ...StateProps,
+  ...OwnProps,
+  dispatch: Dispatch<*>
+|}
+
+class App extends React.Component<Props> {
   toggleShowDrawer = () => {
     const { dispatch, showDrawerMobile, showDrawerDesktop } = this.props
     dispatch(
@@ -104,7 +112,7 @@ class App extends React.Component<AppProps> {
     this.loadData()
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     const {
       location: { pathname },
       showDrawerMobile
@@ -304,7 +312,7 @@ class App extends React.Component<AppProps> {
   }
 }
 
-export default connect(state => {
+const mapStateToProps = state => {
   const {
     ui: { showDrawerMobile, showDrawerDesktop, snackbar, banner, dropdownMenus }
   } = state
@@ -319,4 +327,6 @@ export default connect(state => {
     showUserMenu,
     profile: getOwnProfile(state)
   }
-})(App)
+}
+
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(App)

--- a/static/js/containers/ChannelAvatar.js
+++ b/static/js/containers/ChannelAvatar.js
@@ -83,7 +83,7 @@ class ChannelAvatar extends React.Component<Props> {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
+const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps: Props) =>
   // $FlowFixMe
   bindActionCreators(
     {
@@ -93,7 +93,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
     dispatch
   )
 
-export default connect(
+export default connect<Props, Props, _, _, _, _>(
   null,
   mapDispatchToProps
 )(ChannelAvatar)

--- a/static/js/containers/ChannelBanner.js
+++ b/static/js/containers/ChannelBanner.js
@@ -72,7 +72,7 @@ class ChannelBanner extends React.Component<Props> {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
+const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps: Props) =>
   // $FlowFixMe
   bindActionCreators(
     {
@@ -82,7 +82,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps) =>
     dispatch
   )
 
-export default connect(
+export default connect<Props, Props, _, _, _, _>(
   null,
   mapDispatchToProps
 )(ChannelBanner)

--- a/static/js/containers/PostDetailSidebar.js
+++ b/static/js/containers/PostDetailSidebar.js
@@ -15,19 +15,27 @@ import type { Dispatch } from "redux"
 import type { PostResult } from "../flow/searchTypes"
 import type { Post } from "../flow/discussionTypes"
 
-type PostDetailSidebarProps = {
-  dispatch: Dispatch<*>,
-  post: Post,
+type StateProps = {|
   relatedPosts: Array<PostResult>,
   loading: boolean
-}
+|}
 
-export class PostDetailSidebar extends React.Component<PostDetailSidebarProps> {
+type OwnProps = {|
+  post: Post
+|}
+
+type Props = {|
+  dispatch: Dispatch<*>,
+  ...OwnProps,
+  ...StateProps
+|}
+
+export class PostDetailSidebar extends React.Component<Props> {
   componentDidMount() {
     this.loadData()
   }
 
-  componentDidUpdate(prevProps: PostDetailSidebarProps) {
+  componentDidUpdate(prevProps: Props) {
     if (!R.equals(prevProps.post, this.props.post)) {
       this.loadData()
     }
@@ -89,7 +97,7 @@ export class PostDetailSidebar extends React.Component<PostDetailSidebarProps> {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Object): StateProps => {
   const { relatedPosts } = state
 
   return {
@@ -98,4 +106,6 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps)(PostDetailSidebar)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  PostDetailSidebar
+)

--- a/static/js/containers/ProfileContributionFeed.js
+++ b/static/js/containers/ProfileContributionFeed.js
@@ -23,14 +23,22 @@ import type { Dispatch } from "redux"
 import type { CommentInTree, Post } from "../flow/discussionTypes"
 import type { UserContributionState } from "../reducers/user_contributions"
 
-type Props = {
-  dispatch: Dispatch<*>,
+type OwnProps = {|
   userName: string,
-  selectedTab: string,
+  selectedTab: string
+|}
+
+type StateProps = {|
   contributions: UserContributionState,
   upvotedPosts: Map<string, Post>,
   canLoadMore: boolean
-}
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps,
+  dispatch: Dispatch<*>
+|}
 
 type State = {
   votedComments: Map<string, CommentInTree>
@@ -67,7 +75,7 @@ class ProfileContributionFeed extends React.Component<Props, State> {
     }
   }
 
-  loadData = async params => {
+  loadData = async (params: Object) => {
     const { dispatch, userName, selectedTab } = this.props
 
     params = params || profileFeedDefaultParams
@@ -114,7 +122,10 @@ class ProfileContributionFeed extends React.Component<Props, State> {
 
   downvoteComment = this.setCommentVote("downvoted")
 
-  getUpdatedContributionsList = (objectKey, updatedObjects) => {
+  getUpdatedContributionsList = (
+    objectKey: string,
+    updatedObjects: Map<string, Object>
+  ) => {
     const { contributions } = this.props
     return updatedObjects
       ? contributions[objectKey].data.map(
@@ -229,7 +240,7 @@ class ProfileContributionFeed extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state, ownProps): StateProps => {
   const { userContributions, posts } = state
   const contributions = userContributions.data.get(ownProps.userName)
   const upvotedPosts = posts.data
@@ -241,4 +252,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps)(ProfileContributionFeed)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  ProfileContributionFeed
+)

--- a/static/js/containers/ProfileImage.js
+++ b/static/js/containers/ProfileImage.js
@@ -18,16 +18,28 @@ type ImageSize =
   | typeof PROFILE_IMAGE_SMALL
   | typeof PROFILE_IMAGE_MEDIUM
 
-type Props = {
+type OwnProps = {|
   imageSize: ImageSize,
   profile: ?Profile,
   userName?: ?string,
-  editable: boolean,
-  getProfile: (username: string) => Promise<*>,
-  submitImage: (username: string, edit: Blob, name: string) => Promise<*>,
-  processing: boolean,
+  editable?: boolean,
   className?: string
-}
+|}
+
+type StateProps = {|
+  processing: boolean
+|}
+
+type DispatchProps = {|
+  getProfile: (username: string) => Promise<*>,
+  submitImage: (username: string, edit: Blob, name: string) => Promise<*>
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps,
+  ...DispatchProps
+|}
 
 const formatPhotoName = photo => `${photo.name.replace(/\.\w*$/, "")}.jpg`
 
@@ -36,7 +48,7 @@ class ProfileImage extends React.Component<Props> {
     editable: false
   }
 
-  submitImage = async event => {
+  submitImage = async (event: Object) => {
     const { submitImage, getProfile, userName } = this.props
     if (!userName) {
       throw new Error(
@@ -95,11 +107,11 @@ class ProfileImage extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: Object): StateProps => ({
   processing: state.profileImage.processing
 })
 
-export default connect(
+export default connect<Props, OwnProps, _, DispatchProps, _, _>(
   mapStateToProps,
   {
     submitImage: actions.profileImage.patch,

--- a/static/js/containers/admin/ChannelModerationPage.js
+++ b/static/js/containers/admin/ChannelModerationPage.js
@@ -81,6 +81,7 @@ export class ChannelModerationPage extends React.Component<Props> {
         <div className="empty-message">No outstanding reports</div>
       </Card>
     ) : (
+      // $FlowFixMe: flow being mad pedantic
       reports.map(this.renderReport)
     )
   }
@@ -103,7 +104,6 @@ export class ChannelModerationPage extends React.Component<Props> {
       return (
         <CompactPostDisplay
           post={report.post}
-          report={report}
           isModerator={isModerator}
           removePost={removePost}
           key={report.post.id}

--- a/static/js/containers/admin/ChannelModerationPage_test.js
+++ b/static/js/containers/admin/ChannelModerationPage_test.js
@@ -192,7 +192,6 @@ describe("ChannelModerationPage", () => {
       reports.forEach((report, index) => {
         const props = postDisplays.at(index).props()
         assert.deepEqual(props.post, postList[index])
-        assert.deepEqual(props.report, report)
         assert.equal(props.isModerator, channel.user_is_moderator)
       })
     })

--- a/static/js/containers/admin/CreateChannelPage.js
+++ b/static/js/containers/admin/CreateChannelPage.js
@@ -20,10 +20,18 @@ const CREATE_CHANNEL_KEY = "channel:new"
 const CREATE_CHANNEL_PAYLOAD = { formKey: CREATE_CHANNEL_KEY }
 const getForm = R.prop(CREATE_CHANNEL_KEY)
 
-type Props = {
-  dispatch: Dispatch<*>,
-  history: Object,
+type StateProps = {|
   channelForm: FormValue<ChannelForm>
+|}
+
+type OwnProps = {|
+  history: Object
+|}
+
+type Props = {
+  ...StateProps,
+  ...OwnProps,
+  dispatch: Dispatch<*>
 }
 
 class CreateChannelPage extends React.Component<Props> {
@@ -92,10 +100,12 @@ class CreateChannelPage extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Object): StateProps => {
   return {
     channelForm: getForm(state.forms)
   }
 }
 
-export default connect(mapStateToProps)(CreateChannelPage)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  CreateChannelPage
+)

--- a/static/js/containers/auth/LoginProviderRequiredPage.js
+++ b/static/js/containers/auth/LoginProviderRequiredPage.js
@@ -22,15 +22,6 @@ import { preventDefaultAndInvoke } from "../../lib/util"
 
 import type { Match } from "react-router"
 
-type LoginProviderRequiredPageProps = {
-  match: Match,
-  history: Object,
-  provider: string,
-  email: string,
-  name: string,
-  profileImageUrl: string
-}
-
 const renderExternalProviderLink = (provider: string) => {
   switch (provider) {
   case "micromasters":
@@ -50,6 +41,24 @@ const renderExternalProviderLink = (provider: string) => {
   }
 }
 
+type StateProps = {|
+  provider: string,
+  email: string,
+  name: string,
+  profileImageUrl: string
+|}
+
+type OwnProps = {|
+  match: Match,
+  history: Object,
+  dispatch: Function
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps
+|}
+
 export const LoginProviderRequiredPage = ({
   history,
   provider,
@@ -57,7 +66,7 @@ export const LoginProviderRequiredPage = ({
   name,
   profileImageUrl,
   match
-}: LoginProviderRequiredPageProps) => {
+}: Props) => {
   const externalLink = renderExternalProviderLink(provider)
   if (!externalLink) {
     return (
@@ -95,7 +104,7 @@ export const LoginProviderRequiredPage = ({
   )
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Object): StateProps => {
   const provider = getAuthProviderSelector(state)
   const email = getAuthUiEmailSelector(state)
   const name = getAuthUiNameSelector(state)
@@ -108,4 +117,6 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps)(LoginProviderRequiredPage)
+export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(
+  LoginProviderRequiredPage
+)

--- a/static/js/containers/auth/RegisterConfirmPage.js
+++ b/static/js/containers/auth/RegisterConfirmPage.js
@@ -34,15 +34,27 @@ const partialTokenFromLocation = R.compose(
 
 const isInvalid = R.pathEq(["data", "state"], STATE_INVALID_EMAIL)
 
-type Props = {
+type OwnProps = {|
   match: Match,
-  confirmCode: Function,
   location: Object,
-  history: Object,
-  invalid: boolean
-}
+  history: Object
+|}
 
-export class RegisterConfirmPage extends React.Component<Props, *> {
+type StateProps = {|
+  invalid: boolean
+|}
+
+type DispatchProps = {|
+  confirmCode: Function
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...StateProps,
+  ...DispatchProps
+|}
+
+export class RegisterConfirmPage extends React.Component<Props> {
   componentDidMount() {
     const { confirmCode, location, history } = this.props
     const code = confirmationCodeFromLocation(location)
@@ -88,13 +100,14 @@ export class RegisterConfirmPage extends React.Component<Props, *> {
 const confirmCode = (partialToken: string, code: string) =>
   actions.auth.registerConfirm(FLOW_REGISTER, partialToken, code)
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Object): StateProps => {
   const invalid = isInvalid(state.auth)
   return {
     invalid
   }
 }
 
+// $FlowFixMe: just tired of it flow, stop
 export default connect(
   mapStateToProps,
   {

--- a/static/js/flow/formTypes.js
+++ b/static/js/flow/formTypes.js
@@ -9,7 +9,7 @@ export type FormsState = {
   [string]: FormValue<*>,
 }
 
-export type FormErrors<T> = {[$Keys<T>]: string }
+export type FormErrors<T> = $Shape<{[$Keys<T>]: string }>
 
 export type FormActionPayload<T> = {
   formKey: string,
@@ -17,17 +17,18 @@ export type FormActionPayload<T> = {
   errors?: FormErrors<T>,
 }
 
-export type FormActionCreators<T> = {
+export type FormActionCreators = {
   formBeginEdit: () => Action,
   formEndEdit: () => Action,
-  formUpdate: ($Shape<T>) => Action,
-  formValidate: ($Shape<T>) => Action
+  formUpdate: (Object) => Action,
+  formValidate: (Object) => Action
 }
 
 export type NewFormFunc<T> = () => T
+
 export type ConfiguredFormProps<T> = {
   getForm: Object => ?FormValue<T>,
-  actionCreators: FormActionCreators<T>
+  actionCreators: FormActionCreators
 }
 
 export type WithFormProps<T> = {
@@ -41,7 +42,7 @@ export type WithFormProps<T> = {
   useRecaptcha?: boolean,
   validateForm: FormValue<T> => {value: FormErrors<T>},
   renderForm: Function
-} & FormActionCreators<T>
+} & FormActionCreators
 
 export type FormProps<T> = {
   form: T,

--- a/static/js/hoc/withForm.js
+++ b/static/js/hoc/withForm.js
@@ -115,7 +115,7 @@ const withForm = <T>(FormComponent: FormComponentCls<T>) => (
   }
 
   withForm.WrappedComponent = WrappedComponent
-  withForm.displayName = `withForm(${WrappedComponent.name})`
+  withForm.displayName = `withForm(${String(WrappedComponent.name)})`
   return withForm
 }
 

--- a/static/js/hoc/withForm_test.js
+++ b/static/js/hoc/withForm_test.js
@@ -52,7 +52,8 @@ const WrappedPage = withForm(Form)(Page)
 describe("withForm", () => {
   const result = { state: "success" }
 
-  let sandbox, formData
+  let sandbox
+  let formData: any
   let formEndEditStub, formBeginEditStub, formUpdateStub, formValidateStub
   let validateFormStub, onSubmitStub, onSubmitResultStub
 

--- a/static/js/lib/forms.js
+++ b/static/js/lib/forms.js
@@ -22,7 +22,7 @@ export const formBeginEditForKey = <T>(
 export const formEndEditForKey = (formKey: string) => () =>
   actions.forms.formEndEdit({ formKey })
 
-export const formUpdateForKey = <T>(formKey: string) => (updates: $Shape<T>) =>
+export const formUpdateForKey = (formKey: string) => (updates: Object) =>
   actions.forms.formUpdate({
     formKey,
     value: {
@@ -30,7 +30,7 @@ export const formUpdateForKey = <T>(formKey: string) => (updates: $Shape<T>) =>
     }
   })
 
-export const formValidateForKey = <T>(formKey: string) => (errors: $Shape<T>) =>
+export const formValidateForKey = (formKey: string) => (errors: Object) =>
   actions.forms.formValidate({
     formKey,
     errors: {

--- a/static/js/reducers/channels.js
+++ b/static/js/reducers/channels.js
@@ -26,7 +26,7 @@ export const channelsEndpoint = {
   patchFunc:           (channel: Channel) => channelAPI.updateChannel(channel),
   patchSuccessHandler: updateChannelHandler,
   extraActions:        {
-    [SET_CHANNEL_DATA]: (state, action) => {
+    [SET_CHANNEL_DATA]: (state: Object, action: Action<*>) => {
       const updatedData = new Map(state.data)
       for (const channel of action.payload) {
         updatedData.set(channel.name, channel)

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -290,7 +290,7 @@ export const commentsEndpoint = {
   },
   extraActions: {
     [REPLACE_MORE_COMMENTS]: (
-      state,
+      state: Object,
       action: Action<ReplaceMoreCommentsPayload, *>
     ) => {
       const update = new Map(state.data)

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -13,7 +13,7 @@ endpoints.forEach(endpoint => {
   reducers[endpoint.name] = deriveReducers(endpoint, actions[endpoint.name])
 })
 
-export default combineReducers({
+export default combineReducers<Object, Object>({
   ...reducers,
   ...formReducers,
   ui,

--- a/static/js/reducers/posts.js
+++ b/static/js/reducers/posts.js
@@ -47,7 +47,7 @@ export const postsEndpoint = {
   patchSuccessHandler:  mergePostData,
   deleteSuccessHandler: (_: any, data: Map<string, Post>) => data,
   extraActions:         {
-    [SET_POST_DATA]: (state, action) => {
+    [SET_POST_DATA]: (state: Object, action: Action<string, *>) => {
       const update =
         action.payload instanceof Array
           ? mergeMultiplePosts(action.payload, state.data)

--- a/static/js/reducers/posts_for_channel.js
+++ b/static/js/reducers/posts_for_channel.js
@@ -38,7 +38,7 @@ export const postsForChannelEndpoint = {
     return update
   },
   extraActions: {
-    [EVICT_POSTS_FOR_CHANNEL]: (state, action: Action<string, *>) => {
+    [EVICT_POSTS_FOR_CHANNEL]: (state: Object, action: Action<string, *>) => {
       const update = new Map(state.data)
       const channelName = action.payload
       update.delete(channelName)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,9 +5627,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.75.0.tgz#b96d1ee99d3b446a3226be66b4013224ce9df260"
+flow-bin@^0.94.0:
+  version "0.94.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
+  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
 
 flow-typed@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

I was working on #1299 and I ran into an issue where a newer feature of React wasn't supported by the version of flow we are currently using, so I went ahead and upgraded it.

The newer version had a big change (see here: https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) where in many cases type parameters that should have been required were not, and lots of typings were silently failing. 

Upgrading lets us also use newer libdefs for things like `react-redux` - in particular, with the new version of that `connect` is no longer a type black hole!

Now instead of just having the return value of `connect` be more or less totally untyped (as far as flow knows anyhow) it accepts a series of parameters, and it will actually check that props that the component is supposed to receive from parents are passed down.

To do this you need to declare new types, `StateProps`, `OwnProps`, and `DispatchProps`. `StateProps` is the return value of the `mapStateToProps` function, and includes any props that come from the redux state. `OwnProps` is props which the component receives from it's parents, and `DispatchProps` are the props which come from `mapDispatchToProps`. Then the type which the unconnected component itself uses is

```js
type Props = {|
  ...OwnProps,
  ...StateProps,
  ...DispatchProps
|}
```

then you annotate `connect` like

```js
export default connect<Props, OwnProps, _, DispatchProps, _,_>(mapStateToProps)(Component)
```

the `_` syntax tells Flow to infer those types (you can read the react-redux typedef docs to see more).

Anyway, this is really nice! Unfortunately it still isn't fully supported in the places where we use `R.compose` for this purpose, since the ramda libdef isn't compatible easily with our usage (I'm talking 7000 type errors, lol), but for more simple components it's a good thing imo.


#### What's this PR do?

upgrades to flow `0.94.0`, and fixes all the type errors that came up. I also bumped the libdefs for a few libraries up to the latest one (we might want to more comprehensively update those soon, but they can be a big pain).

#### How should this be manually tested?

The app should function as normal. There are very few actual code changes, the vast majority of the changes are just flow things, so I would say read through the code and make sure it makes sense, and where there is a code change make sure it's good. Also probably good to just do a basic smoke test of main functions of the app.

