### PR TITLE
refactor desktop drawer to collapse instead of hiding itself

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -18,6 +18,9 @@ export const setShowDrawerMobile = createAction<string, *>(
   SET_SHOW_DRAWER_MOBILE
 )
 
+export const SET_SHOW_DRAWER_HOVER = "SET_SHOW_DRAWER_HOVER"
+export const setShowDrawerHover = createAction<string, *>(SET_SHOW_DRAWER_HOVER)
+
 export const SET_SHOW_COURSE_DRAWER = "SET_SHOW_COURSE_DRAWER"
 export const setShowCourseDrawer = createAction<string, *>(
   SET_SHOW_COURSE_DRAWER

--- a/static/js/components/Navigation.js
+++ b/static/js/components/Navigation.js
@@ -4,11 +4,19 @@ import { Link } from "react-router-dom"
 
 import SubscriptionsList from "./SubscriptionsList"
 import LoginPopup from "./LoginPopup"
+import NavigationItem from "./NavigationItem"
 
 import { getChannelNameFromPathname, FRONTPAGE_URL } from "../lib/url"
 import { preventDefaultAndInvoke, userIsAnonymous } from "../lib/util"
 
 import type { Channel } from "../flow/discussionTypes"
+
+const ComposeButtonContents = () => (
+  <NavigationItem
+    badge={() => <i className="material-icons add">add</i>}
+    whenExpanded={() => <span className="title">Compose</span>}
+  />
+)
 
 type NavigationProps = {
   pathname: string,
@@ -52,13 +60,6 @@ class Navigation extends React.Component<NavigationProps, State> {
 
     let composeBtn
     if (showComposeLink) {
-      const composeBtnContents = (
-        <React.Fragment>
-          <i className="material-icons add">add</i>
-          <span className="title">Compose</span>
-        </React.Fragment>
-      )
-
       if (useLoginPopup) {
         composeBtn = (
           <a
@@ -66,13 +67,13 @@ class Navigation extends React.Component<NavigationProps, State> {
             onClick={preventDefaultAndInvoke(this.onTogglePopup)}
             className="new-post-link"
           >
-            {composeBtnContents}
+            <ComposeButtonContents />
           </a>
         )
       } else if (composeHref) {
         composeBtn = (
           <Link to={composeHref} className="new-post-link">
-            {composeBtnContents}
+            <ComposeButtonContents />
           </Link>
         )
       }
@@ -83,8 +84,10 @@ class Navigation extends React.Component<NavigationProps, State> {
         <div className="location-list">
           <div className={homeClassName}>
             <Link className="home-link" to={FRONTPAGE_URL}>
-              <i className="material-icons home">home</i>
-              <span className="title">Home</span>
+              <NavigationItem
+                badge={() => <i className="material-icons home">home</i>}
+                whenExpanded={() => <span className="title">Home</span>}
+              />
             </Link>
           </div>
         </div>

--- a/static/js/components/NavigationItem.js
+++ b/static/js/components/NavigationItem.js
@@ -1,0 +1,22 @@
+// @flow
+import React from "react"
+
+export const NavigationExpansion = React.createContext<boolean>(false)
+
+type Props = {
+  badge?: Function,
+  whenExpanded: Function
+}
+
+const NavigationItem = ({ badge, whenExpanded }: Props) => (
+  <NavigationExpansion.Consumer>
+    {expanded => (
+      <React.Fragment>
+        {badge ? badge() : null}
+        {expanded ? whenExpanded() : null}
+      </React.Fragment>
+    )}
+  </NavigationExpansion.Consumer>
+)
+
+export default NavigationItem

--- a/static/js/components/NavigationItem_test.js
+++ b/static/js/components/NavigationItem_test.js
@@ -1,0 +1,32 @@
+// @flow
+import React from "react"
+import { assert } from "chai"
+import { mount } from "enzyme"
+
+import NavigationItem, { NavigationExpansion } from "./NavigationItem"
+
+import { shouldIf } from "../lib/test_utils"
+
+describe("NavigationItem", () => {
+  const badge = () => <div className="badge" />
+  const whenExpanded = () => <div className="whenExpanded" />
+
+  const renderNavigationItem = (expanded = true) =>
+    mount(
+      <NavigationExpansion.Provider value={expanded}>
+        <NavigationItem badge={badge} whenExpanded={whenExpanded} />
+      </NavigationExpansion.Provider>
+    )
+
+  //
+  ;[true, false].forEach(expanded => {
+    it(`should render badge and ${shouldIf(
+      expanded
+    )} render whenExpended when expanded == ${String(expanded)}`, () => {
+      const wrapper = renderNavigationItem(expanded)
+
+      assert.ok(wrapper.find(".badge").exists())
+      assert.equal(expanded, wrapper.find(".whenExpanded").exists())
+    })
+  })
+})

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -3,7 +3,10 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 import ChannelAvatar from "../containers/ChannelAvatar"
+import NavigationItem from "./NavigationItem"
+
 import { channelURL } from "../lib/url"
+
 import type { Channel } from "../flow/discussionTypes"
 
 type Props = {
@@ -24,8 +27,10 @@ export default class SubscriptionsList extends React.Component<Props> {
         key={channel.name}
       >
         <Link to={channelURL(channel.name)} className="channel-link">
-          <ChannelAvatar channel={channel} imageSize="small" />
-          <span className="title">{channel.title}</span>
+          <NavigationItem
+            badge={() => <ChannelAvatar channel={channel} imageSize="small" />}
+            whenExpanded={() => <span className="title">{channel.title}</span>}
+          />
         </Link>
       </div>
     )
@@ -45,13 +50,19 @@ export default class SubscriptionsList extends React.Component<Props> {
       <div className="location-list subscribed-channels">
         {myChannels.length > 0 ? (
           <div className="my-channels">
-            <div className="heading">Channels you moderate</div>
+            <NavigationItem
+              whenExpanded={() => (
+                <div className="heading">Channels you moderate</div>
+              )}
+            />
             {myChannels.map(this.makeChannelLink)}
           </div>
         ) : null}
         {otherChannels.length > 0 ? (
           <div className="channels">
-            <div className="heading">Channels</div>
+            <NavigationItem
+              whenExpanded={() => <div className="heading">Channels</div>}
+            />
             {otherChannels.map(this.makeChannelLink)}
           </div>
         ) : null}

--- a/static/js/components/SubscriptionsList_test.js
+++ b/static/js/components/SubscriptionsList_test.js
@@ -3,6 +3,7 @@ import { assert } from "chai"
 
 import SubscriptionsList from "./SubscriptionsList"
 
+import NavigationItem from "./NavigationItem"
 import { channelURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 import { configureShallowRenderer } from "../lib/test_utils"
@@ -26,7 +27,6 @@ describe("SubscriptionsList", function() {
 
   it("should show each channel", () => {
     const wrapper = renderSubscriptionsList()
-
     assert.equal(wrapper.find(".channel-link").length, channels.length)
     assert.equal(
       wrapper.find(".my-channels .channel-link").length,
@@ -38,21 +38,17 @@ describe("SubscriptionsList", function() {
     )
 
     wrapper.find(".my-channels .channel-link").forEach((link, index) => {
-      assert.equal(link.find(".title").text(), myChannels[index].title)
       assert.equal(link.props().to, channelURL(myChannels[index].name))
-      assert.deepEqual(
-        link.find("Connect(ChannelAvatar)").props().channel,
-        myChannels[index]
-      )
+      const { badge, whenExpanded } = link.find(NavigationItem).props()
+      assert.equal(whenExpanded().props.children, myChannels[index].title)
+      assert.deepEqual(badge().props.channel, myChannels[index])
     })
 
     wrapper.find(".channels .channel-link").forEach((link, index) => {
-      assert.equal(link.find(".title").text(), notMyChannels[index].title)
       assert.equal(link.props().to, channelURL(notMyChannels[index].name))
-      assert.deepEqual(
-        link.find("Connect(ChannelAvatar)").props().channel,
-        notMyChannels[index]
-      )
+      const { badge, whenExpanded } = link.find(NavigationItem).props()
+      assert.equal(whenExpanded().props.children, notMyChannels[index].title)
+      assert.deepEqual(badge().props.channel, notMyChannels[index])
     })
   })
 
@@ -61,7 +57,6 @@ describe("SubscriptionsList", function() {
     const currentLocation = wrapper.find(".current-location")
     assert.lengthOf(currentLocation, 1)
     assert.equal(currentLocation.props().className, "location current-location")
-    assert.equal(currentLocation.find(".title").text(), channels[0].title)
     assert.equal(
       currentLocation
         .find(".channel-link")

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -4,6 +4,7 @@ import R from "ramda"
 import {
   SET_SHOW_DRAWER_DESKTOP,
   SET_SHOW_DRAWER_MOBILE,
+  SET_SHOW_DRAWER_HOVER,
   SET_SNACKBAR_MESSAGE,
   SET_BANNER_MESSAGE,
   HIDE_BANNER,
@@ -39,6 +40,7 @@ export type CourseDetailState = {
 export type UIState = {
   showDrawerDesktop: boolean,
   showDrawerMobile: boolean,
+  showDrawerHover: boolean,
   courseDetail?: CourseDetailState,
   snackbar: ?SnackbarState,
   banner: BannerState,
@@ -58,8 +60,9 @@ const INITIAL_COURSE_STATE = {
 }
 
 export const INITIAL_UI_STATE: UIState = {
-  showDrawerDesktop: true,
+  showDrawerDesktop: false,
   showDrawerMobile:  false,
+  showDrawerHover:   false,
   courseDetail:      INITIAL_COURSE_STATE,
   snackbar:          null,
   banner:            INITIAL_BANNER_STATE,
@@ -123,6 +126,8 @@ export const ui = (
     return { ...state, showDrawerDesktop: action.payload }
   case SET_SHOW_DRAWER_MOBILE:
     return { ...state, showDrawerMobile: action.payload }
+  case SET_SHOW_DRAWER_HOVER:
+    return { ...state, showDrawerHover: action.payload }
   case SET_SHOW_COURSE_DRAWER:
     return {
       ...state,

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -6,6 +6,7 @@ import { INITIAL_UI_STATE } from "./ui"
 import {
   SET_SHOW_DRAWER_DESKTOP,
   SET_SHOW_DRAWER_MOBILE,
+  SET_SHOW_DRAWER_HOVER,
   SET_SNACKBAR_MESSAGE,
   SHOW_DIALOG,
   HIDE_DIALOG,
@@ -16,6 +17,7 @@ import {
   HIDE_BANNER,
   setShowDrawerDesktop,
   setShowDrawerMobile,
+  setShowDrawerHover,
   setSnackbarMessage,
   showDialog,
   hideDialog,
@@ -68,6 +70,17 @@ describe("ui reducer", () => {
       SET_SHOW_DRAWER_MOBILE
     ])
     assert.isFalse(state.showDrawerMobile)
+  })
+
+  it("should let you toggle desktop drawer hover state", async () => {
+    let state = await dispatchThen(setShowDrawerHover(true), [
+      SET_SHOW_DRAWER_HOVER
+    ])
+    assert.isTrue(state.showDrawerHover)
+    state = await dispatchThen(setShowDrawerHover(false), [
+      SET_SHOW_DRAWER_HOVER
+    ])
+    assert.isFalse(state.showDrawerHover)
   })
 
   it("should set snackbar message", async () => {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -33,6 +33,7 @@ $toolbar-height-desktop: 60px;
 $toolbar-height-mobile: 60px;
 $toolbar-vert-padding: 8px;
 $drawer-width: 300px;
+$collapse-drawer-width: 65px;
 $std-border-radius: 3px;
 $message-component-bg-color: #323232;
 $banner-height: 60px;

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -10,18 +10,28 @@ $footer-height: 152px;
   z-index: 45;
 }
 
+.persistent-drawer-open {
+  .mdc-drawer.mdc-drawer--persistent {
+    width: $drawer-width;
+
+    .mdc-drawer__drawer {
+      width: $drawer-width;
+    }
+  }
+}
+
 .mdc-drawer.mdc-drawer--persistent {
   position: fixed;
   left: 0;
   height: calc(100vh - #{$toolbar-height-desktop});
   top: $toolbar-height-desktop;
-  width: $drawer-width;
+  width: $collapse-drawer-width;
 
   .mdc-drawer__drawer {
     position: absolute;
     top: 0px;
     left: 0px;
-    width: $drawer-width;
+    width: $collapse-drawer-width;
 
     .scrollbar-container {
       display: none;
@@ -71,11 +81,15 @@ $footer-height: 152px;
       color: $red-link-color;
       display: inline-flex;
       align-items: center;
-      padding: 5px 20px 5px 5px;
+      padding: 5px 5px 5px 5px;
       margin-left: 13px;
       border: 1px solid $red-link-color;
       border-radius: 30px;
       height: 26px;
+
+      .title {
+        padding-right: 15px;
+      }
     }
   }
 

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -85,6 +85,10 @@ body {
     padding-left: $drawer-width;
   }
 
+  .persistent-drawer-closed ~ .content {
+    padding-left: $collapse-drawer-width;
+  }
+
   .banner--active ~ .content {
     padding-top: $toolbar-height-desktop + $banner-height;
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1952

#### What's this PR do?

this PR changes the desktop drawer UI to match what is in the mockups (see the linked issue for details). basically currently, when you're on desktop the drawer hides and shows itself by sliding off to the left, this changes things so that instead it's 'hidden' form is like a compact version of itself.

I also changed it so that the drawer defaults to it's closed state on desktop, so the drawer doesn't take up quite so much space by default. 

#### How should this be manually tested?

I think just click around and make sure it works well. In particular you should verify the following:

- on the desktop the drawer should expand out to be wider when you hover your mouse over it and then contract again when you mouse out of it
- on the desktop if you click the hamburger button the drawer should open and then stay open until you click the hamburger again
- whether the drawer is open or closed the main content on the page should resize in a way that makes sense and doesn't get squished or anything like that
- the content we show in the drawer should either go away in the small version or shrink down in a way that makes sense
- the mobile drawer should be unchanged and should behave as usual

#### Screenshots (if appropriate)

![fjfjasdjuuuopen](https://user-images.githubusercontent.com/6207644/56757878-4b0bd280-6763-11e9-8561-fb0fdfbbaee8.png)
![fjfjasdjuuu](https://user-images.githubusercontent.com/6207644/56757880-4b0bd280-6763-11e9-82df-ee1940f5c754.png)
![emptttttyffjfjfj](https://user-images.githubusercontent.com/6207644/56758358-6deab680-6764-11e9-849f-68333444d17a.png)
![empttttty](https://user-images.githubusercontent.com/6207644/56758359-6deab680-6764-11e9-9618-e77bafc096e9.png)
