### PR TITLE
Fix email url to go through static assets

### DIFF
--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n static %}
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
@@ -240,11 +240,11 @@
                       {% block logo %}
                       {% if use_new_branding %}
                       <h1>
-                        <img src="{{ base_url }}/static/images/MIT_circle_red.jpg" width="40" height="40" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;"/>
+                        <img src="{% static 'images/MIT_circle_red.jpg' %}" width="40" height="40" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;"/>
                         <span style="color: #A31F34; font-family: sans-serif; font-size: 28px; line-height: 28px;">{{ site_name }}</span>
                       </h1>
                       {% else %}
-                      <img src="{{ base_url }}/static/images/mit-logo.jpg" width="78" height="41" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;  margin-right: 10px;""/>
+                      <img src="{% static 'images/mit-logo.jpg' %}" width="78" height="41" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;  margin-right: 10px;""/>
                         <span style="color: #A31F34; font-family: sans-serif; font-size: 28px; line-height: 28px;">{{ site_name }}</span>
                       {% endif %}
                       {% endblock %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2002 

#### What's this PR do?
Updates the logo in the emails to be linked via static assets, which should be configured as cloudfront in ci/rc/prod. 

#### How should this be manually tested?

Unfortunately, we can't test cloudfront locally, so you'll need to just verify the emails still render ok:

- Go to http://od.odl.local:8063/__emaildebugger__/ and verify that the emails still render the logo correctly
