### PR TITLE
add sorting for the members page

### DIFF
--- a/profiles/api.py
+++ b/profiles/api.py
@@ -47,6 +47,31 @@ def get_channels(user):
     )
 
 
+def get_channel_join_dates(user):
+    """
+    Get the list of channels and the dates that the user joined them
+
+    Args:
+        user(django.contrib.auth.models.User): the user to retrieve channel names for
+
+    Returns:
+        set of (str: Channel names, datetime: when they joined)
+    """
+    names_and_dates = list(
+        user.channelsubscription_set.values_list("channel__name", "created_on")
+    ) + list(
+        ChannelGroupRole.objects.filter(group__in=user.groups.all()).values_list(
+            "channel__name", "created_on"
+        )
+    )
+
+    output = {}
+    for name, joined in names_and_dates:
+        if name not in output or joined < output[name]:
+            output[name] = joined
+    return [(k, v) for k, v in output.items()]
+
+
 def get_site_type_from_url(url):
     """
     Gets a site type (as defined in profiles.models) from the given URL

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -50,7 +50,13 @@ ENGLISH_TEXT_FIELD = {
 BASE_OBJECT_TYPE = {
     "object_type": {"type": "keyword"},
     "author_id": {"type": "keyword"},
-    "author_name": {"type": "text"},
+    "author_name": {
+        "type": "text",
+        "fields": {
+            "english": {"type": "text", "analyzer": "english"},
+            "raw": {"type": "keyword"},
+        },
+    },
     "author_avatar_small": {"type": "keyword"},
     "author_headline": ENGLISH_TEXT_FIELD,
 }
@@ -59,6 +65,10 @@ PROFILE_OBJECT_TYPE = {
     **BASE_OBJECT_TYPE,
     "author_bio": ENGLISH_TEXT_FIELD,
     "author_channel_membership": {"type": "keyword"},
+    "author_channel_join_data": {
+        "type": "nested",
+        "properties": {"name": {"type": "keyword"}, "joined": {"type": "date"}},
+    },
     "author_avatar_medium": {"type": "keyword"},
 }
 

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.models import Comment, Post
 from course_catalog.models import Course
-from profiles.api import get_channels
+from profiles.api import get_channels, get_channel_join_dates
 from profiles.models import Profile
 from profiles.utils import image_uri
 from search.api import gen_post_id, gen_comment_id, gen_profile_id, gen_course_id
@@ -95,7 +95,13 @@ class ESProfileSerializer(ESProxySerializer):
         return ProfileSerializer
 
     def postprocess_fields(self, discussions_obj, serialized_data):
-        return {"author_channel_membership": sorted(get_channels(discussions_obj.user))}
+        join_data = get_channel_join_dates(discussions_obj.user)
+        return {
+            "author_channel_membership": sorted(get_channels(discussions_obj.user)),
+            "author_channel_join_data": [
+                {"name": name, "joined": created_on} for name, created_on in join_data
+            ],
+        }
 
 
 class ESCourseSerializer(ESModelSerializer):

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -1,5 +1,6 @@
 """Tests for elasticsearch serializers"""
 # pylint: disable=redefined-outer-name,unused-argument
+from datetime import datetime
 import pytest
 
 from channels.constants import POST_TYPE, COMMENT_TYPE, LINK_TYPE_SELF
@@ -170,11 +171,12 @@ def test_es_comment_serializer(has_author):
 def test_es_profile_serializer(mocker, user):
     """
     Test that ESProfileSerializer correctly serializes a profile object
