### PR TITLE
Fix search query for anonymous users

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -147,6 +147,7 @@ def _apply_general_query_filters(search, user):
     Returns:
         elasticsearch_dsl.Search: Search object with filters applied
     """
+    # Get the list of channels a logged in user is a contributor/moderator of
     channel_names = (
         sorted(
             list(
@@ -161,39 +162,48 @@ def _apply_general_query_filters(search, user):
         else []
     )
 
+    # Search for comments and posts from channels
     channels_filter = Q(
         "terms", channel_type=[CHANNEL_TYPE_PUBLIC, CHANNEL_TYPE_RESTRICTED]
     ) | ~Q("terms", object_type=[COMMENT_TYPE, POST_TYPE])
 
+    # Exclude deleted comments and posts
     content_filter = (Q("term", deleted=False) & Q("term", removed=False)) | ~Q(
         "terms", object_type=[COMMENT_TYPE, POST_TYPE]
     )
 
+    # Search only published courses
     course_filter = Q("term", published=True) | ~Q("terms", object_type=[COURSE_TYPE])
 
+    # Search only published bootcamps
     bootcamp_filter = Q("term", published=True) | ~Q(
         "terms", object_type=[BOOTCAMP_TYPE]
     )
 
+    # Search programs
     program_filter = ~Q("terms", object_type=[PROGRAM_TYPE])
 
-    user_list_filter = (
-        Q("term", privacy_level=PrivacyLevel.public.value)
-        | Q("term", author_id=user.id)
-        | ~Q("terms", object_type=[USER_LIST_TYPE])
-    )
-
+    # Search public channels and channels user is a contributor/moderator of
     if channel_names:
         channels_filter = channels_filter | Q("terms", channel_name=channel_names)
 
-    return (
+    filters = (
         search.filter(channels_filter)
         .filter(content_filter)
         .filter(course_filter)
         .filter(bootcamp_filter)
         .filter(program_filter)
-        .filter(user_list_filter)
     )
+
+    if not user.is_anonymous:
+        # Search the user's lists
+        user_list_filter = (
+            Q("term", privacy_level=PrivacyLevel.public.value)
+            | Q("term", author_id=user.id)
+            | ~Q("terms", object_type=[USER_LIST_TYPE])
+        )
+        filters = filters.filter(user_list_filter)
+    return filters
 
 
 def execute_search(*, user, query):

--- a/search/api.py
+++ b/search/api.py
@@ -184,9 +184,8 @@ def _apply_general_query_filters(search, user):
     program_filter = ~Q("terms", object_type=[PROGRAM_TYPE])
 
     # Search public lists (and user's own lists if logged in)
-    user_list_filter = (
-        Q("term", privacy_level=PrivacyLevel.public.value)
-        | ~Q("terms", object_type=[USER_LIST_TYPE])
+    user_list_filter = Q("term", privacy_level=PrivacyLevel.public.value) | ~Q(
+        "terms", object_type=[USER_LIST_TYPE]
     )
     if not user.is_anonymous:
         user_list_filter = user_list_filter | Q("term", author_id=user.id)

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -191,7 +191,11 @@ def test_execute_search(mocker, user):
                                             ]
                                         }
                                     },
-                                    {"term": {"privacy_level": PrivacyLevel.public.value}},
+                                    {
+                                        "term": {
+                                            "privacy_level": PrivacyLevel.public.value
+                                        }
+                                    },
                                     {"term": {"author_id": user.id}},
                                 ]
                             }
@@ -324,7 +328,11 @@ def test_execute_search_anonymous(mocker):
                                             ]
                                         }
                                     },
-                                    {"term": {"privacy_level": PrivacyLevel.public.value}},
+                                    {
+                                        "term": {
+                                            "privacy_level": PrivacyLevel.public.value
+                                        }
+                                    },
                                 ]
                             }
                         },

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -181,12 +181,6 @@ def test_execute_search(mocker, user):
                             "bool": {
                                 "should": [
                                     {
-                                        "term": {
-                                            "privacy_level": PrivacyLevel.public.value
-                                        }
-                                    },
-                                    {"term": {"author_id": user.id}},
-                                    {
                                         "bool": {
                                             "must_not": [
                                                 {
@@ -197,6 +191,8 @@ def test_execute_search(mocker, user):
                                             ]
                                         }
                                     },
+                                    {"term": {"privacy_level": PrivacyLevel.public.value}},
+                                    {"term": {"author_id": user.id}},
                                 ]
                             }
                         },
@@ -312,6 +308,24 @@ def test_execute_search_anonymous(mocker):
                         {
                             "bool": {
                                 "must_not": [{"terms": {"object_type": ["program"]}}]
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "bool": {
+                                            "must_not": [
+                                                {
+                                                    "terms": {
+                                                        "object_type": ["user_list"]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {"term": {"privacy_level": PrivacyLevel.public.value}},
+                                ]
                             }
                         },
                     ]

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -313,30 +313,7 @@ def test_execute_search_anonymous(mocker):
                             "bool": {
                                 "must_not": [{"terms": {"object_type": ["program"]}}]
                             }
-                        },
-                        {
-                            "bool": {
-                                "should": [
-                                    {
-                                        "term": {
-                                            "privacy_level": PrivacyLevel.public.value
-                                        }
-                                    },
-                                    {"term": {"author_id": user.id}},
-                                    {
-                                        "bool": {
-                                            "must_not": [
-                                                {
-                                                    "terms": {
-                                                        "object_type": ["user_list"]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                ]
-                            }
-                        },
+                        }
                     ]
                 }
             },

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -313,7 +313,7 @@ def test_execute_search_anonymous(mocker):
                             "bool": {
                                 "must_not": [{"terms": {"object_type": ["program"]}}]
                             }
-                        }
+                        },
                     ]
                 }
             },


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes broken search for anonymous users

#### How should this be manually tested?
Search for courses and search for posts/comments, while logged in and anonymously.  There should be no errors either way.
