### PR TITLE
Make sure best date fields are writable in serializer

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -240,6 +240,16 @@ def test_parse_valid_mitx_json_data(mock_course_index_functions, mitx_valid_data
     mock_course_index_functions.index_new_course.assert_called_once_with(
         Course.objects.first()
     )
+    assert Course.objects.first().course_runs.first().best_start_date == datetime.strptime(
+        "2019-02-20T15:00:00Z", "%Y-%m-%dT%H:%M:%SZ"
+    ).replace(
+        tzinfo=pytz.UTC
+    )
+    assert Course.objects.first().course_runs.first().best_end_date == datetime.strptime(
+        "2019-05-22T23:30:00Z", "%Y-%m-%dT%H:%M:%SZ"
+    ).replace(
+        tzinfo=pytz.UTC
+    )
 
 
 def test_parse_mitx_json_data_no_runs(mitx_valid_data):

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -158,8 +158,6 @@ class CourseRunSerializer(BaseCourseSerializer):
 
     instructors = CourseInstructorSerializer(read_only=True, many=True, allow_null=True)
     prices = CoursePriceSerializer(read_only=True, many=True, allow_null=True)
-    best_start_date = serializers.ReadOnlyField()
-    best_end_date = serializers.ReadOnlyField()
 
     def handle_many_to_many(self, resource):
         """


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A, related to #2123

#### What's this PR do?
Removes CourseRunSerializer lines that made best_start_date and best_end_date read-only

#### How should this be manually tested?
```
docker-compose run web python manage.py backpopulate_edx_data --overwrite
```
- any course runs with a non-null `enrollment_start/end`, `start/end_date`, or `semester` and `year` should have a populated `best_start/end_date`
