### PR TITLE
add cover image to course index page

### DIFF
--- a/static/js/components/ChannelHeader.js
+++ b/static/js/components/ChannelHeader.js
@@ -10,6 +10,7 @@ import ChannelAvatar, {
 } from "../containers/ChannelAvatar"
 import ChannelSettingsLink from "../containers/ChannelSettingsLink"
 import ChannelFollowControls from "../containers/ChannelFollowControls"
+import { BannerPageHeader } from "../components/PageBanner"
 
 import { channelURL } from "../lib/url"
 
@@ -23,7 +24,7 @@ type Props = {|
 |}
 
 const ChannelHeader = ({ channel, history, isModerator, children }: Props) => (
-  <div className="channel-page-header">
+  <BannerPageHeader>
     <ChannelBanner editable={false} channel={channel} />
     <Grid className="main-content two-column channel-header">
       <Cell className="avatar-headline-row" width={12}>
@@ -51,7 +52,7 @@ const ChannelHeader = ({ channel, history, isModerator, children }: Props) => (
       </Cell>
     </Grid>
     {children}
-  </div>
+  </BannerPageHeader>
 )
 
 export default ChannelHeader

--- a/static/js/components/PageBanner.js
+++ b/static/js/components/PageBanner.js
@@ -1,0 +1,58 @@
+// @flow
+import React from "react"
+import styled from "styled-components"
+
+const bannerHeight = "200px"
+const channelBannerBg = "#20316d"
+
+export const BannerContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  z-index: -1;
+`
+
+const imageStylesheet = `
+  width: 100%;
+  display: block;
+  height: ${bannerHeight};
+`
+
+const StyledImage = styled.img`
+  ${imageStylesheet} object-fit: cover;
+`
+
+const PlaceholderDiv = styled.div`
+  ${imageStylesheet}
+  background-color: ${channelBannerBg};
+`
+
+type ImgProps = {
+  src: ?string,
+  alt?: string
+}
+
+export const BannerImage = ({ src, alt }: ImgProps) =>
+  src ? <StyledImage src={src} alt={alt || ""} /> : <PlaceholderDiv />
+
+export const BannerPageWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`
+
+export const BannerPageHeader = styled.div`
+  margin-bottom: 20px;
+  min-height: ${bannerHeight};
+`
+
+export const Gradient = styled.div`
+  background-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.19),
+    rgba(0, 0, 0, 0.5)
+  );
+  position: absolute;
+  height: ${bannerHeight};
+  width: 100%;
+  display: block;
+  top: 0;
+`

--- a/static/js/components/SearchTextbox.js
+++ b/static/js/components/SearchTextbox.js
@@ -3,11 +3,12 @@ import React from "react"
 import { validationMessage } from "../lib/validation"
 
 type Props = {
-  onChange: Function,
-  onClear: Function,
+  onChange?: Function,
+  onClear?: Function,
   onSubmit: Function,
-  value: string,
-  validation: ?string
+  value?: string,
+  validation?: ?string,
+  noFocusOnLoad?: boolean
 }
 
 export default class SearchTextbox extends React.Component<Props> {
@@ -25,7 +26,10 @@ export default class SearchTextbox extends React.Component<Props> {
   }
 
   componentDidMount() {
-    this.focus()
+    const { noFocusOnLoad } = this.props
+    if (!noFocusOnLoad) {
+      this.focus()
+    }
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -43,6 +47,8 @@ export default class SearchTextbox extends React.Component<Props> {
       onChange,
       value,
       validation,
+      // eslint-disable-next-line no-unused-vars
+      noFocusOnLoad, // have to pull this out here to avoid a console error
       ...extraProps
     } = this.props
     return (

--- a/static/js/components/admin/EditChannelAppearanceForm.js
+++ b/static/js/components/admin/EditChannelAppearanceForm.js
@@ -101,18 +101,20 @@ export default class EditChannelAppearanceForm extends React.Component<Props> {
             </label>
             {validationMessage(validation.public_description)}
           </div>
-          <ChannelBanner
-            channel={channel}
-            channelName={form.name}
-            editable={true}
-            name="banner"
-            onUpdate={onUpdate}
-            formImageUrl={
-              form.banner &&
-              form.banner.edit &&
-              URL.createObjectURL(form.banner.edit)
-            }
-          />
+          <div className="channel-banner-wrapper">
+            <ChannelBanner
+              channel={channel}
+              channelName={form.name}
+              editable={true}
+              name="banner"
+              onUpdate={onUpdate}
+              formImageUrl={
+                form.banner &&
+                form.banner.edit &&
+                URL.createObjectURL(form.banner.edit)
+              }
+            />
+          </div>
         </Card>
         <div className="row actions">
           <button

--- a/static/js/containers/ChannelBanner.js
+++ b/static/js/containers/ChannelBanner.js
@@ -6,6 +6,12 @@ import { bindActionCreators } from "redux"
 
 import ImageUploader, { makeDialogKey } from "./ImageUploader"
 
+import {
+  BannerContainer,
+  BannerImage,
+  Gradient
+} from "../components/PageBanner"
+
 import { showDialog } from "../actions/ui"
 
 import type { Dispatch } from "redux"
@@ -38,36 +44,29 @@ class ChannelBanner extends React.Component<Props> {
     const imageUrl = formImageUrl || channel.banner
 
     return (
-      <div className="banner-container row">
-        <div className="channel-banner">
-          {imageUrl ? (
-            <img
-              src={imageUrl}
-              alt={`Channel banner for ${channel.name}`}
-              className="banner-image"
+      <BannerContainer className="channel-banner">
+        <BannerImage
+          src={imageUrl}
+          alt={`Channel banner for ${channel.name}`}
+        />
+        <Gradient />
+        {editable ? (
+          <React.Fragment>
+            <ImageUploader
+              name={name}
+              showButton={false}
+              onUpdate={onUpdate}
+              isAdd={!imageUrl}
+              description="Channel Banner"
+              width={1150}
+              height={200}
             />
-          ) : (
-            <div className="banner-image default-image" />
-          )}
-          <div className="gradient" />
-          {editable ? (
-            <React.Fragment>
-              <ImageUploader
-                name={name}
-                showButton={false}
-                onUpdate={onUpdate}
-                isAdd={!imageUrl}
-                description="Channel Banner"
-                width={1150}
-                height={200}
-              />
-              <a onClick={showDialog} className="upload-banner grey-surround">
-                Upload cover image
-              </a>
-            </React.Fragment>
-          ) : null}
-        </div>
-      </div>
+            <a onClick={showDialog} className="upload-banner grey-surround">
+              Upload cover image
+            </a>
+          </React.Fragment>
+        ) : null}
+      </BannerContainer>
     )
   }
 }

--- a/static/js/containers/ChannelBanner_test.js
+++ b/static/js/containers/ChannelBanner_test.js
@@ -6,6 +6,7 @@ import sinon from "sinon"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import ChannelBanner from "./ChannelBanner"
 import * as uiActions from "../actions/ui"
+import { Gradient } from "../components/PageBanner"
 
 import { makeChannel } from "../factories/channels"
 
@@ -35,14 +36,10 @@ describe("ChannelBanner", () => {
       channel.banner = hasBanner ? "channel" : null
 
       const { inner } = await renderPage({}, { channel })
-      assert.ok(inner.find(".gradient").exists())
-      if (hasBanner) {
-        const img = inner.find("img")
-        assert.equal(img.props().src, channel.banner)
-        assert.equal(img.props().alt, `Channel banner for ${channel.name}`)
-      } else {
-        assert.ok(inner.find(".default-image").exists())
-      }
+      assert.ok(inner.find(Gradient).exists())
+      const image = inner.find("BannerImage")
+      assert.equal(image.props().src, channel.banner)
+      assert.equal(image.props().alt, `Channel banner for ${channel.name}`)
     })
   })
 

--- a/static/js/containers/ChannelRouter.js
+++ b/static/js/containers/ChannelRouter.js
@@ -13,6 +13,7 @@ import ChannelAboutPage from "./ChannelAboutPage"
 
 import ChannelHeader from "../components/ChannelHeader"
 import ChannelNavbar from "../components/ChannelNavbar"
+import { BannerPageWrapper } from "../components/PageBanner"
 
 import { actions } from "../actions"
 import { getChannelName } from "../lib/util"
@@ -79,7 +80,7 @@ class ChannelRouter extends React.Component<Props> {
     const { channel, match, history } = this.props
 
     return (
-      <div className="channel-page-wrapper">
+      <BannerPageWrapper>
         {channel ? (
           <ChannelHeader
             channel={channel}
@@ -124,7 +125,7 @@ class ChannelRouter extends React.Component<Props> {
             component={this.renderPostPage}
           />
         </Switch>
-      </div>
+      </BannerPageWrapper>
     )
   }
 }

--- a/static/js/containers/CourseIndexPage.js
+++ b/static/js/containers/CourseIndexPage.js
@@ -7,6 +7,15 @@ import { compose } from "redux"
 import CourseDrawer from "./CourseDrawer"
 
 import CourseCarousel from "../components/CourseCarousel"
+import {
+  BannerPageWrapper,
+  BannerPageHeader,
+  BannerContainer,
+  BannerImage,
+  Gradient
+} from "../components/PageBanner"
+import { Cell, Grid } from "../components/Grid"
+import SearchTextbox from "../components/SearchTextbox"
 
 import { setShowCourseDrawer } from "../actions/ui"
 import {
@@ -17,10 +26,13 @@ import {
   newCoursesRequest,
   newCoursesSelector
 } from "../lib/api/courses"
+import { toQueryString, COURSE_SEARCH_URL } from "../lib/url"
 
 import type { Course } from "../flow/discussionTypes"
 
-type OwnProps = {||}
+type OwnProps = {|
+  history: Object
+|}
 
 type StateProps = {|
   featuredCourses: Array<Course>,
@@ -44,12 +56,38 @@ export const CourseIndexPage = ({
   featuredCourses,
   newCourses,
   loaded,
-  setShowCourseDrawer
+  setShowCourseDrawer,
+  history
 }: Props) => (
-  <React.Fragment>
-    <div className="main-content one-column">
+  <BannerPageWrapper>
+    <BannerPageHeader>
+      <BannerContainer>
+        <BannerImage src={null} />
+        <Gradient />
+      </BannerContainer>
+      <Grid className="main-content two-column channel-header course-index-page">
+        <Cell width={12} className="avatar-headline-row">
+          <div className="course-search-greeting">
+            <div className="headline">MIT Online Learning</div>
+          </div>
+          <SearchTextbox
+            onSubmit={e => {
+              const { value } = e.target
+              const newLocation = `${COURSE_SEARCH_URL}${toQueryString({
+                q:    value,
+                type: "course"
+              })}`
+              history.push(newLocation)
+            }}
+            placeholder="Search Learning offerings"
+            noFocusOnLoad
+          />
+        </Cell>
+      </Grid>
+    </BannerPageHeader>
+    <Grid className="main-content one-column">
       {loaded ? (
-        <React.Fragment>
+        <Cell width={12}>
           {featuredCourses.length !== 0 ? (
             <CourseCarousel
               title="Featured Courses"
@@ -67,13 +105,13 @@ export const CourseIndexPage = ({
             courses={newCourses}
             setShowCourseDrawer={setShowCourseDrawer}
           />
-        </React.Fragment>
+        </Cell>
       ) : (
         "loading"
       )}
-    </div>
+    </Grid>
     <CourseDrawer />
-  </React.Fragment>
+  </BannerPageWrapper>
 )
 
 const mapStateToProps = (state: Object): StateProps => ({

--- a/static/js/containers/CourseIndexPage_test.js
+++ b/static/js/containers/CourseIndexPage_test.js
@@ -5,6 +5,11 @@ import sinon from "sinon"
 
 import CourseDrawer from "./CourseDrawer"
 import { CourseIndexPage } from "./CourseIndexPage"
+import {
+  BannerPageWrapper,
+  BannerPageHeader,
+  BannerContainer
+} from "../components/PageBanner"
 
 import { configureShallowRenderer } from "../lib/test_utils"
 import { makeCourse } from "../factories/courses"
@@ -77,5 +82,33 @@ describe("CourseIndexPage", () => {
       "Upcoming Courses",
       "New Courses"
     ])
+  })
+
+  it("should include a banner image", () => {
+    const wrapper = renderCourseIndexPage()
+    ;[BannerPageWrapper, BannerPageHeader, BannerContainer].forEach(
+      component => {
+        assert.ok(wrapper.find(component).exists())
+      }
+    )
+    const { src } = wrapper.find("BannerImage").props()
+    assert.equal(src, null)
+  })
+
+  it("should have a search textbox which redirects you", () => {
+    const pushStub = sandbox.stub()
+    const wrapper = renderCourseIndexPage({
+      history: {
+        push: pushStub
+      }
+    })
+    const searchBox = wrapper.find("SearchTextbox")
+    assert.equal(searchBox.prop("placeholder"), "Search Learning offerings")
+    assert.isTrue(searchBox.prop("noFocusOnLoad"))
+    searchBox.simulate("submit", { target: { value: "search term" } })
+    sinon.assert.calledWith(
+      pushStub,
+      "/courses/search?q=search%20term&type=course"
+    )
   })
 })

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -123,6 +123,6 @@ describe("EditChannelBasicPage", () => {
 
   it("has a channel header", async () => {
     const wrapper = await renderPage()
-    assert.isTrue(wrapper.find(".channel-page-header").exists())
+    assert.isTrue(wrapper.find("ChannelHeader").exists())
   })
 })

--- a/static/js/hoc/withChannelHeader.js
+++ b/static/js/hoc/withChannelHeader.js
@@ -3,6 +3,7 @@ import React from "react"
 import R from "ramda"
 
 import ChannelHeader from "../components/ChannelHeader"
+import { BannerPageWrapper } from "../components/PageBanner"
 
 const withChannelHeader = R.curry(
   (WrappedComponent: Class<React.Component<*, *>>) => {
@@ -13,7 +14,7 @@ const withChannelHeader = R.curry(
         const { channel, history } = this.props
 
         return (
-          <div className="channel-page-wrapper">
+          <BannerPageWrapper>
             {channel ? (
               <ChannelHeader
                 channel={channel}
@@ -22,7 +23,7 @@ const withChannelHeader = R.curry(
               />
             ) : null}
             <WrappedComponent {...this.props} />
-          </div>
+          </BannerPageWrapper>
         )
       }
     }

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -107,6 +107,7 @@ export const PRIVACY_POLICY_URL = "/privacy-statement"
 
 export const SITE_SEARCH_URL = "/search/"
 export const COURSE_URL = "/courses/"
+export const COURSE_SEARCH_URL = "/courses/search"
 
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`

--- a/static/scss/admin.scss
+++ b/static/scss/admin.scss
@@ -143,14 +143,20 @@
   }
 }
 
-.avatar-container,
-.banner-container {
-  .cropper-view-box {
-    border-radius: inherit;
+.channel-banner-wrapper {
+  position: relative;
+  height: 250px;
+
+  .channel-banner {
+    z-index: 0;
   }
 }
 
 .avatar-container {
+  .cropper-view-box {
+    border-radius: inherit;
+  }
+
   .upload-avatar {
     margin-left: 20px;
   }

--- a/static/scss/channel-banner.scss
+++ b/static/scss/channel-banner.scss
@@ -1,40 +1,28 @@
-.banner-container {
-  .channel-banner {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    position: relative;
+.channel-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  position: relative;
 
-    .gradient {
-      background-image: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0.19),
-        rgba(0, 0, 0, 0.5)
-      );
-      position: absolute;
-    }
+  .banner-image,
+  .default-image {
+    width: 100%;
+    display: block;
+    height: $channel-banner-height;
+  }
 
-    .banner-image,
-    .gradient,
-    .default-image {
-      width: 100%;
-      display: block;
-      height: $channel-banner-height;
-    }
+  .banner-image {
+    object-fit: cover;
+  }
 
-    .banner-image {
-      object-fit: cover;
-    }
+  .default-image {
+    background-color: $channel-banner-bg;
+  }
 
-    .default-image {
-      background-color: $channel-banner-bg;
-    }
-
-    .upload-banner {
-      margin-top: 20px;
-      width: fit-content;
-      font-size: 16px;
-      padding: 2px 15px;
-    }
+  .upload-banner {
+    margin-top: 20px;
+    width: fit-content;
+    font-size: 16px;
+    padding: 2px 15px;
   }
 }

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -65,21 +65,6 @@
   }
 }
 
-.channel-page-wrapper {
-  position: relative;
-  width: 100%;
-
-  .channel-page-header {
-    margin-bottom: 20px;
-
-    .banner-container {
-      position: absolute;
-      width: 100%;
-      z-index: -1;
-    }
-  }
-}
-
 .avatar-headline-row {
   height: $channel-banner-height;
   display: flex;

--- a/static/scss/course-index-page.scss
+++ b/static/scss/course-index-page.scss
@@ -1,0 +1,10 @@
+.course-index-page {
+  .course-search-greeting {
+    color: white;
+
+    .headline {
+      font-size: 22px;
+      font-weight: bold;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -62,6 +62,7 @@
 @import "course";
 @import "course-carousel";
 @import "new-course-widget";
+@import "course-index-page";
 
 body {
   font-family: $body-font;

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -1,5 +1,10 @@
 .search-textbox {
   position: relative;
+  min-width: 330px;
+
+  @include breakpoint(mobile) {
+    min-width: unset;
+  }
 
   input {
     padding: 3px 40px 2px 40px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1800 

#### What's this PR do?

this adds a cover image to the top of the course index page. for now it is just showing the fallback background color and gradient that we show on the channel page when the no channel cover image has been set.

#### How should this be manually tested?

To implement this I refactored the styling for the channel cover image into reusable components so we could share the implementation with the course index page. So check that the channel header looks good and is working correctly on all the pages where it is present (channel page, post page, channel settings, etc).

also check that it is display correctly on the course index page. nothing should be weird!

also the search box on the channel index page should work correctly. if you type in a query and hit enter it should redirect you over to the course search page, and show the results for the query you just typed in.


#### Screenshots (if appropriate)

![fjfjfjfjfjfj](https://user-images.githubusercontent.com/6207644/54761273-2c487800-4bc8-11e9-9b3d-d266becabee2.png)
