### PR TITLE
fix course search page loading behavior

### DIFF
--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -72,7 +72,8 @@ type State = {
   activeFacets: Map<string, Array<string>>,
   from: number,
   error: ?string,
-  currentFacetGroup: ?CurrentFacet
+  currentFacetGroup: ?CurrentFacet,
+  incremental: boolean
 }
 
 const facetDisplayMap = [
@@ -98,7 +99,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
       ]),
       from:              0,
       error:             null,
-      currentFacetGroup: null
+      currentFacetGroup: null,
+      incremental:       false
     }
   }
 
@@ -191,11 +193,13 @@ export class CourseSearchPage extends React.Component<Props, State> {
       })
     })
     let from = this.state.from + SETTINGS.search_page_size
-    if (!params.incremental) {
+
+    const { incremental } = params
+    if (!incremental) {
       clearSearch()
       from = 0
     }
-    this.setState({ from })
+    this.setState({ from, incremental })
     await runSearch({
       channelName: null,
       text,
@@ -244,9 +248,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
   renderResults = () => {
     const { results, processing, loaded, total } = this.props
-    const { from } = this.state
+    const { from, incremental } = this.state
 
-    if (processing || !loaded) {
+    if ((processing || !loaded) && !incremental) {
       return <PostLoading />
     }
 

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -91,6 +91,8 @@ describe("CourseSearchPage", () => {
       )
     })
   })
+
+  //
   ;["", "a"].forEach(query => {
     it(`still runs a search if initial search text is '${query}'`, async () => {
       await renderPage({
@@ -131,7 +133,23 @@ describe("CourseSearchPage", () => {
     })
     // from is 5, plus 5 is 10 which is == numHits so no more results
     assert.isFalse(inner.find("InfiniteScroll").prop("hasMore"))
+    assert.deepEqual(inner.state(), {
+      // Because this is non-incremental the previous from value of 7 is replaced with 0
+      text:         "text",
+      activeFacets: new Map(
+        Object.entries({
+          platform:     [],
+          topics:       [],
+          availability: []
+        })
+      ),
+      from:              5,
+      error:             null,
+      currentFacetGroup: null,
+      incremental:       true
+    })
   })
+
   it("searches with parameters", async () => {
     SETTINGS.search_page_size = 5
     await renderPage(
@@ -162,6 +180,8 @@ describe("CourseSearchPage", () => {
       )
     })
   })
+
+  //
   ;[0, 5].forEach(from => {
     it(`InfiniteScroll initialLoad ${shouldIf(
       from > 0
@@ -172,6 +192,8 @@ describe("CourseSearchPage", () => {
       assert.equal(infiniteScroll.prop("initialLoad"), from === 0)
     })
   })
+
+  //
   ;[
     [true, false, false],
     [false, true, true],
@@ -293,7 +315,8 @@ describe("CourseSearchPage", () => {
       ),
       currentFacetGroup: null,
       from:              0,
-      error:             null
+      error:             null,
+      incremental:       false
     })
   })
 
@@ -343,7 +366,8 @@ describe("CourseSearchPage", () => {
       currentFacetGroup: {
         group:  "topics",
         result: makeSearchFacetResult().topics
-      }
+      },
+      incremental: false
     })
   })
 
@@ -363,6 +387,8 @@ describe("CourseSearchPage", () => {
     inner.find("SearchTextbox").prop("onClear")()
     assert.equal(inner.state().text, "")
   })
+
+  //
   ;[false, true].forEach(isChecked => {
     it(`${shouldIf(
       isChecked

--- a/static/js/containers/CreatePostPage_test.js
+++ b/static/js/containers/CreatePostPage_test.js
@@ -127,9 +127,10 @@ describe("CreatePostPage", () => {
     return wrapper.update()
   }
 
-  it("should set the document title", async () => {
+  it("should set the document title and load channels", async () => {
     await renderPage()
     assert.equal(document.title, formatTitle("Submit a Post"))
+    sinon.assert.calledOnce(helper.getChannelStub)
   })
 
   //
@@ -151,12 +152,6 @@ describe("CreatePostPage", () => {
       const { postType } = helper.store.getState().forms[CREATE_POST_KEY].value
       assert.equal(postType, shouldSetPostType ? postTypes[0] : null)
     })
-  })
-
-  it("attempts to clear form and load channels on mount", async () => {
-    const wrapper = await renderPage()
-    assert.include(wrapper.text(), currentChannel.title)
-    sinon.assert.calledOnce(helper.getChannelStub)
   })
 
   for (const isText of [true, false]) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1924 
also closes #1991 (I got too frustrated by build failures haha)

#### What's this PR do?

this fixes an issue with the infinite scroll on the course search page. basically, the issue was that we had two different types of loading states, one which was triggered by scrolling down and one triggered by changing the search text or the selected facets. In the case of the latter we want to reload the whole result UI, clear the old results, and start from scratch, but in the former case we want to show the already-fetched results while the infinite scroll component takes care of the loading indicator at the bottom. But our existing code only dealt with the latter case, and didn't distinguish the former adequately (there is more explanation of this on the issue if this is not clear).

So to fix it I basically just added a value, `incremental: boolean`, to the state on the course search page component. When we're rendering our results we can inspect this value to determine whether the most recent request that was fired off was an incremental reload (i.e. triggered by the infinite scroll component) or a full reload (i.e. triggered by a change in the search text, etc). This lets us determine when to show a full loading UI and when to let the infinite scroll component do its thing.

#### How should this be manually tested?

Look at the course search page on master and confirm the issue. Basically, when you scroll down the whole page should be taken over by a loading indicator, instead of just showing you a small loading indicator at the bottom of the post list.

then check out this branch and confirm that it fixes the issue. if you change facets or search text, though, you should still see the overall loading indicator.

