### PR TITLE
Added test for app.json validity

### DIFF
--- a/open_discussions/app_tests.py
+++ b/open_discussions/app_tests.py
@@ -1,0 +1,13 @@
+"""Application level tests"""
+import json
+
+
+def test_app_json_valid():
+    """Verify app.json is parsable and has some necessary keys"""
+    with open("app.json") as f:
+        config = json.load(f)
+
+    assert isinstance(config, dict)
+
+    for required_key in ["addons", "buildpacks", "env"]:
+        assert required_key in config


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds a test to ensure app.json is parsable and has certain keys, this will avoid a recurring issue where we don't catch this because heroku only executes it for new apps

#### How should this be manually tested?
Tests should pass