### PR TITLE
Modify facet behavior within/between groups

### DIFF
--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -44,9 +44,7 @@ export class SearchFacet extends React.Component<Props> {
     const { results, currentlySelected, showAll } = this.props
     const nextResults = nextProps.results
     return (
-      // $FlowFixMe: Flow is confused, this does return a boolean
-      nextResults &&
-      nextResults.buckets &&
+      _.has(nextResults, "buckets") &&
       (results !== nextResults ||
         currentlySelected !== nextProps.currentlySelected ||
         showAll !== nextProps.showAll)

--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -40,6 +40,19 @@ export class SearchFacet extends React.Component<Props> {
     await dispatch(showAll ? hideSearchFacets(key) : showSearchFacets(key))
   }
 
+  shouldComponentUpdate(nextProps: Props) {
+    const { results, currentlySelected, showAll } = this.props
+    const nextResults = nextProps.results
+    return (
+      // $FlowFixMe: Flow is confused, this does return a boolean
+      nextResults &&
+      nextResults.buckets &&
+      (results !== nextResults ||
+        currentlySelected !== nextProps.currentlySelected ||
+        showAll !== nextProps.showAll)
+    )
+  }
+
   render() {
     const {
       name,
@@ -53,45 +66,47 @@ export class SearchFacet extends React.Component<Props> {
     } = this.props
     const maxCount = displayCount || 5
 
-    return results ? (
+    return (
       <div className="facets">
         <div className="facet-title">{title}</div>
-        {results.buckets.map((facet, i) => (
-          <React.Fragment key={i}>
-            <div
-              className={
-                showAll || i < maxCount ? "facet-visible" : "facet-hidden"
-              }
-            >
-              <Checkbox
-                name={name}
-                value={facet.key}
-                checked={R.contains(facet.key, currentlySelected || [])}
-                onClick={onUpdate}
+        {results && results.buckets
+          ? results.buckets.map((facet, i) => (
+            <React.Fragment key={i}>
+              <div
+                className={
+                  showAll || i < maxCount ? "facet-visible" : "facet-hidden"
+                }
               >
-                <div className="facet-label-div">
-                  <div className="facet-key">
-                    {labelFunction ? labelFunction(facet.key) : facet.key}
-                  </div>
-                  <div className="facet-count">{facet.doc_count}</div>
-                </div>
-              </Checkbox>
-            </div>
-            {(!showAll &&
-              i === maxCount &&
-              maxCount < results.buckets.length) ||
-            (showAll && i === results.buckets.length - 1) ? (
-                <div
-                  className="facet-more-less"
-                  onClick={() => this.toggleAllFacets(name)}
+                <Checkbox
+                  name={name}
+                  value={facet.key}
+                  checked={R.contains(facet.key, currentlySelected || [])}
+                  onClick={onUpdate}
                 >
-                  {showAll ? "View less" : "View more"}
-                </div>
-              ) : null}
-          </React.Fragment>
-        ))}
+                  <div className="facet-label-div">
+                    <div className="facet-key">
+                      {labelFunction ? labelFunction(facet.key) : facet.key}
+                    </div>
+                    <div className="facet-count">{facet.doc_count}</div>
+                  </div>
+                </Checkbox>
+              </div>
+              {(!showAll &&
+                  i === maxCount &&
+                  maxCount < results.buckets.length) ||
+                (showAll && i === results.buckets.length - 1) ? (
+                  <div
+                    className="facet-more-less"
+                    onClick={() => this.toggleAllFacets(name)}
+                  >
+                    {showAll ? "View less" : "View more"}
+                  </div>
+                ) : null}
+            </React.Fragment>
+          ))
+          : null}
       </div>
-    ) : null
+    )
   }
 }
 

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -101,4 +101,23 @@ describe("SearchFacet", () => {
       )
     })
   })
