### PR TITLE
add option for custom html on URL widgets

### DIFF
--- a/static/js/components/widgets/UrlWidget.js
+++ b/static/js/components/widgets/UrlWidget.js
@@ -1,15 +1,31 @@
 // @flow
-import React from "react"
+import React, { useEffect } from "react"
 
 import EmbedlyCard from "../EmbedlyCard"
 
 import type { WidgetComponentProps } from "../../flow/widgetTypes"
 
+export const TwitterEmbed = ({ embed }: { embed: string }) => {
+  useEffect(() => {
+    window.twttr.widgets.load()
+  })
+
+  return (
+    <div
+      className="twitter-embed"
+      dangerouslySetInnerHTML={{ __html: embed }}
+    />
+  )
+}
+
 const UrlWidget = ({
   widgetInstance: {
-    configuration: { url }
+    configuration: { url, custom_html } // eslint-disable-line camelcase
   }
-}: WidgetComponentProps) => (
-  <EmbedlyCard url={url} className="no-embedly-title" />
-)
+}: WidgetComponentProps) =>
+  url ? (
+    <EmbedlyCard url={url} className="no-embedly-title" />
+  ) : (
+    <TwitterEmbed embed={custom_html} /> // eslint-disable-line camelcase
+  )
 export default UrlWidget

--- a/static/js/components/widgets/UrlWidget_test.js
+++ b/static/js/components/widgets/UrlWidget_test.js
@@ -1,14 +1,25 @@
 // @flow
 import React from "react"
-import { shallow } from "enzyme"
+import { shallow, mount } from "enzyme"
 import { assert } from "chai"
+import sinon from "sinon"
 
-import UrlWidget from "./UrlWidget"
+import UrlWidget, { TwitterEmbed } from "./UrlWidget"
 
 import { WIDGET_TYPE_URL } from "../../lib/constants"
 import { makeWidgetInstance } from "../../factories/widgets"
 
 describe("UrlWidget", () => {
+  let sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   it("renders a UrlWidget", () => {
     const widgetInstance = makeWidgetInstance(WIDGET_TYPE_URL)
     const wrapper = shallow(<UrlWidget widgetInstance={widgetInstance} />)
@@ -16,5 +27,31 @@ describe("UrlWidget", () => {
       wrapper.find("EmbedlyCard").prop("url"),
       widgetInstance.configuration.url
     )
+  })
+
+  it("renders using the TwitterEmbed, if that's what it is given", () => {
+    const widgetInstance = makeWidgetInstance(WIDGET_TYPE_URL)
+    widgetInstance.configuration.url = null
+    const html = '<div class="asdf">fooooo</div>'
+    widgetInstance.configuration.custom_html = html
+    const twitterEmbed = shallow(
+      <UrlWidget widgetInstance={widgetInstance} />
+    ).find("TwitterEmbed")
+    assert.ok(twitterEmbed.exists())
+    assert.equal(twitterEmbed.prop("embed"), html)
+  })
+
+  it("twitter embed calls twitter platform after loading", () => {
+    const twitterPlatformStub = sandbox.stub()
+    window.twttr = {
+      widgets: {
+        load: twitterPlatformStub
+      }
+    }
+    const wrapper = mount(
+      <TwitterEmbed embed="<div class='asdf'>fooooo</div>" />
+    )
+    sinon.assert.called(twitterPlatformStub)
+    assert.equal(wrapper.text(), "fooooo")
   })
 })

--- a/static/js/components/widgets/WidgetEditDialog.js
+++ b/static/js/components/widgets/WidgetEditDialog.js
@@ -136,6 +136,9 @@ export default class WidgetEditDialog extends React.Component<Props> {
                   validation
                 )
               )}
+              {fieldSpec.under_text ? (
+                <div className="under-text">{fieldSpec.under_text}</div>
+              ) : null}
             </label>
           )
         })}

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -14,6 +14,7 @@ import * as authUtils from "../lib/auth"
 import { makeFrontpageSetting, makeCommentSetting } from "../factories/settings"
 import { makeChannelPostList } from "../factories/posts"
 import { shouldIf, shouldIfGt0, mockCourseAPIMethods } from "../lib/test_utils"
