### PR TITLE
Add endpoints for users to favorite and view favorited items

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -1,6 +1,8 @@
 """
 course_catalog serializers
 """
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
 from course_catalog.constants import PlatformType, AvailabilityType, ResourceType
@@ -14,6 +16,7 @@ from course_catalog.models import (
     UserList,
     Program,
     ProgramItem,
+    FavoriteItem,
 )
 from course_catalog.utils import get_ocw_topic, get_year_and_semester, get_course_url
 
@@ -32,6 +35,50 @@ class GenericForeignKeyFieldSerializer(serializers.ModelSerializer):
             raise Exception("Unexpected type of tagged object")
 
         return serializer.data
+
+
+class FavoriteItemContentSerializer(serializers.ModelSerializer):
+    """
+    Special field to handle the generic foreign key in FavoriteItem
+    """
+
+    def to_representation(self, instance):
+        # Pass context on to the serializers so that they have access to the user
+        context = self.context
+        if isinstance(instance, Bootcamp):
+            serializer = BootcampSerializer(instance, context=context)
+        elif isinstance(instance, Course):
+            serializer = CourseSerializer(instance, context=context)
+        elif isinstance(instance, UserList):
+            serializer = UserListSerializer(instance, context=context)
+        elif isinstance(instance, Program):
+            serializer = ProgramSerializer(instance, context=context)
+        else:
+            raise Exception("Unexpected type of tagged object")
+
+        return serializer.data
+
+
+class FavoriteSerializerMixin(serializers.Serializer):
+    """
+    Mixin to serializer is_favorite for various models
+    """
+
+    is_favorite = serializers.SerializerMethodField()
+
+    def get_is_favorite(self, obj):
+        """
+        Check if user has a favorite item for object, otherwise return false
+        """
+        request = self.context.get("request")
+        if request and hasattr(request, "user") and isinstance(request.user, User):
+            return FavoriteItem.objects.filter(
+                user=request.user,
+                object_id=obj.id,
+                content_type=ContentType.objects.get_for_model(obj),
+            ).exists()
+        else:
+            return False
 
 
 class CourseInstructorSerializer(serializers.ModelSerializer):
@@ -64,7 +111,7 @@ class CourseTopicSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class BaseCourseSerializer(serializers.ModelSerializer):
+class BaseCourseSerializer(FavoriteSerializerMixin, serializers.ModelSerializer):
     """
     Serializer with common functions to be used by CourseSerializer and BootcampSerialzer
     """
@@ -276,7 +323,7 @@ class UserListItemSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class UserListSerializer(serializers.ModelSerializer):
+class UserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
     """
     Serializer for UserList model
     """
@@ -302,7 +349,7 @@ class ProgramItemSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class ProgramSerializer(serializers.ModelSerializer):
+class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
     """
     Serializer for Program model
     """
@@ -312,4 +359,17 @@ class ProgramSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Program
+        fields = "__all__"
+
+
+class FavoriteItemSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Favorite Item
+    """
+
+    content_data = FavoriteItemContentSerializer(source="item")
+    content_type = serializers.CharField(source="content_type.name")
+
+    class Meta:
+        model = FavoriteItem
         fields = "__all__"

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -18,6 +18,8 @@ from course_catalog.serializers import (
     BootcampSerializer,
     ProgramItemSerializer,
     FavoriteItemSerializer,
+    UserListSerializer,
+    ProgramSerializer,
 )
 from open_discussions.factories import UserFactory
 
@@ -97,11 +99,11 @@ def test_favorites_serializer():
 
     favorite_item = FavoriteItem(user=user, item=user_list)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data") == UserListFactory(user_list).data
+    assert serializer.data.get("content_data") == UserListSerializer(user_list).data
 
     favorite_item = FavoriteItem(user=user, item=program)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data") == ProgramFactory(program).data
+    assert serializer.data.get("content_data") == ProgramSerializer(program).data
 
     favorite_item = FavoriteItem(user=user, item=course_topic)
     serializer = FavoriteItemSerializer(favorite_item)

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -89,19 +89,19 @@ def test_favorites_serializer():
 
     favorite_item = FavoriteItem(user=user, item=course)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data").get("id") == course.id
+    assert serializer.data.get("content_data") == CourseSerializer(course).data
 
     favorite_item = FavoriteItem(user=user, item=bootcamp)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data").get("id") == bootcamp.id
+    assert serializer.data.get("content_data") == BootcampSerializer(bootcamp).data
 
     favorite_item = FavoriteItem(user=user, item=user_list)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data").get("id") == user_list.id
+    assert serializer.data.get("content_data") == UserListFactory(user_list).data
 
     favorite_item = FavoriteItem(user=user, item=program)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data").get("id") == program.id
+    assert serializer.data.get("content_data") == ProgramFactory(program).data
 
     favorite_item = FavoriteItem(user=user, item=course_topic)
     serializer = FavoriteItemSerializer(favorite_item)

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -10,13 +10,16 @@ from course_catalog.factories import (
     CourseInstructorFactory,
     BootcampFactory,
     ProgramFactory,
+    UserListFactory,
 )
-from course_catalog.models import ProgramItem
+from course_catalog.models import ProgramItem, FavoriteItem
 from course_catalog.serializers import (
     CourseSerializer,
     BootcampSerializer,
     ProgramItemSerializer,
+    FavoriteItemSerializer,
 )
+from open_discussions.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -71,3 +74,36 @@ def test_generic_foreign_key_serializer():
     serializer = ProgramItemSerializer(program_item)
     with pytest.raises(Exception):
         assert serializer.data.get("item").get("id") == course_topic.id
+
+
+def test_favorites_serializer():
+    """
+    Test that the favorite serializer generic foreign key works and also rejects unexpected classes
+    """
+    user = UserFactory()
+    course = CourseFactory()
+    bootcamp = BootcampFactory()
+    user_list = UserListFactory(author=user)
+    program = ProgramFactory()
+    course_topic = CourseTopicFactory()
+
+    favorite_item = FavoriteItem(user=user, item=course)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data").get("id") == course.id
+
+    favorite_item = FavoriteItem(user=user, item=bootcamp)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data").get("id") == bootcamp.id
+
+    favorite_item = FavoriteItem(user=user, item=user_list)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data").get("id") == user_list.id
+
+    favorite_item = FavoriteItem(user=user, item=program)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data").get("id") == program.id
+
+    favorite_item = FavoriteItem(user=user, item=course_topic)
+    serializer = FavoriteItemSerializer(favorite_item)
+    with pytest.raises(Exception):
+        assert serializer.data.get("content_data").get("id") == course_topic.id

--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -24,6 +24,7 @@ router.register(r"courses", views.CourseViewSet, basename="courses")
 router.register(r"bootcamps", views.BootcampViewSet, basename="bootcamps")
 router.register(r"programs", views.ProgramViewSet, basename="programs")
 router.register(r"userlists", views.UserListViewSet, basename="userlists")
+router.register(r"favorites", views.FavoriteItemViewSet, basename="favorites")
 
 urlpatterns = [
     url(r"^api/v0/", include(router.urls)),

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -2,7 +2,6 @@
 course_catalog views
 """
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
 from django.utils import timezone
