### PR TITLE
add professional programs data

### DIFF
--- a/course_catalog/data/professional_programs.json
+++ b/course_catalog/data/professional_programs.json
@@ -1,0 +1,77 @@
+[{
+		"id": "SysEngx",
+		"program_name": "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+		"program_url": "",
+		"course_keys": [
+			"course-v1:MITProfessionalX+SysEngx1+1T2017",
+			"course-v1:MITProfessionalX+SysEngx1+3T2016",
+			"course-v1:MITProfessionalX+SysEngx2+1T2017",
+			"course-v1:MITProfessionalX+SysEngx2+3T2016",
+			"course-v1:MITProfessionalX+SysEngx3+1T2017",
+			"course-v1:MITProfessionalX+SysEngx3+3T2016",
+			"course-v1:MITProfessionalX+SysEngx4+1T2017",
+			"course-v1:MITProfessionalX+SysEngx4+3T2016",
+			"course-v1:MITProfessionalX+SysEngxB1+1T2017",
+			"course-v1:MITProfessionalX+SysEngxB1+3T2016",
+			"course-v1:MITProfessionalX+SysEngxB2+1T2017",
+			"course-v1:MITProfessionalX+SysEngxB2+3T2016",
+			"course-v1:MITProfessionalX+SysEngxB3+1T2017",
+			"course-v1:MITProfessionalX+SysEngxB3+3T2016",
+			"course-v1:MITProfessionalX+SysEngxB4+1T2017",
+			"course-v1:MITProfessionalX+SysEngxB4+3T2016",
+			"course-v1:MITxPRO+SysEngx+1T2019",
+			"course-v1:MITxPRO+SysEngx1+1T2018",
+			"course-v1:MITxPRO+SysEngx1+1T2019",
+			"course-v1:MITxPRO+SysEngx1+3T2017",
+			"course-v1:MITxPRO+SysEngx2+1T2018",
+			"course-v1:MITxPRO+SysEngx2+1T2019",
+			"course-v1:MITxPRO+SysEngx2+3T2017",
+			"course-v1:MITxPRO+SysEngx3+1T2018",
+			"course-v1:MITxPRO+SysEngx3+1T2019",
+			"course-v1:MITxPRO+SysEngx3+3T2017",
+			"course-v1:MITxPRO+SysEngx3+3T2018",
+			"course-v1:MITxPRO+SysEngx4+1T2018",
+			"course-v1:MITxPRO+SysEngx4+1T2019",
+			"course-v1:MITxPRO+SysEngx4+3T2017",
+			"course-v1:MITxPRO+SysEngx4+3T2018",
+			"course-v1:MITxPRO+SysEngxB1+1T2018",
+			"course-v1:MITxPRO+SysEngxB1+3T2017",
+			"course-v1:MITxPRO+SysEngxB2+1T2018",
+			"course-v1:MITxPRO+SysEngxB2+3T2017",
+			"course-v1:MITxPRO+SysEngxB3+1T2018",
+			"course-v1:MITxPRO+SysEngxB3+3T2017",
+			"course-v1:MITxPRO+SysEngxB4+1T2018",
+			"course-v1:MITxPRO+SysEngxB4+3T2017"
+		]
+	},
+	{
+		"id": "AMx",
+		"program_name": "Additive Manufacturing for Innovative Design and Production",
+		"program_url": "",
+		"course_keys": [
+			"course-v1:MITxPRO+AMx+1T2018",
+			"course-v1:MITxPRO+AMx+1T2019",
+			"course-v1:MITxPRO+AMxB+1T2018"
+		]
+	}, {
+		"id": "QCx",
+		"program_name": "Quantum Computing Fundamentals Online Program",
+		"program_url": "",
+		"course_keys": [
+			"course-v1:MITxPRO+QCx1+1T2019",
+			"course-v1:MITxPRO+QCx1+2T2017",
+			"course-v1:MITxPRO+QCx1+2T2018",
+			"course-v1:MITxPRO+QCx1B+2T2018",
+			"course-v1:MITxPRO+QCx2+1T2019",
+			"course-v1:MITxPRO+QCx2+2T2017",
+			"course-v1:MITxPRO+QCx2+2T2018",
+			"course-v1:MITxPRO+QCx2B+2T2018",
+			"course-v1:MITxPRO+QCx3+1T2019",
+			"course-v1:MITxPRO+QCx3+2T2017",
+			"course-v1:MITxPRO+QCx3+2T2018",
+			"course-v1:MITxPRO+QCx4+1T2019",
+			"course-v1:MITxPRO+QCx4+2T2017",
+			"course-v1:MITxPRO+QCx4+2T2018"
+		]
+	}
+]

