### PR TITLE
fix a few drawer styling issues

### DIFF
--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -27,7 +27,9 @@ $drawer-trans: width 500ms;
 .persistent-drawer-closed {
   z-index: 1;
   position: relative;
+}
 
+.persistent-drawer-hover {
   .mdc-drawer.mdc-drawer--persistent {
     transition: $drawer-trans 300ms;
   }
@@ -87,6 +89,7 @@ $drawer-trans: width 500ms;
     margin-left: $text-padding-left;
     font-size: 18px;
     word-break: break-word;
+    display: block;
   }
 
   .new-post-link-container {
@@ -147,6 +150,10 @@ $drawer-trans: width 500ms;
       font-size: 18px;
       padding: $link-padding;
       flex-grow: 1;
+
+      .title {
+        margin-left: 7px;
+      }
     }
 
     .avatar-image {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

This fixes a few small styling issues with the drawer. 

the first is an issue that crops up with long channel titles, like this one on production:

![longtitleicky](https://user-images.githubusercontent.com/6207644/61005857-f413a380-a336-11e9-8d8b-8aaf48887728.png)

basically it shouldn't be all wonky. and also, the left edge of the channel titles is supposed to be aligned with the 'Compose' and 'Home' text.

I also fixed a weird behavior with the `transition-delay` property I had set.

#### How should this be manually tested?

create a channel with a long title and make sure it doesn't totally break everything. also make sure the drawer looks alright and feels like it should to use.


#### Screenshots (if appropriate)
![fifififnddddmob](https://user-images.githubusercontent.com/6207644/61006008-5371b380-a337-11e9-9516-ae658f109740.png)
![fifififndddd](https://user-images.githubusercontent.com/6207644/61006009-5371b380-a337-11e9-9573-5b973723d986.png)