+
+  //
+  ;[
+    // [true, false, false],
+    // [false, true, false],
+    // [false, false, true],
+    [false, false, false]
+  ].forEach(([newResults, isSelected, showAll]) => {
+    it(`component ${shouldIf(newResults || isSelected || showAll)} update when ${newResults ? "facets" : isSelected ? "selected facets" : showAll ? "showAll toggle" : "nothing"} changed`, () => {
+      const wrapper = renderSearchFacet()
+      const currentlySelected = isSelected ? ["fakeSelection"] : wrapper.props().currentlySelected
+      const nextResults = newResults ? new Map(Object.entries(makeSearchFacetResult())).get("availability") : results
+      assert.equal(wrapper.instance().shouldComponentUpdate({
+        showAll: wrapper.props().showAll,
+        currentlySelected: wrapper.props().currentlySelected,
+        results: wrapper.props().results
+      }), (showAll))
+    })
+  })
 })

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -104,20 +104,38 @@ describe("SearchFacet", () => {
 
   //
   ;[
-    // [true, false, false],
-    // [false, true, false],
-    // [false, false, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, true],
     [false, false, false]
-  ].forEach(([newResults, isSelected, showAll]) => {
-    it(`component ${shouldIf(newResults || isSelected || showAll)} update when ${newResults ? "facets" : isSelected ? "selected facets" : showAll ? "showAll toggle" : "nothing"} changed`, () => {
-      const wrapper = renderSearchFacet()
-      const currentlySelected = isSelected ? ["fakeSelection"] : wrapper.props().currentlySelected
-      const nextResults = newResults ? new Map(Object.entries(makeSearchFacetResult())).get("availability") : results
-      assert.equal(wrapper.instance().shouldComponentUpdate({
-        showAll: wrapper.props().showAll,
-        currentlySelected: wrapper.props().currentlySelected,
-        results: wrapper.props().results
-      }), (showAll))
+  ].forEach(([newResults, newSelected, newShow]) => {
+    it(`component ${shouldIf(
+      newResults || newSelected || newShow
+    )} update when ${
+      newResults
+        ? "facets"
+        : newSelected
+          ? "selected facets"
+          : newShow
+            ? "showAll toggle"
+            : "nothing"
+    } changed`, () => {
+      const instance = renderSearchFacet().instance()
+      const nextSelected = newSelected
+        ? ["fakeSelection"]
+        : instance.props.currentlySelected
+      const nextResults = newResults ? { buckets: [] } : instance.props.results
+      const nextShowAll = newShow
+        ? !instance.props.showAll
+        : instance.props.showAll
+      assert.equal(
+        instance.shouldComponentUpdate({
+          showAll:           nextShowAll,
+          currentlySelected: nextSelected,
+          results:           nextResults
+        }),
+        newShow || newSelected || newResults
+      )
     })
   })
 })

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -69,7 +69,8 @@ type State = {
   text: ?string,
   activeFacets: Map<string, Array<string>>,
   from: number,
-  error: ?string
+  error: ?string,
+  currentFacetGroup: ?Map<string, FacetResult>
 }
 
 const facetDisplayMap = [
@@ -78,9 +79,7 @@ const facetDisplayMap = [
   ["platform", "Platform", _.upperCase]
 ]
 
-const shouldRunSearch = R.complement(
-  R.allPass([R.eqProps("text"), R.eqProps("activeFacets")])
-)
+const shouldRunSearch = R.complement(R.eqProps("activeFacets"))
 
 export class CourseSearchPage extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -95,8 +94,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
           _.union(toArray(qs.parse(props.location.search).a) || [])
         ]
       ]),
-      from:  0,
-      error: null
+      from:              0,
+      error:             null,
+      currentFacetGroup: null
     }
   }
 
@@ -121,8 +121,43 @@ export class CourseSearchPage extends React.Component<Props, State> {
         ["platform", []],
         ["availability", []],
         ["topics", []]
-      ])
+      ]),
+      currentFacetGroup: null
     })
