### PR TITLE
Buttons to clear facets

### DIFF
--- a/static/js/components/SearchFilter.js
+++ b/static/js/components/SearchFilter.js
@@ -1,0 +1,24 @@
+// @flow
+// using the 'import * as' syntax to include types
+import React from "react"
+
+type Props = {|
+  clearFacet: Function,
+  labelFunction: ?Function,
+  title: string,
+  value?: string
+|}
+
+const SearchFilter = ({ title, value, clearFacet, labelFunction }: Props) => (
+  <div className={"search-filter-div"}>
+    <div>
+      {title}
+      {value ? `: ${labelFunction ? labelFunction(value) : value}` : ""}
+    </div>
+    <div className="search-filter-close" onClick={clearFacet}>
+      <i className="material-icons">close</i>
+    </div>
+  </div>
+)
+
+export default SearchFilter

--- a/static/js/components/SearchFilter.js
+++ b/static/js/components/SearchFilter.js
@@ -1,5 +1,4 @@
 // @flow
-// using the 'import * as' syntax to include types
 import React from "react"
 
 type Props = {|

--- a/static/js/components/SearchFilter_test.js
+++ b/static/js/components/SearchFilter_test.js
@@ -1,0 +1,48 @@
+// @flow
+import React from "react"
+import _ from "lodash"
+import { assert } from "chai"
+import { shallow } from "enzyme"
+import * as sinon from "sinon"
+
+import SearchFilter from "./SearchFilter"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+describe("SearchFilter", () => {
+  let helper, onClickStub
+
+  const renderSearchFilter = props => {
+    return shallow(<SearchFilter clearFacet={onClickStub} {...props} />)
+  }
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    onClickStub = helper.sandbox.stub()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render a search filter correctly", () => {
+    const title = "Availability"
+    const value = "Upcoming"
+    const wrapper = renderSearchFilter({
+      title,
+      value,
+      labelFunction: _.upperCase
+    })
+    const label = wrapper
+      .find(".search-filter-div")
+      .at(0)
+      .text()
+    assert.isTrue(label.includes(_.upperCase(value)))
+    assert.isTrue(label.includes(title))
+  })
+
+  it("should trigger clearFacet function on click", async () => {
+    const wrapper = renderSearchFilter({ title: "Platform", value: "ocw" })
+    wrapper.find(".search-filter-close").simulate("click")
+    sinon.assert.calledOnce(onClickStub)
+  })
+})

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -14,6 +14,7 @@ import Card from "../components/Card"
 import { Cell, Grid } from "../components/Grid"
 import { Loading, PostLoading } from "../components/Loading"
 import SearchFacet from "../components/SearchFacet"
+import SearchFilter from "../components/SearchFilter"
 import SearchTextbox from "../components/SearchTextbox"
 import SearchResult from "../components/SearchResult"
 import { actions } from "../actions"
@@ -29,7 +30,6 @@ import type {
   Result,
   FacetResult
 } from "../flow/searchTypes"
