### PR TITLE
grid width / layout tweaks

### DIFF
--- a/static/js/components/ChannelNavbar.js
+++ b/static/js/components/ChannelNavbar.js
@@ -23,7 +23,7 @@ export default class ChannelNavbar extends React.Component<Props> {
     return (
       <div className="channel-intra-nav-wrapper">
         <Grid className="main-content two-column channel-intra-nav">
-          <Cell width={8}>
+          <Cell mobileWidth={8} width={7}>
             <IntraPageNav>
               <NavLink
                 exact

--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -1,5 +1,7 @@
 // @flow
-import React from "react"
+import React, { useState, useEffect } from "react"
+
+import { isMobileGridWidth } from "../lib/util"
 
 type GridProps = {
   children: any,
@@ -48,12 +50,37 @@ type CellWidth =
 type CellProps = {
   children: any,
   width: CellWidth,
+  mobileWidth?: CellWidth,
   className?: string
 }
 
 const cellClassName = (width, className) =>
   `mdc-layout-grid__cell--span-${width} ${className || ""}`.trim()
 
-export const Cell = ({ children, width, className }: CellProps) => (
-  <div className={cellClassName(width, className)}>{children}</div>
-)
+export const Cell = ({
+  children,
+  width,
+  mobileWidth,
+  className
+}: CellProps) => {
+  const [, setState] = useState(null)
+
+  useEffect(() => {
+    window.addEventListener("resize", setState)
+
+    return () => {
+      window.removeEventListener("resize", setState)
+    }
+  })
+
+  return (
+    <div
+      className={cellClassName(
+        mobileWidth && isMobileGridWidth() ? mobileWidth : width,
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/static/js/components/Grid_test.js
+++ b/static/js/components/Grid_test.js
@@ -1,11 +1,25 @@
 // @flow
 import React from "react"
-import { shallow } from "enzyme"
+import { mount, shallow } from "enzyme"
 import { assert } from "chai"
+import sinon from "sinon"
 
 import { Grid, Cell } from "./Grid"
+import * as utils from "../lib/util"
+import { shouldIf } from "../lib/test_utils"
 
 describe("Grid components", () => {
+  let sandbox, isMobileWidthStub
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    isMobileWidthStub = sandbox.stub(utils, "isMobileGridWidth").returns(false)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   it("should render a grid with children", () => {
     const wrapper = shallow(
       <Grid>
@@ -20,21 +34,18 @@ describe("Grid components", () => {
   //
   ;[1, 12].forEach(width => {
     it(`should create a cell with width ${width}`, () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Cell width={width}>
           <div className="child" />
         </Cell>
       )
-      assert.equal(
-        wrapper.props().className,
-        `mdc-layout-grid__cell--span-${width}`
-      )
+      assert.ok(wrapper.find(`.mdc-layout-grid__cell--span-${width}`).exists())
       assert.ok(wrapper.find(".child").exists())
     })
   })
 
   it("should allow passing a className to Grid", () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Grid width={2} className="foobar">
         <div />
       </Grid>
@@ -42,8 +53,27 @@ describe("Grid components", () => {
     assert.ok(wrapper.find(".foobar"))
   })
 
+  //
+  ;[true, false].forEach(isMobileWidth => {
+    it(`${shouldIf(
+      isMobileWidth
+    )} use mobileWidth if present and mobile==${String(isMobileWidth)}`, () => {
+      isMobileWidthStub.returns(isMobileWidth)
+      const wrapper = mount(
+        <Cell width={4} mobileWidth={7}>
+          <div />
+        </Cell>
+      )
+      assert.ok(
+        wrapper
+          .find(`.mdc-layout-grid__cell--span-${isMobileWidth ? 7 : 4}`)
+          .exists()
+      )
+    })
+  })
+
   it("should allow passing a className to Cell", () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Cell width={2} className="foobar">
         <div />
       </Cell>

--- a/static/js/containers/SearchPage.js
+++ b/static/js/containers/SearchPage.js
@@ -237,7 +237,7 @@ export class SearchPage extends React.Component<Props, State> {
 
     return (
       <Grid className="main-content two-column search-page">
-        <Cell width={8}>
+        <Cell mobileWidth={8} width={7}>
           <MetaTags>
             <CanonicalLink match={match} />
           </MetaTags>

--- a/static/js/hoc/withSidebar.js
+++ b/static/js/hoc/withSidebar.js
@@ -19,10 +19,10 @@ export const withSidebar = R.curry(
       render() {
         return (
           <Grid className={`main-content two-column ${className}`}>
-            <Cell width={8}>
+            <Cell mobileWidth={8} width={7}>
               <WrappedComponent {...this.props} />
             </Cell>
-            <Cell width={4}>
+            <Cell width={5}>
               <Sidebar className="sidebar-right">
                 <SidebarComponent {...this.props} />
               </Sidebar>

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -85,6 +85,11 @@ export const DRAWER_BREAKPOINT = 950
 
 export const isMobileWidth = () => getViewportWidth() < DRAWER_BREAKPOINT
 
+export const GRID_MOBILE_BREAKPOINT = 840
+
+export const isMobileGridWidth = () =>
+  getViewportWidth() < GRID_MOBILE_BREAKPOINT
+
 export const truncate = (text: ?string, length: number): string =>
   text ? _.truncate(text, { length: length, separator: " " }) : ""
 

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -18,6 +18,12 @@
   }
 }
 
+.channel-page {
+  .sidebar-right {
+    padding-top: 34px;
+  }
+}
+
 .channel-intra-nav-wrapper {
   background-color: #ffffff;
   padding: 6px 0 0;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -130,7 +130,7 @@ body {
         width: 90%;
 
         @include breakpoint(desktop) {
-          max-width: 960px;
+          max-width: 1440px;
         }
 
         @include breakpoint(phone) {

--- a/static/scss/post.scss
+++ b/static/scss/post.scss
@@ -109,7 +109,7 @@
 
       &.link-thumbnail {
         display: flex;
-        justify-content: center;
+        justify-content: flex-end;
         min-width: 34%;
         width: 34%;
         overflow: hidden;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

closes #2016

#### What's this PR do?

- increases desktop width of the two-column layout from 960px to 1440px
- changes from 8 / 4 column setup to 7 / 5
- adds padding to the top of the widget list, so it lines up visually with the first card in the post list

#### How should this be manually tested?

check out the branch and make sure that it looks alright and everything is usable and so on. check on mobile too.

#### Screenshots (if appropriate)

![newdesktopppdrawerasdfasdffffasdfasdfsdfasdf](https://user-images.githubusercontent.com/6207644/57865997-934f6b00-77cc-11e9-94e2-1931ff71cf2f.png)
![newdesktopppdrawerasdfasdffffasdfasdf](https://user-images.githubusercontent.com/6207644/57865998-934f6b00-77cc-11e9-8b7c-7505817c9ffa.png)
![newdesktopppdrawerasdfasdffff](https://user-images.githubusercontent.com/6207644/57865999-934f6b00-77cc-11e9-9c60-76f249c9bc70.png)
![newdesktopppdrawerasdfasdf](https://user-images.githubusercontent.com/6207644/57866000-93e80180-77cc-11e9-8ab8-d6726bbc84ab.png)
![newdesktopppdrawer](https://user-images.githubusercontent.com/6207644/57866001-93e80180-77cc-11e9-88a6-ba6afbaaee77.png)
![newdesktoppp](https://user-images.githubusercontent.com/6207644/57866002-93e80180-77cc-11e9-9083-257af337adda.png)
