### PR TITLE
split out widget API stuff from the big `lib/api/api.js`

### DIFF
--- a/static/js/lib/api/api.js
+++ b/static/js/lib/api/api.js
@@ -22,7 +22,6 @@ import type {
   PostListPaginationParams
 } from "../../flow/discussionTypes"
 import type { NotificationSetting } from "../../flow/settingsTypes"
-import type { WidgetListResponse } from "../../flow/widgetTypes"
 import type { SearchParams } from "../../flow/searchTypes"
 
 export function search(params: SearchParams): Promise<*> {
@@ -277,17 +276,3 @@ export const postSetPassword = (
 export function getSocialAuthTypes(): Promise<Array<SocialAuth>> {
   return fetchJSONWithAuthFailure("/api/v0/auths/")
 }
-
-export const getWidgetList = (
-  widgetListId: number
-): Promise<WidgetListResponse> =>
-  fetchJSONWithAuthFailure(`/api/v0/widget_lists/${widgetListId}/`)
-
-export const patchWidgetList = (
-  widgetListId: number,
-  payload: Object
-): Promise<WidgetListResponse> =>
-  fetchJSONWithAuthFailure(`/api/v0/widget_lists/${widgetListId}/`, {
-    method: PATCH,
-    body:   JSON.stringify(payload)
-  })

--- a/static/js/lib/api/api_test.js
+++ b/static/js/lib/api/api_test.js
@@ -22,16 +22,13 @@ import {
   postPasswordResetNewPassword,
   postSetPassword,
   search,
-  getRelatedPosts,
-  getWidgetList,
-  patchWidgetList
+  getRelatedPosts
 } from "./api"
 import { makePost, makeChannelPostList } from "../../factories/posts"
 import { makeCommentsResponse } from "../../factories/comments"
 import * as authFuncs from "./fetch_auth"
 import * as searchFuncs from "../search"
 import { makeProfile } from "../../factories/profiles"
-import { makeWidgetListResponse } from "../../factories/widgets"
 
 describe("api", function() {
   this.timeout(5000) // eslint-disable-line no-invalid-this
@@ -313,37 +310,6 @@ describe("api", function() {
         sinon.assert.calledWith(fetchJSONStub, `/api/v0/related/${postId}/`, {
           method: POST
         })
-      })
-    })
-
-    describe("widget functions", () => {
-      it("fetches a widget list", async () => {
-        const widgetList = makeWidgetListResponse()
-        fetchJSONStub.returns(Promise.resolve(widgetList))
-        const widgetListId = widgetList.id
-        const response = await getWidgetList(widgetListId)
-        assert.deepEqual(response, widgetList)
-        sinon.assert.calledWith(
-          fetchJSONStub,
-          `/api/v0/widget_lists/${widgetListId}/`
-        )
-      })
-
-      it("patches a widget list", async () => {
-        const widgetList = makeWidgetListResponse()
-        fetchJSONStub.returns(Promise.resolve(widgetList))
-        const widgetListId = widgetList.id
-        const args = { some: "args" }
-        const response = await patchWidgetList(widgetListId, args)
-        assert.deepEqual(response, widgetList)
-        sinon.assert.calledWith(
-          fetchJSONStub,
-          `/api/v0/widget_lists/${widgetListId}/`,
-          {
-            method: "PATCH",
-            body:   JSON.stringify(args)
-          }
-        )
       })
     })
   })

--- a/static/js/lib/api/widgets.js
+++ b/static/js/lib/api/widgets.js
@@ -1,0 +1,20 @@
+// @flow
+import { PATCH } from "redux-hammock/constants"
+
+import { fetchJSONWithAuthFailure } from "./fetch_auth"
+
+import type { WidgetListResponse } from "../../flow/widgetTypes"
+
+export const getWidgetList = (
+  widgetListId: number
+): Promise<WidgetListResponse> =>
+  fetchJSONWithAuthFailure(`/api/v0/widget_lists/${widgetListId}/`)
+
+export const patchWidgetList = (
+  widgetListId: number,
+  payload: Object
+): Promise<WidgetListResponse> =>
+  fetchJSONWithAuthFailure(`/api/v0/widget_lists/${widgetListId}/`, {
+    method: PATCH,
+    body:   JSON.stringify(payload)
+  })

--- a/static/js/lib/api/widgets_test.js
+++ b/static/js/lib/api/widgets_test.js
@@ -1,0 +1,49 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+import * as fetchFuncs from "redux-hammock/django_csrf_fetch"
+
+import { getWidgetList, patchWidgetList } from "./widgets"
+import { makeWidgetListResponse } from "../../factories/widgets"
+
+describe("widget functions", () => {
+  let fetchJSONStub, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetchJSONStub = sandbox.stub(fetchFuncs, "fetchJSONWithCSRF")
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("fetches a widget list", async () => {
+    const widgetList = makeWidgetListResponse()
+    fetchJSONStub.returns(Promise.resolve(widgetList))
+    const widgetListId = widgetList.id
+    const response = await getWidgetList(widgetListId)
+    assert.deepEqual(response, widgetList)
+    sinon.assert.calledWith(
+      fetchJSONStub,
+      `/api/v0/widget_lists/${widgetListId}/`
+    )
+  })
+
+  it("patches a widget list", async () => {
+    const widgetList = makeWidgetListResponse()
+    fetchJSONStub.returns(Promise.resolve(widgetList))
+    const widgetListId = widgetList.id
+    const args = { some: "args" }
+    const response = await patchWidgetList(widgetListId, args)
+    assert.deepEqual(response, widgetList)
+    sinon.assert.calledWith(
+      fetchJSONStub,
+      `/api/v0/widget_lists/${widgetListId}/`,
+      {
+        method: "PATCH",
+        body:   JSON.stringify(args)
+      }
+    )
+  })
+})

--- a/static/js/reducers/widgets.js
+++ b/static/js/reducers/widgets.js
@@ -1,7 +1,7 @@
 // @flow
 import { GET, PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
-import * as api from "../lib/api/api"
+import * as widgetAPI from "../lib/api/widgets"
 
 import type { WidgetListResponse } from "../flow/widgetTypes"
 
@@ -16,7 +16,7 @@ export const widgetsEndpoint = {
     }
   },
   getFunc: (widgetListId: number): Promise<WidgetListResponse> =>
-    api.getWidgetList(widgetListId),
+    widgetAPI.getWidgetList(widgetListId),
   patchFunc: (widgetListId: number, payload: Object) =>
-    api.patchWidgetList(widgetListId, payload)
+    widgetAPI.patchWidgetList(widgetListId, payload)
 }

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -20,6 +20,7 @@ import * as postAPI from "../lib/api/posts"
 import * as commentAPI from "../lib/api/comments"
 import * as livestreamAPI from "../lib/api/livestream"
 import * as courseAPI from "../lib/api/courses"
+import * as widgetAPI from "../lib/api/widgets"
 import rootReducer from "../reducers"
 import * as utilFuncs from "../lib/util"
 
@@ -54,7 +55,8 @@ export default class IntegrationTestHelper {
       postAPI,
       commentAPI,
       livestreamAPI,
-      courseAPI
+      courseAPI,
+      widgetAPI
     ].forEach(apiModule => {
       for (const methodName in apiModule) {
         if (typeof apiModule[methodName] === "function") {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

more work on #1667 

#### What's this PR do?

just splits the widget-related API functions out into a separate file, like we've already done for a number of other files.

#### How should this be manually tested?

make sure that the changes look reasonable and all frontend widget-related activities work as normal.