+import * as embedLib from "../lib/embed"
 
 describe("App", () => {
   let helper, renderComponent, channels, postList
@@ -35,6 +36,7 @@ describe("App", () => {
     helper.getLivestreamEventsStub.returns(Promise.resolve({ data: [] }))
     renderComponent = helper.renderComponent.bind(helper)
     mockCourseAPIMethods(helper)
+    helper.sandbox.stub(embedLib, "ensureTwitterEmbedJS")
   })
 
   afterEach(() => {

--- a/static/js/containers/ChannelPage.js
+++ b/static/js/containers/ChannelPage.js
@@ -27,6 +27,7 @@ import { formatTitle } from "../lib/title"
 import { clearChannelError } from "../actions/channel"
 import { evictPostsForChannel } from "../actions/posts_for_channel"
 import { updatePostSortParam, POSTS_SORT_HOT } from "../lib/picker"
+import { ensureTwitterEmbedJS } from "../lib/embed"
 
 import type { Dispatch } from "redux"
 import type { Match, Location } from "react-router"
@@ -64,6 +65,7 @@ const shouldLoadData = R.complement(
 export class ChannelPage extends React.Component<ChannelPageProps> {
   componentDidMount() {
     this.loadData()
+    ensureTwitterEmbedJS()
   }
 
   componentWillUnmount() {

--- a/static/js/containers/ChannelPage_test.js
+++ b/static/js/containers/ChannelPage_test.js
@@ -21,9 +21,17 @@ import { channelURL } from "../lib/url"
 import { formatTitle } from "../lib/title"
 import { POSTS_SORT_HOT, VALID_POST_SORT_TYPES } from "../lib/picker"
 import { makeReportRecord } from "../factories/reports"
+import * as embedLib from "../lib/embed"
 
 describe("ChannelPage", () => {
-  let helper, render, channels, currentChannel, otherChannel, postList, postIds
+  let helper,
+    render,
+    channels,
+    currentChannel,
+    otherChannel,
+    postList,
+    postIds,
+    ensureTwitterStub
 
   beforeEach(() => {
     channels = makeChannelList(10)
@@ -82,6 +90,7 @@ describe("ChannelPage", () => {
         history: helper.browserHistory
       }
     )
+    ensureTwitterStub = helper.sandbox.stub(embedLib, "ensureTwitterEmbedJS")
   })
 
   afterEach(() => {
@@ -177,6 +186,11 @@ describe("ChannelPage", () => {
         assert.equal(helper.currentLocation.search, `?sort=${sortType}`)
       }
     })
+  })
+
+  it("should call the ensure twitter function", async () => {
+    await render()
+    sinon.assert.called(ensureTwitterStub)
   })
 
   it("should handle missing data gracefully", async () => {

--- a/static/js/containers/admin/EditChannelBasicPage_test.js
+++ b/static/js/containers/admin/EditChannelBasicPage_test.js
@@ -10,6 +10,7 @@ import { LINK_TYPE_TEXT, CHANNEL_TYPE_RESTRICTED } from "../../lib/channels"
 import { formatTitle } from "../../lib/title"
 import { editChannelBasicURL, channelURL } from "../../lib/url"
 import IntegrationTestHelper from "../../util/integration_test_helper"
+import * as embedLib from "../../lib/embed"
 
 describe("EditChannelBasicPage", () => {
   let helper, renderComponent, channel, listenForActions
@@ -37,6 +38,7 @@ describe("EditChannelBasicPage", () => {
     renderComponent = helper.renderComponent.bind(helper)
     listenForActions = helper.listenForActions.bind(helper)
     helper.sandbox.stub(window, "scrollTo")
+    helper.sandbox.stub(embedLib, "ensureTwitterEmbedJS")
   })
 
   afterEach(() => {

--- a/static/js/containers/admin/EditChannelModeratorsPage_test.js
+++ b/static/js/containers/admin/EditChannelModeratorsPage_test.js
@@ -30,6 +30,7 @@ import { formatTitle } from "../../lib/title"
 import { editChannelModeratorsURL, channelURL } from "../../lib/url"
 import { wait } from "../../lib/util"
 import IntegrationTestHelper from "../../util/integration_test_helper"
+import * as embedLib from "../../lib/embed"
 
 describe("EditChannelModeratorsPage", () => {
   let helper, render, channel, moderators, initialState, initialProps
@@ -91,6 +92,7 @@ describe("EditChannelModeratorsPage", () => {
     helper.getProfileStub.returns(Promise.resolve(""))
     helper.getWidgetListStub.returns(Promise.resolve(makeWidgetListResponse(0)))
     helper.sandbox.stub(window, "scrollTo")
+    helper.sandbox.stub(embedLib, "ensureTwitterEmbedJS")
   })
 
   afterEach(() => {

--- a/static/js/factories/widgets.js
+++ b/static/js/factories/widgets.js
@@ -127,7 +127,8 @@ export const makeFieldSpec = (
         min: 1,
         max: casual.integer(1, 8)
       },
-      default: 3
+      default:    3,
+      under_text: null
     }
 
   default:
@@ -139,7 +140,8 @@ export const makeFieldSpec = (
         min_length:  "",
         placeholder: `Placeholder ${casual.words}`
       },
-      default: ""
+      default:    "",
+      under_text: null
     }
   }
 }

--- a/static/js/flow/widgetTypes.js
+++ b/static/js/flow/widgetTypes.js
@@ -13,7 +13,8 @@ export type WidgetFieldSpec = {
   label: string,
   input_type: string,
   props: Object,
-  default: any
+  default: any,
+  under_text: ?string,
 }
 
 export type WidgetSpec = {

--- a/static/js/lib/html.js
+++ b/static/js/lib/html.js
@@ -1,0 +1,27 @@
+// @flow
+import R from "ramda"
+
+export const pullOutURLs = (htmlString: string): Array<string> => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(htmlString, "text/html")
+
+  return R.flatten(
+    [["a", "href"], ["img", "src"], ["script", "src"]].map(
+      ([tagName, urlAttribute]) =>
+        // $FlowFixMe
+        [...doc.querySelectorAll(tagName)].map(el => el[urlAttribute])
+    )
+  )
+}
+
+const twitterHostNames = ["twitter.com", "platform.twitter.com", "t.co"]
+
+export const hasOnlyTwitterURLS = (htmlString: string) => {
+  for (const url of pullOutURLs(htmlString)) {
+    const parsed = new URL(url)
+    if (!twitterHostNames.includes(parsed.hostname)) {
+      return false
+    }
+  }
+  return true
+}

--- a/static/js/lib/html_test.js
+++ b/static/js/lib/html_test.js
@@ -1,0 +1,52 @@
+// @flow
+import { assert } from "chai"
+
+import { hasOnlyTwitterURLS, pullOutURLs } from "./html"
+
+describe("html parsing functions", () => {
+  it("pullOutURLs should pull out all URL attributes", () => {
+    assert.deepEqual(
+      pullOutURLs(`
+        <a href="foobar.example.com"/>
+        <img src="https://cats.example.com/images/1" />
+        <script src="https://all-viruses.example.com/platform.js" />
+    `),
+      [
+        "foobar.example.com",
+        "https://cats.example.com/images/1",
+        "https://all-viruses.example.com/platform.js"
+      ]
+    )
+  })
+
+  //
+  ;[
+    [
+      `<a href="https://foobar.example.com"/>
+      <img src="https://cats.example.com/images/1" />
+      <script src="https://all-viruses.example.com/platform.js" />`,
+      false
+    ],
+    [
+      `<a href="https://platform.twitter.com"/>
+      <img src="https://cats.example.com/images/1" />`,
+      false
+    ],
+    [
+      `<a class="twitter-timeline" href="https://twitter.com/TwitterDev?ref_src=twsrc%5Etfw">Tweets by TwitterDev</a>
+      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>`,
+      true
+    ],
+    [
+      `<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">[FAQ] How can I find USGS historical photographs? Check out hundreds of still photographs dating from the 1870’s. <a href="https://t.co/m56BN9LFfd">https://t.co/m56BN9LFfd</a>  This image shows an engineer establishing plane table location by three point method, 1952. <a href="https://twitter.com/hashtag/tbt?src=hash&amp;ref_src=twsrc%5Etfw">#tbt</a> <a href="https://t.co/Z7jpRMRYwB">pic.twitter.com/Z7jpRMRYwB</a></p>&mdash; USGS (@USGS) <a href="https://twitter.com/USGS/status/1126513466351788032?ref_src=twsrc%5Etfw">May 9, 2019</a></blockquote>
+      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>`,
+      true
+    ]
+  ].forEach(([html, expectation]) => {
+    it(`hasOnlyTwitterURLS should return ${String(
+      expectation
+    )} when we expect it to`, () => {
+      assert.equal(hasOnlyTwitterURLS(html), expectation)
+    })
+  })
+})

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -127,7 +127,9 @@ export function* incrementer(): Generator<number, *, *> {
 }
 
 export const isValidUrl = (url: string): boolean =>
-  isURL(url, { allow_underscores: true, require_protocol: true })
+  _.isString(url)
+    ? isURL(url, { allow_underscores: true, require_protocol: true })
+    : false
 
 export const toArray = (obj: any) =>
   Array.isArray(obj) ? obj : obj ? [obj] : undefined

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -188,7 +188,15 @@ describe("utility functions", () => {
   describe("isValidUrl", () => {
     it("should assert that a URL allows underscores and requires a protocol prefix", () => {
       assert.isFalse(isValidUrl("mit.edu"))
+      assert.isFalse(isValidUrl(""))
       assert.isTrue(isValidUrl("http://mit.edu/a_url_here"))
+    })
+
+    it("should be null safe", () => {
+      // $FlowFixMe
+      assert.isFalse(isValidUrl(null))
+      // $FlowFixMe
+      assert.isFalse(isValidUrl(undefined))
     })
   })
 

--- a/static/scss/widget.scss
+++ b/static/scss/widget.scss
@@ -1,6 +1,11 @@
 .widget-list {
   .card-contents {
     padding: 20px 16px 6px 16px;
+
+    .twitter-embed {
+      max-height: 400px;
+      overflow: scroll;
+    }
   }
 
   .manage-widgets {
@@ -31,6 +36,8 @@ $person-z-index: 10;
 .widget-dialog {
   min-width: auto;
   max-width: $dialog-max-width;
+  max-height: 80%;
+  overflow: scroll;
 
   .mdc-dialog__header {
     padding: 40px $body-x-padding 20px $body-x-padding;
@@ -47,6 +54,12 @@ $person-z-index: 10;
 
   .mdc-dialog__footer {
     padding: 0 $body-x-padding 30px $body-x-padding;
+  }
+
+  .under-text {
+    font-size: 14px;
+    line-height: 15px;
+    margin-top: 5px;
   }
 
   .react-autosuggest__suggestions-list {

--- a/widgets/serializers/react_fields.py
+++ b/widgets/serializers/react_fields.py
@@ -30,6 +30,7 @@ class ReactField:
         return {
             "field_name": self.field_name,
             "label": self.label,
+            "under_text": getattr(self, "under_text", None),
             "input_type": self._get_input_type(),
             "props": self._get_props(),
             # DRF uses empty as a marker for no-input, but it's not JSON serializable
@@ -39,6 +40,12 @@ class ReactField:
 
 class ReactCharField(serializers.CharField, ReactField):
     """ReactField extension of DRF CharField"""
+
+    def __init__(self, **kwargs):
+        if "under_text" in kwargs:
+            self.under_text = kwargs.pop("under_text")
+
+        super().__init__(**kwargs)
 
     def _get_input_type(self):
         """Returns the field's input type"""
@@ -79,6 +86,9 @@ class ReactURLField(serializers.URLField, ReactField):
             self.show_embed = kwargs.pop("show_embed")
         else:
             self.show_embed = False
+
+        if "under_text" in kwargs:
+            self.under_text = kwargs.pop("under_text")
 
         super().__init__(**kwargs)
 

--- a/widgets/serializers/url.py
+++ b/widgets/serializers/url.py
@@ -3,13 +3,27 @@ from widgets.serializers.widget_instance import (
     WidgetConfigSerializer,
     WidgetInstanceSerializer,
 )
-from widgets.serializers.react_fields import ReactURLField
+from widgets.serializers.react_fields import ReactURLField, ReactCharField
 
 
 class URLWidgetConfigSerializer(WidgetConfigSerializer):
     """Serializer for URLWidget config"""
 
-    url = ReactURLField(help_text="Enter URL", label="URL", show_embed=True)
+    url = ReactURLField(
+        help_text="Enter URL",
+        label="URL",
+        under_text="Paste url from YouTube, New York Times, Instragram and more than 400 content providers. Or any other web url",
+        show_embed=True,
+        required=False,
+        allow_null=True,
+    )
+    custom_html = ReactCharField(
+        help_text="For more specific embeds, enter the embed code here",
+        under_text="For security reasons, we only allow embed code from Twitter. If you have something else in mind, contact us.",
+        default=None,
+        required=False,
+        allow_null=True,
+    )
 
 
 class URLWidgetSerializer(WidgetInstanceSerializer):

--- a/widgets/views_test.py
+++ b/widgets/views_test.py
@@ -17,6 +17,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "source",
                 "input_type": "markdown_wysiwyg",
                 "label": "Text",
+                "under_text": None,
                 "props": {"placeholder": "Enter widget text"},
                 "default": "",
             }
@@ -30,6 +31,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "url",
                 "input_type": "url",
                 "label": "URL",
+                "under_text": "Paste url from YouTube, New York Times, Instragram and more than 400 content providers. Or any other web url",
                 "props": {
                     "max_length": "",
                     "min_length": "",
@@ -37,7 +39,19 @@ EXPECTED_AVAILABLE_WIDGETS = [
                     "show_embed": True,
                 },
                 "default": "",
-            }
+            },
+            {
+                "field_name": "custom_html",
+                "input_type": "textarea",
+                "label": "Custom html",
+                "under_text": "For security reasons, we only allow embed code from Twitter. If you have something else in mind, contact us.",
+                "props": {
+                    "max_length": "",
+                    "min_length": "",
+                    "placeholder": "For more specific embeds, enter the embed code here",
+                },
+                "default": None,
+            },
         ],
         "widget_type": "URL",
         "description": "Embedded URL",
@@ -48,6 +62,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "url",
                 "input_type": "url",
                 "label": "URL",
+                "under_text": None,
                 "props": {
                     "max_length": "",
                     "min_length": "",
@@ -60,6 +75,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "feed_display_limit",
                 "input_type": "number",
                 "label": "Max number of items",
+                "under_text": None,
                 "props": {"max": 10, "min": 1},
                 "default": 5,
             },
@@ -75,6 +91,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "people",
                 "input_type": "people",
                 "label": "Add members to widget",
+                "under_text": None,
                 "props": {"placeholder": "Enter widget text"},
             },
             {
@@ -82,6 +99,7 @@ EXPECTED_AVAILABLE_WIDGETS = [
                 "field_name": "show_all_members_link",
                 "input_type": "checkbox",
                 "label": "Show all members link",
+                "under_text": None,
                 "props": {},
             },
         ],


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1951 

#### What's this PR do?

This changes the URL widget so that the user can enter custom html embed code for embedding content from Twitter. This is because standard embeds from Twitter with embedly aren't so good for some pages, and some users would like to be able to use publish.twitter.com to make custom embeds to include on their channels.

Basically, now there are two fields on the embed widget, a URL field and a 'custom html' field. The URL field works as before. The 'custom html' field lets you put in some twitter embed code. There's validation to make sure that the content is only from twitter and also that the user only fills out the url field or the custom html field, not both.

#### How should this be manually tested?

Make sure that your existing URL widgets work ok with this code.

Then make sure you can make a new URL widget, using a standard URL.

Then make sure that if you go to publish.twitter.com and create a custom embed you can paste this into a new URL widget and have it render correctly.

#### Screenshots (if appropriate)
![twittjfjfjjji](https://user-images.githubusercontent.com/6207644/57331204-07f81a80-70e6-11e9-80ac-31d78e2e57d8.png)
![twittjfjf](https://user-images.githubusercontent.com/6207644/57331205-07f81a80-70e6-11e9-9088-859cef785852.png)
