### PR TITLE
tweak the post page grid and column widths

### DIFF
--- a/static/js/hoc/withSidebar.js
+++ b/static/js/hoc/withSidebar.js
@@ -19,10 +19,10 @@ export const withSidebar = R.curry(
       render() {
         return (
           <Grid className={`main-content two-column ${className}`}>
-            <Cell mobileWidth={8} width={7}>
+            <Cell width={8}>
               <WrappedComponent {...this.props} />
             </Cell>
-            <Cell width={5}>
+            <Cell width={4}>
               <Sidebar className="sidebar-right">
                 <SidebarComponent {...this.props} />
               </Sidebar>

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -130,7 +130,7 @@ body {
         width: 90%;
 
         @include breakpoint(desktop) {
-          max-width: 1440px;
+          max-width: 1100px;
         }
 
         @include breakpoint(phone) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

this closes #2022 

#### What's this PR do?

this changes the width of the overall grid to 1100px and goes back to an 8 / 4 column split.

#### How should this be manually tested?

check out the branch and make sure everything looks good on mobile and desktop.


#### Screenshots (if appropriate)

![asdfffnno](https://user-images.githubusercontent.com/6207644/58892638-94353780-86bc-11e9-86b5-4ebf4b8c7bdd.png)
