### PR TITLE
add animation to the drawer opening and closing

### DIFF
--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -3,7 +3,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 import ChannelAvatar from "../containers/ChannelAvatar"
-import NavigationItem from "./NavigationItem"
+import NavigationItem, { NavigationExpansion } from "./NavigationItem"
 
 import { channelURL } from "../lib/url"
 
@@ -16,6 +16,12 @@ type Props = {
 
 const channelClassName = (channelName, currentChannel) =>
   currentChannel === channelName ? "location current-location" : "location"
+
+const NavigationHeading = ({ children }) => (
+  <NavigationExpansion.Consumer>
+    {expanded => <div className="heading">{expanded ? children : null}</div>}
+  </NavigationExpansion.Consumer>
+)
 
 export default class SubscriptionsList extends React.Component<Props> {
   makeChannelLink = (channel: Channel) => {
@@ -50,19 +56,13 @@ export default class SubscriptionsList extends React.Component<Props> {
       <div className="location-list subscribed-channels">
         {myChannels.length > 0 ? (
           <div className="my-channels">
-            <NavigationItem
-              whenExpanded={() => (
-                <div className="heading">Channels you moderate</div>
-              )}
-            />
+            <NavigationHeading>Channels you moderate</NavigationHeading>
             {myChannels.map(this.makeChannelLink)}
           </div>
         ) : null}
         {otherChannels.length > 0 ? (
           <div className="channels">
-            <NavigationItem
-              whenExpanded={() => <div className="heading">Channels</div>}
-            />
+            <NavigationHeading>Channels</NavigationHeading>
             {otherChannels.map(this.makeChannelLink)}
           </div>
         ) : null}

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -2,6 +2,8 @@ $red-link-color: #9a2a33;
 $link-padding: 11px 20px 11px $icon-padding-left;
 $footer-height: 152px;
 
+$drawer-trans: width 500ms;
+
 .mdc-list {
   font-family: inherit;
 }
@@ -26,12 +28,14 @@ $footer-height: 152px;
   height: calc(100vh - #{$toolbar-height-desktop});
   top: $toolbar-height-desktop;
   width: $collapse-drawer-width;
+  transition: $drawer-trans;
+  overflow: hidden;
 
   .mdc-drawer__drawer {
     position: absolute;
     top: 0px;
     left: 0px;
-    width: $collapse-drawer-width;
+    width: $drawer-width;
 
     .scrollbar-container {
       display: none;
@@ -113,6 +117,7 @@ $footer-height: 152px;
       color: #8a8b8c;
       padding: 11px 0;
       font-size: 18px;
+      min-height: 25px;
     }
   }
 
@@ -131,6 +136,10 @@ $footer-height: 152px;
       flex-grow: 1;
     }
 
+    .avatar-image {
+      height: 25px;
+    }
+
     .settings-link {
       padding: 11px 20px;
       color: $red-link-color;
@@ -143,6 +152,7 @@ $footer-height: 152px;
 
     .home-link {
       display: flex;
+      min-height: 25px;
       align-items: center;
       padding: $link-padding;
       color: $navigation-text;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -98,7 +98,7 @@ body {
     flex-direction: column;
     align-items: center;
     padding-top: $toolbar-height-desktop;
-    transition: $banner-slide-content-trans;
+    transition: $banner-slide-content-trans, $drawer-trans;
 
     @include breakpoint(materialmobile) {
       padding-top: $toolbar-height-mobile;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1994
closes #1998

#### What's this PR do?

This takes care of two things. The first is adding a css transition to animate the change between the expanded and compact state (for the desktop drawer). 

For this I just did a css transition of 500ms on the `width` property. I also changed the styling slightly to deal with things getting a little squished while the animation was planing. Basically, before we had the `.mdc-drawer--persistent` div, and the `.mdc-drawer__drawer` inside of that, and both of those changed their width when the open / closed state was toggled. I changed it around so that `.mdc-drawer__drawer` is always the full width, but `.mdc-drawer--persistent` has `overflow: hidden` so we don't see the full width of that div when the drawer is compacted.

I also changed how the navigation subtitles are rendered, so that they always occupy the same amount of vertical space, even if the drawer is compacted. this should make it so there is no visual jumping up and down between the compact and expanded state.

#### How should this be manually tested?

play around with the drawer and make sure it feels nice to use. also confirm that the mobile drawer is unaffected.

#### Screenshots (if appropriate)

this shows the spacers:

![closesfodpff](https://user-images.githubusercontent.com/6207644/57146265-eb30af80-6d92-11e9-93e9-e36c7e2f540b.png)
![closes](https://user-images.githubusercontent.com/6207644/57146266-eb30af80-6d92-11e9-92c0-fce93185f374.png)
