### PR TITLE
Support cancelling notifications for disabled notifications

### DIFF
--- a/notifications/notifiers/base.py
+++ b/notifications/notifiers/base.py
@@ -61,7 +61,10 @@ class BaseNotifier:
         Returns:
             bool: True if we're due to send another notification
         """
-        if not self.notification_settings.user.is_active:
+        if (
+            not self.notification_settings.user.is_active
+            or self.notification_settings.is_triggered_never
+        ):
             return False
 
         # special case if we've never sent a notification or the setting is for an immediate send

--- a/notifications/notifiers/base_test.py
+++ b/notifications/notifiers/base_test.py
@@ -63,6 +63,12 @@ def test_can_notify(notifier, mocker, frequency, expected, hour_of_day):
     assert notifier.can_notify(notification) is expected
 
 
+def test_can_notify_never(notifier, mocker):
+    """Tests that if the settings are for never the can_notify is False"""
+    notifier.notification_settings = NotificationSettingsFactory.create(never=True)
+    assert notifier.can_notify(mocker.Mock()) is False
+
+
 def test_can_notify_invalid_frequency(notifier, mocker):
     """Tests that this raises an error if an unsupported trigger_frequency is used"""
     notifier.notification_settings = NotificationSettingsFactory.create(

--- a/notifications/notifiers/frontpage.py
+++ b/notifications/notifiers/frontpage.py
@@ -110,16 +110,16 @@ class FrontpageDigestNotifier(EmailNotifier):
         Returns:
             bool: True if we're due to send another notification
         """
-        return (
-            features.is_enabled(features.FRONTPAGE_EMAIL_DIGESTS)
-            and super().can_notify(last_notification)
-            and
+        if features.is_enabled(features.FRONTPAGE_EMAIL_DIGESTS) and super().can_notify(
+            last_notification
+        ):
+
             # do this last as it's expensive if the others are False anyway
             # check if we have posts since the last notification
-            bool(
+            return bool(
                 _posts_since_notification(self.notification_settings, last_notification)
             )
-        )
+        return False
 
     def _get_notification_data(
         self, current_notification, last_notification


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2176
Fixes #2119 

#### What's this PR do?
Fixes two errors where a notification frequency of "never" should be cancelling the notification, but those exceptions are instead uncaught.

#### How should this be manually tested?
Actually functionally testing these scenarios is difficult because they're race conditions we really only see at scale. I'd say carefully review the changes and the tests to verify we're replicating those scenarios. Also test the happy path by confirming that notifications for new posts still work.
