### PR TITLE
Added redirect for handling themove.mit.edu

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -6,6 +6,12 @@ server {
 }
 
 server {
+    server_name themove.mit.edu;
+    listen 8063;
+    return 301 https://open.mit.edu/c/themove;
+}
+
+server {
     listen 8063 default_server;
     root /src;
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -45,6 +45,12 @@ http {
     }
 
     server {
+        server_name themove.mit.edu;
+        listen <%= ENV["PORT"] %>;
+        return 301 https://open.mit.edu/c/themove;
+    }
+
+    server {
         listen <%= ENV["PORT"] %> default_server;
         server_name _;
         root /app;


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds a redirect for themove.mit.edu to a discussions channel

#### How should this be manually tested?
Testing locally, add an `/etc/hosts` entry for the app that points themove.mit.edu at localhost