### PR TITLE
Improved resilience and sending speed of frontpage notifications

### DIFF
--- a/app.json
+++ b/app.json
@@ -224,6 +224,18 @@
       "description": "Maximum depth of a comment",
       "required": false
     },
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_RATE_LIMIT": {
+      "description": "The per-worker rate limit at which to generate pending EmailNotification frontpage records",
+      "required": false
+    },
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_CHUNK_SIZE": {
+      "description": "The size of each attempt batch",
+      "required": false
+    },
+    "OPEN_DISCUSSIONS_NOTIFICATION_SEND_CHUNK_SIZE": {
+      "description": "The size of each sending batch",
+      "required": false
+    },
     "OPEN_DISCUSSIONS_REDDIT_ACCESS_TOKEN": {
       "description": "Access token for securing trusted APIs to reddit",
       "required": false

--- a/notifications/tasks_test.py
+++ b/notifications/tasks_test.py
@@ -1,21 +1,79 @@
 """Tests for notifications tasks"""
+import pytest
+
 from notifications import tasks
+from notifications.factories import NotificationSettingsFactory
 
 
-def test_send_daily_frontpage_digests(mocker):
+@pytest.mark.django_db
+def test_send_daily_frontpage_digests(mocker, settings, mocked_celery):
     """Tests that send_daily_frontpage_digests calls the API method"""
-    api_mock = mocker.patch("notifications.api.send_daily_frontpage_digests")
+    notification_settings = NotificationSettingsFactory.create_batch(
+        4, daily=True, frontpage_type=True
+    )
 
-    tasks.send_daily_frontpage_digests.delay()
-    api_mock.assert_called_once_with()
+    settings.NOTIFICATION_ATTEMPT_CHUNK_SIZE = 2
+    mock_attempt_send_notification_batch = mocker.patch(
+        "notifications.tasks.attempt_send_notification_batch", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        tasks.send_daily_frontpage_digests.delay()
+
+    assert mocked_celery.group.call_count == 1
+
+    # Celery's 'group' function takes a generator as an argument. In order to make assertions about the items
+    # in that generator, 'list' is being called to force iteration through all of those items.
+    list(mocked_celery.group.call_args[0][0])
+
+    assert mock_attempt_send_notification_batch.si.call_count == 2
+
+    mock_attempt_send_notification_batch.si.assert_any_call(
+        [notification_settings[0].id, notification_settings[1].id]
+    )
+    mock_attempt_send_notification_batch.si.assert_any_call(
+        [notification_settings[2].id, notification_settings[3].id]
+    )
 
 
-def test_send_weekly_frontpage_digests(mocker):
+@pytest.mark.django_db
+def test_send_weekly_frontpage_digests(mocker, settings, mocked_celery):
     """Tests that send_weekly_frontpage_digests calls the API method"""
-    api_mock = mocker.patch("notifications.api.send_weekly_frontpage_digests")
+    notification_settings = NotificationSettingsFactory.create_batch(
+        4, weekly=True, frontpage_type=True
+    )
 
-    tasks.send_weekly_frontpage_digests.delay()
-    api_mock.assert_called_once_with()
+    settings.NOTIFICATION_ATTEMPT_CHUNK_SIZE = 2
+    mock_attempt_send_notification_batch = mocker.patch(
+        "notifications.tasks.attempt_send_notification_batch", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        tasks.send_weekly_frontpage_digests.delay()
+
+    assert mocked_celery.group.call_count == 1
+
+    # Celery's 'group' function takes a generator as an argument. In order to make assertions about the items
+    # in that generator, 'list' is being called to force iteration through all of those items.
+    list(mocked_celery.group.call_args[0][0])
+
+    assert mock_attempt_send_notification_batch.si.call_count == 2
+
+    mock_attempt_send_notification_batch.si.assert_any_call(
+        [notification_settings[0].id, notification_settings[1].id]
+    )
+    mock_attempt_send_notification_batch.si.assert_any_call(
+        [notification_settings[2].id, notification_settings[3].id]
+    )
+
+
+def test_attempt_send_notification_batch(mocker):
+    """Tests that attempt_send_notification_batch calls the API method"""
+    api_mock = mocker.patch("notifications.api.attempt_send_notification_batch")
+
+    ids = [1, 2, 3]
+    tasks.attempt_send_notification_batch.delay(ids)
+    api_mock.assert_called_once_with(ids)
 
 
 def test_send_unsent_email_notifications(mocker):

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -307,10 +307,6 @@ EMAIL_USE_TLS = get_bool("OPEN_DISCUSSIONS_EMAIL_TLS", False)
 EMAIL_SUPPORT = get_string("OPEN_DISCUSSIONS_SUPPORT_EMAIL", "support@example.com")
 DEFAULT_FROM_EMAIL = get_string("OPEN_DISCUSSIONS_FROM_EMAIL", "webmaster@localhost")
 
-NOTIFICATION_EMAIL_BACKEND = get_string(
-    "OPEN_DISCUSSIONS_NOTIFICATION_EMAIL_BACKEND",
-    "anymail.backends.mailgun.EmailBackend",
-)
 
 MAILGUN_SENDER_DOMAIN = get_string("MAILGUN_SENDER_DOMAIN", None)
 if not MAILGUN_SENDER_DOMAIN:
@@ -333,6 +329,24 @@ if ADMIN_EMAIL != "":
     ADMINS = (("Admins", ADMIN_EMAIL),)
 else:
     ADMINS = ()
+
+# Email Notifications config
+
+NOTIFICATION_EMAIL_BACKEND = get_string(
+    "OPEN_DISCUSSIONS_NOTIFICATION_EMAIL_BACKEND",
+    "anymail.backends.mailgun.EmailBackend",
+)
+# See https://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.rate_limit
+NOTIFICATION_ATTEMPT_RATE_LIMIT = get_string(
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_RATE_LIMIT", None  # default is no rate limit
+)
+
+NOTIFICATION_ATTEMPT_CHUNK_SIZE = get_int(
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_CHUNK_SIZE", 100
+)
+NOTIFICATION_SEND_CHUNK_SIZE = get_int(
+    "OPEN_DISCUSSIONS_NOTIFICATION_SEND_CHUNK_SIZE", 100
+)
 
 # SAML settings
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = get_string(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

Part of #1985 

#### What's this PR do?
This PR tries to make our frontpage email sending more resilient by making the following changes:
- Updates the cron tasks to generate a bunch of subtasks to walk batches of the eligible users rather than trying to walk all users in one task.
  - The idea here is that this reduces the scope of a failure to a retry of a small subset of users and improves parallelism on the send (so it hopefully doesn't take several hours)
  - This will also help this task tolerate heroku restarts and OOM-killing better
  - Each of these batches have extra task flags set to ensure celery doesn't preemptively acknowledge them (`acks_late`) or acknowledge them when the worker gets stopped / killed (`reject_on_worker_lost`)
- It also adds some configuration knobs for a few things:
  - `rate_limit` for processing of the batch tasks that generate notification records
  - Chunk size limits for both the check for who is eligible for frontpage notifications and the actual send


#### How should this be manually tested?
- Create some posts and then trigger `notifications.tasks.send_daily_frontpage_digests.delay()`. You may need to prune your `EmailNotification` table first to ensure records go out (remember this blasts to all your users).
- If you have enough users you should be able to kill your worker and it should resume and complete sending on restart
  - `docker-compose stop celery` (you can probably add a `time.sleep()` call in the `notifications.api.attempt_send_notification_batch` loop to make the task run artificially longer so you have a bigger window to kill the worker).