-
     """
     mocker.patch(
         "search.serializers.get_channels", return_value={"channel01", "channel02"}
     )
+    return_value = [("channel01", datetime.now()), ("channel02", datetime.now())]
+    mocker.patch("search.serializers.get_channel_join_dates", return_value=return_value)
     serialized = ESProfileSerializer().serialize(user.profile)
     assert serialized == {
         "object_type": PROFILE_TYPE,
@@ -185,6 +187,9 @@ def test_es_profile_serializer(mocker, user):
         "author_bio": user.profile.bio,
         "author_headline": user.profile.headline,
         "author_channel_membership": ["channel01", "channel02"],
+        "author_channel_join_data": [
+            {"name": name, "joined": created_on} for name, created_on in return_value
+        ],
     }
 
 

--- a/static/js/components/Picker.js
+++ b/static/js/components/Picker.js
@@ -8,7 +8,8 @@ import { DropDownArrow, DropUpArrow } from "./Arrow"
 import {
   VALID_POST_SORT_LABELS,
   VALID_COMMENT_SORT_LABELS,
-  VALID_SEARCH_FILTER_LABELS
+  VALID_SEARCH_FILTER_LABELS,
+  VALID_MEMBERS_SORT_LABELS
 } from "../lib/picker"
 
 type Props = {
@@ -71,3 +72,9 @@ export const SearchFilterPicker = Picker(
   "search-filter-picker"
 )
 SearchFilterPicker.displayName = "SearchFilterPicker"
+
+export const ChannelMembersSortPicker = Picker(
+  VALID_MEMBERS_SORT_LABELS,
+  "channel-member-sort-picker"
+)
+ChannelMembersSortPicker.displayName = "ChannelMembersSortPicker"

--- a/static/js/components/Picker_test.js
+++ b/static/js/components/Picker_test.js
@@ -3,12 +3,18 @@ import { assert } from "chai"
 import R from "ramda"
 import sinon from "sinon"
 
-import { PostSortPicker, CommentSortPicker, SearchFilterPicker } from "./Picker"
+import {
+  PostSortPicker,
+  CommentSortPicker,
+  SearchFilterPicker,
+  ChannelMembersSortPicker
+} from "./Picker"
 
 import {
   VALID_POST_SORT_LABELS,
   VALID_COMMENT_SORT_LABELS,
-  VALID_SEARCH_FILTER_LABELS
+  VALID_SEARCH_FILTER_LABELS,
+  VALID_MEMBERS_SORT_LABELS
 } from "../lib/picker"
 import { configureShallowRenderer } from "../lib/test_utils"
 
@@ -27,7 +33,8 @@ describe("Picker", () => {
     [
       [VALID_POST_SORT_LABELS, PostSortPicker],
       [VALID_COMMENT_SORT_LABELS, CommentSortPicker],
-      [VALID_SEARCH_FILTER_LABELS, SearchFilterPicker]
+      [VALID_SEARCH_FILTER_LABELS, SearchFilterPicker],
+      [VALID_MEMBERS_SORT_LABELS, ChannelMembersSortPicker]
     ].forEach(([labels, Component]) => {
       const wrapper = renderComponent(Component)()
       // $FlowFixMe
@@ -47,7 +54,8 @@ describe("Picker", () => {
     [
       [PostSortPicker, VALID_POST_SORT_LABELS],
       [CommentSortPicker, VALID_COMMENT_SORT_LABELS],
-      [SearchFilterPicker, VALID_SEARCH_FILTER_LABELS]
+      [SearchFilterPicker, VALID_SEARCH_FILTER_LABELS],
+      [ChannelMembersSortPicker, VALID_MEMBERS_SORT_LABELS]
     ].forEach(([Component, labels]) => {
       labels.forEach(([value, label]) => {
         const wrapper = renderComponent(Component)({ value })
@@ -60,7 +68,8 @@ describe("Picker", () => {
     [
       [PostSortPicker, VALID_POST_SORT_LABELS],
       [CommentSortPicker, VALID_COMMENT_SORT_LABELS],
-      [SearchFilterPicker, VALID_SEARCH_FILTER_LABELS]
+      [SearchFilterPicker, VALID_SEARCH_FILTER_LABELS],
+      [ChannelMembersSortPicker, VALID_MEMBERS_SORT_LABELS]
     ].forEach(([Component, labels]) => {
       labels.forEach(([type, label], idx) => {
         updateParamStub = sinon.stub()
@@ -76,24 +85,28 @@ describe("Picker", () => {
   })
 
   it("should open and close", () => {
-    [PostSortPicker, CommentSortPicker, SearchFilterPicker].forEach(
-      Component => {
-        const wrapper = renderComponent(Component)()
-        assert.isFalse(wrapper.find("Menu").props().open)
-        assert.isFalse(wrapper.state("menuOpen"))
-        wrapper.instance().toggleMenuOpen()
-        wrapper.update()
-        assert.isTrue(wrapper.find("Menu").props().open)
-        assert.isTrue(wrapper.state("menuOpen"))
-      }
-    )
+    [
+      PostSortPicker,
+      CommentSortPicker,
+      SearchFilterPicker,
+      ChannelMembersSortPicker
+    ].forEach(Component => {
+      const wrapper = renderComponent(Component)()
+      assert.isFalse(wrapper.find("Menu").props().open)
+      assert.isFalse(wrapper.state("menuOpen"))
+      wrapper.instance().toggleMenuOpen()
+      wrapper.update()
+      assert.isTrue(wrapper.find("Menu").props().open)
+      assert.isTrue(wrapper.state("menuOpen"))
+    })
   })
 
   it("sets the className", () => {
     [
       ["post-sort-picker", PostSortPicker],
       ["comment-sort-picker", CommentSortPicker],
-      ["search-filter-picker", SearchFilterPicker]
+      ["search-filter-picker", SearchFilterPicker],
+      ["channel-member-sort-picker", ChannelMembersSortPicker]
     ].forEach(([cssClass, Component]) => {
       const wrapper = renderComponent(Component)()
       assert.equal(wrapper.prop("className"), `picker ${cssClass}`)

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -105,11 +105,17 @@ export type SearchInputs = {
   incremental:      boolean
 }
 
+export type SortParam = {
+  field: string,
+  option: string | Object
+}
+
 export type SearchParams = {
-  type:             ?string,
-  text:             ?string,
-  from:             number,
-  size:             number,
-  channelName:      ?string,
-  facets?:           Map<string, Array<string>>
+  type:              ?string,
+  text:              ?string,
+  from:              number,
+  size:              number,
+  channelName:       ?string,
+  facets?:           Map<string, Array<string>>,
+  sort?:             SortParam,
 }

--- a/static/js/lib/picker.js
+++ b/static/js/lib/picker.js
@@ -55,6 +55,19 @@ export const VALID_SEARCH_FILTER_LABELS = [
   [SEARCH_FILTER_PROFILE, "Profile"]
 ]
 
+export const MEMBERS_SORT_AUTHOR_NAME = "author_name.raw"
+export const MEMBERS_SORT_JOIN_DATE = "author_channel_join_data.joined"
+
+export const VALID_MEMBERS_SORT_TYPES = [
+  MEMBERS_SORT_AUTHOR_NAME,
+  MEMBERS_SORT_JOIN_DATE
+]
+
+export const VALID_MEMBERS_SORT_LABELS = [
+  [MEMBERS_SORT_AUTHOR_NAME, "Name"],
+  [MEMBERS_SORT_JOIN_DATE, "New"]
+]
+
 const updatePickerParam = R.curry(
   (validPickerTypes, fieldName, props, value, e) => {
     const {

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -117,7 +117,7 @@ const COMMENT_QUERY_FIELDS = ["text.english"]
 const PROFILE_QUERY_FIELDS = [
   "author_headline.english",
   "author_bio.english",
-  "author_name"
+  "author_name.english"
 ]
 const COURSE_QUERY_FIELDS = [
   "title.english",
@@ -155,6 +155,7 @@ import { searchFields } from "./search"
 const POST_CHANNEL_FIELD = "channel_name"
 const COMMENT_CHANNEL_FIELD = "channel_name"
 const PROFILE_CHANNEL_FIELD = "author_channel_membership"
+
 const _channelField = (type: ?string) => {
   if (type === "post") {
     return POST_CHANNEL_FIELD
@@ -175,7 +176,8 @@ export const buildSearchQuery = ({
   channelName,
   from,
   size,
-  facets
+  facets,
+  sort
 }: SearchParams): Object => {
   let builder = bodybuilder()
 
@@ -185,6 +187,11 @@ export const buildSearchQuery = ({
   if (!R.isNil(size)) {
     builder = builder.size(size)
   }
+  if (sort !== undefined) {
+    const { field, option } = sort
+    builder.sort(field, option)
+  }
+
   const types = type ? [type] : ["comment", "post", "profile"]
   for (const type of types) {
     // One of the text fields must match
@@ -192,8 +199,9 @@ export const buildSearchQuery = ({
       ? {
         must: {
           multi_match: {
-            query:  text,
-            fields: searchFields(type)
+            query:     text,
+            fields:    searchFields(type),
+            fuzziness: "AUTO"
           }
         }
       }

--- a/static/scss/channel-member-page.scss
+++ b/static/scss/channel-member-page.scss
@@ -4,4 +4,14 @@
   .profile-search-result {
     margin: 0;
   }
+
+  .header-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 8px;
+
+    .picker-label {
+      margin-right: 5px;
+    }
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1941 

#### What's this PR do?

this adds sorting to the channel members page, currently it just lets you pick between sorting based on the members' names and when they joined the channel.

#### How should this be manually tested?

If you go to the channel member page you should see options for switching the sort. it should change it in a way that makes sense - so the people should be alphabetically sorted with the name option, and the people should be sorted so that the most recently added to the channel are at the top with the channel join date option.

You'll need to run the `recreate_index` command to put the new info into the index.


#### Screenshots (if appropriate)

![asdffffffffjfjfjfffasffdfa](https://user-images.githubusercontent.com/6207644/56389427-8bb19c00-61f7-11e9-95b5-e8dd78527d8a.png)
![asdffffffffjfjfjfffas](https://user-images.githubusercontent.com/6207644/56389428-8bb19c00-61f7-11e9-8b39-7a3e50371607.png)
![asdffffffffjfjfj](https://user-images.githubusercontent.com/6207644/56389429-8bb19c00-61f7-11e9-91bd-d4a145399f23.png)
![asdfffffff](https://user-images.githubusercontent.com/6207644/56389430-8bb19c00-61f7-11e9-8d4e-ab62ab40713f.png)