-import SearchFilter from "../components/SearchFilter"
 
 type OwnProps = {|
   dispatch: Dispatch<any>,

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -69,6 +69,12 @@ type State = {
   error: ?string
 }
 
+const facetDisplayMap = [
+  ["topics", "Subject Area", null],
+  ["availability", "Availability", null],
+  ["platform", "Platform", _.upperCase]
+]
+
 const shouldRunSearch = R.complement(
   R.allPass([R.eqProps("text"), R.eqProps("activeFacets")])
 )
@@ -214,11 +220,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
   render() {
     const { match, facets, total, loaded, processing } = this.props
     const { text, error, activeFacets } = this.state
-    const facetDisplayMap = [
-      ["topics", "Subject Area", null],
-      ["availability", "Availability", null],
-      ["platform", "Platform", _.upperCase]
-    ]
 
     return (
       <React.Fragment>

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -85,9 +85,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
     this.state = {
       text:         qs.parse(props.location.search).q,
       activeFacets: new Map([
-        ["platform", toArray(qs.parse(props.location.search).p) || []],
-        ["topics", toArray(qs.parse(props.location.search).t) || []],
-        ["availability", toArray(qs.parse(props.location.search).a) || []]
+        ["platform", _.union(toArray(qs.parse(props.location.search).p) || [])],
+        ["topics", _.union(toArray(qs.parse(props.location.search).t) || [])],
+        [
+          "availability",
+          _.union(toArray(qs.parse(props.location.search).a) || [])
+        ]
       ]),
       from:  0,
       error: null

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -216,7 +216,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { text, error, activeFacets } = this.state
     const facetDisplayMap = [
       ["topics", "Subject Area", null],
-      ["availability", "Availability", _.capitalize],
+      ["availability", "Availability", null],
       ["platform", "Platform", _.upperCase]
     ]
 

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -238,17 +238,15 @@ export class CourseSearchPage extends React.Component<Props, State> {
             </div>
             <div className="search-filters-row">
               {facetDisplayMap.map(([name, title, labelFunction]) =>
-                (activeFacets
-                  .get(name) || [])
-                  .map((facet, i) => (
-                    <SearchFilter
-                      key={i}
-                      title={title}
-                      value={facet}
-                      clearFacet={() => this.toggleFacet(name, facet, false)}
-                      labelFunction={labelFunction}
-                    />
-                  ))
+                (activeFacets.get(name) || []).map((facet, i) => (
+                  <SearchFilter
+                    key={i}
+                    title={title}
+                    value={facet}
+                    clearFacet={() => this.toggleFacet(name, facet, false)}
+                    labelFunction={labelFunction}
+                  />
+                ))
               )}
               {_.flatten(_.toArray(activeFacets.values())).length > 0 ? (
                 <div

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -239,6 +239,26 @@ describe("CourseSearchPage", () => {
     assert.equal(inner.state().text, text)
   })
 
+  it("displays filters and clicking 'Clear all filters' removes all active facets", async () => {
+    const { inner } = await renderPage()
+    const text = "text"
+    const activeFacets = new Map([
+      ["platform", ["ocw"]],
+      ["topics", ["Science", "Law"]],
+      ["availability", ["Current"]]
+    ])
+    inner.setState({ text, activeFacets })
+    assert.equal(inner.state().text, text)
+    assert.deepEqual(inner.state().activeFacets, activeFacets)
+    assert.equal(inner.find("SearchFilter").length, 4)
+    inner.find(".search-filters-clear").simulate("click")
+    assert.equal(inner.state().text, null)
+    assert.deepEqual(
+      inner.state().activeFacets,
+      new Map([["platform", []], ["topics", []], ["availability", []]])
+    )
+  })
+
   it("triggers a non-incremental search from textbox input", async () => {
     const { inner } = await renderPage(
       {},

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -258,12 +258,16 @@ describe("CourseSearchPage", () => {
       type: "course"
     })
     assert.deepEqual(inner.state(), {
-      from:           0,
       text,
-      error:          null,
-      topics:         undefined,
-      platforms:      undefined,
-      availabilities: undefined
+      activeFacets: new Map(
+        Object.entries({
+          topics:       [],
+          platform:     [],
+          availability: []
+        })
+      ),
+      from:  0,
+      error: null
     })
   })
 
@@ -287,9 +291,9 @@ describe("CourseSearchPage", () => {
       type:        "course",
       facets:      new Map(
         Object.entries({
-          platforms:      ["ocw"],
-          topics:         ["Engineering"],
-          availabilities: ["prior"]
+          platform:     ["ocw"],
+          topics:       ["Engineering"],
+          availability: ["prior"]
         })
       )
     })
@@ -300,12 +304,16 @@ describe("CourseSearchPage", () => {
     })
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
-      from:           0,
       text,
-      error:          null,
-      topics:         ["Engineering"],
-      platforms:      undefined,
-      availabilities: undefined
+      activeFacets: new Map(
+        Object.entries({
+          topics:       ["Engineering"],
+          platform:     [],
+          availability: []
+        })
+      ),
+      from:  0,
+      error: null
     })
   })
 
@@ -313,10 +321,8 @@ describe("CourseSearchPage", () => {
     const { inner } = await renderPage()
     helper.searchStub.reset()
     inner.setState({
-      text:           inner.state().text,
-      topics:         inner.state().topics,
-      platforms:      inner.state().platforms,
-      availabilities: inner.state().availabilities
+      text:         inner.state().text,
+      activeFacets: inner.state().activeFacets
     })
     sinon.assert.notCalled(helper.searchStub)
   })
@@ -332,7 +338,16 @@ describe("CourseSearchPage", () => {
       isChecked
     )} include a topic facet in search after checkbox change`, async () => {
       const { inner } = await renderPage()
-      inner.setState({ text: "some text" })
+      inner.setState({
+        text:         "some text",
+        activeFacets: new Map(
+          Object.entries({
+            platform:     [],
+            topics:       isChecked ? [] : ["Science"],
+            availability: []
+          })
+        )
+      })
       helper.searchStub.reset()
       await inner.instance().onUpdateFacets({
         target: {
@@ -349,9 +364,9 @@ describe("CourseSearchPage", () => {
         type:        "course",
         facets:      new Map(
           Object.entries({
-            platforms:      undefined,
-            topics:         isChecked ? ["Science"] : [],
-            availabilities: undefined
+            platform:     [],
+            topics:       isChecked ? ["Science"] : [],
+            availability: []
           })
         )
       })

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -96,9 +96,6 @@ export type Result = PostResult | CommentResult | ProfileResult | CourseResult
 export type SearchInputs = {
   text?:            string,
   type?:            string,
-  platforms?:       string,
-  topics?:          string,
-  availabilities?:  string,
   incremental:      boolean
 }
 

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -90,3 +90,35 @@
   flex-direction: row;
   justify-content: space-between;
 }
+
+.search-filters-row {
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.search-filter-div {
+  margin: 0px 0px 5px 10px;
+  background-color: #ddeff7;
+  padding: 6px 10px;
+  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.search-filter-close {
+  display: flex;
+  cursor: pointer;
+
+  i {
+    transform: scale(0.75);
+  }
+}
+
+.search-filters-clear {
+  margin-left: 10px;
+  display: inline-flex;
+  cursor: pointer;
+  color: $link-blue;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1887

#### What's this PR do?
Adds buttons below the text input field for each active facet filter, along with a 'Clear all filters' link.
Each button should remove the specified facet from the search filter.
The 'Clear all filters' link should remove all facets and text input from the search.

#### How should this be manually tested?
- Run a search with some facets selected and some search text.
- There should be buttons below the text input field for each selected facet.
- Click the 'x' on some of these buttons.  The appropriate facets should be unchecked and the search results should update.
- Click 'Clear all filters'.  All the facets should be unchecked and the text input should be cleared.  Search results should update accordingly.

#### Screenshots (if appropriate)
![Screen Shot 2019-03-12 at 4 55 36 PM](https://user-images.githubusercontent.com/187676/54236059-1280a400-44e9-11e9-828a-565cf603512d.png)

![Screen Shot 2019-03-12 at 4 56 16 PM](https://user-images.githubusercontent.com/187676/54236058-1280a400-44e9-11e9-85f5-ceb6d41fef13.png)



