### PR TITLE
Index course runs under courses

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -115,6 +115,31 @@ COURSE_OBJECT_TYPE = {
     "published": {"type": "boolean"},
     "availability": {"type": "keyword"},
     "offered_by": {"type": "keyword"},
+    "course_runs": {
+        "type": "nested",
+        "properties": {
+            "id": {"type": "long"},
+            "course_id": {"type": "keyword"},
+            "title": ENGLISH_TEXT_FIELD,
+            "short_description": ENGLISH_TEXT_FIELD,
+            "full_description": ENGLISH_TEXT_FIELD,
+            "language": {"type": "keyword"},
+            "level": {"type": "keyword"},
+            "semester": {"type": "keyword"},
+            "year": {"type": "keyword"},
+            "start_date": {"type": "date"},
+            "end_date": {"type": "date"},
+            "enrollment_start": {"type": "date"},
+            "enrollment_end": {"type": "date"},
+            "topics": {"type": "keyword"},
+            "instructors": {"type": "text"},
+            "price": {"type": "nested"},
+            "image_src": {"type": "keyword"},
+            "published": {"type": "boolean"},
+            "availability": {"type": "keyword"},
+            "offered_by": {"type": "keyword"},
+        },
+    },
 }
 
 BOOTCAMP_OBJECT_TYPE = {

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from channels.constants import POST_TYPE, COMMENT_TYPE
 from channels.models import Comment, Post
-from course_catalog.models import Course, Bootcamp, Program, UserList
+from course_catalog.models import Course, CourseRun, Bootcamp, Program, UserList
 from profiles.api import get_channels, get_channel_join_dates
 from profiles.models import Profile
 from profiles.utils import image_uri
@@ -116,73 +116,6 @@ class ESProfileSerializer(ESProxySerializer):
                 {"name": name, "joined": created_on} for name, created_on in join_data
             ],
         }
-
-
-class ESCourseSerializer(ESModelSerializer):
-    """
-    Elasticsearch serializer class for courses
-    """
-
-    object_type = COURSE_TYPE
-
-    prices = serializers.SerializerMethodField()
-    instructors = serializers.SerializerMethodField()
-    topics = serializers.SerializerMethodField()
-    availability = serializers.SerializerMethodField()
-
-    def get_prices(self, course):
-        """
-        Get the prices for a course
-        """
-        return list(course.prices.values("price", "mode"))
-
-    def get_instructors(self, course):
-        """
-        Get a list of instructor names for the course
-        """
-        return [" ".join([i.first_name, i.last_name]) for i in course.instructors.all()]
-
-    def get_topics(self, course):
-        """
-        Get the topic names for a course
-        """
-        return [topic.name for topic in course.topics.all()]
-
-    def get_availability(self, course):
-        """
-        Get the availability for a course
-        """
-        if course.availability:
-            return course.availability.title()
-        return None
-
-    class Meta:
-        model = Course
-        fields = [
-            "id",
-            "course_id",
-            "short_description",
-            "full_description",
-            "platform",
-            "language",
-            "semester",
-            "year",
-            "level",
-            "start_date",
-            "end_date",
-            "enrollment_start",
-            "enrollment_end",
-            "title",
-            "image_src",
-            "topics",
-            "prices",
-            "instructors",
-            "published",
-            "availability",
-            "offered_by",
-        ]
-
-        read_only_fields = fields
 
 
 class ESPostSerializer(ESModelSerializer):
@@ -325,6 +258,142 @@ class ESCommentSerializer(ESModelSerializer):
             "created",
         )
         read_only_fields = ("text", "score", "created", "removed", "deleted")
+
+
+class ESCourseRunSerializer(serializers.ModelSerializer):
+    """
+    Elasticsearch serializer class for course runs
+    """
+
+    prices = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
+
+    def get_prices(self, course_run):
+        """
+        Get the prices for a course run
+        """
+        return list(course_run.prices.values("price", "mode"))
+
+    def get_instructors(self, course_run):
+        """
+        Get a list of instructor names for the course run
+        """
+        return [
+            " ".join([i.first_name, i.last_name]) for i in course_run.instructors.all()
+        ]
+
+    def get_topics(self, course_run):
+        """
+        Get the topic names for a course run
+        """
+        return [topic.name for topic in course_run.topics.all()]
+
+    def get_availability(self, course_run):
+        """
+        Get the availability for a course run
+        """
+        if course_run.availability:
+            return course_run.availability.title()
+        return None
+
+    class Meta:
+        model = CourseRun
+        fields = [
+            "id",
+            "course_run_id",
+            "short_description",
+            "full_description",
+            "language",
+            "semester",
+            "year",
+            "level",
+            "start_date",
+            "end_date",
+            "enrollment_start",
+            "enrollment_end",
+            "title",
+            "image_src",
+            "topics",
+            "prices",
+            "instructors",
+            "published",
+            "availability",
+            "offered_by",
+        ]
+
+        read_only_fields = fields
+
+
+class ESCourseSerializer(ESModelSerializer):
+    """
+    Elasticsearch serializer class for courses
+    """
+
+    object_type = COURSE_TYPE
+
+    prices = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
+
+    course_runs = ESCourseRunSerializer(many=True)
+
+    def get_prices(self, course):
+        """
+        Get the prices for a course
+        """
+        return list(course.prices.values("price", "mode"))
+
+    def get_instructors(self, course):
+        """
+        Get a list of instructor names for the course
+        """
+        return [" ".join([i.first_name, i.last_name]) for i in course.instructors.all()]
+
+    def get_topics(self, course):
+        """
+        Get the topic names for a course
+        """
+        return [topic.name for topic in course.topics.all()]
+
+    def get_availability(self, course):
+        """
+        Get the availability for a course
+        """
+        if course.availability:
+            return course.availability.title()
+        return None
+
+    class Meta:
+        model = Course
+        fields = [
+            "id",
+            "course_id",
+            "short_description",
+            "full_description",
+            "platform",
+            "language",
+            "semester",
+            "year",
+            "level",
+            "start_date",
+            "end_date",
+            "enrollment_start",
+            "enrollment_end",
+            "title",
+            "image_src",
+            "topics",
+            "prices",
+            "instructors",
+            "published",
+            "availability",
+            "offered_by",
+            "course_runs",
+        ]
+
+        read_only_fields = fields
 
 
 class ESBootcampSerializer(ESCourseSerializer):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2116 

#### What's this PR do?
Expands course indexing to also include course runs

#### How should this be manually tested?

- Run `./manage.py recreate_index`
- Verify the search page is still as functional as `master`
- You should also see nested `course_runs` data coming back in `_source` on the results
- Try running a query to find courses with specific course runs. An example one is provided in this PR:
```
curl --header "Content-Type: application/json" \
  --request POST -s \
  --data "$(cat test_json/es/2015_course_runs.json)" \
  http://localhost:9101/local_all_default/_search | jq
```