### PR TITLE
Make topic and price sequences again in tests

### DIFF
--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -42,7 +42,7 @@ class CourseInstructorFactory(DjangoModelFactory):
 class CourseTopicFactory(DjangoModelFactory):
     """Factory for course topics"""
 
-    name = factory.Faker("word")
+    name = factory.Sequence(lambda n: "Topic %03d" % n)
 
     class Meta:
         model = CourseTopic
@@ -52,7 +52,7 @@ class CourseTopicFactory(DjangoModelFactory):
 class CoursePriceFactory(DjangoModelFactory):
     """Factory for course prices"""
 
-    price = factory.Faker("pyfloat", right_digits=2, min_value=1, max_value=1500)
+    price = factory.Sequence(lambda n: 0.00 + float(n))
     mode = factory.Faker("word")
     upgrade_deadline = None
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Changes `CourseTopicFactory.name` and `CoursePriceFactory.price` to sequences in order to make certain each one is unique, otherwise the expected counts may not always equal the actual counts and tests will intermittently fail.

#### How should this be manually tested?
Run `docker-compose run web pytest course_catalog/serializers_test.py` 5 or 6 times, there should be no failures.
