### PR TITLE
fix rendering height of channel navbar on mobile

### DIFF
--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -62,6 +62,10 @@
       padding: 5px 15px;
       margin: 0 5px;
     }
+
+    &:empty {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review


#### What are the relevant tickets?

closes #1843

#### What's this PR do?

this fixes a small rendering bug that we had with the channel navbar. previously, it was rendering too tall on mobile and it looked weird (see screenshots below). this fixes the issue.

#### How should this be manually tested?

check out this branch and confirm that the channel navbar now looks as it should everywhere, on both desktop and mobile.

#### Screenshots (if appropriate)

before, on mobile:

![notfixedyet](https://user-images.githubusercontent.com/6207644/57631376-60f40280-756d-11e9-9b1a-181efb330841.png)

with the fix, mobile:

![fixed](https://user-images.githubusercontent.com/6207644/57631400-6b160100-756d-11e9-844f-7b68b8e3f0c6.png)


desktop:

![fixeddesktop](https://user-images.githubusercontent.com/6207644/57631412-6ea98800-756d-11e9-91ab-a85579084f5a.png)

