### PR TITLE
drawer open/close animation tweak

### DIFF
--- a/static/js/components/NavigationItem.js
+++ b/static/js/components/NavigationItem.js
@@ -5,15 +5,22 @@ export const NavigationExpansion = React.createContext<boolean>(false)
 
 type Props = {
   badge?: Function,
-  whenExpanded: Function
+  whenExpanded: Function,
+  fading?: boolean
 }
 
-const NavigationItem = ({ badge, whenExpanded }: Props) => (
+const NavigationItem = ({ badge, whenExpanded, fading }: Props) => (
   <NavigationExpansion.Consumer>
     {expanded => (
       <React.Fragment>
         {badge ? badge() : null}
-        {expanded ? whenExpanded() : null}
+        {fading ? (
+          <div className={expanded ? "fading-item expanded" : "fading-item"}>
+            {whenExpanded()}
+          </div>
+        ) : expanded ? (
+          whenExpanded()
+        ) : null}
       </React.Fragment>
     )}
   </NavigationExpansion.Consumer>

--- a/static/js/components/SubscriptionsList.js
+++ b/static/js/components/SubscriptionsList.js
@@ -3,7 +3,7 @@ import React from "react"
 import { Link } from "react-router-dom"
 
 import ChannelAvatar from "../containers/ChannelAvatar"
-import NavigationItem, { NavigationExpansion } from "./NavigationItem"
+import NavigationItem from "./NavigationItem"
 
 import { channelURL } from "../lib/url"
 
@@ -18,9 +18,10 @@ const channelClassName = (channelName, currentChannel) =>
   currentChannel === channelName ? "location current-location" : "location"
 
 const NavigationHeading = ({ children }) => (
-  <NavigationExpansion.Consumer>
-    {expanded => <div className="heading">{expanded ? children : null}</div>}
-  </NavigationExpansion.Consumer>
+  <NavigationItem
+    fading
+    whenExpanded={() => <div className="heading">{children}</div>}
+  />
 )
 
 export default class SubscriptionsList extends React.Component<Props> {
@@ -34,6 +35,7 @@ export default class SubscriptionsList extends React.Component<Props> {
       >
         <Link to={channelURL(channel.name)} className="channel-link">
           <NavigationItem
+            fading
             badge={() => <ChannelAvatar channel={channel} imageSize="small" />}
             whenExpanded={() => <span className="title">{channel.title}</span>}
           />

--- a/static/js/containers/Drawer.js
+++ b/static/js/containers/Drawer.js
@@ -1,4 +1,5 @@
 // @flow
+
 import React from "react"
 import R from "ramda"
 import { connect } from "react-redux"
@@ -99,6 +100,23 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
     }
   }
 
+  get wrappingClass() {
+    const { showDrawerDesktop, showDrawerHover } = this.props
+
+    const isMobile = isMobileWidth()
+
+    if (isMobile) {
+      return ""
+    }
+    if (showDrawerDesktop) {
+      return "persistent-drawer-open"
+    }
+    if (showDrawerHover) {
+      return "persistent-drawer-hover"
+    }
+    return "persistent-drawer-closed"
+  }
+
   render() {
     const {
       channels,
@@ -109,12 +127,6 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
       location: { pathname }
     } = this.props
     const isMobile = isMobileWidth()
-
-    const wrappingClass = isMobile
-      ? ""
-      : showDrawerDesktop || showDrawerHover
-        ? "persistent-drawer-open"
-        : "persistent-drawer-closed"
 
     const channelName = getChannelNameFromPathname(pathname)
     const currentChannel = channels.get(channelName)
@@ -133,7 +145,7 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
     const expanded = isMobile ? true : showDrawerDesktop || showDrawerHover
 
     return (
-      <div className={wrappingClass}>
+      <div className={this.wrappingClass}>
         <Theme>
           <Drawer
             persistent={!isMobile}
@@ -162,7 +174,7 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
                       useLoginPopup={useLoginPopup}
                     />
                   </div>
-                  <NavigationItem whenExpanded={() => <Footer />} />
+                  <NavigationItem fading whenExpanded={() => <Footer />} />
                 </NavigationExpansion.Provider>
               </DrawerContent>
             </ScrollArea>

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -12,13 +12,24 @@ $drawer-trans: width 500ms;
   z-index: 45;
 }
 
-.persistent-drawer-open {
+.persistent-drawer-open,
+.persistent-drawer-hover {
   .mdc-drawer.mdc-drawer--persistent {
     width: $drawer-width;
 
     .mdc-drawer__drawer {
       width: $drawer-width;
     }
+  }
+}
+
+.persistent-drawer-hover,
+.persistent-drawer-closed {
+  z-index: 1;
+  position: relative;
+
+  .mdc-drawer.mdc-drawer--persistent {
+    transition: $drawer-trans 300ms;
   }
 }
 
@@ -30,6 +41,7 @@ $drawer-trans: width 500ms;
   width: $collapse-drawer-width;
   transition: $drawer-trans;
   overflow: hidden;
+  box-shadow: 1px -1px 3px -3px rgba(0, 0, 0, 0.75);
 
   .mdc-drawer__drawer {
     position: absolute;
@@ -125,6 +137,7 @@ $drawer-trans: width 500ms;
     display: flex;
     flex-direction: row;
     align-items: center;
+    max-height: 47px;
 
     .channel-link {
       display: flex;
@@ -163,6 +176,15 @@ $drawer-trans: width 500ms;
       background-color: #e7ebf5;
       font-weight: 600;
     }
+  }
+}
+
+.fading-item {
+  opacity: 0;
+  transition: opacity 500ms 300ms;
+
+  &.expanded {
+    opacity: 1;
   }
 }
 

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -85,7 +85,8 @@ body {
     padding-left: $drawer-width;
   }
 
-  .persistent-drawer-closed ~ .content {
+  .persistent-drawer-closed ~ .content,
+  .persistent-drawer-hover ~ .content {
     padding-left: $collapse-drawer-width;
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

no ticket, but follow-on from #2000 

#### What's this PR do?

This modifies the drawer again to be more in-line with the behavior that exists for gmail. Basically, this changes a few things about how the hover-over version works:

- now only opening / closing with the hamburger button causes the rest of the page to move. if you hover over the drawer expands, but the content on the rest of the page doesn't move.
- I also added a slight delay only for the hover-over open. I noticed that gmail has this - it prevents the animation from starting if you just quickly mouse in and then out, which can prevent some unsightly animation flashing. you can see how this looks in the gif below.
- I also added a very slight box-shadow to the right edge of the desktop drawer, just to add a slight visual indicator for where the edge of the drawer is. without the main content shrinking it looked a little weird to have it run into the content at certain narrower widths.

I think that's it?

#### How should this be manually tested?

check out this branch and make sure that all the above described things work as advertised. there shouldn't be any weirdness! one thing to be sure to test is to make sure it works the same everywhere on the app - I ran into a weird bug where it worked differently on the channel and post pages from the home page, I fixed that but there could be a few more strange little edge cases lurking out there.

the mobile drawer should be unchanged, but best to check that too.

#### Screenshots (if appropriate)

![drawer](https://user-images.githubusercontent.com/6207644/59518417-986b0d00-8e93-11e9-9352-60067ad0d5da.gif)

