### PR TITLE
fix drawer open / close animation

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -98,7 +98,7 @@ body {
     flex-direction: column;
     align-items: center;
     padding-top: $toolbar-height-desktop;
-    transition: $banner-slide-content-trans, $drawer-trans;
+    transition: $banner-slide-content-trans, padding-left 500ms;
 
     @include breakpoint(materialmobile) {
       padding-top: $toolbar-height-mobile;


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

small tweak to the drawer animation. I wanted to have a transition on the `.content` div as well, so that when the drawer opened or closed the change in size in the content div would be animated as well. I goofed though and forgot that we don't set the `width` property on `.content`, but we change it's size by changing the amount of `padding-left`. This corrects the `transition` property on `.content` so that the change in width for the content animates nicely along with the drawer opening and closing.

#### How should this be manually tested?

open and close the drawer a few times on master, and observe how although the drawer itself is animated the width change for the pages content isn't smooth. then check out this branch and observe the fancy animation.