### PR TITLE
refresh post list after removing a post (from channel index page)

### DIFF
--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -188,6 +188,11 @@ const mapDispatchToProps = (
     )
     dispatch(setPostData(response.response.posts))
   },
+  clearPosts: async () => {
+    const { channelName } = ownProps
+
+    dispatch(actions.postsForChannel.clear(channelName))
+  },
   dispatch: dispatch
 })
 

--- a/static/js/hoc/withPostModeration.js
+++ b/static/js/hoc/withPostModeration.js
@@ -2,6 +2,7 @@
 /* global SETTINGS: false */
 import React from "react"
 import R from "ramda"
+import qs from "query-string"
 
 import ReportForm from "../components/ReportForm"
 import Dialog from "../components/Dialog"
@@ -64,13 +65,21 @@ export const withPostModeration = (
         dispatch,
         focusedPost,
         channelName,
-        shouldGetReports
+        shouldGetReports,
+        loadPosts,
+        clearPosts,
+        location: { search }
       } = this.props
       event.preventDefault()
 
       await removePost(dispatch, focusedPost)
       if (shouldGetReports) {
         await dispatch(actions.reports.get(channelName))
+      }
+
+      if (loadPosts && clearPosts) {
+        clearPosts()
+        await loadPosts(qs.parse(search))
       }
       this.hideRemoveDialog()
       dispatch(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1926 

#### What's this PR do?

this makes it so that after you click 'remove post' on a post in the channel index page the post listing will be cleared and then refreshed. this will make it so that the removed post goes away after you click, instead of the current behavior where it just sticks around forever.

#### How should this be manually tested?

go to a channel where you're a moderator and make a post. then remove the post from the post list (not from the post detail page). after you confirm that you want to remove the post, you should see the post list refresh, and the removed post should no longer be there.

it might be good to also confirm that you can reproduce the issue on `master`.