### PR TITLE
Serializers, views, factories, and tests for course_catalog models

### DIFF
--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -1,10 +1,23 @@
 """Factories for making test data"""
 import factory
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyChoice
+from factory.fuzzy import FuzzyChoice, FuzzyText
+
+from django.contrib.contenttypes.models import ContentType
 
 from course_catalog.constants import PlatformType, AvailabilityType
-from course_catalog.models import Course, CourseInstructor, CourseTopic, CoursePrice
+from course_catalog.models import (
+    Course,
+    CourseInstructor,
+    CourseTopic,
+    CoursePrice,
+    Bootcamp,
+    Program,
+    ProgramItem,
+    LearningPath,
+    LearningPathItem,
+)
+
 
 # pylint: disable=unused-argument
 
@@ -84,3 +97,138 @@ class CourseFactory(DjangoModelFactory):
 
     class Meta:
         model = Course
+
+
+class BootcampFactory(DjangoModelFactory):
+    """Factory for Bootcamps"""
+
+    course_id = factory.Sequence(lambda n: "BOOTCAMP%03d.MIT" % n)
+    availability = FuzzyChoice(
+        (
+            AvailabilityType.current.value,
+            AvailabilityType.upcoming.value,
+            AvailabilityType.starting_soon.value,
+            AvailabilityType.archived.value,
+        )
+    )
+
+    @factory.post_generation
+    def instructors(self, create, extracted, **kwargs):
+        """Create instructors for bootcamp"""
+        if not create:
+            return
+
+        if extracted:
+            for instructor in extracted:
+                self.instructors.add(instructor)
+
+    @factory.post_generation
+    def topics(self, create, extracted, **kwargs):
+        """Create topics for bootcamp"""
+        if not create:
+            return
+
+        if extracted:
+            for topic in extracted:
+                self.topics.add(topic)
+
+    @factory.post_generation
+    def prices(self, create, extracted, **kwargs):
+        """Create prices for bootcamp"""
+        if not create:
+            return
+
+        if extracted:
+            for price in extracted:
+                self.prices.add(price)
+
+    class Meta:
+        model = Bootcamp
+
+
+class ListItemFactory(DjangoModelFactory):
+    """Factory for List Items"""
+
+    position = factory.Sequence(lambda n: n)
+    object_id = factory.SelfAttribute("content_object.id")
+    content_type = factory.LazyAttribute(
+        lambda o: ContentType.objects.get_for_model(o.content_object)
+    )
+
+    class Meta:
+        exclude = ["content_object"]
+        abstract = True
+
+
+class ProgramItemCourseFactory(ListItemFactory):
+    """Factory for Program Item Courses"""
+
+    content_object = factory.SubFactory(CourseFactory)
+
+    class Meta:
+        model = ProgramItem
+
+
+class ProgramItemBootcampFactory(ListItemFactory):
+    """Factory for Program Item Bootcamps"""
+
+    content_object = factory.SubFactory(BootcampFactory)
+
+    class Meta:
+        model = ProgramItem
+
+
+class ProgramFactory(DjangoModelFactory):
+    """Factory for Programs"""
+
+    title = FuzzyText()
+
+    @factory.post_generation
+    def topics(self, create, extracted, **kwargs):
+        """Create topics for program"""
+        if not create:
+            return
+
+        if extracted:
+            for topic in extracted:
+                self.topics.add(topic)
+
+    class Meta:
+        model = Program
+
+
+class LearningPathCourseFactory(ListItemFactory):
+    """Factory for Learning Path Item Courses"""
+
+    content_object = factory.SubFactory(CourseFactory)
+
+    class Meta:
+        model = LearningPathItem
+
+
+class LearningPathBootcampFactory(ListItemFactory):
+    """Factory for Learning Path Item Bootcamps"""
+
+    content_object = factory.SubFactory(BootcampFactory)
+
+    class Meta:
+        model = LearningPathItem
+
+
+class LearningPathFactory(DjangoModelFactory):
+    """Factory for Learning Paths"""
+
+    title = FuzzyText()
+
+    @factory.post_generation
+    def topics(self, create, extracted, **kwargs):
+        """Create topics for learning path"""
+        if not create:
+            return
+
+        if extracted:
+            for topic in extracted:
+                self.topics.add(topic)
+
+    class Meta:
+        model = LearningPath

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -9,9 +9,14 @@ from course_catalog.factories import (
     CoursePriceFactory,
     CourseInstructorFactory,
     BootcampFactory,
-    ProgramFactory)
+    ProgramFactory,
+)
 from course_catalog.models import ProgramItem
