### PR TITLE
Import courses and course runs for MITx

### DIFF
--- a/app.json
+++ b/app.json
@@ -107,6 +107,10 @@
     "MAILGUN_SENDER_DOMAIN": {
       "description": "Domain used for emails sent via mailgun"
     },
+    "MAX_S3_GET_ITERATIONS": {
+      "description": "Max retry attempts to get an S3 object",
+      "required": false
+    },
     "MICROMASTERS_COURSE_URL": {
       "description": "URL for MicroMasters course info",
       "required": false

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -74,9 +74,7 @@ def parse_mitx_json_data(course_data, force_overwrite=False):
         compare_datetime = datetime.strptime(
             course_modified, "%Y-%m-%dT%H:%M:%S.%fZ"
         ).astimezone(pytz.utc)
-        needs_update = (
-            compare_datetime <= course.last_modified
-        ) or force_overwrite
+        needs_update = (compare_datetime >= course.last_modified) or force_overwrite
         index_func = update_course
     except Course.DoesNotExist:
         index_func = index_new_course
@@ -123,7 +121,7 @@ def parse_mitx_json_data(course_data, force_overwrite=False):
                     # Try and get the CourseRun instance. If it exists check to see if it needs updating
                     try:
                         courserun_instance = CourseRun.objects.get(
-                            course_run_id=course_run.get("key"), course=course
+                            course_run_id=course_run.get("key")
                         )
                         compare_datetime = datetime.strptime(
                             max_modified, "%Y-%m-%dT%H:%M:%S.%fZ"

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -119,6 +119,17 @@ def test_parse_valid_mitx_json_data(mock_course_index_functions, mitx_valid_data
     )
 
 
+def test_parse_mitx_json_data_no_runs(mitx_valid_data):
+    """
+    Test that a course without runs is skipped
+    """
+    mitx_data = copy.copy(mitx_valid_data)
+    mitx_data["course_runs"] = []
+    parse_mitx_json_data(mitx_data)
+    course_count = Course.objects.count()
+    assert course_count == 0
+
+
 def test_parse_invalid_mitx_json_data(mitx_valid_data):
     """
     Test parsing invalid mitx json data for a course

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -10,7 +10,7 @@ import pytz
 from django.utils import timezone
 
 from course_catalog.constants import PlatformType, AvailabilityType, ResourceType
-from course_catalog.factories import CourseFactory
+from course_catalog.factories import CourseFactory, CourseRunFactory
 from course_catalog.models import Course, CourseInstructor, CoursePrice, CourseTopic
 from course_catalog.utils import get_ocw_topic
 from course_catalog.api import (
@@ -42,13 +42,16 @@ def test_parse_mitx_json_data_overwrite(
     """
     Test that valid mitx json data is skipped if it doesn't need an update
     """
-    CourseFactory.create(
-        course_id=mitx_valid_data["course_runs"][0]["key"],
+    course = CourseFactory.create(
+        course_id=mitx_valid_data["key"],
         last_modified=datetime.now().astimezone(pytz.utc),
     )
-    mock_save = mocker.patch("course_catalog.api.EDXSerializer.save")
+    CourseRunFactory.create(course=course, course_run_id=mitx_valid_data["course_runs"][0]["key"])
+    mock_save_course = mocker.patch("course_catalog.api.EDXCourseRunSerializer.save")
+    mock_save_run = mocker.patch("course_catalog.api.EDXCourseSerializer.save")
     parse_mitx_json_data(mitx_valid_data, force_overwrite=force_overwrite)
-    assert mock_save.call_count == (1 if force_overwrite else 0)
+    assert mock_save_course.call_count == (1 if force_overwrite else 0)
+    assert mock_save_run.call_count == (1 if force_overwrite else 0)
     assert mock_course_index_functions.update_course.call_count == (
         1 if force_overwrite else 0
     )

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -17,7 +17,8 @@ from course_catalog.models import (
     ProgramItem,
     UserList,
     UserListItem,
-    CourseRun)
+    CourseRun,
+)
 
 
 # pylint: disable=unused-argument
@@ -111,6 +112,7 @@ class CourseFactory(DjangoModelFactory):
 
 class CourseRunFactory(DjangoModelFactory):
     """Factory for CourseRuns"""
+
     course_run_id = factory.Sequence(lambda n: "COURSEN%03d.MIT_run" % n)
     course = SubFactory(CourseFactory)
 

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -136,16 +136,6 @@ class CourseRunFactory(DjangoModelFactory):
                 self.instructors.add(instructor)
 
     @factory.post_generation
-    def topics(self, create, extracted, **kwargs):
-        """Create topics for course"""
-        if not create:
-            return
-
-        if extracted:
-            for topic in extracted:
-                self.topics.add(topic)
-
-    @factory.post_generation
     def prices(self, create, extracted, **kwargs):
         """Create prices for course"""
         if not create:

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -1,5 +1,6 @@
 """Factories for making test data"""
 import factory
+from factory import SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
 
@@ -16,7 +17,7 @@ from course_catalog.models import (
     ProgramItem,
     UserList,
     UserListItem,
-)
+    CourseRun)
 
 
 # pylint: disable=unused-argument
@@ -106,6 +107,54 @@ class CourseFactory(DjangoModelFactory):
 
     class Meta:
         model = Course
+
+
+class CourseRunFactory(DjangoModelFactory):
+    """Factory for CourseRuns"""
+    course_run_id = factory.Sequence(lambda n: "COURSEN%03d.MIT_run" % n)
+    course = SubFactory(CourseFactory)
+
+    availability = FuzzyChoice(
+        (
+            AvailabilityType.current.value,
+            AvailabilityType.upcoming.value,
+            AvailabilityType.starting_soon.value,
+            AvailabilityType.archived.value,
+        )
+    )
+
+    @factory.post_generation
+    def instructors(self, create, extracted, **kwargs):
+        """Create instructors for course"""
+        if not create:
+            return
+
+        if extracted:
+            for instructor in extracted:
+                self.instructors.add(instructor)
+
+    @factory.post_generation
+    def topics(self, create, extracted, **kwargs):
+        """Create topics for course"""
+        if not create:
+            return
+
+        if extracted:
+            for topic in extracted:
+                self.topics.add(topic)
+
+    @factory.post_generation
+    def prices(self, create, extracted, **kwargs):
+        """Create prices for course"""
+        if not create:
+            return
+
+        if extracted:
+            for price in extracted:
+                self.prices.add(price)
+
+    class Meta:
+        model = CourseRun
 
 
 class BootcampFactory(DjangoModelFactory):

--- a/course_catalog/management/commands/backpopulate_edx_data.py
+++ b/course_catalog/management/commands/backpopulate_edx_data.py
@@ -1,8 +1,10 @@
 """Management command for populating edx course data"""
 from django.core.management import BaseCommand
 
+from course_catalog.models import Course
 from course_catalog.tasks import sync_and_upload_edx_data
 from open_discussions.utils import now_in_utc
+from search.task_helpers import delete_course
 
 
 class Command(BaseCommand):
@@ -10,11 +12,46 @@ class Command(BaseCommand):
 
     help = "Populate edx courses"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--overwrite",
+            dest="force_overwrite",
+            action="store_true",
+            help="Overwrite any existing records",
+        )
+        parser.add_argument(
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete all existing records first",
+        )
+        parser.add_argument(
+            "--skip-s3",
+            dest="upload_to_s3",
+            action="store_false",
+            help="skip uploading course files to s3",
+        )
+        super().add_arguments(parser)
+
     def handle(self, *args, **options):
         """Run Populate edx courses"""
-        task = sync_and_upload_edx_data.delay()
+        if options["delete"]:
+            self.stdout.write(
+                "Deleting all existing MITx courses from database and ElasticSearch"
+            )
+            for course in Course.objects.filter(platform="mitx"):
+                course.delete()
+                delete_course(course)
+        task = sync_and_upload_edx_data.delay(
+            force_overwrite=options["force_overwrite"],
+            upload_to_s3=options["upload_to_s3"],
+        )
         self.stdout.write(
-            "Started celery task {task} to get edx course data".format(task=task)
+            "Started task {task} to get edx course data w/force_overwrite={overwrite}, upload_to_s3={s3}".format(
+                task=task,
+                overwrite=options["force_overwrite"],
+                s3=options["upload_to_s3"],
+            )
         )
         self.stdout.write("Waiting on task...")
         start = now_in_utc()

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -1,8 +1,10 @@
 """Management command for populating ocw course data"""
 from django.core.management import BaseCommand
 
+from course_catalog.models import Course
 from course_catalog.tasks import get_ocw_data
 from open_discussions.utils import now_in_utc
+from search.task_helpers import delete_course
 
 
 class Command(BaseCommand):
@@ -10,11 +12,44 @@ class Command(BaseCommand):
 
     help = "Populate ocw courses"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--overwrite",
+            dest="force_overwrite",
+            action="store_true",
+            help="Overwrite any existing records",
+        )
+        parser.add_argument(
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete all existing records first",
+        )
+        parser.add_argument(
+            "--skip-s3",
+            dest="upload_to_s3",
+            action="store_false",
+            help="skip uploading course files to s3",
+        )
+        super().add_arguments(parser)
+
     def handle(self, *args, **options):
-        """Run Populate edx courses"""
-        task = get_ocw_data.delay()
+        """Run Populate ocw courses"""
+        if options["delete"]:
+            self.stdout.write("Deleting all existing OCW courses")
+            for course in Course.objects.filter(platform="ocw"):
+                course.delete()
+                delete_course(course)
+        task = get_ocw_data.delay(
+            force_overwrite=options["force_overwrite"],
+            upload_to_s3=options["upload_to_s3"],
+        )
         self.stdout.write(
-            "Started celery task {task} to get ocw course data".format(task=task)
+            "Started task {task} to get ocw course data w/force_overwrite={overwrite}, upload_to_s3={s3}".format(
+                task=task,
+                overwrite=options["force_overwrite"],
+                s3=options["upload_to_s3"],
+            )
         )
         self.stdout.write("Waiting on task...")
         start = now_in_utc()

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -179,7 +179,7 @@ class CourseSerializer(BaseCourseSerializer):
         extra_kwargs = {"raw_json": {"write_only": True}}
 
 
-class EDXCourseRunSerializer(serializers.ModelSerializer):
+class EDXCourseRunSerializer(BaseCourseSerializer):
     """
     Serializer for creating CourseRun objects from edx data
     """
@@ -246,6 +246,7 @@ class EDXCourseSerializer(CourseSerializer):
     """
     Serializer for creating Course objects from edx data
     """
+
     course_runs = EDXCourseRunSerializer(many=True, read_only=True)
 
     def to_internal_value(self, data):
@@ -283,7 +284,7 @@ class EDXCourseSerializer(CourseSerializer):
     class Meta:
         model = Course
         fields = "__all__"
-        
+
 
 class OCWSerializer(CourseSerializer):
     """

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -247,8 +247,6 @@ class EDXCourseSerializer(CourseSerializer):
     Serializer for creating Course objects from edx data
     """
 
-    course_runs = EDXCourseRunSerializer(many=True, read_only=True)
-
     def to_internal_value(self, data):
         """
         Custom function to parse data out of the raw edx json

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -217,10 +217,11 @@ def test_get_mitx_data_unexpected_error(
     assert Course.objects.count() == 0
 
 
-def test_get_mitx_data_no_settings(get_micromasters_data):
+def test_get_mitx_data_no_settings(settings, get_micromasters_data):
     """
     No data should be imported if MITx settings are missing
     """
+    settings.EDX_API_URL = None
     sync_and_upload_edx_data()
     assert Course.objects.count() == 0
 
@@ -257,10 +258,11 @@ def test_get_ocw_data(settings, mock_course_index_functions):
     assert json.loads(obj.get()["Body"].read())
 
 
-def test_get_ocw_data_no_settings():
+def test_get_ocw_data_no_settings(settings):
     """
     No data should be imported if OCW settings are missing
     """
+    settings.OCW_CONTENT_ACCESS_KEY = None
     get_ocw_data()
     assert Course.objects.count() == 0
 

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -787,6 +787,7 @@ OCW_LEARNING_COURSE_SECRET_ACCESS_KEY = get_string(
 )
 OCW_UPLOAD_IMAGE_ONLY = get_bool("OCW_UPLOAD_IMAGE_ONLY", False)
 OCW_ITERATOR_CHUNK_SIZE = get_int("OCW_ITERATOR_CHUNK_SIZE", 100)
+MAX_S3_GET_ITERATIONS = get_int("MAX_S3_GET_ITERATIONS", 3)
 
 # Base URL's for courses
 OCW_BASE_URL = get_string("OCW_BASE_URL", "http://ocw.mit.edu/")

--- a/test_json/test_mitx_course01.json
+++ b/test_json/test_mitx_course01.json
@@ -147,6 +147,7 @@
 			"recent_enrollment_count": 1619
 		}],
 		"entitlements": [],
+		"image_src": "",
 		"owners": [{
 			"uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
 			"key": "MITx",
@@ -159,7 +160,7 @@
 			"marketing_url": "https://www.edx.org/school/mitx"
 		}],
 		"image": {
-			"src": "image_src",
+			"src": "http://image_src.com/img.jpg",
 			"height": null,
 			"width": null,
 			"description": null

--- a/test_json/test_mitx_course01.json
+++ b/test_json/test_mitx_course01.json
@@ -147,7 +147,6 @@
 			"recent_enrollment_count": 1619
 		}],
 		"entitlements": [],
