### PR TITLE
fix under text font size

### DIFF
--- a/static/scss/widget.scss
+++ b/static/scss/widget.scss
@@ -57,7 +57,7 @@ $person-z-index: 10;
   }
 
   .under-text {
-    font-size: 14px;
+    font-size: 11px;
     line-height: 15px;
     margin-top: 5px;
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

none, follow on change from #2004 

#### What's this PR do?

this makes the help text on the URL widget form 11px instead of 14px.

#### How should this be manually tested?

Just check out the branch and make sure it looks like what's in the screenshots below I suppose.

#### Screenshots (if appropriate)

![smallhelptext](https://user-images.githubusercontent.com/6207644/57630473-ab747f80-756b-11e9-9848-cb9afc8b3bed.png)
