### PR TITLE
persist desktop drawer open / close value to localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "redux-asserts": "^0.0.10",
     "redux-debounced": "^0.5.0",
     "redux-hammock": "^0.3.0",
+    "redux-localstorage": "^0.4.1",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.3",
     "redux-query": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10236,6 +10236,11 @@ redux-hammock@^0.3.0:
     ramda "^0.24.1"
     redux-actions "^2.0.3"
 
+redux-localstorage@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/redux-localstorage/-/redux-localstorage-0.4.1.tgz#faf6d719c581397294d811473ffcedee065c933c"
+  integrity sha1-+vbXGcWBOXKU2BFHP/zt7gZckzw=
+
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Changes have been manually tested



#### What are the relevant tickets?

none

#### What's this PR do?

this adds redux-localstorage and configures it to persist the value for `ui.showDrawerDesktop` to the localstorage. this will persist the value that the user sets, and when the app loads next the saved value will be used to set the initial state for the app. this means that if the user prefers to have the drawer open on desktop it will be 'sticky' between full page refreshes.

#### How should this be manually tested?

confirm it works as described above and nothing else is broken!

