### PR TITLE
Ignore allowed_post_types from django-admin

### DIFF
--- a/channels/admin.py
+++ b/channels/admin.py
@@ -9,7 +9,7 @@ class ChannelAdmin(admin.ModelAdmin):
     """Customized Channel admin model"""
 
     model = Channel
-    exclude = ("banner", "avatar", "widget_list")
+    exclude = ("banner", "avatar", "widget_list", "allowed_post_types")
     search_fields = ("name",)
     readonly_fields = ("name",)
     list_filter = ("ga_tracking_id",)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

Fixes #2093 

#### What's this PR do?
Hides `allowed_post_types` in django-admin. Unfortunately `BitField` is broken under django 2.1+, and pending either migration away from this or a new release of the library being cut, this is the quickest fix. This field can still be updated in the react app by a channel moderator.

#### How should this be manually tested?
Go to django admin for a channel and verify you can make changes.
