### PR TITLE
Different toolbar and no channel drawer for courses

### DIFF
--- a/static/js/components/CourseToolbar.js
+++ b/static/js/components/CourseToolbar.js
@@ -1,24 +1,22 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { NavLink } from "react-router-dom"
+import { Link } from "react-router-dom"
 import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
 
+import MITLogoLink from "./MITLogoLink"
 import UserMenu from "./UserMenu"
-import HamburgerAndLogo from "../components/HamburgerAndLogo"
-
-import { SITE_SEARCH_URL } from "../lib/url"
+import { COURSE_URL } from "../lib/url"
 
 import type { Profile } from "../flow/discussionTypes"
 
 type Props = {
   profile: ?Profile,
   showUserMenu: boolean,
-  toggleShowDrawer: Function,
   toggleShowUserMenu: Function
 }
 
-export default class Toolbar extends React.Component<Props> {
+export default class CourseToolbar extends React.Component<Props> {
   toolbarRoot: HTMLElement | null
   toolbar: Object
 
@@ -32,12 +30,6 @@ export default class Toolbar extends React.Component<Props> {
     }
   }
 
-  toggleShowDrawer = (e: Event) => {
-    const { toggleShowDrawer } = this.props
-    e.preventDefault()
-    toggleShowDrawer()
-  }
-
   render() {
     const { toggleShowUserMenu, showUserMenu, profile } = this.props
 
@@ -46,19 +38,14 @@ export default class Toolbar extends React.Component<Props> {
         <header className="mdc-toolbar" ref={div => (this.toolbarRoot = div)}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
-              <HamburgerAndLogo onHamburgerClick={this.toggleShowDrawer} />
+              <MITLogoLink />
+              <span className="mdc-toolbar__title">
+                <Link to="/">MIT Open</Link>
+                {" | "}
+                <Link to={COURSE_URL}>Courses</Link>
+              </span>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
-              {SETTINGS.allow_search ? (
-                <NavLink
-                  exact
-                  to={SITE_SEARCH_URL}
-                  activeClassName="active"
-                  className="search-link navy"
-                >
-                  <i className="material-icons">search</i>
-                </NavLink>
-              ) : null}
               <UserMenu
                 toggleShowUserMenu={toggleShowUserMenu}
                 showUserMenu={showUserMenu}

--- a/static/js/components/CourseToolbar.js
+++ b/static/js/components/CourseToolbar.js
@@ -17,11 +17,18 @@ type Props = {
 }
 
 export default class CourseToolbar extends React.Component<Props> {
-  toolbarRoot: HTMLElement | null
+  toolbarRoot: { current: null | React$ElementRef<typeof HTMLElement> }
   toolbar: Object
 
+  constructor(props: Props) {
+    super(props)
+    this.toolbarRoot = React.createRef()
+  }
+
   componentDidMount() {
-    this.toolbar = new MDCToolbar(this.toolbarRoot)
+    if (this.toolbarRoot.current) {
+      this.toolbar = new MDCToolbar(this.toolbarRoot.current)
+    }
   }
 
   componentWillUnmount() {
@@ -35,7 +42,7 @@ export default class CourseToolbar extends React.Component<Props> {
 
     return (
       <div className="navbar">
-        <header className="mdc-toolbar" ref={div => (this.toolbarRoot = div)}>
+        <header className="mdc-toolbar" ref={this.toolbarRoot}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
               <MITLogoLink />

--- a/static/js/components/CourseToolbar_test.js
+++ b/static/js/components/CourseToolbar_test.js
@@ -1,0 +1,51 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import sinon from "sinon"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+
+import CourseToolbar from "./CourseToolbar"
+
+import { COURSE_URL } from "../lib/url"
+import { makeProfile } from "../factories/profiles"
+
+describe("CourseToolbar", () => {
+  let sandbox
+
+  const renderToolbar = () =>
+    shallow(
+      <CourseToolbar
+        toggleShowUserMenu={sandbox.stub()}
+        showUserMenu={false}
+        profile={makeProfile()}
+      />,
+      { disableLifecycleMethods: true }
+    )
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should include UserMenu", () => {
+    assert.isTrue(
+      renderToolbar()
+        .find("UserMenu")
+        .exists()
+    )
+  })
+
+  it("should include a link to courses", () => {
+    assert.equal(
+      renderToolbar()
+        .find("Link")
+        .at(1)
+        .prop("to"),
+      COURSE_URL
+    )
+  })
+})

--- a/static/js/components/HamburgerAndLogo.js
+++ b/static/js/components/HamburgerAndLogo.js
@@ -1,6 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
+
 import MITLogoLink from "./MITLogoLink"
 
 type Props = {

--- a/static/js/components/HamburgerAndLogo.js
+++ b/static/js/components/HamburgerAndLogo.js
@@ -1,6 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
+import MITLogoLink from "./MITLogoLink"
 
 type Props = {
   onHamburgerClick: Function
@@ -15,15 +16,7 @@ const HamburgerAndLogo = ({ onHamburgerClick }: Props) => (
     >
       menu
     </a>
-    <a href="http://www.mit.edu" className="mitlogo">
-      <img
-        src={`/static/images/${
-          SETTINGS.use_new_branding
-            ? "MIT_circle.svg"
-            : "mit-logo-transparent3.svg"
-        }`}
-      />
-    </a>
+    <MITLogoLink />
     <span className="mdc-toolbar__title">
       <a href={SETTINGS.authenticated_site.base_url}>
         {SETTINGS.authenticated_site.title}

--- a/static/js/components/HamburgerAndLogo_test.js
+++ b/static/js/components/HamburgerAndLogo_test.js
@@ -1,6 +1,5 @@
 // @flow
 /* global SETTINGS: false */
-import { assert } from "chai"
 import sinon from "sinon"
 
 import HamburgerAndLogo from "./HamburgerAndLogo"
@@ -19,17 +18,5 @@ describe("HamburgerAndLogo", () => {
     const wrapper = renderComponent({ onHamburgerClick })
     wrapper.find(".material-icons").simulate("click")
     sinon.assert.called(onHamburgerClick)
-  })
-
-  //
-  ;[
-    ["/static/images/MIT_circle.svg", true],
-    ["/static/images/mit-logo-transparent3.svg", false]
-  ].forEach(([logoName, enabled]) => {
-    it("should render the ${logoName} logo depending if use_new_branding = ${enabled}", () => {
-      SETTINGS.use_new_branding = enabled
-      const wrapper = renderComponent()
-      assert.equal(wrapper.find(".mitlogo img").props().src, logoName)
-    })
   })
 })

--- a/static/js/components/MITLogoLink.js
+++ b/static/js/components/MITLogoLink.js
@@ -1,0 +1,17 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+
+const MITLogoLink = () => (
+  <a href="http://www.mit.edu" className="mitlogo">
+    <img
+      src={`/static/images/${
+        SETTINGS.use_new_branding
+          ? "MIT_circle.svg"
+          : "mit-logo-transparent3.svg"
+      }`}
+    />
+  </a>
+)
+
+export default MITLogoLink

--- a/static/js/components/MITLogoLink_test.js
+++ b/static/js/components/MITLogoLink_test.js
@@ -1,0 +1,27 @@
+// @flow
+/* global SETTINGS: false */
+import { assert } from "chai"
+
+import MITLogoLink from "./MITLogoLink"
+
+import { configureShallowRenderer } from "../lib/test_utils"
+
+describe("MITLogoLink", () => {
+  let renderComponent
+
+  beforeEach(() => {
+    renderComponent = configureShallowRenderer(MITLogoLink)
+  })
+  ;[
+    ["/static/images/MIT_circle.svg", true],
+    ["/static/images/mit-logo-transparent3.svg", false]
+  ].forEach(([logoName, enabled]) => {
+    it(`should render the ${logoName} logo depending if use_new_branding = ${String(
+      enabled
+    )}`, () => {
+      SETTINGS.use_new_branding = enabled
+      const wrapper = renderComponent()
+      assert.equal(wrapper.find(".mitlogo img").props().src, logoName)
+    })
+  })
+})

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -19,11 +19,18 @@ type Props = {
 }
 
 export default class Toolbar extends React.Component<Props> {
-  toolbarRoot: HTMLElement | null
+  toolbarRoot: { current: null | React$ElementRef<typeof HTMLElement> }
   toolbar: Object
 
+  constructor(props: Props) {
+    super(props)
+    this.toolbarRoot = React.createRef()
+  }
+
   componentDidMount() {
-    this.toolbar = new MDCToolbar(this.toolbarRoot)
+    if (this.toolbarRoot.current) {
+      this.toolbar = new MDCToolbar(this.toolbarRoot.current)
+    }
   }
 
   componentWillUnmount() {
@@ -43,7 +50,7 @@ export default class Toolbar extends React.Component<Props> {
 
     return (
       <div className="navbar">
-        <header className="mdc-toolbar" ref={div => (this.toolbarRoot = div)}>
+        <header className="mdc-toolbar" ref={this.toolbarRoot}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
               <HamburgerAndLogo onHamburgerClick={this.toggleShowDrawer} />

--- a/static/js/components/Toolbar.js
+++ b/static/js/components/Toolbar.js
@@ -1,13 +1,13 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { NavLink } from "react-router-dom"
+import { Link, NavLink } from "react-router-dom"
 import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
 
 import UserMenu from "./UserMenu"
 import HamburgerAndLogo from "../components/HamburgerAndLogo"
 
-import { siteSearchURL } from "../lib/url"
+import { coursesURL, siteSearchURL } from "../lib/url"
 
 import type { Profile } from "../flow/discussionTypes"
 
@@ -15,7 +15,8 @@ type Props = {
   profile: ?Profile,
   showUserMenu: boolean,
   toggleShowDrawer: Function,
-  toggleShowUserMenu: Function
+  toggleShowUserMenu: Function,
+  isCourseUrl: boolean
 }
 
 export default class Toolbar extends React.Component<Props> {
@@ -39,17 +40,41 @@ export default class Toolbar extends React.Component<Props> {
   }
 
   render() {
-    const { toggleShowUserMenu, showUserMenu, profile } = this.props
+    const {
+      toggleShowUserMenu,
+      showUserMenu,
+      profile,
+      isCourseUrl
+    } = this.props
 
     return (
       <div className="navbar">
         <header className="mdc-toolbar" ref={div => (this.toolbarRoot = div)}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
-              <HamburgerAndLogo onHamburgerClick={this.toggleShowDrawer} />
+              {isCourseUrl ? (
+                <React.Fragment>
+                  <a href="http://www.mit.edu" className="mitlogo">
+                    <img
+                      src={`/static/images/${
+                        SETTINGS.use_new_branding
+                          ? "MIT_circle.svg"
+                          : "mit-logo-transparent3.svg"
+                      }`}
+                    />
+                  </a>
+                  <span className="mdc-toolbar__title">
+                    <Link to="/">MIT Open</Link>
+                    {" | "}
+                    <Link to={coursesURL()}>Courses</Link>
+                  </span>
+                </React.Fragment>
+              ) : (
+                <HamburgerAndLogo onHamburgerClick={this.toggleShowDrawer} />
+              )}
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
-              {SETTINGS.allow_search ? (
+              {SETTINGS.allow_search && !isCourseUrl ? (
                 <NavLink
                   exact
                   to={siteSearchURL()}
@@ -59,6 +84,7 @@ export default class Toolbar extends React.Component<Props> {
                   <i className="material-icons">search</i>
                 </NavLink>
               ) : null}
+
               <UserMenu
                 toggleShowUserMenu={toggleShowUserMenu}
                 showUserMenu={showUserMenu}

--- a/static/js/components/Toolbar_test.js
+++ b/static/js/components/Toolbar_test.js
@@ -8,20 +8,17 @@ import { shallow } from "enzyme"
 import Toolbar from "./Toolbar"
 
 import { makeProfile } from "../factories/profiles"
-import { shouldIf } from "../lib/test_utils"
 
 describe("Toolbar", () => {
   let toggleShowDrawerStub, sandbox
 
-  const renderToolbar = (props = {}) =>
+  const renderToolbar = () =>
     shallow(
       <Toolbar
         toggleShowDrawer={toggleShowDrawerStub}
         toggleShowUserMenu={sandbox.stub()}
         showUserMenu={false}
         profile={makeProfile()}
-        isCourseUrl={false}
-        {...props}
       />,
       { disableLifecycleMethods: true }
     )
@@ -51,23 +48,6 @@ describe("Toolbar", () => {
         .find("UserMenu")
         .exists()
     )
-  })
-
-  //
-  ;[true, false].forEach(isCourseUrl => {
-    it(`${shouldIf(isCourseUrl)} have a courses link, ${shouldIf(
-      !isCourseUrl
-    )} have a Hamburger`, () => {
-      const wrapper = renderToolbar({ isCourseUrl })
-      assert.equal(wrapper.find("HamburgerAndLogo").exists(), !isCourseUrl)
-      assert.equal(
-        wrapper
-          .find("Link")
-          .at(1)
-          .exists(),
-        isCourseUrl
-      )
-    })
   })
 
   //

--- a/static/js/components/Toolbar_test.js
+++ b/static/js/components/Toolbar_test.js
@@ -8,17 +8,20 @@ import { shallow } from "enzyme"
 import Toolbar from "./Toolbar"
 
 import { makeProfile } from "../factories/profiles"
+import { shouldIf } from "../lib/test_utils"
 
 describe("Toolbar", () => {
   let toggleShowDrawerStub, sandbox
 
-  const renderToolbar = () =>
+  const renderToolbar = (props = {}) =>
     shallow(
       <Toolbar
         toggleShowDrawer={toggleShowDrawerStub}
         toggleShowUserMenu={sandbox.stub()}
         showUserMenu={false}
         profile={makeProfile()}
+        isCourseUrl={false}
+        {...props}
       />,
       { disableLifecycleMethods: true }
     )
@@ -48,6 +51,23 @@ describe("Toolbar", () => {
         .find("UserMenu")
         .exists()
     )
+  })
+
+  //
+  ;[true, false].forEach(isCourseUrl => {
+    it(`${shouldIf(isCourseUrl)} have a courses link, ${shouldIf(
+      !isCourseUrl
+    )} have a Hamburger`, () => {
+      const wrapper = renderToolbar({ isCourseUrl })
+      assert.equal(wrapper.find("HamburgerAndLogo").exists(), !isCourseUrl)
+      assert.equal(
+        wrapper
+          .find("Link")
+          .at(1)
+          .exists(),
+        isCourseUrl
+      )
+    })
   })
 
   //

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -177,6 +177,8 @@ class App extends React.Component<Props> {
       return <Redirect to={AUTH_REQUIRED_URL} />
     }
 
+    const isCourseUrl = pathname.startsWith(`/courses`)
+
     return (
       <div className="app">
         <MetaTags>
@@ -187,8 +189,9 @@ class App extends React.Component<Props> {
           toggleShowUserMenu={this.toggleShowUserMenu}
           showUserMenu={showUserMenu}
           profile={profile}
+          isCourseUrl={isCourseUrl}
         />
-        <Drawer />
+        {isCourseUrl ? null : <Drawer />}
         <Snackbar snackbar={snackbar} />
         <Banner
           banner={banner}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -58,6 +58,7 @@ import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
 import type { SnackbarState, BannerState } from "../reducers/ui"
 import type { Profile } from "../flow/discussionTypes"
+import CourseToolbar from "../components/CourseToolbar"
 
 export const USER_MENU_DROPDOWN = "USER_MENU_DROPDOWN"
 
@@ -177,21 +178,33 @@ class App extends React.Component<Props> {
       return <Redirect to={AUTH_REQUIRED_URL} />
     }
 
-    const isCourseUrl = pathname.startsWith(`/courses`)
-
     return (
       <div className="app">
         <MetaTags>
           <title>MIT Open Learning</title>
         </MetaTags>
-        <Toolbar
-          toggleShowDrawer={this.toggleShowDrawer}
-          toggleShowUserMenu={this.toggleShowUserMenu}
-          showUserMenu={showUserMenu}
-          profile={profile}
-          isCourseUrl={isCourseUrl}
-        />
-        {isCourseUrl ? null : <Drawer />}
+        <Switch>
+          <Route path={`${match.url}courses/`}>
+            <CourseToolbar
+              toggleShowUserMenu={this.toggleShowUserMenu}
+              showUserMenu={showUserMenu}
+              profile={profile}
+            />
+          </Route>
+          <Route
+            render={() => (
+              <React.Fragment>
+                <Toolbar
+                  toggleShowDrawer={this.toggleShowDrawer}
+                  toggleShowUserMenu={this.toggleShowUserMenu}
+                  showUserMenu={showUserMenu}
+                  profile={profile}
+                />
+                <Drawer />
+              </React.Fragment>
+            )}
+          />
+        </Switch>
         <Snackbar snackbar={snackbar} />
         <Banner
           banner={banner}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -36,6 +36,7 @@ import Snackbar from "../components/material/Snackbar"
 import Banner from "../components/material/Banner"
 import Drawer from "../containers/Drawer"
 import Toolbar from "../components/Toolbar"
+import CourseToolbar from "../components/CourseToolbar"
 
 import { actions } from "../actions"
 import {
@@ -58,7 +59,6 @@ import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
 import type { SnackbarState, BannerState } from "../reducers/ui"
 import type { Profile } from "../flow/discussionTypes"
-import CourseToolbar from "../components/CourseToolbar"
 
 export const USER_MENU_DROPDOWN = "USER_MENU_DROPDOWN"
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -133,10 +133,14 @@ describe("App", () => {
   })
 
   //
-  ;[["/courses/", false], ["/", true]].forEach(([url, hasDrawer]) => {
-    it(`${shouldIf(hasDrawer)} include a Drawer if url is ${url}`, async () => {
+  ;[["/courses/", true], ["/", false]].forEach(([url, isCourseUrl]) => {
+    it(`${shouldIf(!isCourseUrl)} include a Drawer, ${shouldIf(
+      isCourseUrl
+    )} include CourseToolbar if url is ${url}`, async () => {
       const [wrapper] = await renderComponent(url, [])
-      assert.equal(wrapper.find("Drawer").exists(), hasDrawer)
+      assert.equal(wrapper.find("CourseToolbar").exists(), isCourseUrl)
+      assert.equal(wrapper.find("Toolbar").exists(), !isCourseUrl)
+      assert.equal(wrapper.find("Drawer").exists(), !isCourseUrl)
     })
   })
 })

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -131,4 +131,12 @@ describe("App", () => {
       )
     })
   })
+
+  //
+  ;[["/courses/", false], ["/", true]].forEach(([url, hasDrawer]) => {
+    it(`${shouldIf(hasDrawer)} include a Drawer if url is ${url}`, async () => {
+      const [wrapper] = await renderComponent(url, [])
+      assert.equal(wrapper.find("Drawer").exists(), hasDrawer)
+    })
+  })
 })

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -70,9 +70,6 @@ export const absolutizeURL = (url: string) =>
 export const postPermalink = (post: Post): string =>
   absolutizeURL(postDetailURL(post.channel_name, post.id, post.slug))
 
-export const siteSearchURL = (): string => "/search/"
-export const coursesURL = (): string => "/courses/"
-
 // pull the channel name out of location.pathname
 // see here for why this hackish approach was necessary:
 // https://github.com/mitodl/open-discussions/pull/118#discussion_r135284591
@@ -107,6 +104,9 @@ export const MICROMASTERS_URL = "/login/micromasters/"
 
 export const TERMS_OF_SERVICE_URL = "/terms-and-conditions"
 export const PRIVACY_POLICY_URL = "/privacy-statement"
+
+export const SITE_SEARCH_URL = "/search/"
+export const COURSE_URL = "/courses/"
 
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -71,6 +71,7 @@ export const postPermalink = (post: Post): string =>
   absolutizeURL(postDetailURL(post.channel_name, post.id, post.slug))
 
 export const siteSearchURL = (): string => "/search/"
+export const coursesURL = (): string => "/courses/"
 
 // pull the channel name out of location.pathname
 // see here for why this hackish approach was necessary:

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -25,8 +25,8 @@ import {
   absolutizeURL,
   getNextParam,
   channelSearchURL,
-  siteSearchURL,
-  coursesURL
+  SITE_SEARCH_URL,
+  COURSE_URL
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -168,6 +168,8 @@ describe("url helper functions", () => {
     it("should have appropriate values for each constant", () => {
       assert.equal(AUTH_REQUIRED_URL, "/auth_required/")
       assert.equal(FRONTPAGE_URL, "/")
+      assert.equal(SITE_SEARCH_URL, "/search/")
+      assert.equal(COURSE_URL, "/courses/")
     })
   })
 
@@ -220,18 +222,6 @@ describe("url helper functions", () => {
       assert.ok(
         url.includes(postDetailURL(post.channel_name, post.id, post.slug))
       )
-    })
-  })
-
-  describe("siteSearchURL", () => {
-    it("returns a site search URL", () => {
-      assert.equal(siteSearchURL(), "/search/")
-    })
-  })
-
-  describe("coursesURL", () => {
-    it("returns a courses URL", () => {
-      assert.equal(coursesURL(), "/courses/")
     })
   })
 

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -25,7 +25,8 @@ import {
   absolutizeURL,
   getNextParam,
   channelSearchURL,
-  siteSearchURL
+  siteSearchURL,
+  coursesURL
 } from "./url"
 import { makePost } from "../factories/posts"
 
@@ -225,6 +226,12 @@ describe("url helper functions", () => {
   describe("siteSearchURL", () => {
     it("returns a site search URL", () => {
       assert.equal(siteSearchURL(), "/search/")
+    })
+  })
+
+  describe("coursesURL", () => {
+    it("returns a courses URL", () => {
+      assert.equal(coursesURL(), "/courses/")
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1889

#### What's this PR do?
Modifies `App` to use a different toolbar and no channel drawer for url's starting with `/courses`

#### How should this be manually tested?
- Go to `/courses/search`.  There should be no drawer at any width, no menu icon to display the drawer, and the toolbar should display the title "MIT Open | Courses" This title should consist of two links - one to the root url, the other to `/courses/` (which will be the course index page in another PR).  The toolbar should still have a working profile icon.
- Go to any other page, the channel drawer and toolbar should look and behave the same as always.

#### Any background context you want to provide?
I'm guessing that the course index page URL will be `/courses/`, if not then this PR will need to be tweaked to the correct value.

#### Screenshots

<img width="1036" alt="screen shot 2019-03-08 at 12 32 36 pm" src="https://user-images.githubusercontent.com/187676/54045024-7845f680-419e-11e9-9041-5601f7db33a8.png">

<img width="373" alt="screen shot 2019-03-08 at 12 33 17 pm" src="https://user-images.githubusercontent.com/187676/54045009-6b290780-419e-11e9-9b3d-f96d1354c26f.png">
