### PR TITLE
Se/use bootcamps model

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -2,7 +2,13 @@
 course_catalog serializers
 """
 from rest_framework import serializers
-from course_catalog.models import Course, CourseInstructor, CoursePrice, CourseTopic
+from course_catalog.models import (
+    Course,
+    CourseInstructor,
+    CoursePrice,
+    CourseTopic,
+    Bootcamp,
+)
 
 
 class CourseInstructorSerializer(serializers.ModelSerializer):
@@ -48,3 +54,17 @@ class CourseSerializer(serializers.ModelSerializer):
         model = Course
         fields = "__all__"
         extra_kwargs = {"raw_json": {"write_only": True}}
+
+
+class BootcampSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Bootcamp model
+    """
+
+    instructors = CourseInstructorSerializer(read_only=True, many=True, allow_null=True)
+    topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
+    prices = CoursePriceSerializer(read_only=True, many=True, allow_null=True)
+
+    class Meta:
+        model = Bootcamp
+        fields = "__all__"

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -4,6 +4,8 @@ course_catalog tasks
 import logging
 
 import json
+
+import copy
 import requests
 import boto3
 from django.conf import settings
@@ -21,7 +23,8 @@ from course_catalog.task_helpers import (
     format_date,
     generate_course_prefix_list,
     tag_edx_course_program,
-    parse_bootcamp_json_data,
+    parse_bootcamp_json_data_course,
+    parse_bootcamp_json_data_bootcamp,
 )
 
 
@@ -230,4 +233,5 @@ def get_bootcamp_data():
     if response.status_code == 200:
         bootcamp_json = response.json()
         for bootcamp in bootcamp_json:
-            parse_bootcamp_json_data(bootcamp)
+            parse_bootcamp_json_data_course(copy.deepcopy(bootcamp))
+            parse_bootcamp_json_data_bootcamp(bootcamp)

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -14,7 +14,13 @@ from moto import mock_s3
 
 from course_catalog.constants import PlatformType
 from course_catalog.factories import CourseFactory
-from course_catalog.models import Course, CoursePrice, CourseInstructor, CourseTopic
+from course_catalog.models import (
+    Course,
+    CoursePrice,
+    CourseInstructor,
+    CourseTopic,
+    Bootcamp,
+)
 from course_catalog.tasks import (
     sync_and_upload_edx_data,
     get_ocw_data,
@@ -342,19 +348,27 @@ def test_process_bootcamps(mock_get_bootcamps):
     Test that bootcamp json data is properly parsed
     """
     get_bootcamp_data()
+    assert Bootcamp.objects.count() == 3
     assert Course.objects.count() == 3
 
-    course = Course.objects.get(course_id="Bootcamp1")
-    assert course.platform == PlatformType.bootcamps.value
-    assert course.title == "MIT HMS Healthcare Innovation Bootcamp"
+    bootcamp = Course.objects.get(course_id="Bootcamp1")
+    assert bootcamp.title == "MIT HMS Healthcare Innovation Bootcamp"
 
-    course = Course.objects.get(course_id="Bootcamp2")
-    assert course.platform == PlatformType.bootcamps.value
-    assert course.title == "MIT Deep Technology Bootcamp"
+    bootcamp = Course.objects.get(course_id="Bootcamp2")
+    assert bootcamp.title == "MIT Deep Technology Bootcamp"
 
-    course = Course.objects.get(course_id="Bootcamp3")
-    assert course.platform == PlatformType.bootcamps.value
-    assert course.title == "MIT Sports Entrepreneurship Bootcamp"
+    bootcamp = Course.objects.get(course_id="Bootcamp3")
+    assert bootcamp.title == "MIT Sports Entrepreneurship Bootcamp"
 
+    bootcamp = Course.objects.get(course_id="Bootcamp1")
+    assert bootcamp.title == "MIT HMS Healthcare Innovation Bootcamp"
+
+    bootcamp = Course.objects.get(course_id="Bootcamp2")
+    assert bootcamp.title == "MIT Deep Technology Bootcamp"
+
+    bootcamp = Course.objects.get(course_id="Bootcamp3")
+    assert bootcamp.title == "MIT Sports Entrepreneurship Bootcamp"
     get_bootcamp_data()
+
+    assert Bootcamp.objects.count() == 3
     assert Course.objects.count() == 3


### PR DESCRIPTION
#### What are the relevant tickets?
#2028 
closes #2041 

#### What's this PR do?
This PR changes the bootcamp parsing code to use the new Bootcamp database model.

#### How should this be manually tested?
Open up the shell, import and run `get_bootcamp_data` from `course_catalog.tasks`. Then check to see that the Bootcamp model is being properly populated with bootcamp data.

