### PR TITLE
Fix RSS widgets for invalid urls and add admin ui for them

### DIFF
--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -81,6 +81,7 @@ INSTALLED_APPS = (
     "hijack",
     "hijack_admin",
     "guardian",
+    "django_json_widget",
     # Put our apps after this point
     "open_discussions",
     "authentication",

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ django-anymail[mailgun]==3.*
 django-compat==1.0.15
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
+django-json-widget==0.2.0
 djangorestframework==3.9.0
 djangorestframework-jwt==1.11.0
 djoser

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ django-cors-headers==2.1.0
 django-guardian==1.4.9
 django-hijack-admin==2.1.10
 django-hijack==2.1.10
+django-json-widget==0.2.0
 django-redis==4.7.0
 django-server-status==0.5.0
 django-storages==1.6.6

--- a/widgets/admin.py
+++ b/widgets/admin.py
@@ -1,0 +1,39 @@
+"""Widget admin interface"""
+from django import forms
+from django.contrib import admin
+
+from django_json_widget.widgets import JSONEditorWidget
+
+from widgets.models import WidgetList, WidgetInstance
+from widgets.serializers.utils import get_widget_type_names
+
+
+class WidgetInstanceForm(forms.ModelForm):
+    """Custom admin form for WidgetInstances"""
+
+    class Meta:
+        model = WidgetInstance
+        fields = ("title", "widget_type", "position", "configuration")
+        widgets = {
+            "widget_type": forms.Select(
+                choices=[(name, name) for name in get_widget_type_names()]
+            ),
+            "configuration": JSONEditorWidget(),
+        }
+
+
+class WidgetInstanceInline(admin.StackedInline):
+    """Inline admin interface for instances"""
+
+    model = WidgetInstance
+    form = WidgetInstanceForm
+    extra = 0
+
+
+@admin.register(WidgetList)
+class WidgetListAdmin(admin.ModelAdmin):
+    """WidgetList admin form"""
+
+    model = WidgetList
+
+    inlines = [WidgetInstanceInline]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1982 

#### What's this PR do?
- Fixes the RSS widget so it doesn't cause the entire API to fail if an invalid RSS url is input or the url becomes invalid after a successful save.
- Adds `WidgetList`and friends to django admin

#### How should this be manually tested?

- Verify django admin works within reason (`position` needs to be maintained manually and there is no validation of the configuration)
- Verify that if you enter an invalid url (through django admin) that the widget list returns, but with an empty list.