### PR TITLE
Remove fields from OCW course master_json files

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ html5lib==0.999999999
 ipython
 markdown2
 newrelic
-ocw-data-parser==0.2.6
+ocw-data-parser==0.2.7
 Pillow==3.4.2
 psycopg2==2.7
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ lxml==4.1.1               # via xmlsec
 markdown2==2.3.7
 newrelic==4.2.0.100
 oauthlib==2.0.7           # via requests-oauthlib, social-auth-core
-ocw-data-parser==0.2.6
+ocw-data-parser==0.2.7
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==3.4.2


### PR DESCRIPTION

#### What are the relevant tickets?
#2010

#### What's this PR do?
Updates ocw data parser in requirements to use version that removes certain fields from master_json

#### How should this be manually tested?
Manually run the ocw sync, and check that the master_json files do not have 'course_owner' or 'mit_id' fields.