--- a/course_catalog/data/professional_programs.json
+++ b/course_catalog/data/professional_programs.json
@@ -1,378 +1,413 @@
 [
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx1+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx1+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx2+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx2+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx3+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx3+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx4+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngx4+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB1+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB1+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB2+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB2+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB3+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB3+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB4+1T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB4+3T2016",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx1+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx1+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx1+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx2+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx2+3T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx2+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx2+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx3+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx3+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx3+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx3+3T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx4+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx4+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx4+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngx4+3T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB1+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB1+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB2+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB2+1T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB2+3T2018",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB2+1T2019",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITProfessionalX+SysEngxB2+3T2017",
     "program_key": "SysEngx",
     "program_title":
       "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "MITProfessionalX+SysEngxB2+3T2018",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB3+1T2018",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB3+3T2017",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB4+1T2018",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITxPRO+SysEngxB4+3T2017",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITxPRO+AMx+1T2018",
     "program_key": "AMx",
     "program_title":
       "Additive Manufacturing for Innovative Design and Production",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+AMx+1T2019",
     "program_key": "AMx",
     "program_title":
       "Additive Manufacturing for Innovative Design and Production",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+AMxB+1T2018",
     "program_key": "AMx",
     "program_title":
       "Additive Manufacturing for Innovative Design and Production",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx1+1T2019",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx1+2T2017",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx1+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx1B+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx2+1T2019",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx2+2T2017",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx2+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx2B+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx3+1T2019",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx3+2T2017",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx3+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx4+1T2019",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx4+2T2017",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""
   },
   {
-    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "edx_course_key": "course-v1:MITxPRO+QCx4+2T2018",
     "program_key": "QCx",
     "program_title": "Quantum Computing Fundamentals Online Program",
     "program_url": ""

--- a/course_catalog/data/professional_programs.json
+++ b/course_catalog/data/professional_programs.json
@@ -1,77 +1,380 @@
-[{
-		"id": "SysEngx",
-		"program_name": "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
-		"program_url": "",
-		"course_keys": [
-			"course-v1:MITProfessionalX+SysEngx1+1T2017",
-			"course-v1:MITProfessionalX+SysEngx1+3T2016",
-			"course-v1:MITProfessionalX+SysEngx2+1T2017",
-			"course-v1:MITProfessionalX+SysEngx2+3T2016",
-			"course-v1:MITProfessionalX+SysEngx3+1T2017",
-			"course-v1:MITProfessionalX+SysEngx3+3T2016",
-			"course-v1:MITProfessionalX+SysEngx4+1T2017",
-			"course-v1:MITProfessionalX+SysEngx4+3T2016",
-			"course-v1:MITProfessionalX+SysEngxB1+1T2017",
-			"course-v1:MITProfessionalX+SysEngxB1+3T2016",
-			"course-v1:MITProfessionalX+SysEngxB2+1T2017",
-			"course-v1:MITProfessionalX+SysEngxB2+3T2016",
-			"course-v1:MITProfessionalX+SysEngxB3+1T2017",
-			"course-v1:MITProfessionalX+SysEngxB3+3T2016",
-			"course-v1:MITProfessionalX+SysEngxB4+1T2017",
-			"course-v1:MITProfessionalX+SysEngxB4+3T2016",
-			"course-v1:MITxPRO+SysEngx+1T2019",
-			"course-v1:MITxPRO+SysEngx1+1T2018",
-			"course-v1:MITxPRO+SysEngx1+1T2019",
-			"course-v1:MITxPRO+SysEngx1+3T2017",
-			"course-v1:MITxPRO+SysEngx2+1T2018",
-			"course-v1:MITxPRO+SysEngx2+1T2019",
-			"course-v1:MITxPRO+SysEngx2+3T2017",
-			"course-v1:MITxPRO+SysEngx3+1T2018",
-			"course-v1:MITxPRO+SysEngx3+1T2019",
-			"course-v1:MITxPRO+SysEngx3+3T2017",
-			"course-v1:MITxPRO+SysEngx3+3T2018",
-			"course-v1:MITxPRO+SysEngx4+1T2018",
-			"course-v1:MITxPRO+SysEngx4+1T2019",
-			"course-v1:MITxPRO+SysEngx4+3T2017",
-			"course-v1:MITxPRO+SysEngx4+3T2018",
-			"course-v1:MITxPRO+SysEngxB1+1T2018",
-			"course-v1:MITxPRO+SysEngxB1+3T2017",
-			"course-v1:MITxPRO+SysEngxB2+1T2018",
-			"course-v1:MITxPRO+SysEngxB2+3T2017",
-			"course-v1:MITxPRO+SysEngxB3+1T2018",
-			"course-v1:MITxPRO+SysEngxB3+3T2017",
-			"course-v1:MITxPRO+SysEngxB4+1T2018",
-			"course-v1:MITxPRO+SysEngxB4+3T2017"
-		]
-	},
-	{
-		"id": "AMx",
-		"program_name": "Additive Manufacturing for Innovative Design and Production",
-		"program_url": "",
-		"course_keys": [
-			"course-v1:MITxPRO+AMx+1T2018",
-			"course-v1:MITxPRO+AMx+1T2019",
-			"course-v1:MITxPRO+AMxB+1T2018"
-		]
-	}, {
-		"id": "QCx",
-		"program_name": "Quantum Computing Fundamentals Online Program",
-		"program_url": "",
-		"course_keys": [
-			"course-v1:MITxPRO+QCx1+1T2019",
-			"course-v1:MITxPRO+QCx1+2T2017",
-			"course-v1:MITxPRO+QCx1+2T2018",
-			"course-v1:MITxPRO+QCx1B+2T2018",
-			"course-v1:MITxPRO+QCx2+1T2019",
-			"course-v1:MITxPRO+QCx2+2T2017",
-			"course-v1:MITxPRO+QCx2+2T2018",
-			"course-v1:MITxPRO+QCx2B+2T2018",
-			"course-v1:MITxPRO+QCx3+1T2019",
-			"course-v1:MITxPRO+QCx3+2T2017",
-			"course-v1:MITxPRO+QCx3+2T2018",
-			"course-v1:MITxPRO+QCx4+1T2019",
-			"course-v1:MITxPRO+QCx4+2T2017",
-			"course-v1:MITxPRO+QCx4+2T2018"
-		]
-	}
+[
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "SysEngx",
+    "program_title":
+      "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "AMx",
+    "program_title":
+      "Additive Manufacturing for Innovative Design and Production",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "AMx",
+    "program_title":
+      "Additive Manufacturing for Innovative Design and Production",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "AMx",
+    "program_title":
+      "Additive Manufacturing for Innovative Design and Production",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  },
+  {
+    "edx_course_key": "course-v1:MITx+Analog+Learning+100+Aug_2015",
+    "program_key": "QCx",
+    "program_title": "Quantum Computing Fundamentals Online Program",
+    "program_url": ""
+  }
 ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #1979 professional ed metadata

#### What's this PR do?

Adds an occasionally-updated json file that maps course keys to program metadata. This is used to augment course metadata when it's imported from the edX course catalog API .

#### How should this be manually tested?

For now, this is just for an eyeball-review of the data structure. Presumably there will be additional PRs with code and tests that use this data. 

#### Any background context you want to provide?

See https://docs.google.com/document/d/1UtVeoeXaWfv887t_ZoTcDRhzwZRguZD6sn8ltQELP4M/edit?ts=5cbde991#heading=h.235cvdpv81v4