+  }
+
+  mergeFacetOptions = (group: string) => {
+    const { facets } = this.props
+    const { activeFacets, currentFacetGroup } = this.state
+    const resultFacets = facets ? facets.get(group) : null
+
+    // add any selected facets not in results to the group
+    if (resultFacets && resultFacets.buckets) {
+      // $FlowFixMe: this is not undefined
+      activeFacets.get(group).map(facet => {
+        if (!_.find(resultFacets.buckets, { key: facet })) {
+          resultFacets.buckets.push({
+            key:       facet,
+            doc_count: 0
+          })
+        }
+      })
+    }
+
+    // if this is the currentFacetGroup, add any new facets in that group from search results
+    if (currentFacetGroup && currentFacetGroup.keys().next().value === group) {
+      const mergedFacetGroup = _.clone(currentFacetGroup).get(group)
+      if (mergedFacetGroup && resultFacets) {
+        resultFacets.buckets.map(facet => {
+          if (!_.find(mergedFacetGroup.buckets, { key: facet.key })) {
+            mergedFacetGroup.buckets.push(facet)
+          }
+        })
+      }
+      return mergedFacetGroup
+    }
+
+    return resultFacets
   }
 
   loadMore = async () => {
@@ -177,24 +212,37 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 
   toggleFacet = async (name: string, value: string, isEnabled: boolean) => {
-    const { activeFacets } = this.state
+    const { activeFacets, currentFacetGroup } = this.state
+    const { facets } = this.props
     const updatedFacets = new Map(activeFacets)
     if (isEnabled) {
       updatedFacets.set(name, _.union(activeFacets.get(name) || [], [value]))
     } else {
       updatedFacets.set(name, _.without(activeFacets.get(name) || [], value))
     }
-    this.setState({ activeFacets: updatedFacets })
+    // Retain the current facet options and counts for this facet group
+    const updatedFacetGroup =
+      currentFacetGroup && currentFacetGroup.get(name)
+        ? currentFacetGroup
+        : new Map([[name, facets.get(name)]])
+    this.setState({
+      activeFacets:      updatedFacets,
+      // $FlowFixMe: this isn't going to be undefined
+      currentFacetGroup: updatedFacetGroup
+    })
   }
 
   onUpdateFacets = (e: Object) => {
     this.toggleFacet(e.target.name, e.target.value, e.target.checked)
   }
 
-  updateText = (event: ?Event) => {
+  updateText = async (event: ?Event) => {
     // $FlowFixMe: event.target.value exists
     const text = event ? event.target.value : ""
-    this.setState({ text })
+    await this.setState({ text, currentFacetGroup: new Map() })
+    if (!text) {
+      this.runSearch()
+    }
   }
 
   renderResults = () => {
@@ -203,6 +251,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
     if (processing || !loaded) {
       return <PostLoading />
+    }
+
+    if (total === 0 && !processing && loaded) {
+      return (
+        <div className="empty-list-msg">There are no results to display.</div>
+      )
     }
 
     return (
@@ -224,7 +278,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 
   render() {
-    const { match, facets, total, loaded, processing } = this.props
+    const { match } = this.props
     const { text, error, activeFacets } = this.state
 
     return (
@@ -264,28 +318,21 @@ export class CourseSearchPage extends React.Component<Props, State> {
                 </div>
               ) : null}
             </div>
-            {total === 0 && !processing && loaded ? (
-              <div className="empty-list-msg">
-                There are no results to display.
-              </div>
-            ) : null}
           </Cell>
           <Cell width={4}>
-            {facets && total > 0 ? (
-              <Card>
-                {facetDisplayMap.map(([name, title, labelFunction], i) => (
-                  <SearchFacet
-                    key={i}
-                    title={title}
-                    name={name}
-                    results={facets.get(name)}
-                    onUpdate={this.onUpdateFacets}
-                    currentlySelected={activeFacets.get(name) || []}
-                    labelFunction={labelFunction}
-                  />
-                ))}
-              </Card>
-            ) : null}
+            <Card>
+              {facetDisplayMap.map(([name, title, labelFunction], i) => (
+                <SearchFacet
+                  key={i}
+                  title={title}
+                  name={name}
+                  results={this.mergeFacetOptions(name)}
+                  onUpdate={this.onUpdateFacets}
+                  currentlySelected={activeFacets.get(name) || []}
+                  labelFunction={labelFunction}
+                />
+              ))}
+            </Card>
           </Cell>
           <Cell width={8}>{error ? null : this.renderResults()}</Cell>
         </Grid>

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -103,11 +103,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const { clearSearch, loaded, processing } = this.props
+    const { clearSearch } = this.props
     clearSearch()
-    if (!loaded && !processing) {
-      this.runSearch()
-    }
+    this.runSearch()
   }
 
   componentDidUpdate(prevProps: Object, prevState: Object) {
@@ -212,23 +210,22 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { activeFacets, currentFacetGroup } = this.state
     const { facets } = this.props
     const updatedFacets = new Map(activeFacets)
+    const facetsGroup = facets.get(name) || { buckets: [] }
     if (isEnabled) {
       updatedFacets.set(name, _.union(activeFacets.get(name) || [], [value]))
     } else {
       updatedFacets.set(name, _.without(activeFacets.get(name) || [], value))
     }
-    // Retain the current facet options and counts for this facet group
-    const updatedFacetGroup =
-      currentFacetGroup && currentFacetGroup.group === name
-        ? currentFacetGroup
-        : {
-          group:  name,
-          result: facets.get(name)
-        }
     // $FlowFixMe: nothing undefined here
     this.setState({
       activeFacets:      updatedFacets,
-      currentFacetGroup: updatedFacetGroup
+      currentFacetGroup: {
+        group:  name,
+        result:
+          currentFacetGroup && currentFacetGroup.group === name
+            ? mergeFacetResults(currentFacetGroup.result, facetsGroup)
+            : facetsGroup
+      }
     })
   }
 

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -132,7 +132,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const resultFacets = facets ? facets.get(group) : null
 
     // add any selected facets not in results to the group
-    if (resultFacets && resultFacets.buckets) {
+    if (resultFacets && _.has(resultFacets, "buckets")) {
       // $FlowFixMe: this is not undefined
       activeFacets.get(group).map(facet => {
         if (!_.find(resultFacets.buckets, { key: facet })) {
@@ -147,7 +147,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     // if this is the currentFacetGroup, add any new facets in that group from search results
     if (currentFacetGroup && currentFacetGroup.keys().next().value === group) {
       const mergedFacetGroup = _.clone(currentFacetGroup).get(group)
-      if (mergedFacetGroup && resultFacets) {
+      if (mergedFacetGroup && resultFacets && _.has(resultFacets, "buckets")) {
         resultFacets.buckets.map(facet => {
           if (!_.find(mergedFacetGroup.buckets, { key: facet.key })) {
             mergedFacetGroup.buckets.push(facet)

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -7,7 +7,11 @@ import sinon from "sinon"
 import ConnectedCourseSearchPage, { CourseSearchPage } from "./CourseSearchPage"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { shouldIf } from "../lib/test_utils"
-import { makeCourseResult, makeSearchResponse } from "../factories/search"
+import {
+  makeCourseResult,
+  makeSearchFacetResult,
+  makeSearchResponse
+} from "../factories/search"
 import { makeChannel } from "../factories/channels"
 
 describe("CourseSearchPage", () => {
@@ -286,8 +290,9 @@ describe("CourseSearchPage", () => {
           availability: []
         })
       ),
-      from:  0,
-      error: null
+      currentFacetGroup: null,
+      from:              0,
+      error:             null
     })
   })
 
@@ -301,7 +306,7 @@ describe("CourseSearchPage", () => {
       .at(0)
       .props()
       .onUpdate({
-        target: { name: "topics", value: "Engineering", checked: true }
+        target: { name: "topics", value: "Physics", checked: true }
       })
     sinon.assert.calledWith(helper.searchStub, {
       channelName: null,
@@ -312,7 +317,7 @@ describe("CourseSearchPage", () => {
       facets:      new Map(
         Object.entries({
           platform:     ["ocw"],
-          topics:       ["Engineering"],
+          topics:       ["Physics"],
           availability: ["prior"]
         })
       )
@@ -320,20 +325,21 @@ describe("CourseSearchPage", () => {
     assert.deepEqual(qs.parse(helper.currentLocation.search), {
       type: "course",
       q:    text,
-      t:    "Engineering"
+      t:    "Physics"
     })
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
       text,
       activeFacets: new Map(
         Object.entries({
-          topics:       ["Engineering"],
+          topics:       ["Physics"],
           platform:     [],
           availability: []
         })
       ),
-      from:  0,
-      error: null
+      from:              0,
+      error:             null,
+      currentFacetGroup: new Map([["topics", makeSearchFacetResult().topics]])
     })
   })
 

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -340,7 +340,10 @@ describe("CourseSearchPage", () => {
       ),
       from:              0,
       error:             null,
-      currentFacetGroup: new Map([["topics", makeSearchFacetResult().topics]])
+      currentFacetGroup: {
+        group:  "topics",
+        result: makeSearchFacetResult().topics
+      }
     })
   })
 
@@ -416,9 +419,10 @@ describe("CourseSearchPage", () => {
 
   it("mergeFacetOptions adds any search facets not in current facet group", async () => {
     const { inner } = await renderPage()
-    const currentFacetGroup = new Map([
-      ["platform", { buckets: [{ key: "ocw", doc_count: 20 }] }]
-    ])
+    const currentFacetGroup = {
+      group:  "platform",
+      result: { buckets: [{ key: "ocw", doc_count: 20 }] }
+    }
     const missingFacetGroup = _.find(
       // $FlowFixMe: platform exists in aggregation result
       searchResponse.aggregations.platform.buckets,

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -92,6 +92,11 @@ export type FacetResult = {
   buckets:    Array<FacetBucket>
 }
 
+export type CurrentFacet = {
+  group: string,
+  result: FacetResult
+}
+
 export type Result = PostResult | CommentResult | ProfileResult | CourseResult
 
 export type SearchInputs = {

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -14,7 +14,8 @@ import type {
   CommentResult,
   ProfileResult,
   SearchParams,
-  CourseResult
+  CourseResult,
+  FacetResult
 } from "../flow/searchTypes"
 
 export const searchResultToComment = (
@@ -247,3 +248,9 @@ export const buildSearchQuery = ({
   }
   return builder.build()
 }
+
+export const mergeFacetResults = (...args: Array<FacetResult>) => ({
+  buckets: args
+    .map(R.prop("buckets"))
+    .reduce((buckets, acc) => R.unionWith(R.eqBy(R.prop("key")), buckets, acc))
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1917 
Fixes #1923

#### What's this PR do?
Adds a `currentFacetGroup` property to `CourseSearchPage` to track which group of facets was most recently changed and what facets are contained therein, along with a new `mergeFacetOptions` method to determine which facets should be sent to the `SearchFacet` component.

#### How should this be manually tested?
- Within the 'Availability' group, select "Starting Soon".  The other Availability facets should continue to display without changes in counts, but "OCW" should disappear from the "Platform" group.
- Select "Available Now" in the "Availability" group.  The other Availability facets should continue to display without changes in counts, and "OCW" should reappear in the "Platform" group.
- Choose both "OCW" and "MITx" in the "Platform" group.  Then unselect "Available Now" from "Availability".  "OCW" should continue to display but with a count of 0, because it is still a selected facet.
- Unselect "OCW" from Platform, it should continue to display.  Only "Starting Soon" should appear in "Availability".
- Unselect "Starting Soon".  4 facet choices should appear again for "Availability". 
- Unselect "MITX".  "OCW" should appear again for "Platform"
- Start typing in the text input field.  No new search should be performed until you click 'Enter' (#1923)

#### Screenshots (if appropriate)
![facets](https://user-images.githubusercontent.com/187676/54542442-28231d00-4972-11e9-9ef7-8ab17a4eb7a4.gif)

