### PR TITLE
change out course card UI

### DIFF
--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -5,6 +5,7 @@ import Carousel from "nuka-carousel"
 
 import LearningResourceCard from "./LearningResourceCard"
 
+import { SEARCH_GRID_UI } from "../lib/search"
 import { CAROUSEL_PAGE_SIZE } from "../lib/constants"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"
@@ -55,6 +56,7 @@ const CourseCarousel = ({ title, courses, setShowResourceDrawer }: Props) => (
           key={idx}
           object={course}
           setShowResourceDrawer={setShowResourceDrawer}
+          searchResultLayout={SEARCH_GRID_UI}
         />
       ))}
     </Carousel>

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -90,24 +90,24 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 
 type LearningResourceProps = {
   result: LearningResourceResult,
-  toggleFacet?: Function,
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
-  overrideObject?: Object
+  overrideObject?: Object,
+  searchResultLayout?: string
 }
 
 const LearningResourceSearchResult = ({
   result,
-  toggleFacet,
   setShowResourceDrawer,
-  overrideObject
+  overrideObject,
+  searchResultLayout
 }: LearningResourceProps) => {
   // $FlowFixMe: this should only be used for courses
 
   return (
     <LearningResourceCard
       object={searchResultToLearningResource(result, overrideObject)}
-      toggleFacet={toggleFacet}
       setShowResourceDrawer={setShowResourceDrawer}
+      searchResultLayout={searchResultLayout}
     />
   )
 }
@@ -121,7 +121,8 @@ type Props = {
   votedComment?: ?CommentInTree,
   toggleFacet?: Function,
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
-  overrideObject?: Object
+  overrideObject?: Object,
+  searchResultLayout?: string
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
@@ -134,7 +135,8 @@ export default class SearchResult extends React.Component<Props> {
       commentDownvote,
       toggleFacet,
       setShowResourceDrawer,
-      overrideObject
+      overrideObject,
+      searchResultLayout
     } = this.props
     if (result.object_type === "post") {
       // $FlowFixMe: This will always be a PostResult
@@ -169,9 +171,9 @@ export default class SearchResult extends React.Component<Props> {
       return (
         <LearningResourceSearchResult
           result={result}
-          toggleFacet={toggleFacet}
           setShowResourceDrawer={setShowResourceDrawer}
           overrideObject={overrideObject}
+          searchResultLayout={searchResultLayout}
         />
       )
     }

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -39,7 +39,11 @@ import {
   LR_TYPE_USERLIST
 } from "../lib/constants"
 import { emptyOrNil, preventDefaultAndInvoke, toArray } from "../lib/util"
-import { mergeFacetResults } from "../lib/search"
+import {
+  mergeFacetResults,
+  SEARCH_GRID_UI,
+  SEARCH_LIST_UI
+} from "../lib/search"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
 import {
   favoritesRequest,
@@ -96,7 +100,8 @@ type State = {
   from: number,
   error: ?string,
   currentFacetGroup: ?CurrentFacet,
-  incremental: boolean
+  incremental: boolean,
+  searchResultLayout: string
 }
 
 const facetDisplayMap = [
@@ -122,10 +127,11 @@ export class CourseSearchPage extends React.Component<Props, State> {
           _.union(toArray(qs.parse(props.location.search).a) || [])
         ]
       ]),
-      from:              0,
-      error:             null,
-      currentFacetGroup: null,
-      incremental:       false
+      from:               0,
+      error:              null,
+      currentFacetGroup:  null,
+      incremental:        false,
+      searchResultLayout: SEARCH_GRID_UI
     }
   }
 
@@ -241,6 +247,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
     })
   }
 
+  setSearchUI = (searchResultLayout: string) => {
+    this.setState({
+      searchResultLayout
+    })
+  }
+
   toggleFacet = async (name: string, value: string, isEnabled: boolean) => {
     const { activeFacets, currentFacetGroup } = this.state
     const { facets } = this.props
@@ -300,7 +312,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
       total,
       setShowResourceDrawer
     } = this.props
