### PR TITLE
fix flaky test

### DIFF
--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -14,13 +14,14 @@ import {
 import type { Bootcamp, Course } from "../flow/discussionTypes"
 
 const incrCourse = incrementer()
+const courseId: any = incrementer()
 
 const dateFormat = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 
 export const makeCourse = (): Course => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   course_id:         `course_${incrCourse.next().value}`,
-  id:                casual.integer(1, 1000),
+  id:                courseId.next().value,
   title:             casual.title,
   url:               casual.url,
   image_src:         "http://image.medium.url",
@@ -50,11 +51,12 @@ export const makeCourse = (): Course => ({
 })
 
 const incrBootcamp = incrementer()
+const bootcampId: any = incrementer()
 
 export const makeBootcamp = (): Bootcamp => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   course_id:         `bootcamp_${incrBootcamp.next().value}`,
-  id:                casual.integer(1, 1000),
+  id:                bootcampId.next().value,
   title:             casual.title,
   url:               casual.url,
   image_src:         "http://image.medium.url",


### PR DESCRIPTION

#### What are the relevant tickets?

closes #2150 

#### What's this PR do?

fixes a flaky test which was caused by having non-incrementing ids on the course and bootcamp factories, which could sometimes collide.

#### How should this be manually tested?

If the tests are passing and things look good it should be ok. If you want you can check out the code and modify `static/js/lib/queries/courses_test.js` to run the test titled `"selector should grab the right stuff"` like 200 times or something to check that it doesn't fail (the failure rate before was roughly 5% of the time or so).

