### PR TITLE
hide 'manage widgets' button in settings dropdown on post page

### DIFF
--- a/static/js/containers/ChannelSettingsLink.js
+++ b/static/js/containers/ChannelSettingsLink.js
@@ -4,6 +4,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 import R from "ramda"
 import { connect } from "react-redux"
+import { Route } from "react-router-dom"
 
 import DropdownMenu from "../components/DropdownMenu"
 
@@ -50,19 +51,25 @@ export class ChannelSettingsLink extends React.Component<Props> {
           <i className="material-icons settings">settings</i>
         </a>
         {isOpen ? (
-          <DropdownMenu
-            closeMenu={hideDropdown}
-            className="settings-menu-dropdown"
-          >
-            <li>
-              <Link to={editChannelBasicURL(channel.name)}>
-                Channel settings
-              </Link>
-            </li>
-            <li>
-              <a onClick={this.startEdit}>Manage widgets</a>
-            </li>
-          </DropdownMenu>
+          <Route path={`${channelURL(channel.name)}/:postID/:postSlug?`}>
+            {({ match }) => (
+              <DropdownMenu
+                closeMenu={hideDropdown}
+                className="settings-menu-dropdown"
+              >
+                <li>
+                  <Link to={editChannelBasicURL(channel.name)}>
+                    Channel settings
+                  </Link>
+                </li>
+                {match ? null : (
+                  <li>
+                    <a onClick={this.startEdit}>Manage widgets</a>
+                  </li>
+                )}
+              </DropdownMenu>
+            )}
+          </Route>
         ) : null}
       </React.Fragment>
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1947

#### What's this PR do?

this hides the 'manage widgets' button in the moderator settings menu (from the little gear icon) when the user is on the post detail page (keeps it everywhere else).

#### How should this be manually tested?

If you're on the channel page or the channel settings page you should still see the 'manage widgets' button in the settings dropdown. on the post detail page it should be absent.