-    const { from, incremental } = this.state
+    const { from, incremental, searchResultLayout } = this.state
 
     if ((processing || !loaded) && !incremental) {
       return <PostLoading />
@@ -321,7 +333,10 @@ export class CourseSearchPage extends React.Component<Props, State> {
       >
         <Grid>
           {results.map((result, i) => (
-            <Cell width={4} key={i}>
+            <Cell
+              width={searchResultLayout === SEARCH_GRID_UI ? 4 : 12}
+              key={i}
+            >
               <SearchResult
                 result={result}
                 overrideObject={
@@ -330,6 +345,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
                 }
                 toggleFacet={this.toggleFacet}
                 setShowResourceDrawer={setShowResourceDrawer}
+                searchResultLayout={searchResultLayout}
               />
             </Cell>
           ))}
@@ -340,7 +356,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
   render() {
     const { match } = this.props
-    const { text, error, activeFacets } = this.state
+    const { text, error, activeFacets, searchResultLayout } = this.state
 
     return (
       <BannerPageWrapper>
@@ -391,6 +407,27 @@ export class CourseSearchPage extends React.Component<Props, State> {
                   Clear all filters
                 </div>
               ) : null}
+            </div>
+          </Cell>
+          <Cell width={3} />
+          <Cell width={9}>
+            <div className="layout-buttons">
+              <div
+                onClick={() => this.setSearchUI(SEARCH_LIST_UI)}
+                className={
+                  searchResultLayout === SEARCH_LIST_UI ? "active" : ""
+                }
+              >
+                <i className="material-icons view_list">view_list</i>
+              </div>
+              <div
+                onClick={() => this.setSearchUI(SEARCH_GRID_UI)}
+                className={
+                  searchResultLayout === SEARCH_GRID_UI ? "active" : ""
+                }
+              >
+                <i className="material-icons view_comfy">view_comfy</i>
+              </div>
             </div>
           </Cell>
           <Cell width={3}>

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -17,6 +17,7 @@ import {
 } from "../factories/search"
 import { makeChannel } from "../factories/channels"
 import { LR_TYPE_COURSE, LR_TYPE_ALL } from "../lib/constants"
+import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
 
 describe("CourseSearchPage", () => {
   let helper,
@@ -183,10 +184,11 @@ describe("CourseSearchPage", () => {
           type:         []
         })
       ),
-      from:              5,
-      error:             null,
-      currentFacetGroup: null,
-      incremental:       true
+      from:               5,
+      error:              null,
+      currentFacetGroup:  null,
+      incremental:        true,
+      searchResultLayout: SEARCH_GRID_UI
     })
   })
 
@@ -361,10 +363,11 @@ describe("CourseSearchPage", () => {
           type:         ["course"]
         })
       ),
-      currentFacetGroup: null,
-      from:              0,
-      error:             null,
-      incremental:       false
+      currentFacetGroup:  null,
+      from:               0,
+      error:              null,
+      incremental:        false,
+      searchResultLayout: SEARCH_GRID_UI
     })
   })
 
@@ -416,7 +419,8 @@ describe("CourseSearchPage", () => {
         group:  "topics",
         result: makeSearchFacetResult().topics
       },
-      incremental: false
+      incremental:        false,
+      searchResultLayout: SEARCH_GRID_UI
     })
   })
 

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -15,18 +15,27 @@ const ocwPlatform = "ocw"
 const edxPlatform = "mitx"
 const bootcampsPlatform = "bootcamps"
 const micromastersPlatform = "micromasters"
+
 export const platforms = {
   OCW:          ocwPlatform,
   edX:          edxPlatform,
   bootcamps:    bootcampsPlatform,
   micromasters: micromastersPlatform
 }
+
 export const platformLogoUrls = {
   [ocwPlatform]:          "/static/images/mit-ocw-logo-square.png",
   [edxPlatform]:          "/static/images/mitx-logo.png",
   [bootcampsPlatform]:    "/static/images/mit-bootcamp-logo.png",
   [micromastersPlatform]: "/static/images/mit-micromasters-logo.png",
   "":                     "/static/images/blank.png"
+}
+
+export const platformReadableNames = {
+  [ocwPlatform]:          "MIT OpenCourseWare",
+  [edxPlatform]:          "edX",
+  [bootcampsPlatform]:    "MIT Bootcamp",
+  [micromastersPlatform]: "MIT MicroMasters"
 }
 
 export const WIDGET_TYPE_MARKDOWN = "Markdown"
@@ -56,3 +65,10 @@ export const LR_TYPE_ALL = [
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST
 ]
+
+export const readableLearningResources = {
+  [LR_TYPE_COURSE]:   "Course",
+  [LR_TYPE_BOOTCAMP]: "Bootcamp",
+  [LR_TYPE_PROGRAM]:  "Program",
+  [LR_TYPE_USERLIST]: "Learning Path"
+}

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -303,3 +303,6 @@ export const mergeFacetResults = (...args: Array<FacetResult>) => ({
     .map(R.prop("buckets"))
     .reduce((buckets, acc) => R.unionWith(R.eqBy(R.prop("key")), buckets, acc))
 })
+
+export const SEARCH_GRID_UI = "grid"
+export const SEARCH_LIST_UI = "list"

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -65,3 +65,6 @@ $teal: #3dbdbf;
 
 // font
 $body-font: "Source Sans Pro", helvetica, arial, sans-serif !important;
