### PR TITLE
Show min price instead of max price for courses

### DIFF
--- a/static/js/components/CompactCourseDisplay.js
+++ b/static/js/components/CompactCourseDisplay.js
@@ -6,7 +6,7 @@ import _ from "lodash"
 
 import Card from "./Card"
 import { setShowCourseDrawer } from "../actions/ui"
-import { courseAvailability, maxPrice } from "../lib/courses"
+import { courseAvailability, minPrice } from "../lib/courses"
 import { embedlyThumbnail } from "../lib/url"
 import { EMBEDLY_THUMB_HEIGHT, EMBEDLY_THUMB_WIDTH } from "../lib/posts"
 
@@ -66,7 +66,7 @@ export class CompactCourseDisplay extends React.Component<Props> {
             <div className="course-platform">
               {course.platform.toUpperCase()}
             </div>
-            <div className="course-price">{maxPrice(course)}</div>
+            <div className="course-price">{minPrice(course)}</div>
           </div>
         </div>
         {course.image_src ? (

--- a/static/js/components/CompactCourseDisplay_test.js
+++ b/static/js/components/CompactCourseDisplay_test.js
@@ -6,7 +6,7 @@ import { mount } from "enzyme"
 import Router from "../Router"
 import CompactCourseDisplay from "./CompactCourseDisplay"
 import { makeCourse } from "../factories/courses"
-import { courseAvailability, maxPrice } from "../lib/courses"
+import { courseAvailability, minPrice } from "../lib/courses"
 import { shouldIf } from "../lib/test_utils"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import * as uiActions from "../actions/ui"
@@ -48,7 +48,7 @@ describe("CompactCourseDisplay", () => {
       wrapper.find(".course-platform").text(),
       course.platform.toUpperCase()
     )
-    assert.equal(wrapper.find(".course-price").text(), maxPrice(course))
+    assert.equal(wrapper.find(".course-price").text(), minPrice(course))
     assert.equal(
       wrapper.find(".course-availability").text(),
       courseAvailability(course)

--- a/static/js/components/ExpandedCourseDisplay.js
+++ b/static/js/components/ExpandedCourseDisplay.js
@@ -8,7 +8,7 @@ import { AllHtmlEntities } from "html-entities"
 import ClampLines from "react-clamp-lines"
 
 import { platforms } from "../lib/constants"
-import { maxPrice } from "../lib/courses"
+import { minPrice } from "../lib/courses"
 import { embedlyThumbnail } from "../lib/url"
 import { languageName } from "../lib/util"
 
@@ -95,7 +95,7 @@ export default class ExpandedCourseDisplay extends React.Component<Props> {
           <div className="course-info-row">
             <i className="material-icons attach_money">attach_money</i>
             <div className="course-info-label">Cost:</div>
-            <div className="course-info-value">{maxPrice(course)}</div>
+            <div className="course-info-value">{minPrice(course)}</div>
           </div>
           <div className="course-info-row">
             <i className="material-icons bar_chart">bar_chart</i>

--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -24,3 +24,8 @@ export const maxPrice = (course: Course) => {
   const price = Math.max(...R.map(R.view(R.lensProp("price")), course.prices))
   return price > 0 ? `$${price}` : "Free"
 }
+
+export const minPrice = (course: Course) => {
+  const price = Math.min(...R.map(R.view(R.lensProp("price")), course.prices))
+  return price > 0 && price !== Infinity ? `$${price}` : "Free"
+}

--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -1,6 +1,5 @@
 //@flow
 import moment from "moment"
-import R from "ramda"
 import _ from "lodash"
 
 import type { Course } from "../flow/discussionTypes"
@@ -21,11 +20,11 @@ export const courseAvailability = (course: Course) =>
         : COURSE_AVAILABLE_NOW
 
 export const maxPrice = (course: Course) => {
-  const price = Math.max(...R.map(R.view(R.lensProp("price")), course.prices))
+  const price = Math.max(...course.prices.map(price => price.price))
   return price > 0 ? `$${price}` : "Free"
 }
 
 export const minPrice = (course: Course) => {
-  const price = Math.min(...R.map(R.view(R.lensProp("price")), course.prices))
+  const price = Math.min(...course.prices.map(price => price.price))
   return price > 0 && price !== Infinity ? `$${price}` : "Free"
 }

--- a/static/js/lib/courses_test.js
+++ b/static/js/lib/courses_test.js
@@ -8,7 +8,7 @@ import {
   COURSE_PRIOR,
   COURSE_UPCOMING
 } from "./constants"
-import { courseAvailability, maxPrice } from "./courses"
+import { courseAvailability, minPrice, maxPrice } from "./courses"
 
 describe("Course utils", () => {
   [
@@ -25,18 +25,20 @@ describe("Course utils", () => {
       assert.equal(courseAvailability(course), expected)
     })
   })
+
+  //
   ;[
-    [[0.0, 50.0], "$50"],
-    [[null, null], "Free"],
-    [[null, 0], "Free"],
-    [[20, 100], "$100"],
-    [[null, 100], "$100"]
-  ].forEach(([prices, expected]) => {
-    it(`maxPrice should return ${expected} for price range ${prices.toString()}`, () => {
+    [[0.0, 50.0, 25.0], "$50", "Free"],
+    [[null, null], "Free", "Free"],
+    [[null, 0], "Free", "Free"],
+    [[20, 100, 50], "$100", "$20"],
+    [[null, 100, 75], "$100", "Free"]
+  ].forEach(([prices, expectedMax, expectedMin]) => {
+    it(`minPrice, maxPrice should return ${expectedMin}, ${expectedMax} for price range ${prices.toString()}`, () => {
       const course = makeCourse()
       course.prices = []
       prices.forEach(price => {
-        if (price) {
+        if (!isNaN(price)) {
           // $FlowFixMe: course.prices is definitely not null here
           course.prices.push({
             mode:  "test",
@@ -44,7 +46,8 @@ describe("Course utils", () => {
           })
         }
       })
-      assert.equal(maxPrice(course), expected)
+      assert.equal(minPrice(course), expectedMin)
+      assert.equal(maxPrice(course), expectedMax)
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1901

#### What's this PR do?
Shows the minimum price ("Free" if 0) instead of the maximum price.

#### How should this be manually tested?
- Search for courses.  Almost all of them should show "Free" for price in the compact and expanded course views.
- Search for "Basic Circuit Analysis" with the "Current" Availability facet checked.  The minimum price for one of the top results should be $9.99

The `maxPrice` function in `static/js/lib/courses.js` is no longer used, but I left it there in case we decide in the future to show a price range instead.