### PR TITLE
Added a redirect rule to handle traffic to the lemelsonx subdomain

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,5 +1,11 @@
 # This is the version used in development environments
 server {
+    server_name lemelsonx.mit.edu;
+    listen 8063;
+    return 301 https://open.mit.edu/c/lemelsoneducators;
+}
+
+server {
     listen 8063 default_server;
     root /src;
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -39,6 +39,12 @@ http {
     sendfile on;
 
     server {
+        server_name lemelsonx.mit.edu;
+        listen <%= ENV["PORT"] %>;
+        return 301 https://open.mit.edu/c/lemelsoneducators;
+    }
+
+    server {
         listen <%= ENV["PORT"] %> default_server;
         server_name _;
         root /app;


### PR DESCRIPTION
#### What are the relevant tickets?
This is from an email request

#### What's this PR do?
We need to be able to handle a redirect from the lemelsonx.mit.edu domain to a specific channel in open so this redirect will serve that purpose. We will update the DNS to be a cname of open.mit.edu so that anyone who goes to that endpoint will wind up where we want them to.

#### How should this be manually tested?
Use a Charles proxy to override the DNS for lemelsonx.mit.edu to point to the CI domain for open