### PR TITLE
course home favorites

### DIFF
--- a/static/js/containers/CourseIndexPage.js
+++ b/static/js/containers/CourseIndexPage.js
@@ -4,6 +4,7 @@ import { connectRequest, querySelectors } from "redux-query"
 import { connect } from "react-redux"
 import { compose } from "redux"
 import { Link } from "react-router-dom"
+import { createSelector } from "reselect"
 
 import LearningResourceDrawer from "./LearningResourceDrawer"
 
@@ -26,6 +27,10 @@ import {
   newCoursesRequest,
   newCoursesSelector
 } from "../lib/queries/courses"
+import {
+  favoritesRequest,
+  favoritesSelector
+} from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
 
 import type { Course } from "../flow/discussionTypes"
@@ -38,6 +43,7 @@ type StateProps = {|
   featuredCourses: Array<Course>,
   upcomingCourses: Array<Course>,
   newCourses: Array<Course>,
+  favorites: Array<Object>,
   loaded: boolean
 |}
 
@@ -57,7 +63,8 @@ export const CourseIndexPage = ({
   newCourses,
   loaded,
   setShowResourceDrawer,
-  history
+  history,
+  favorites
 }: Props) => (
   <BannerPageWrapper>
     <BannerPageHeader tall>
@@ -85,6 +92,11 @@ export const CourseIndexPage = ({
     <Grid className="main-content one-column">
       {loaded ? (
         <Cell width={12}>
+          <CourseCarousel
+            title="Favorites"
+            courses={favorites}
+            setShowResourceDrawer={setShowResourceDrawer}
+          />
           {featuredCourses.length !== 0 ? (
             <CourseCarousel
               title="Featured Courses"
@@ -111,14 +123,26 @@ export const CourseIndexPage = ({
   </BannerPageWrapper>
 )
 
+const favoritesListSelector = createSelector(
+  favoritesSelector,
+  ({ courses, bootcamps, programs, userLists }) => [
+    ...Object.values(courses),
+    ...Object.values(bootcamps),
+    ...Object.values(programs),
+    ...Object.values(userLists)
+  ]
+)
+
 const mapStateToProps = (state: Object): StateProps => ({
   featuredCourses: featuredCoursesSelector(state),
   upcomingCourses: upcomingCoursesSelector(state),
   newCourses:      newCoursesSelector(state),
+  favorites:       favoritesListSelector(state),
   loaded:
     querySelectors.isFinished(state.queries, featuredCoursesRequest()) &&
     querySelectors.isFinished(state.queries, upcomingCoursesRequest()) &&
-    querySelectors.isFinished(state.queries, newCoursesRequest())
+    querySelectors.isFinished(state.queries, newCoursesRequest()) &&
+    querySelectors.isFinished(state.queries, favoritesRequest())
 })
 
 const mapDispatchToProps = {
@@ -128,7 +152,8 @@ const mapDispatchToProps = {
 const mapPropsToConfig = () => [
   featuredCoursesRequest(),
   upcomingCoursesRequest(),
-  newCoursesRequest()
+  newCoursesRequest(),
+  favoritesRequest()
 ]
 
 export default compose(

--- a/static/js/containers/CourseIndexPage_test.js
+++ b/static/js/containers/CourseIndexPage_test.js
@@ -22,16 +22,19 @@ describe("CourseIndexPage", () => {
     setShowResourceDrawerStub,
     renderCourseIndexPage,
     sandbox,
-    courseLists
+    courseLists,
+    favorites
 
   beforeEach(() => {
     featuredCourses = R.times(makeCourse, 10)
+    favorites = R.times(makeCourse, 10)
     upcomingCourses = R.times(makeCourse, 10)
     newCourses = R.times(makeCourse, 10)
     courseLists = {
       featuredCourses,
       upcomingCourses,
-      newCourses
+      newCourses,
+      favorites
     }
     sandbox = sinon.createSandbox()
     setShowResourceDrawerStub = sandbox.stub()
@@ -48,6 +51,7 @@ describe("CourseIndexPage", () => {
 
   //
   ;[
+    ["favorites", "Favorites"],
     ["featuredCourses", "Featured Courses"],
     ["upcomingCourses", "Upcoming Courses"],
     ["newCourses", "New Courses"]
@@ -78,8 +82,9 @@ describe("CourseIndexPage", () => {
     const carousels = renderCourseIndexPage({ featuredCourses: [] }).find(
       "CourseCarousel"
     )
-    assert.lengthOf(carousels, 2)
+    assert.lengthOf(carousels, 3)
     assert.deepEqual(carousels.map(el => el.prop("title")), [
+      "Favorites",
       "Upcoming Courses",
       "New Courses"
     ])

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -9,7 +9,6 @@ import { MetaTags } from "react-meta-tags"
 import _ from "lodash"
 import { connectRequest } from "redux-query"
 import { compose } from "redux"
-import { createSelector } from "reselect"
 
 import LearningResourceDrawer from "./LearningResourceDrawer"
 
@@ -42,7 +41,10 @@ import {
 import { emptyOrNil, preventDefaultAndInvoke, toArray } from "../lib/util"
 import { mergeFacetResults } from "../lib/search"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
-import { favoritesRequest } from "../lib/queries/learning_resources"
+import {
+  favoritesRequest,
+  favoritesSelector
+} from "../lib/queries/learning_resources"
 
 import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
@@ -414,22 +416,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 }
 
-const filterFavorite = (entities: Object) =>
-  R.filter(R.propEq("is_favorite", true), entities || {})
-
-const getFavorites = createSelector(
-  state => state.entities.courses,
-  state => state.entities.bootcamps,
-  state => state.entities.programs,
-  state => state.entities.userLists,
-  (courses, bootcamps, programs, userLists) => ({
-    courses:   filterFavorite(courses),
-    bootcamps: filterFavorite(bootcamps),
-    programs:  filterFavorite(programs),
-    userLists: filterFavorite(userLists)
-  })
-)
-
 const mapStateToProps = (state): StateProps => {
   const { search } = state
   const { results, total, initialLoad, facets } = search.data
@@ -441,7 +427,7 @@ const mapStateToProps = (state): StateProps => {
     initialLoad,
     loaded:     search.loaded,
     processing: search.processing,
-    favorites:  getFavorites(state)
+    favorites:  favoritesSelector(state)
   }
 }
 

--- a/static/js/lib/queries/learning_resources.js
+++ b/static/js/lib/queries/learning_resources.js
@@ -1,5 +1,6 @@
 // @flow
 import R from "ramda"
+import { createSelector } from "reselect"
 
 import { favoritesURL } from "../url"
 import { constructIdMap } from "../redux_query"
@@ -40,3 +41,19 @@ export const favoritesRequest = () => ({
     next:      (prev: string, next: string) => next
   }
 })
+
+const filterFavorite = (entities: Object) =>
+  R.filter(R.propEq("is_favorite", true), entities || {})
+
+export const favoritesSelector = createSelector(
+  state => state.entities.courses,
+  state => state.entities.bootcamps,
+  state => state.entities.programs,
+  state => state.entities.userLists,
+  (courses, bootcamps, programs, userLists) => ({
+    courses:   filterFavorite(courses),
+    bootcamps: filterFavorite(bootcamps),
+    programs:  filterFavorite(programs),
+    userLists: filterFavorite(userLists)
+  })
+)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2092

#### What's this PR do?

This adds a very basic display of the favorites to the course home page, along the same lines as what we already do for the other lists of courses on that page. The design for what this will look like is not finalized yet, so I did not want to go ahead and implement a different design for this than what we use for the existing carousels - when it is finalized I'll circle back to implement the favorites-specific design.

#### How should this be manually tested?

Go to the course home page and make sure your favorites show up there! that's it.

#### Screenshots (if appropriate)

![favoriteswowfff](https://user-images.githubusercontent.com/6207644/62805297-8d141680-babd-11e9-9170-4923891349ff.png)
