### PR TITLE
Zagaran/upload master json

### DIFF
--- a/course_catalog/management/commands/upload_all_master_json.py
+++ b/course_catalog/management/commands/upload_all_master_json.py
@@ -1,0 +1,29 @@
+"""Management command for uploading master json data for OCW courses"""
+from django.core.management import BaseCommand
+
+from course_catalog.tasks import upload_ocw_master_json
+from open_discussions.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Upload OCW master json"""
+
+    help = "Upload OCW master json"
+
+    def handle(self, *args, **options):
+        """Run Upload OCW master json"""
+        task = upload_ocw_master_json.delay()
+        self.stdout.write(
+            "Started celery task {task} to upload ocw master json files to s3".format(
+                task=task
+            )
+        )
+        self.stdout.write("Waiting on task...")
+        start = now_in_utc()
+        task.get()
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            "Finished uploading ocw master json files to s3, took {} seconds".format(
+                total_seconds
+            )
+        )

--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,7 @@ html5lib==0.999999999
 ipython
 markdown2
 newrelic
-ocw-data-parser==0.2.4
+ocw-data-parser==0.2.6
 Pillow==3.4.2
 psycopg2==2.7
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ lxml==4.1.1               # via xmlsec
 markdown2==2.3.7
 newrelic==4.2.0.100
 oauthlib==2.0.7           # via requests-oauthlib, social-auth-core
-ocw-data-parser==0.2.4
+ocw-data-parser==0.2.6
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==3.4.2


### PR DESCRIPTION
#### What are the relevant tickets?
#1972 

#### What's this PR do?
Updates requirements to use ocw-data-parser 0.2.6, and modifies course catalog to take advantage of the upload master json feature.

#### How should this be manually tested?
Use course catalog to process courses and then check that files with the name [uid]_master.json show up in the S3 bucket.
