### PR TITLE
fix facet responsiveness issue

### DIFF
--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -9,6 +9,7 @@ import { MetaTags } from "react-meta-tags"
 import _ from "lodash"
 import { connectRequest } from "redux-query"
 import { compose } from "redux"
+import debounce from "lodash/debounce"
 
 import LearningResourceDrawer from "./LearningResourceDrawer"
 
@@ -146,7 +147,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Object, prevState: Object) {
     if (shouldRunSearch(prevState, this.state)) {
-      this.runSearch()
+      this.debouncedRunSearch()
     }
   }
 
@@ -249,6 +250,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
       size:        SETTINGS.search_page_size
     })
   }
+
+  debouncedRunSearch = debounce(this.runSearch, 500)
 
   setSearchUI = (searchResultLayout: string) => {
     this.setState({

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -18,6 +18,7 @@ import {
 import { makeChannel } from "../factories/channels"
 import { LR_TYPE_COURSE, LR_TYPE_ALL } from "../lib/constants"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
+import { wait } from "../lib/util"
 
 describe("CourseSearchPage", () => {
   let helper,
@@ -383,6 +384,8 @@ describe("CourseSearchPage", () => {
       .onUpdate({
         target: { name: "topics", value: "Physics", checked: true }
       })
+    // this ensures that the debounced calls go through without having to wait
+    inner.instance().debouncedRunSearch.flush()
     sinon.assert.calledWith(helper.searchStub, {
       channelName: null,
       from:        0,
@@ -458,6 +461,8 @@ describe("CourseSearchPage", () => {
           value:   "nextWeek"
         }
       })
+      // this ensures that the debounced calls go through without having to wait
+      inner.instance().debouncedRunSearch.flush()
       sinon.assert.calledWith(helper.searchStub, {
         channelName: null,
         from:        0,
@@ -507,5 +512,6 @@ describe("CourseSearchPage", () => {
       _.findIndex(mergedFacets.buckets, { doc_count: 20, key: "ocw" }) > -1
     )
     assert.isTrue(_.findIndex(mergedFacets.buckets, missingFacetGroup) > -1)
+    await wait(600)
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2180

#### What's this PR do?

this fixes an issue with the facets on the course search (see the attached issue) where they were basically not as responsive as they should be. In particular, if the user clicked a number of facets at the same time a search request was fired off for each one, which led to some laggyness in the UI (and probably some unnecessary load on the elasticsearch). We only care about the last request, so I just debounced this to we'll wait until the user stops interacting to fire off the request.

#### How should this be manually tested?

I think just check out `master` first and confirm you can kind of reproduce the issue as described. then check out this branch and make sure it fixes it and isn't, idk, weird or something.