-from course_catalog.serializers import CourseSerializer, BootcampSerializer, ProgramItemSerializer
+from course_catalog.serializers import (
+    CourseSerializer,
+    BootcampSerializer,
+    ProgramItemSerializer,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -62,10 +67,7 @@ def test_generic_foreign_key_serializer():
     """
     program = ProgramFactory()
     course_topic = CourseTopicFactory()
-    program_item = ProgramItem(
-        program=program,
-        item=course_topic,
-    )
+    program_item = ProgramItem(program=program, item=course_topic)
     serializer = ProgramItemSerializer(program_item)
     with pytest.raises(Exception):
-        assert serializer.data.get('item').get('id') == course_topic.id
+        assert serializer.data.get("item").get("id") == course_topic.id

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -8,8 +8,9 @@ from course_catalog.factories import (
     CourseTopicFactory,
     CoursePriceFactory,
     CourseInstructorFactory,
+    BootcampFactory,
 )
-from course_catalog.serializers import CourseSerializer
+from course_catalog.serializers import CourseSerializer, BootcampSerializer
 
 pytestmark = pytest.mark.django_db
 
@@ -24,6 +25,26 @@ def test_serialize_course_related_models():
         instructors=CourseInstructorFactory.create_batch(2),
     )
     serializer = CourseSerializer(course)
+    assert len(serializer.data["prices"]) == 2
+    for attr in ("mode", "price"):
+        assert attr in serializer.data["prices"][0].keys()
+    assert len(serializer.data["instructors"]) == 2
+    for attr in ("first_name", "last_name"):
+        assert attr in serializer.data["instructors"][0].keys()
+    assert len(serializer.data["topics"]) == 3
+    assert "name" in serializer.data["topics"][0].keys()
+
+
+def test_serialize_bootcamp_related_models():
+    """
+    Verify that a serialized bootcamp contains attributes for related objects
+    """
+    bootcamp = BootcampFactory(
+        topics=CourseTopicFactory.create_batch(3),
+        prices=CoursePriceFactory.create_batch(2),
+        instructors=CourseInstructorFactory.create_batch(2),
+    )
+    serializer = BootcampSerializer(bootcamp)
     assert len(serializer.data["prices"]) == 2
     for attr in ("mode", "price"):
         assert attr in serializer.data["prices"][0].keys()

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -9,8 +9,9 @@ from course_catalog.factories import (
     CoursePriceFactory,
     CourseInstructorFactory,
     BootcampFactory,
-)
-from course_catalog.serializers import CourseSerializer, BootcampSerializer
+    ProgramFactory)
+from course_catalog.models import ProgramItem
+from course_catalog.serializers import CourseSerializer, BootcampSerializer, ProgramItemSerializer
 
 pytestmark = pytest.mark.django_db
 
@@ -53,3 +54,18 @@ def test_serialize_bootcamp_related_models():
         assert attr in serializer.data["instructors"][0].keys()
     assert len(serializer.data["topics"]) == 3
     assert "name" in serializer.data["topics"][0].keys()
+
+
+def test_generic_foreign_key_serializer():
+    """
+    Test that generic foreign key serializer properly rejects unexpected classes
+    """
+    program = ProgramFactory()
+    course_topic = CourseTopicFactory()
+    program_item = ProgramItem(
+        program=program,
+        item=course_topic,
+    )
+    serializer = ProgramItemSerializer(program_item)
+    with pytest.raises(Exception):
+        assert serializer.data.get('item').get('id') == course_topic.id

--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -17,12 +17,17 @@ from django.conf.urls import url
 from django.urls import include
 from rest_framework.routers import DefaultRouter
 
-from course_catalog.views import CourseViewSet, ocw_course_report
+from course_catalog import views
 
 router = DefaultRouter()
-router.register(r"courses", CourseViewSet, basename="courses")
+router.register(r"courses", views.CourseViewSet, basename="courses")
+router.register(r"bootcamps", views.BootcampViewSet, basename="bootcamps")
+router.register(r"programs", views.ProgramViewSet, basename="programs")
+router.register(r"learningpaths", views.LearningPathViewSet, basename="learningpaths")
 
 urlpatterns = [
     url(r"^api/v0/", include(router.urls)),
-    url(r"^api/v0/ocw-course-report", ocw_course_report, name="ocw-course-report"),
+    url(
+        r"^api/v0/ocw-course-report", views.ocw_course_report, name="ocw-course-report"
+    ),
 ]

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -9,8 +9,13 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from course_catalog.constants import ResourceType, PlatformType
-from course_catalog.models import Course
-from course_catalog.serializers import CourseSerializer
+from course_catalog.models import Course, LearningPath, Program, Bootcamp
+from course_catalog.serializers import (
+    CourseSerializer,
+    LearningPathSerializer,
+    ProgramSerializer,
+    BootcampSerializer,
+)
 from open_discussions.permissions import AnonymousAccessReadonlyPermission
 
 # pylint:disable=unused-argument
@@ -45,9 +50,9 @@ def ocw_course_report(request):
     )
 
 
-class CoursePagination(LimitOffsetPagination):
+class DefaultPagination(LimitOffsetPagination):
     """
-    Pagination class for CourseViewSet which gets default_limit and max_limit from settings
+    Pagination class for course_catalog viewsets which gets default_limit and max_limit from settings
     """
 
     default_limit = settings.COURSE_API_DEFAULT_LIMIT
@@ -61,7 +66,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Course.objects.all().prefetch_related("topics", "instructors", "prices")
     serializer_class = CourseSerializer
-    pagination_class = CoursePagination
+    pagination_class = DefaultPagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
 
     @action(methods=["GET"], detail=False)
@@ -92,3 +97,38 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         page = self.paginate_queryset(self.queryset.filter(featured=True))
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
+
+
+class BootcampViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for Bootcamps
+    """
+
+    queryset = Bootcamp.objects.all().prefetch_related(
+        "topics", "instructors", "prices"
+    )
+    serializer_class = BootcampSerializer
+    pagination_class = DefaultPagination
+    permission_classes = (AnonymousAccessReadonlyPermission,)
+
+
+class LearningPathViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for Learning Paths
+    """
+
+    queryset = LearningPath.objects.all().prefetch_related("items")
+    serializer_class = LearningPathSerializer
+    pagination_class = DefaultPagination
+    permission_classes = (AnonymousAccessReadonlyPermission,)
+
+
+class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for Programs
+    """
+
+    queryset = Program.objects.all().prefetch_related("items")
+    serializer_class = ProgramSerializer
+    pagination_class = DefaultPagination
+    permission_classes = (AnonymousAccessReadonlyPermission,)

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -1,0 +1,87 @@
+"""Tests for course_catalog views"""
+
+from django.urls import reverse
+
+from course_catalog.factories import (
+    CourseFactory,
+    CourseTopicFactory,
+    CoursePriceFactory,
+    CourseInstructorFactory,
+    BootcampFactory,
+    ProgramFactory,
+    LearningPathFactory,
+    LearningPathBootcampFactory,
+    LearningPathCourseFactory,
+    ProgramItemCourseFactory,
+    ProgramItemBootcampFactory,
+)
+from open_discussions.factories import UserFactory
+
+
+def test_course_endpoint(client):
+    """Test course endpoint"""
+    course = CourseFactory(
+        topics=CourseTopicFactory.create_batch(3),
+        prices=CoursePriceFactory.create_batch(2),
+        instructors=CourseInstructorFactory.create_batch(2),
+    )
+
+    resp = client.get(reverse("courses-list"))
+    assert resp.data.get("count") == 1
+
+    resp = client.get(reverse("courses-detail", args=[course.id]))
+    assert resp.data.get("course_id") == course.course_id
+
+
+def test_bootcamp_endpoint(client):
+    """Test bootcamp endpoint"""
+    bootcamp = BootcampFactory(
+        topics=CourseTopicFactory.create_batch(3),
+        prices=CoursePriceFactory.create_batch(2),
+        instructors=CourseInstructorFactory.create_batch(2),
+    )
+
+    resp = client.get(reverse("bootcamps-list"))
+    assert resp.data.get("count") == 1
+
+    resp = client.get(reverse("bootcamps-detail", args=[bootcamp.id]))
+    assert resp.data.get("course_id") == bootcamp.course_id
+
+
+def test_program_endpoint(client):
+    """Test program endpoint"""
+    program = ProgramFactory(topics=CourseTopicFactory.create_batch(3))
+    bootcamp_item = ProgramItemBootcampFactory(program=program, position=1)
+    course_item = ProgramItemCourseFactory(program=program, position=2)
+
+    resp = client.get(reverse("programs-list"))
+    assert resp.data.get("count") == 1
+
+    resp = client.get(reverse("programs-detail", args=[program.id]))
+    assert resp.data.get("title") == program.title
+    for item in resp.data.get("items"):
+        if item.get("position") == 1:
+            assert item.get("id") == bootcamp_item.id
+        else:
+            assert item.get("id") == course_item.id
+
+
+def test_learning_path_endpoint(client):
+    """Test learning path endpoint"""
+    user = UserFactory()
+    learning_path = LearningPathFactory(
+        topics=CourseTopicFactory.create_batch(3), author=user
+    )
+    bootcamp_item = LearningPathBootcampFactory(learning_path=learning_path, position=1)
+    course_item = LearningPathCourseFactory(learning_path=learning_path, position=2)
+
+    resp = client.get(reverse("learningpaths-list"))
+    assert resp.data.get("count") == 1
+
+    resp = client.get(reverse("learningpaths-detail", args=[learning_path.id]))
+    assert resp.data.get("title") == learning_path.title
+    for item in resp.data.get("items"):
+        if item.get("position") == 1:
+            assert item.get("id") == bootcamp_item.id
+        else:
+            assert item.get("id") == course_item.id


### PR DESCRIPTION
#### What are the relevant tickets?
#2057

#### What's this PR do?
This PR adds views, serializers, factories, and tests for the new course catalog models.

#### How should this be manually tested?
Create courses, bootcamps, programs, and learning paths, and then navigate to the relevant pages.
`api/v0/[courses|bootcamps|programs|learningpaths]`