-		"image_src": "",
 		"owners": [{
 			"uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
 			"key": "MITx",
@@ -160,7 +159,7 @@
 			"marketing_url": "https://www.edx.org/school/mitx"
 		}],
 		"image": {
-			"src": "http://image_src.com/img.jpg",
+			"src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
 			"height": null,
 			"width": null,
 			"description": null

--- a/test_json/test_mitx_course02.json
+++ b/test_json/test_mitx_course02.json
@@ -150,7 +150,12 @@
             "marketing_url": "https://www.edx.org/school/mitx"
         }
     ],
-    "image": {"src": "image_src", "height": null, "width": null, "description": null},
+    "image": {
+        "src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+        "height": null,
+        "width": null,
+        "description": null
+    },
     "short_description": "short_description",
     "full_description": "full description",
     "level_type": "Intermediate",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
- Closes #2115
- Adds an overlooked setting to api.json and settings.py (`MAX_S3_GET_ITERATIONS`)

#### What's this PR do?
Imports MITx data into both `Course` and `CourseRun` objects.

#### How should this be manually tested?
- Set required .env variables (you can copy from heroku CI):
```
EDX_API_URL
EDX_API_CLIENT_ID
EDX_API_CLIENT_SECRET
OCW_*
```
- Run `docker-compose run web python manage.py backpopulate_edx_courses --delete`
- Verify that `Course` objects with `platform=mitx` were created, and each of these courses have at least 1 `CourseRun` object.
- Verify that the `Course` objects have associated `CourseTopic` objects, and that the `CourseRun` objects have associated `CourseInstructor` and `CoursePrice` objects.
- Go to `http://od.odl.local:8063/courses/search`, there should be results for MITx platform courses, and they should display almost the same as before (except they will always be shown as free because the price info is now in the course run - this will need to be fixed in #2116).  
- Clicking on any MITx course card should still bring up the drawer with more details.  However some of those details will be missing because they'e now stored in the CourseRun model (to be fixed in #2124)
- Try importing some OCW courses too, there shouldn't be any issues with those:
  `docker-compose run web python manage.py backpopulate_ocw_courses --delete`
