### PR TITLE
Addresses issue #1930

### DIFF
--- a/course_catalog/task_helpers.py
+++ b/course_catalog/task_helpers.py
@@ -61,6 +61,10 @@ def parse_mitx_json_data(course_data, force_overwrite=False):
 
     # Parse each course run individually
     for course_run in course_data.get("course_runs"):
+
+        if should_skip_course(course_run.get("title")):
+            continue
+
         course_run_key = course_run.get("key")
 
         # Get the last modified date from the course run
@@ -459,3 +463,27 @@ def get_course_availability(course):
         for run in course_runs:
             if run.get("key") == course.course_id:
                 return run.get("availability")
+
+
+def should_skip_course(course_title):
+    """
+    Returns True if '[delete]', 'delete ' (note the ending space character)
+    exists in a course's title or if the course title equals 'delete' for the
+    purpose of skipping the course
+
+    Args:
+        course_title (str): The course.title of the course
+
+    Returns:
+        bool
+
+    """
+    title = course_title.strip().lower()
+    if (
+        "[delete]" in title
+        or "(delete)" in title
+        or "delete " in title
+        or title == "delete"
+    ):
+        return True
+    return False

--- a/course_catalog/task_helpers_test.py
+++ b/course_catalog/task_helpers_test.py
@@ -19,6 +19,7 @@ from course_catalog.task_helpers import (
     safe_load_json,
     get_course_url,
     get_course_availability,
+    should_skip_course,
 )
 
 pytestmark = pytest.mark.django_db
@@ -344,3 +345,13 @@ def test_get_course_availability(mitx_valid_data):
         raw_json=mitx_valid_data, platform=PlatformType.mitx.value
     )
     assert get_course_availability(mitx_course_no_runs_json) is None
+
+
+def test_should_skip_course():
+    """ Tests should_skip_course returns as expected """
+    assert should_skip_course("DELETE")
+    assert should_skip_course("Delete")
+    assert should_skip_course("Delete ")
+    assert should_skip_course("Delete wrong institution")
+    assert should_skip_course("[DELETE]Management in Engineering II]")
+    assert should_skip_course("Introduction to Syntax") is False


### PR DESCRIPTION
#### Pre-Flight checklist
**As part of merging this PR, an manual action should be performed: 
Remove the Course instances for the six courses of interest as well as their Elasticsearch index objects. (alternatively, set their instance Course.published to False)**

#### What are the relevant tickets?
Closes #1930 

#### What's this PR do?
This PR prevent "deleted" Courses by being ingested again at the next data sync with a code change to course_catalog.task_helpers

#### How should this be manually tested?
To test, after the code change, we can perform a sync and see if the courses of interest get synced again.
