### PR TITLE
add channel navbar to post detail page

### DIFF
--- a/static/js/containers/ChannelRouter.js
+++ b/static/js/containers/ChannelRouter.js
@@ -18,7 +18,6 @@ import { BannerPageWrapper } from "../components/PageBanner"
 
 import { actions } from "../actions"
 import { getChannelName } from "../lib/util"
-import { searchRoute } from "../lib/routing"
 
 import type { Channel } from "../flow/discussionTypes"
 import type { Match } from "react-router"
@@ -73,15 +72,6 @@ class ChannelRouter extends React.Component<Props> {
     return <ChannelAboutPage channel={channel} />
   }
 
-  renderChannelNavbar = (withWidgetHeader: boolean) => {
-    const { channel } = this.props
-    return (
-      <ChannelNavbar channel={channel}>
-        {withWidgetHeader ? <ManageWidgetHeader channel={channel} /> : null}
-      </ChannelNavbar>
-    )
-  }
-
   render() {
     const { channel, match, history } = this.props
 
@@ -93,23 +83,9 @@ class ChannelRouter extends React.Component<Props> {
             history={history}
             isModerator={channel.user_is_moderator}
           >
-            <Route
-              exact
-              path={match.url}
-              render={() => this.renderChannelNavbar(true)}
-            />
-            <Route
-              path={`${match.url}/about/`}
-              render={() => this.renderChannelNavbar(true)}
-            />
-            <Route
-              path={`${match.url}/members/`}
-              render={() => this.renderChannelNavbar(true)}
-            />
-            <Route
-              path={searchRoute(match.url)}
-              render={() => this.renderChannelNavbar(false)}
-            />
+            <ChannelNavbar channel={channel}>
+              <ManageWidgetHeader channel={channel} />
+            </ChannelNavbar>
           </ChannelHeader>
         ) : null}
         <Route exact path={match.url} render={this.renderChannelIndexPage} />


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

closes #2005

#### What's this PR do?

This adds the channel navbar (the thing that shows 'Home', 'About', etc) to the post detail page. It looks like when the element was added there was an inconsistency in the design mockups, some showing it on the post detail page and some not, so that might be why it was inadvertently not added to the post detail page. 

#### How should this be manually tested?

click around on the all the channel sub pages, and make sure that the channel navbar shows up when you expect it to and, like, works and stuff, haha.

it should show up on the post detail page in particular.



#### Screenshots (if appropriate)
![navbarmob](https://user-images.githubusercontent.com/6207644/57386104-ba30f000-7181-11e9-961d-b7facfd7052e.png)
![navbardesktop](https://user-images.githubusercontent.com/6207644/57386105-ba30f000-7181-11e9-8003-055ead02428f.png)
