### PR TITLE
Label course availability by model field instead of dates in UI

### DIFF
--- a/static/js/components/CompactCourseDisplay.js
+++ b/static/js/components/CompactCourseDisplay.js
@@ -7,7 +7,7 @@ import _ from "lodash"
 import Card from "./Card"
 
 import { setShowCourseDrawer } from "../actions/ui"
-import { courseAvailability, minPrice } from "../lib/courses"
+import { availabilityLabel, minPrice } from "../lib/courses"
 import { embedlyThumbnail } from "../lib/url"
 import { EMBEDLY_THUMB_HEIGHT, EMBEDLY_THUMB_WIDTH } from "../lib/posts"
 
@@ -62,7 +62,7 @@ export class CompactCourseDisplay extends React.Component<Props> {
           </div>
           <div className="row preview-footer">
             <div className="course-availability">
-              {courseAvailability(course)}
+              {availabilityLabel(course.availability)}
             </div>
             <div className="course-platform">
               {course.platform.toUpperCase()}

--- a/static/js/components/CompactCourseDisplay_test.js
+++ b/static/js/components/CompactCourseDisplay_test.js
@@ -6,7 +6,7 @@ import { mount } from "enzyme"
 import Router from "../Router"
 import CompactCourseDisplay from "./CompactCourseDisplay"
 import { makeCourse } from "../factories/courses"
-import { courseAvailability, minPrice } from "../lib/courses"
+import { availabilityLabel, minPrice } from "../lib/courses"
 import { shouldIf } from "../lib/test_utils"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import * as uiActions from "../actions/ui"
@@ -51,7 +51,7 @@ describe("CompactCourseDisplay", () => {
     assert.equal(wrapper.find(".course-price").text(), minPrice(course))
     assert.equal(
       wrapper.find(".course-availability").text(),
-      courseAvailability(course)
+      availabilityLabel(course.availability)
     )
     assert.ok(
       wrapper

--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -7,7 +7,7 @@ import R from "ramda"
 
 import Card from "./Card"
 
-import { courseAvailability, minPrice } from "../lib/courses"
+import { availabilityLabel, minPrice } from "../lib/courses"
 import { embedlyThumbnail } from "../lib/url"
 
 import type { Course } from "../flow/discussionTypes"
@@ -58,7 +58,9 @@ export const CarouselCourseCard = ({
       <Dotdotdot clamp={3}>{course.title}</Dotdotdot>
     </div>
     <div className="row availability-and-price">
-      <div className="availability">{courseAvailability(course)}</div>
+      <div className="availability">
+        {availabilityLabel(course.availability)}
+      </div>
       <div className="price">{minPrice(course)}</div>
     </div>
   </Card>

--- a/static/js/components/CourseCarousel_test.js
+++ b/static/js/components/CourseCarousel_test.js
@@ -7,7 +7,7 @@ import { mount } from "enzyme"
 
 import CourseCarousel, { CarouselCourseCard } from "./CourseCarousel"
 
-import { courseAvailability, minPrice } from "../lib/courses"
+import { availabilityLabel, minPrice } from "../lib/courses"
 import { configureShallowRenderer, shouldIf } from "../lib/test_utils"
 import { makeCourse } from "../factories/courses"
 
@@ -88,7 +88,7 @@ describe("CourseCarousel", () => {
     assert.equal(wrapper.find("Dotdotdot").props().children, course.title)
     assert.equal(
       wrapper.find(".availability").text(),
-      courseAvailability(course)
+      availabilityLabel(course.availability)
     )
     assert.equal(wrapper.find(".price").text(), minPrice(course))
   })

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -21,6 +21,7 @@ import SearchResult from "../components/SearchResult"
 
 import { actions } from "../actions"
 import { clearSearch } from "../actions/search"
+import { availabilityLabel } from "../lib/courses"
 import { SEARCH_FILTER_COURSE } from "../lib/picker"
 import { preventDefaultAndInvoke, toArray } from "../lib/util"
 
@@ -73,7 +74,7 @@ type State = {
 
 const facetDisplayMap = [
   ["topics", "Subject Area", null],
-  ["availability", "Availability", null],
+  ["availability", "Availability", availabilityLabel],
   ["platform", "Platform", _.upperCase]
 ]
 

--- a/static/js/factories/courses.js
+++ b/static/js/factories/courses.js
@@ -2,7 +2,7 @@
 import casual from "casual-browserify"
 
 import { incrementer } from "../lib/util"
-import { platforms } from "../lib/constants"
+import {COURSE_ARCHIVED, COURSE_CURRENT, platforms} from "../lib/constants"
 
 import type { Course } from "../flow/discussionTypes"
 
@@ -27,6 +27,7 @@ export const makeCourse = (): Course => {
     end_date:          casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
     enrollment_start:  casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
     enrollment_end:    casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
+    availability:      casual.random_element([COURSE_ARCHIVED, COURSE_CURRENT, "Upcoming"]),
     instructors:       [
       { first_name: casual.name, last_name: casual.name },
       { first_name: casual.name, last_name: casual.name }

--- a/static/js/factories/courses.js
+++ b/static/js/factories/courses.js
@@ -2,7 +2,7 @@
 import casual from "casual-browserify"
 
 import { incrementer } from "../lib/util"
-import {COURSE_ARCHIVED, COURSE_CURRENT, platforms} from "../lib/constants"
+import { COURSE_ARCHIVED, COURSE_CURRENT, platforms } from "../lib/constants"
 
 import type { Course } from "../flow/discussionTypes"
 
@@ -27,8 +27,12 @@ export const makeCourse = (): Course => {
     end_date:          casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
     enrollment_start:  casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
     enrollment_end:    casual.date("YYYY-MM-DD[T]HH:mm:ss[Z]"),
-    availability:      casual.random_element([COURSE_ARCHIVED, COURSE_CURRENT, "Upcoming"]),
-    instructors:       [
+    availability:      casual.random_element([
+      COURSE_ARCHIVED,
+      COURSE_CURRENT,
+      "Upcoming"
+    ]),
+    instructors: [
       { first_name: casual.name, last_name: casual.name },
       { first_name: casual.name, last_name: casual.name }
     ],

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -4,6 +4,7 @@ import casual from "casual-browserify"
 import R from "ramda"
 
 import { LINK_TYPE_LINK, LINK_TYPE_TEXT } from "../lib/channels"
+import { COURSE_ARCHIVED, COURSE_CURRENT, platforms } from "../lib/constants"
 
 import type {
   CommentResult,
@@ -11,7 +12,6 @@ import type {
   PostResult,
   ProfileResult
 } from "../flow/searchTypes"
-import {COURSE_ARCHIVED, COURSE_CURRENT, platforms} from "../lib/constants"
 
 export const makeProfileResult = (): ProfileResult => ({
   author_avatar_medium: casual.url,
@@ -89,7 +89,8 @@ export const makeCourseResult = (): CourseResult => ({
   topics:            [casual.word, casual.word],
   prices:            [{ mode: "audit", price: casual.number }],
   object_type:       "course",
-  availability:      casual.random_element[COURSE_ARCHIVED, COURSE_CURRENT, "Upcoming"]
+  availability:
+    casual.random_element[(COURSE_ARCHIVED, COURSE_CURRENT, "Upcoming")]
 })
 
 export const makeSearchResult = (type: ?string) => {

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -11,7 +11,7 @@ import type {
   PostResult,
   ProfileResult
 } from "../flow/searchTypes"
-import { platforms } from "../lib/constants"
+import {COURSE_ARCHIVED, COURSE_CURRENT, platforms} from "../lib/constants"
 
 export const makeProfileResult = (): ProfileResult => ({
   author_avatar_medium: casual.url,
@@ -88,7 +88,8 @@ export const makeCourseResult = (): CourseResult => ({
   instructors:       ["instuctor 1", "instructor 2"],
   topics:            [casual.word, casual.word],
   prices:            [{ mode: "audit", price: casual.number }],
-  object_type:       "course"
+  object_type:       "course",
+  availability:      casual.random_element[COURSE_ARCHIVED, COURSE_CURRENT, "Upcoming"]
 })
 
 export const makeSearchResult = (type: ?string) => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -339,7 +339,8 @@ export type Course = {
   enrollment_end:     ?string,
   instructors:        Array<CourseInstructor>,
   topics:             Array<CourseTopic>,
-  prices:             Array<CoursePrice>
+  prices:             Array<CoursePrice>,
+  availability:       ?string
 }
 
 export type CoursePrice = {

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -77,6 +77,7 @@ export type CourseResult = {
   end_date:           ?string,
   enrollment_start:   ?string,
   enrollment_end:     ?string,
+  availability:       ?string,
   instructors:        Array<string>,
   topics:             Array<string>,
   prices:             Array<CoursePrice>

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -6,16 +6,10 @@ export const SOCIAL_SITE_TYPE = "social"
 export const POSTS_OBJECT_TYPE = "posts"
 export const COMMENTS_OBJECT_TYPE = "comments"
 
-export const COURSE_CURRENT = "current"
-export const COURSE_UPCOMING = "upcoming"
-export const COURSE_PRIOR = "prior"
+export const COURSE_CURRENT = "Current"
 export const COURSE_AVAILABLE_NOW = "Available Now"
-
-export const COURSE_AVAILABILITIES = [
-  COURSE_CURRENT,
-  COURSE_UPCOMING,
-  COURSE_PRIOR
-]
+export const COURSE_ARCHIVED = "Archived"
+export const COURSE_PRIOR = "Prior"
 
 export const platforms = {
   OCW: "ocw",

--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -1,23 +1,23 @@
 //@flow
-import moment from "moment"
-import _ from "lodash"
-
-import type { Course } from "../flow/discussionTypes"
 import {
-  platforms,
+  COURSE_ARCHIVED,
   COURSE_AVAILABLE_NOW,
-  COURSE_PRIOR,
-  COURSE_UPCOMING
+  COURSE_CURRENT,
+  COURSE_PRIOR
 } from "./constants"
 
-export const courseAvailability = (course: Course) =>
-  course.platform === platforms.OCW
-    ? COURSE_AVAILABLE_NOW
-    : moment(course.start_date).isAfter(moment())
-      ? _.capitalize(COURSE_UPCOMING)
-      : moment(course.end_date).isBefore(moment())
-        ? _.capitalize(COURSE_PRIOR)
-        : COURSE_AVAILABLE_NOW
+import type { Course } from "../flow/discussionTypes"
+
+export const courseAvailability = (course: Course) => {
+  switch (course.availability) {
+  case COURSE_CURRENT:
+    return COURSE_AVAILABLE_NOW
+  case COURSE_ARCHIVED:
+    return COURSE_PRIOR
+  default:
+    return course.availability
+  }
+}
 
 export const maxPrice = (course: Course) => {
   const price = Math.max(...course.prices.map(price => price.price))

--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -8,14 +8,14 @@ import {
 
 import type { Course } from "../flow/discussionTypes"
 
-export const courseAvailability = (course: Course) => {
-  switch (course.availability) {
+export const availabilityLabel = (availability: ?string) => {
+  switch (availability) {
   case COURSE_CURRENT:
     return COURSE_AVAILABLE_NOW
   case COURSE_ARCHIVED:
     return COURSE_PRIOR
   default:
-    return course.availability
+    return availability
   }
 }
 

--- a/static/js/lib/courses_test.js
+++ b/static/js/lib/courses_test.js
@@ -4,24 +4,22 @@ import _ from "lodash"
 
 import { makeCourse } from "../factories/courses"
 import {
+  COURSE_ARCHIVED,
   COURSE_AVAILABLE_NOW,
-  COURSE_PRIOR,
-  COURSE_UPCOMING
+  COURSE_CURRENT,
+  COURSE_PRIOR
 } from "./constants"
 import { courseAvailability, minPrice, maxPrice } from "./courses"
 
 describe("Course utils", () => {
   [
-    ["2000-01-01", "2000-02-02", "mitx", _.capitalize(COURSE_PRIOR)],
-    ["2000-01-01", "2500-02-02", "mitx", COURSE_AVAILABLE_NOW],
-    ["2400-01-01", "2500-02-02", "mitx", _.capitalize(COURSE_UPCOMING)],
-    ["2000-01-01", "2000-02-02", "ocw", COURSE_AVAILABLE_NOW]
-  ].forEach(([startDate, endDate, platform, expected]) => {
-    it(`courseAvailability should return ${expected} for ${platform} course running ${startDate} to ${endDate}`, () => {
+    [COURSE_ARCHIVED, COURSE_PRIOR],
+    [COURSE_CURRENT, COURSE_AVAILABLE_NOW],
+    ["Upcoming", "Upcoming"]
+  ].forEach(([availability, expected]) => {
+    it(`courseAvailability should return ${expected} for course.availability of ${availability}`, () => {
       const course = makeCourse()
-      course.start_date = startDate
-      course.end_date = endDate
-      course.platform = platform
+      course.availability = availability
       assert.equal(courseAvailability(course), expected)
     })
   })

--- a/static/js/lib/courses_test.js
+++ b/static/js/lib/courses_test.js
@@ -1,6 +1,5 @@
 // @flow
 import { assert } from "chai"
-import _ from "lodash"
 
 import { makeCourse } from "../factories/courses"
 import {
@@ -9,7 +8,7 @@ import {
   COURSE_CURRENT,
   COURSE_PRIOR
 } from "./constants"
-import { courseAvailability, minPrice, maxPrice } from "./courses"
+import { availabilityLabel, minPrice, maxPrice } from "./courses"
 
 describe("Course utils", () => {
   [
@@ -17,10 +16,10 @@ describe("Course utils", () => {
     [COURSE_CURRENT, COURSE_AVAILABLE_NOW],
     ["Upcoming", "Upcoming"]
   ].forEach(([availability, expected]) => {
-    it(`courseAvailability should return ${expected} for course.availability of ${availability}`, () => {
+    it(`availabilityLabel should return ${expected} for course.availability of ${availability}`, () => {
       const course = makeCourse()
       course.availability = availability
-      assert.equal(courseAvailability(course), expected)
+      assert.equal(availabilityLabel(course.availability), expected)
     })
   })
 

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -101,6 +101,7 @@ export const searchResultToCourse = (result: CourseResult): Course => ({
   end_date:          result.end_date,
   enrollment_start:  result.enrollment_start,
   enrollment_end:    result.enrollment_end,
+  availability:      result.availability,
   instructors:       [],
   topics:            result.topics.map(topic => ({ name: topic })),
   prices:            result.prices

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -128,7 +128,8 @@ describe("search functions", () => {
       instructors:       [],
       topics:            result.topics.map(topic => ({ name: topic })),
       prices:            result.prices,
-      url:               result.url
+      url:               result.url,
+      availability:      result.availability
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1910
Closes #1861

#### What's this PR do?
Displays course availability based on the `Course` model's availability field, rather than start and end dates.  In particular, changes the `courseAvailability` function and renames it to `availabilityLabel`.  This function will now replace "Archived" with "Prior", "Current" with "Available Now", and display other availabilities as is.

#### How should this be manually tested?
Go to `/courses/search`.  The search results and facet choices should show these availabilities: Available Now, Prior, Upcoming, Starting Soon.  Select the 'Available Now' or 'Prior' facet and verify that they still work correctly.