### PR TITLE
changes to course page top bar

### DIFF
--- a/static/js/components/CourseToolbar.js
+++ b/static/js/components/CourseToolbar.js
@@ -41,16 +41,20 @@ export default class CourseToolbar extends React.Component<Props> {
     const { toggleShowUserMenu, showUserMenu, profile } = this.props
 
     return (
-      <div className="navbar">
+      <div className="navbar course-toolbar">
         <header className="mdc-toolbar" ref={this.toolbarRoot}>
           <div className="mdc-toolbar__row">
             <section className="mdc-toolbar__section mdc-toolbar__section--align-start">
               <MITLogoLink />
-              <span className="mdc-toolbar__title">
-                <Link to="/">MIT Open</Link>
-                {" | "}
-                <Link to={COURSE_URL}>Courses</Link>
-              </span>
+              <div className="mdc-toolbar__title">
+                <Link className="home-link" to="/">
+                  MIT Open
+                </Link>
+                <div className="bar">{" | "}</div>
+                <Link className="learning-link" to={COURSE_URL}>
+                  LEARNING
+                </Link>
+              </div>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
               <UserMenu

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -184,16 +184,15 @@ class App extends React.Component<Props> {
         <MetaTags>
           <title>MIT Open Learning</title>
         </MetaTags>
-        <Switch>
-          <Route path={`${match.url}courses/`}>
-            <CourseToolbar
-              toggleShowUserMenu={this.toggleShowUserMenu}
-              showUserMenu={showUserMenu}
-              profile={profile}
-            />
-          </Route>
-          <Route
-            render={() => (
+        <Route path={`${match.url}courses/`}>
+          {({ match }) =>
+            match ? (
+              <CourseToolbar
+                toggleShowUserMenu={this.toggleShowUserMenu}
+                showUserMenu={showUserMenu}
+                profile={profile}
+              />
+            ) : (
               <React.Fragment>
                 <Toolbar
                   toggleShowDrawer={this.toggleShowDrawer}
@@ -203,9 +202,9 @@ class App extends React.Component<Props> {
                 />
                 <Drawer />
               </React.Fragment>
-            )}
-          />
-        </Switch>
+            )
+          }
+        </Route>
         <Snackbar snackbar={snackbar} />
         <Banner
           banner={banner}

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -58,6 +58,7 @@ $rouge: #a31f34;
 $navy: #03152d;
 $pale-grey: #f4f6fa;
 $white-smoky: #4f4f4f;
+$nice-red: #a32034;
 
 // font
 $body-font: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -1,3 +1,24 @@
+.course-toolbar {
+  .mdc-toolbar__title {
+    display: flex;
+    align-items: center;
+
+    .bar {
+      margin-bottom: 3px;
+    }
+
+    .home-link {
+      margin-right: 8px;
+    }
+
+    .learning-link {
+      font-size: 24px;
+      color: $nice-red;
+      margin-left: 8px;
+    }
+  }
+}
+
 .course-search-input {
   max-width: 600px;
   margin: auto;

--- a/static/scss/navigation.scss
+++ b/static/scss/navigation.scss
@@ -24,7 +24,7 @@ a.mitlogo {
 .mdc-toolbar__title,
 .mdc-toolbar__title a {
   color: $navy;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #1997

#### What's this PR do?

this changes the label in the couse-page-specific top bar to be in-line with the new designs. I also did a slight refactor in how we figure out when to show the course top bar vs the top bar for the rest of the site.

#### How should this be manually tested?

go to the homepage, things should look normal. then go to `/courses`, you should see something like the screenshots below. make sure it looks ok on mobile and so on.


#### Screenshots (if appropriate)

![tobar](https://user-images.githubusercontent.com/6207644/59289101-4c298e00-8c43-11e9-9ec2-4015d33677c7.png)
![topbarmob](https://user-images.githubusercontent.com/6207644/59289162-69f6f300-8c43-11e9-93b4-d127abed897d.png)
