### PR TITLE
fix article post UI sluggishness

### DIFF
--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -2,6 +2,7 @@
 // @flow
 import React from "react"
 import CustomEditor from "@mitodl/ckeditor-custom-build"
+import debounce from "lodash/debounce"
 
 import { getCKEditorJWT } from "../lib/api/ckeditor"
 import { loadEmbedlyPlatform, renderEmbedlyCard } from "../lib/embed"
@@ -53,12 +54,15 @@ export default class ArticleEditor extends React.Component<Props> {
       })
 
       if (!readOnly) {
-        editor.model.document.on("change:data", event => {
-          if (onChange) {
-            onChange(event, editor)
-            onChange(editor.getData())
-          }
-        })
+        editor.model.document.on(
+          "change:data",
+          // editor.getData() is kind of expensive so we debounce
+          debounce(() => {
+            if (onChange) {
+              onChange(editor.getData())
+            }
+          }, 250)
+        )
 
         if (this.node) {
           this.node.appendChild(editor.ui.view.toolbar.element)


### PR DESCRIPTION

#### What are the relevant tickets?

none

#### What's this PR do?

Just a little tweak that occurred to me (which I probably should have done before!).

The `ArticleEditor` component can get a little bit heavy sometimes and lead to some noticeable UI sluggishness when editing, I think because the `editor.getData()` method is a little bit expensive, and in our current setup we call that method on each keystroke. I just added the lodash `debounce` function to reduce that to once every 250ms, which makes it feel a lot more responsive to me.

#### How should this be manually tested?

I think go to the article post editor on master and just confirm that it sometimes feels a little sluggish when editing, especially if you're typing fast you should sometimes notice that the UI doesn't quite keep up with your input.

then check out this branch and confirm that it's better.