@@ -75,10 +74,7 @@ class FavoriteViewMixin:
         """
         obj = self.get_object()
         try:
-            if isinstance(request.user, User):
-                FavoriteItem.objects.create(user=request.user, item=obj)
-            else:
-                return Response(status=status.HTTP_401_UNAUTHORIZED)
+            FavoriteItem.objects.create(user=request.user, item=obj)
         except IntegrityError:
             pass
         return Response(status=status.HTTP_200_OK)
@@ -89,18 +85,12 @@ class FavoriteViewMixin:
         Delete a favorite item for this object
         """
         obj = self.get_object()
-        try:
-            if isinstance(request.user, User):
-                favorite_item = FavoriteItem.objects.filter(
-                    user=request.user,
-                    object_id=obj.id,
-                    content_type=ContentType.objects.get_for_model(obj),
-                )
-                favorite_item.delete()
-            else:
-                return Response(status=status.HTTP_401_UNAUTHORIZED)
-        except FavoriteItem.DoesNotExist:
-            pass
+        favorite_item = FavoriteItem.objects.filter(
+            user=request.user,
+            object_id=obj.id,
+            content_type=ContentType.objects.get_for_model(obj),
+        )
+        favorite_item.delete()
         return Response(status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
_This is PR is intended to start the conversation around how the frontend and backend will interact to create the feature of users being able to favorite learning resource objects and displaying search results as favorited or not. Ideally, a user can favorite and unfavorite an item in real-time and have that be quickly reflected in their Favorites list_

Questions:
- How can we display whether a Search result is favorited or not?
- How do we populate the "My Favorites" list on the home page? Does the content from Elasticsearch, or does it come from an backend endpoint? If course/etc data comes from Elasticsearch, do we make ES queries for each favorited object?
- Would endpoint that takes in `object_id, object_type` pairs and returns true/false whether it is a favorite of the current user be helpful?

A starting proposal: 
Right now, what each favorites is not being indexed. Instead, we could do something akin to this: when the frontend loads and displays search results, it makes a request with a userid to a Favorites API that returns ids of what objects have been favorited, stored by the frontend. If the Id matches what comes up in a search result, the frontend displays the object’s card to be visually marked as favorited. 

Note that anonymous users (not logged in) don’t get to favorite things (otherwise we would have to come up with a scheme to store temporary IDs of what people favorite in their cookie or similar)

#### What are the relevant tickets?
A user needs a way to favorite and unfavorite various course_catalog models. They also need to see which objects they favorited. 

#### What's this PR do?
This PR adds a viewset to view all FavoriteItem objects for a user. It also adds an is_favorite field to the serializers for Bootcamps, Courses, Programs, and UserLists.

#### How should this be manually tested?
Manually create some Bootcamps, Courses, Programs, and UserLists in the backend. Also create a user. Then create FavoriteItem objects linking the user to the other objects. Check the relevant endpoints to see that the `is_favorite` flag populates correctly, and then check `/api/v0/favorites` to see that all of the favorited items show up.