+
+$search-layout-active: #355b6b;
+$search-layout-inactive: #c2c0bf;

--- a/static/scss/course-carousel.scss
+++ b/static/scss/course-carousel.scss
@@ -6,7 +6,7 @@
   }
 
   .slider-list {
-    max-height: 475px;
+    max-height: 365px;
   }
 
   .title {

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -230,3 +230,19 @@
     font-family: inherit;
   }
 }
+
+.search-page {
+  .layout-buttons {
+    display: flex;
+
+    i {
+      cursor: pointer;
+      font-size: 40px;
+      color: $search-layout-inactive;
+    }
+
+    .active i {
+      color: $search-layout-active;
+    }
+  }
+}

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -1,13 +1,44 @@
 .learning-resource-card {
-  @extend %card;
-
   width: initial;
-  border: 1px solid #c2c0bf;
   margin-bottom: 0;
   font-family: roboto;
 
-  .card-contents {
-    padding: 16px;
+  &.borderless {
+    .lr-info {
+      padding: 16px;
+    }
+
+    .cover-image img {
+      border-radius: 5px 5px 0 0;
+    }
+  }
+
+  &.list-view {
+    .card-contents {
+      display: flex;
+
+      .cover-image {
+        height: 130px;
+        margin-left: 16px;
+        width: 46%;
+
+        img {
+          height: 130px;
+          border-radius: 3px;
+        }
+      }
+    }
+
+    .lr-info {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      width: 100%;
+
+      .availability-price-favorite {
+        margin-top: 0;
+      }
+    }
   }
 
   .cover-image {
@@ -24,52 +55,64 @@
   .row {
     display: flex;
 
+    &.resource-type {
+      font-size: 13px;
+      color: $font-grey-mid;
+      text-transform: uppercase;
+      font-weight: 500;
+    }
+
     &.course-title {
-      margin: 15px 0 10px 0;
+      margin: 10px 0;
+      margin-top: 2px;
       min-height: 40px;
-      font-size: 16px;
+      font-size: 18px;
       color: black;
       font-weight: 500;
       cursor: pointer;
     }
 
-    &.topics {
-      min-height: 108px;
-      display: inline-block;
+    &.subtitle {
+      margin-bottom: 5px;
 
-      .topic {
+      .lr-subtitle {
         font-size: 14px;
-        color: white;
-        background-color: $teal;
-        display: inline-block;
-        padding: 4px 10px;
-        height: 100%;
-        border-radius: 15px;
-        margin: 5px 8px 5px 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 100%;
+
+        .grey {
+          color: $font-grey-light;
+        }
       }
     }
 
-    &.availability,
-    &.price {
-      font-weight: 500;
-      font-size: 14px;
+    &.availability-price-favorite {
+      justify-content: flex-start;
+      margin-top: 25px;
+
+      .availability,
+      .price {
+        font-size: 12px;
+        padding-right: 10px;
+
+        i {
+          font-size: 12px;
+          margin-right: 4px;
+        }
+      }
+
+      .price {
+        margin-right: 5px;
+      }
+
+      .favorite {
+        margin-left: auto;
+        cursor: pointer;
+        height: 18px;
+        width: 18px;
+      }
     }
-  }
-
-  .blue-bottom-border {
-    background-color: $course-blue;
-    height: 12px;
-    border-radius: 0 0 5px 5px;
-  }
-
-  .course-platform {
-    max-height: 32px;
-    margin: 7px 0;
-  }
-
-  .favorite {
-    cursor: pointer;
-    width: 40px;
-    height: 40px;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2160 
closes #2159 

#### What's this PR do?

this implements the new design for the course cards, including the list and grid views.

#### How should this be manually tested?

go to the course home page. you should see the new design for the cards int he course carousels. then navigate to the course search page. all functionality should be there, and you should be able to choose between the 'grid' and 'list' views. the ui should match the mockups pretty well (although some things like the filters up top haven't been updated yet)


#### Screenshots (if appropriate)

![newcardsasdffffffffff](https://user-images.githubusercontent.com/6207644/63534368-060f6700-c4dd-11e9-8caa-eb7086359433.png)
![newcardsasdfffffff](https://user-images.githubusercontent.com/6207644/63534369-060f6700-c4dd-11e9-8d25-cd87eb3b8294.png)
![newcardsasdf](https://user-images.githubusercontent.com/6207644/63534370-060f6700-c4dd-11e9-8a5a-4f3593b03a8f.png)
![newcards](https://user-images.githubusercontent.com/6207644/63534371-060f6700-c4dd-11e9-8056-f8257399f0f9.png)
![newcardsasdffffffffffcarou](https://user-images.githubusercontent.com/6207644/63534389-10316580-c4dd-11e9-8b24-39d0c0ad0754.png)
