### PR TITLE
Include course runs in CourseSerializer

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -20,7 +20,7 @@ from course_catalog.models import Course, Bootcamp, CourseRun
 from course_catalog.serializers import (
     BootcampSerializer,
     EDXCourseSerializer,
-    EDXCourseRunSerializer,
+    CourseRunSerializer,
     OCWSerializer,
 )
 from search.task_helpers import update_course, index_new_course
@@ -133,7 +133,7 @@ def parse_mitx_json_data(course_data, force_overwrite=False):
                     except CourseRun.DoesNotExist:
                         courserun_instance = None
 
-                    run_serializer = EDXCourseRunSerializer(
+                    run_serializer = CourseRunSerializer(
                         data={
                             **course_run,
                             "max_modified": max_modified,

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -60,7 +60,7 @@ def test_parse_mitx_json_data_overwrite_course(
     mock_save_course = mocker.patch(
         "course_catalog.api.EDXCourseSerializer.save", return_value=course
     )
-    mock_save_run = mocker.patch("course_catalog.api.EDXCourseRunSerializer.save")
+    mock_save_run = mocker.patch("course_catalog.api.CourseRunSerializer.save")
     assert course.course_id == mitx_valid_data["key"]
     parse_mitx_json_data(mitx_valid_data, force_overwrite=force_overwrite)
     assert mock_save_course.call_count == (1 if force_overwrite else 0)
@@ -89,7 +89,7 @@ def test_parse_mitx_json_data_overwrite_courserun(
     mock_save_course = mocker.patch(
         "course_catalog.api.EDXCourseSerializer.save", return_value=course
     )
-    mock_save_run = mocker.patch("course_catalog.api.EDXCourseRunSerializer.save")
+    mock_save_run = mocker.patch("course_catalog.api.CourseRunSerializer.save")
     assert course.course_id == mitx_valid_data["key"]
     parse_mitx_json_data(mitx_valid_data, force_overwrite=force_overwrite)
     assert mock_save_course.call_count == 1

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -168,18 +168,7 @@ class BaseCourseSerializer(FavoriteSerializerMixin, serializers.ModelSerializer)
             course.prices.add(course_price)
 
 
-class CourseSerializer(BaseCourseSerializer):
-    """
-    Serializer for Course model
-    """
-
-    class Meta:
-        model = Course
-        fields = "__all__"
-        extra_kwargs = {"raw_json": {"write_only": True}}
-
-
-class EDXCourseRunSerializer(BaseCourseSerializer):
+class CourseRunSerializer(BaseCourseSerializer):
     """
     Serializer for creating CourseRun objects from edx data
     """
@@ -240,6 +229,19 @@ class EDXCourseRunSerializer(BaseCourseSerializer):
     class Meta:
         model = CourseRun
         fields = "__all__"
+
+
+class CourseSerializer(BaseCourseSerializer):
+    """
+    Serializer for Course model
+    """
+
+    course_runs = CourseRunSerializer(read_only=True, many=True, allow_null=True)
+
+    class Meta:
+        model = Course
+        fields = "__all__"
+        extra_kwargs = {"raw_json": {"write_only": True}}
 
 
 class EDXCourseSerializer(CourseSerializer):

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -29,7 +29,14 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
-    "offered_by,has_runs", [[OfferedBy.mitx.value, True], [OfferedBy.ocw.value, False]]
+    "offered_by,has_runs",
+    [
+        [OfferedBy.mitx.value, True],
+        [OfferedBy.xpro.value, True],
+        [OfferedBy.micromasters.value, True],
+        [OfferedBy.ocw.value, False],
+        [OfferedBy.bootcamps.value, False],
+    ],
 )
 def test_serialize_course_related_models(offered_by, has_runs):
     """

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -3,6 +3,7 @@ Test course_catalog serializers
 """
 import pytest
 
+from course_catalog.constants import OfferedBy
 from course_catalog.factories import (
     CourseFactory,
     CourseTopicFactory,
@@ -20,17 +21,22 @@ from course_catalog.serializers import (
     FavoriteItemSerializer,
     UserListSerializer,
     ProgramSerializer,
+    CourseRunSerializer,
 )
 from open_discussions.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
-def test_serialize_course_related_models():
+@pytest.mark.parametrize(
+    "offered_by,has_runs", [[OfferedBy.mitx.value, True], [OfferedBy.ocw.value, False]]
+)
+def test_serialize_course_related_models(offered_by, has_runs):
     """
     Verify that a serialized course contains attributes for related objects
     """
     course = CourseFactory(
+        offered_by=offered_by,
         topics=CourseTopicFactory.create_batch(3),
         prices=CoursePriceFactory.create_batch(2),
         instructors=CourseInstructorFactory.create_batch(2),
@@ -44,6 +50,10 @@ def test_serialize_course_related_models():
         assert attr in serializer.data["instructors"][0].keys()
     assert len(serializer.data["topics"]) == 3
     assert "name" in serializer.data["topics"][0].keys()
+    assert (len(serializer.data["course_runs"]) > 0) == has_runs
+    assert serializer.data["course_runs"] == [
+        CourseRunSerializer(instance=run).data for run in course.course_runs.all()
+    ]
 
 
 def test_serialize_bootcamp_related_models():


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2122

#### What's this PR do?
Adds course runs to the `CourseSerializer`

#### How should this be manually tested?
Go to `http://od.odl.local:8063/api/v0/courses/<course_id>` for an MITx course and an OCW course.  The returned JSON for the MITx course should include all the data for the course runs.  The JSON for the OCW course should be an empty list.

