### PR TITLE
fix styling of links in 'markdown' widget

### DIFF
--- a/static/scss/widget.scss
+++ b/static/scss/widget.scss
@@ -91,6 +91,16 @@ $person-z-index: 10;
     color: black;
   }
 
+  .markdown {
+    a {
+      color: $link-blue;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
   hr {
     margin: 4px 0;
     border: 0;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

closes #1877

#### What's this PR do?

just a few little css tweaks to make it obvious that links in the markdown widget are, you know, links

#### How should this be manually tested?

make a markdown widget with a link in it, and confirm that it looks like a link. should be blue, should underline on hover.

#### Screenshots (if appropriate)

![linkswow](https://user-images.githubusercontent.com/6207644/57385484-8608ff80-7180-11e9-8dbb-06b616cc6ded.png)
