### PR TITLE
Show most relevant availability for search result

### DIFF
--- a/flow-typed/npm/moment_v2.x.x.js
+++ b/flow-typed/npm/moment_v2.x.x.js
@@ -1,29 +1,29 @@
-// flow-typed signature: 92a33b062085f6db1b97258fd12b6beb
-// flow-typed version: 5a82c7cd27/moment_v2.x.x/flow_>=v0.28.x
+// flow-typed signature: 62491fb5f1b8d0ce28db6ce91c8599c6
+// flow-typed version: e56c0337dc/moment_v2.x.x/flow_>=v0.25.x <=v0.103.x
 
 type moment$MomentOptions = {
-  y?: number|string,
-  year?: number|string,
-  years?: number|string,
-  M?: number|string,
-  month?: number|string,
-  months?: number|string,
-  d?: number|string,
-  day?: number|string,
-  days?: number|string,
-  date?: number|string,
-  h?: number|string,
-  hour?: number|string,
-  hours?: number|string,
-  m?: number|string,
-  minute?: number|string,
-  minutes?: number|string,
-  s?: number|string,
-  second?: number|string,
-  seconds?: number|string,
-  ms?: number|string,
-  millisecond?: number|string,
-  milliseconds?: number|string,
+  y?: number | string,
+  year?: number | string,
+  years?: number | string,
+  M?: number | string,
+  month?: number | string,
+  months?: number | string,
+  d?: number | string,
+  day?: number | string,
+  days?: number | string,
+  date?: number | string,
+  h?: number | string,
+  hour?: number | string,
+  hours?: number | string,
+  m?: number | string,
+  minute?: number | string,
+  minutes?: number | string,
+  s?: number | string,
+  second?: number | string,
+  seconds?: number | string,
+  ms?: number | string,
+  millisecond?: number | string,
+  milliseconds?: number | string
 };
 
 type moment$MomentObject = {
@@ -33,25 +33,29 @@ type moment$MomentObject = {
   hours: number,
   minutes: number,
   seconds: number,
-  milliseconds: number,
+  milliseconds: number
 };
 
 type moment$MomentCreationData = {
   input: string,
   format: string,
-  locale: Object,
-  isUTC: bool,
-  strict: bool,
+  locale: {},
+  isUTC: boolean,
+  strict: boolean
 };
 
+type moment$CalendarFormat = string | ((moment: moment$Moment) => string);
+
 type moment$CalendarFormats = {
-  sameDay?: string,
-  nextDay?: string,
-  nextWeek?: string,
-  lastDay?: string,
-  lastWeek?: string,
-  sameElse?: string,
+  sameDay?: moment$CalendarFormat,
+  nextDay?: moment$CalendarFormat,
+  nextWeek?: moment$CalendarFormat,
+  lastDay?: moment$CalendarFormat,
+  lastWeek?: moment$CalendarFormat,
+  sameElse?: moment$CalendarFormat
 };
+
+type moment$Inclusivity = "()" | "[)" | "()" | "(]" | "[]";
 
 declare class moment$LocaleData {
   months(moment: moment$Moment): string;
@@ -62,10 +66,24 @@ declare class moment$LocaleData {
   weekdaysMin(moment: moment$Moment): string;
   weekdaysParse(weekDay: string): number;
   longDateFormat(dateFormat: string): string;
-  isPM(date: string): bool;
-  meridiem(hours: number, minutes: number, isLower: bool): string;
-  calendar(key: 'sameDay'|'nextDay'|'lastDay'|'nextWeek'|'prevWeek'|'sameElse', moment: moment$Moment): string;
-  relativeTime(number: number, withoutSuffix: bool, key: 's'|'m'|'mm'|'h'|'hh'|'d'|'dd'|'M'|'MM'|'y'|'yy', isFuture: bool): string;
+  isPM(date: string): boolean;
+  meridiem(hours: number, minutes: number, isLower: boolean): string;
+  calendar(
+    key:
+      | "sameDay"
+      | "nextDay"
+      | "lastDay"
+      | "nextWeek"
+      | "prevWeek"
+      | "sameElse",
+    moment: moment$Moment
+  ): string;
+  relativeTime(
+    number: number,
+    withoutSuffix: boolean,
+    key: "s" | "m" | "mm" | "h" | "hh" | "d" | "dd" | "M" | "MM" | "y" | "yy",
+    isFuture: boolean
+  ): string;
   pastFuture(diff: any, relTime: string): string;
   ordinal(number: number): string;
   preparse(str: string): any;
@@ -76,7 +94,7 @@ declare class moment$LocaleData {
   firstDayOfYear(): number;
 }
 declare class moment$MomentDuration {
-  humanize(suffix?: bool): string;
+  humanize(suffix?: boolean): string;
   milliseconds(): number;
   asMilliseconds(): number;
   seconds(): number;
@@ -88,28 +106,108 @@ declare class moment$MomentDuration {
   days(): number;
   asDays(): number;
   months(): number;
+  asWeeks(): number;
+  weeks(): number;
   asMonths(): number;
   years(): number;
   asYears(): number;
-  add(value: number|moment$MomentDuration|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|Object, unit?: string): this;
+  add(value: number | moment$MomentDuration | {}, unit?: string): this;
+  subtract(value: number | moment$MomentDuration | {}, unit?: string): this;
   as(unit: string): number;
   get(unit: string): number;
   toJSON(): string;
+  toISOString(): string;
+  isValid(): boolean;
 }
 declare class moment$Moment {
   static ISO_8601: string;
-  static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
-  static (initDate: ?Object|number|Date|Array<number>|moment$Moment|string): moment$Moment;
+  static (string?: ?string): moment$Moment;
+  static (
+    initDate:
+      | moment$MomentOptions
+      | number
+      | Date
+      | Array<number>
+      | moment$Moment
+      | string
+      | null
+      | void
+      | []
+      | {}
+  ): moment$Moment;
+  static (array: []): moment$Moment;
+  static (object: {}): moment$Moment;
+  static (string: ?string, format: string | Array<string>): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
   static unix(seconds: number): moment$Moment;
   static utc(): moment$Moment;
-  static utc(number: number|Array<number>): moment$Moment;
-  static utc(str: string, str2?: string|Array<string>, str3?: string): moment$Moment;
-  static utc(moment: moment$Moment): moment$Moment;
-  static utc(date: Date): moment$Moment;
-  static parseZone(rawDate: string): moment$Moment;
-  isValid(): bool;
-  invalidAt(): 0|1|2|3|4|5|6;
+  static utc(
+    initDate:
+      | moment$MomentOptions
+      | number
+      | Date
+      | Array<number>
+      | moment$Moment
+      | string
+      | null
+      | void
+  ): moment$Moment;
+  static utc(string: string, format: string | Array<string>): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
+  static parseZone(): moment$Moment;
+  static parseZone(rawDate: string | null | void): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
+  isValid(): boolean;
+  invalidAt(): 0 | 1 | 2 | 3 | 4 | 5 | 6;
   creationData(): moment$MomentCreationData;
   millisecond(number: number): this;
   milliseconds(number: number): this;
@@ -131,15 +229,15 @@ declare class moment$Moment {
   dates(number: number): this;
   date(): number;
   dates(): number;
-  day(day: number|string): this;
-  days(day: number|string): this;
+  day(day: number | string): this;
+  days(day: number | string): this;
   day(): number;
   days(): number;
   weekday(number: number): this;
   weekday(): number;
-  isoWeekday(number: number): this;
+  isoWeekday(day: number | string): this;
   isoWeekday(): number;
-  dayOfYear(number: number): this;
+  dayOfYear(day: number): this;
   dayOfYear(): number;
   week(number: number): this;
   weeks(number: number): this;
@@ -167,51 +265,91 @@ declare class moment$Moment {
   isoWeeksInYear(): number;
   get(string: string): number;
   set(unit: string, value: number): this;
-  set(options: { unit: string, value: number }): this;
+  set(options: { [unit: string]: number }): this;
   static max(...dates: Array<moment$Moment>): moment$Moment;
   static max(dates: Array<moment$Moment>): moment$Moment;
   static min(...dates: Array<moment$Moment>): moment$Moment;
   static min(dates: Array<moment$Moment>): moment$Moment;
-  add(value: number|moment$MomentDuration|moment$Moment|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|moment$Moment|string, unit?: string): this;
+  add(
+    value: number | moment$MomentDuration | moment$Moment | {}, unit?: string): this;
+  subtract(
+    value: number | moment$MomentDuration | moment$Moment | string | {}, unit?: string): this;
   startOf(unit: string): this;
   endOf(unit: string): this;
-  local(): void;
-  utc(): void;
-  utcOffset(offset?: number|string): void;
+  local(): this;
+  utc(): this;
+  utcOffset(
+    offset: number | string,
+    keepLocalTime?: boolean,
+    keepMinutes?: boolean
+  ): this;
+  utcOffset(): number;
   format(format?: string): string;
-  fromNow(removeSuffix?: bool): string;
-  from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
-  toNow(removePrefix?: bool): string;
-  to(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
+  fromNow(removeSuffix?: boolean): string;
+  from(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
+  toNow(removePrefix?: boolean): string;
+  to(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
   calendar(refTime?: any, formats?: moment$CalendarFormats): string;
-  diff(date: moment$Moment|string|number|Date|Array<number>, format?: string, floating?: bool): number;
+  diff(
+    date: moment$Moment | string | number | Date | Array<number>,
+    format?: string,
+    floating?: boolean
+  ): number;
   valueOf(): number;
   unix(): number;
   daysInMonth(): number;
   toDate(): Date;
   toArray(): Array<number>;
   toJSON(): string;
-  toISOString(): string;
+  toISOString(keepOffset?: boolean): string;
   toObject(): moment$MomentObject;
-  isBefore(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSame(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isAfter(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrBefore(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrAfter(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isBetween(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isDST(): bool;
-  isDSTShifted(): bool;
-  isLeapYear(): bool;
+  isBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSame(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isBetween(
+    from: moment$Moment | string | number | Date | Array<number>,
+    to: moment$Moment | string | number | Date | Array<number>,
+    units?: string,
+    inclusivity?: moment$Inclusivity
+  ): boolean;
+  isDST(): boolean;
+  isDSTShifted(): boolean;
+  isLeapYear(): boolean;
   clone(): moment$Moment;
-  static isMoment(obj: any): bool;
-  static isDatE(obj: any): bool;
-  static locale(locale: string, localeData?: Object): void;
-  static locale(locales: Array<string>): void;
-  locale(locale: string, customization?: Object|null): void;
+  static isMoment(obj: any): boolean;
+  static isDate(obj: any): boolean;
+  static updateLocale(locale: string, localeData?: ?{}): void;
+  static defineLocale(locale: string, localeData?: ?{}): void;
+  static locale(locale?: string, localeData?: {}): string;
+  static locale(locales: Array<string>): string;
+  locale(locale: string, customization?: {} | null): moment$Moment;
   locale(): string;
   static months(): Array<string>;
   static monthsShort(): Array<string>;
+  static now(): number;
   static weekdays(): Array<string>;
   static weekdaysShort(): Array<string>;
   static weekdaysMin(): Array<string>;
@@ -221,12 +359,16 @@ declare class moment$Moment {
   static weekdaysShort(): string;
   static weekdaysMin(): string;
   static localeData(key?: string): moment$LocaleData;
-  static duration(value: number|Object|string, unit?: string): moment$MomentDuration;
-  static isDuration(obj: any): bool;
+  localeData(): moment$LocaleData;
+  static duration(
+    value: number | {} | string,
+    unit?: string
+  ): moment$MomentDuration;
+  static isDuration(obj: any): boolean;
   static normalizeUnits(unit: string): string;
   static invalid(object: any): moment$Moment;
 }
 
-declare module 'moment' {
+declare module "moment" {
   declare module.exports: Class<moment$Moment>;
 }

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -116,7 +116,9 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
         <div className="course-info-row">
           <i className="material-icons attach_money">attach_money</i>
           <div className="course-info-label">Cost:</div>
-          <div className="course-info-value">{minPrice(object.course_runs[0])}</div>
+          <div className="course-info-value">
+            {minPrice(object.course_runs[0])}
+          </div>
         </div>
         {isCourse ? (
           <div className="course-info-row">

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -116,7 +116,7 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
         <div className="course-info-row">
           <i className="material-icons attach_money">attach_money</i>
           <div className="course-info-label">Cost:</div>
-          <div className="course-info-value">{minPrice(object)}</div>
+          <div className="course-info-value">{minPrice(object.course_runs[0])}</div>
         </div>
         {isCourse ? (
           <div className="course-info-row">

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -37,7 +37,8 @@ import { emptyOrNil } from "../lib/util"
 type OwnProps = {|
   object: LearningResourceSummary,
   setShowResourceDrawer: Function,
-  searchResultLayout?: string
+  searchResultLayout?: string,
+  availabilities: Array<string>
 |}
 
 type DispatchProps = {|
@@ -98,13 +99,17 @@ export const LearningResourceCard = ({
   object,
   setShowResourceDrawer,
   toggleFavorite,
-  searchResultLayout
+  searchResultLayout,
+  availabilities
 }: Props) => {
   const showResourceDrawer = () =>
     setShowResourceDrawer({
       objectId:   object.id,
       objectType: object.object_type
     })
+
+  const availableRuns = object.course_runs
+
 
   return (
     <Card

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -108,7 +108,7 @@ export const LearningResourceCard = ({
   // This run will be passed on to showResourceDrawer in a subsequent PR
   const bestAvailableRun =
     bestRun(filterRunsByAvailability(object.course_runs, availabilities)) ||
-    object.course_runs[0]
+    (object.course_runs ? object.course_runs[0] : null)
 
   const showResourceDrawer = () =>
     setShowResourceDrawer({

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -41,7 +41,7 @@ type OwnProps = {|
   object: LearningResourceSummary,
   setShowResourceDrawer: Function,
   searchResultLayout?: string,
-  availabilities: Array<string>
+  availabilities?: Array<string>
 |}
 
 type DispatchProps = {|

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -7,7 +7,12 @@ import { connect } from "react-redux"
 
 import Card from "./Card"
 
-import {filterRunsByAvailability, bestRunLabel, bestRun, minPrice} from "../lib/learning_resources"
+import {
+  filterRunsByAvailability,
+  bestRunLabel,
+  bestRun,
+  minPrice
+} from "../lib/learning_resources"
 import {
   embedlyThumbnail,
   starSelectedURL,
@@ -100,11 +105,10 @@ export const LearningResourceCard = ({
   searchResultLayout,
   availabilities
 }: Props) => {
-
   // This run will be passed on to showResourceDrawer in a subsequent PR
-  const bestAvailableRun = bestRun(
-    filterRunsByAvailability(object.course_runs, availabilities)
-  ) || object.course_runs[0]
+  const bestAvailableRun =
+    bestRun(filterRunsByAvailability(object.course_runs, availabilities)) ||
+    object.course_runs[0]
 
   const showResourceDrawer = () =>
     setShowResourceDrawer({
@@ -136,9 +140,7 @@ export const LearningResourceCard = ({
           </div>
           <div className="availability grey-surround">
             <i className="material-icons calendar_today">calendar_today</i>
-            {
-              bestRunLabel(bestAvailableRun)
-            }
+            {bestRunLabel(bestAvailableRun)}
           </div>
           <div className="favorite grey-surround">
             <img

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -7,7 +7,7 @@ import { connect } from "react-redux"
 
 import Card from "./Card"
 
-import { availabilityLabel, minPrice } from "../lib/learning_resources"
+import {filterRunsByAvailability, bestRunLabel, bestRun, minPrice} from "../lib/learning_resources"
 import {
   embedlyThumbnail,
   starSelectedURL,
@@ -21,7 +21,6 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_USERLIST,
   LR_TYPE_PROGRAM,
-  COURSE_AVAILABLE_NOW,
   platformReadableNames,
   readableLearningResources
 } from "../lib/constants"
@@ -32,7 +31,6 @@ import { favoriteUserListMutation } from "../lib/queries/user_lists"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"
-import { emptyOrNil } from "../lib/util"
 
 type OwnProps = {|
   object: LearningResourceSummary,
@@ -102,14 +100,17 @@ export const LearningResourceCard = ({
   searchResultLayout,
   availabilities
 }: Props) => {
+
+  // This run will be passed on to showResourceDrawer in a subsequent PR
+  const bestAvailableRun = bestRun(
+    filterRunsByAvailability(object.course_runs, availabilities)
+  ) || object.course_runs[0]
+
   const showResourceDrawer = () =>
     setShowResourceDrawer({
       objectId:   object.id,
       objectType: object.object_type
     })
-
-  const availableRuns = object.course_runs
-
 
   return (
     <Card
@@ -131,15 +132,13 @@ export const LearningResourceCard = ({
         <div className="row availability-price-favorite">
           <div className="price grey-surround">
             <i className="material-icons attach_money">attach_money</i>
-            {minPrice(object)}
+            {minPrice(bestAvailableRun)}
           </div>
           <div className="availability grey-surround">
             <i className="material-icons calendar_today">calendar_today</i>
-            {availabilityLabel(
-              !emptyOrNil(object.course_runs)
-                ? object.course_runs[0].availability
-                : COURSE_AVAILABLE_NOW
-            )}
+            {
+              bestRunLabel(bestAvailableRun)
+            }
           </div>
           <div className="favorite grey-surround">
             <img

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -6,7 +6,12 @@ import { mount } from "enzyme"
 
 import { LearningResourceCard } from "./LearningResourceCard"
 
-import { availabilityLabel, minPrice } from "../lib/learning_resources"
+import {
+  availabilityLabel,
+  bestRun,
+  bestRunLabel,
+  minPrice
+} from "../lib/learning_resources"
 import { makeLearningResource } from "../factories/learning_resources"
 import {
   CAROUSEL_IMG_WIDTH,
@@ -153,7 +158,7 @@ describe("LearningResourceCard", () => {
           .text()
           .replace("calendar_today", ""),
         [LR_TYPE_COURSE, LR_TYPE_BOOTCAMP].includes(objectType)
-          ? availabilityLabel(object.course_runs[0].availability)
+          ? bestRunLabel(bestRun(object.course_runs))
           : COURSE_AVAILABLE_NOW
       )
     })

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -93,7 +93,7 @@ type LearningResourceProps = {
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
   overrideObject?: Object,
   searchResultLayout?: string,
-  availabilities: Array<string>
+  availabilities?: Array<string>
 }
 
 const LearningResourceSearchResult = ({

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -126,7 +126,6 @@ type Props = {
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
   overrideObject?: Object,
   searchResultLayout?: string
-
 }
 export default class SearchResult extends React.Component<Props> {
   render() {

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -92,14 +92,16 @@ type LearningResourceProps = {
   result: LearningResourceResult,
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
   overrideObject?: Object,
-  searchResultLayout?: string
+  searchResultLayout?: string,
+  availabilities: Array<string>
 }
 
 const LearningResourceSearchResult = ({
   result,
   setShowResourceDrawer,
   overrideObject,
-  searchResultLayout
+  searchResultLayout,
+  availabilities
 }: LearningResourceProps) => {
   // $FlowFixMe: this should only be used for courses
 
@@ -108,6 +110,7 @@ const LearningResourceSearchResult = ({
       object={searchResultToLearningResource(result, overrideObject)}
       setShowResourceDrawer={setShowResourceDrawer}
       searchResultLayout={searchResultLayout}
+      availabilities={availabilities}
     />
   )
 }
@@ -119,10 +122,11 @@ type Props = {
   toggleUpvote?: Post => void,
   upvotedPost?: ?Post,
   votedComment?: ?CommentInTree,
-  toggleFacet?: Function,
+  availabilities?: Array<string>,
   setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
   overrideObject?: Object,
   searchResultLayout?: string
+
 }
 export default class SearchResult extends React.Component<Props> {
   render() {
@@ -133,7 +137,7 @@ export default class SearchResult extends React.Component<Props> {
       votedComment,
       commentUpvote,
       commentDownvote,
-      toggleFacet,
+      availabilities,
       setShowResourceDrawer,
       overrideObject,
       searchResultLayout
@@ -174,6 +178,7 @@ export default class SearchResult extends React.Component<Props> {
           setShowResourceDrawer={setShowResourceDrawer}
           overrideObject={overrideObject}
           searchResultLayout={searchResultLayout}
+          availabilities={availabilities}
         />
       )
     }

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -318,7 +318,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
       total,
       setShowResourceDrawer
     } = this.props
-    const { from, incremental, searchResultLayout } = this.state
+    const { from, incremental, searchResultLayout, activeFacets } = this.state
 
     if ((processing || !loaded) && !incremental) {
       return <PostLoading />
@@ -350,6 +350,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
                   this.getFavoriteObject(result)
                 }
                 toggleFacet={this.toggleFacet}
+                availabilities={activeFacets.get("availability")}
                 setShowResourceDrawer={setShowResourceDrawer}
                 searchResultLayout={searchResultLayout}
               />

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -24,7 +24,7 @@ import type {
 const incrCourse = incrementer()
 const courseId: any = incrementer()
 
-const dateFormat = "YYYY-MM-DD[T]HH:mm:ss[Z]"
+export const dateFormat = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 
 const incrCourseRun = incrementer()
 

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -42,6 +42,8 @@ export const makeCourseRun = (): CourseRun => {
     level:             casual.random_element(["Graduate", "Undergraduate", null]),
     start_date:        casual.date(dateFormat),
     end_date:          casual.date(dateFormat),
+    best_start_date:        casual.date(dateFormat),
+    best_end_date:          casual.date(dateFormat),
     enrollment_start:  casual.date(dateFormat),
     enrollment_end:    casual.date(dateFormat),
     availability:      casual.random_element([

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -42,8 +42,8 @@ export const makeCourseRun = (): CourseRun => {
     level:             casual.random_element(["Graduate", "Undergraduate", null]),
     start_date:        casual.date(dateFormat),
     end_date:          casual.date(dateFormat),
-    best_start_date:        casual.date(dateFormat),
-    best_end_date:          casual.date(dateFormat),
+    best_start_date:   casual.date(dateFormat),
+    best_end_date:     casual.date(dateFormat),
     enrollment_start:  casual.date(dateFormat),
     enrollment_end:    casual.date(dateFormat),
     availability:      casual.random_element([

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -10,7 +10,8 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
-  LR_TYPE_USERLIST
+  LR_TYPE_USERLIST,
+  DATE_FORMAT
 } from "../lib/constants"
 
 import type {
@@ -23,9 +24,6 @@ import type {
 
 const incrCourse = incrementer()
 const courseId: any = incrementer()
-
-export const dateFormat = "YYYY-MM-DD[T]HH:mm:ss[Z]"
-
 const incrCourseRun = incrementer()
 
 export const makeCourseRun = (): CourseRun => {
@@ -40,12 +38,12 @@ export const makeCourseRun = (): CourseRun => {
     semester:          casual.random_element(["Fall", "Spring", null]),
     year:              casual.year,
     level:             casual.random_element(["Graduate", "Undergraduate", null]),
-    start_date:        casual.date(dateFormat),
-    end_date:          casual.date(dateFormat),
-    best_start_date:   casual.date(dateFormat),
-    best_end_date:     casual.date(dateFormat),
-    enrollment_start:  casual.date(dateFormat),
-    enrollment_end:    casual.date(dateFormat),
+    start_date:        casual.date(DATE_FORMAT),
+    end_date:          casual.date(DATE_FORMAT),
+    best_start_date:   casual.date(DATE_FORMAT),
+    best_end_date:     casual.date(DATE_FORMAT),
+    enrollment_start:  casual.date(DATE_FORMAT),
+    enrollment_end:    casual.date(DATE_FORMAT),
     availability:      casual.random_element([
       COURSE_ARCHIVED,
       COURSE_CURRENT,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -340,6 +340,8 @@ export type CourseRun = {
   end_date:           ?string,
   enrollment_start:   ?string,
   enrollment_end:     ?string,
+  best_start_date:    ?string,
+  best_end_date:      ?string,
   instructors:        Array<CourseInstructor>,
   prices:             Array<CoursePrice>,
   availability:       ?string

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -67,7 +67,7 @@ export type LearningResourceRun = {
   enrollment_start?:   ?string,
   enrollment_end?:     ?string,
   best_start_date?:    ?string,
-  best_end_date?:           ?string,
+  best_end_date?:      ?string,
   availability?:       ?string,
   instructors:         Array<CourseInstructor>,
   prices:              Array<CoursePrice>

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -66,6 +66,8 @@ export type LearningResourceRun = {
   end_date?:           ?string,
   enrollment_start?:   ?string,
   enrollment_end?:     ?string,
+  best_start_date?:    ?string,
+  best_end_date?:           ?string,
   availability?:       ?string,
   instructors:         Array<CourseInstructor>,
   prices:              Array<CoursePrice>

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -74,3 +74,5 @@ export const readableLearningResources = {
 }
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
+export const DEFAULT_START_DT = "1970-01-01T00:00:00Z"
+export const DEFAULT_END_DT = "2500-01-01T00:00:00Z"

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -72,3 +72,5 @@ export const readableLearningResources = {
   [LR_TYPE_PROGRAM]:  "Program",
   [LR_TYPE_USERLIST]: "Learning Path"
 }
+
+export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -75,4 +75,4 @@ export const readableLearningResources = {
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 export const DEFAULT_START_DT = "1970-01-01T00:00:00Z"
-export const DEFAULT_END_DT = "2500-01-01T00:00:00Z"
+export const DEFAULT_END_DT = "2500-01-01T23:59:59Z"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -10,6 +10,7 @@ import {
 } from "./constants"
 import { capitalize, emptyOrNil } from "./util"
 import { AVAILABILITY_MAPPING } from "./search"
+import moment from "moment"
 
 export const availabilityFacetLabel = (availability: ?string) => {
   const facetKey = availability ? AVAILABILITY_MAPPING[availability] : null
@@ -26,6 +27,19 @@ export const availabilityLabel = (availability: ?string) => {
     return availability
   }
 }
+
+export const sortedAvailabilities = (availabilities: Array<string>) => (
+  availabilities.sort((a,b) => AVAILABILITY_MAPPING[a] && AVAILABILITY_MAPPING[b]
+    ? AVAILABILITY_MAPPING[a].order - AVAILABILITY_MAPPING[b].order
+    : 1))
+
+export const inDateRanges = (run: CourseRun, availabilities: Array<string>) => {
+  availabilities.forEach()
+}
+
+export const filterRunsByAvailability = (runs, availabilities) => (
+  runs.filter((run) => inDateRanges(run, availabilities))
+)
 
 export const resourceLabel = (resource: string) => {
   return resource === LR_TYPE_USERLIST

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -32,7 +32,7 @@ export const availabilityLabel = (availability: ?string) => {
   }
 }
 
-export const availabilityFilterToMoment = (filter: string) => {
+export const availabilityFilterToMoment = (filter: string, ending: boolean) => {
   // Convert an Elasticsearch date_range filter string to a moment
   const format = /(now)(\+)?(\d+)?([Md])?/
   const match = format.exec(filter)
@@ -40,6 +40,13 @@ export const availabilityFilterToMoment = (filter: string) => {
     let dt = moment()
     if (match[3] && match[4]) {
       dt = dt.add(match[3], match[4] === "d" ? "days" : "months")
+    }
+    if (ending) {
+      // $FlowFixMe: this is fine according to moment docs, and it works
+      dt.set({ hour: 23, minute: 59, second: 59 })
+    } else {
+      // $FlowFixMe: this is fine according to moment docs, and it works
+      dt.set({ hour: 0, minute: 0, second: 0 })
     }
     return dt
   }
@@ -50,10 +57,12 @@ export const inDateRanges = (run: CourseRun, availabilities: Array<string>) => {
   availabilities.forEach(availability => {
     if (AVAILABILITY_MAPPING[availability]) {
       const from = availabilityFilterToMoment(
-        AVAILABILITY_MAPPING[availability].filter.from
+        AVAILABILITY_MAPPING[availability].filter.from,
+        false
       )
       const to = availabilityFilterToMoment(
-        AVAILABILITY_MAPPING[availability].filter.to
+        AVAILABILITY_MAPPING[availability].filter.to,
+        true
       )
       const startDate = runStartDate(run)
       if (

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -1,5 +1,5 @@
 //@flow
-import { concat } from "ramda"
+import {concat, isNil} from "ramda"
 
 import {
   COURSE_ARCHIVED,
@@ -9,8 +9,10 @@ import {
   LR_TYPE_USERLIST
 } from "./constants"
 import { capitalize, emptyOrNil } from "./util"
-import { AVAILABILITY_MAPPING } from "./search"
+import {AVAILABILITY_MAPPING, AVAILABLE_NOW} from "./search"
 import moment from "moment"
+import {dateFormat} from "../factories/learning_resources";
+import type {CourseRun} from "../flow/discussionTypes";
 
 export const availabilityFacetLabel = (availability: ?string) => {
   const facetKey = availability ? AVAILABILITY_MAPPING[availability] : null
@@ -28,17 +30,76 @@ export const availabilityLabel = (availability: ?string) => {
   }
 }
 
-export const sortedAvailabilities = (availabilities: Array<string>) => (
-  availabilities.sort((a,b) => AVAILABILITY_MAPPING[a] && AVAILABILITY_MAPPING[b]
-    ? AVAILABILITY_MAPPING[a].order - AVAILABILITY_MAPPING[b].order
-    : 1))
+export const parseDateFilter = (filter) => {
+  const format = /(now)(\+)?(\d+)?([Md])?/
+  const match = format.exec(filter)
+  if (match) {
+     let dt = moment()
+     if (match[3] && match[4]){
+       dt = dt.add(match[3], match[4] === "d" ? "days" : "months")
+     }
+    return dt
+  }
+}
 
 export const inDateRanges = (run: CourseRun, availabilities: Array<string>) => {
-  availabilities.forEach()
+  let inRange = false
+  availabilities.forEach(availability => {
+      if (AVAILABILITY_MAPPING[availability]) {
+        const from = parseDateFilter(AVAILABILITY_MAPPING[availability].filter.from)
+        const to = parseDateFilter(AVAILABILITY_MAPPING[availability].filter.to)
+        const start_date = run.best_start_date ? moment(run.best_start_date, dateFormat) : null
+        if (((isNil(start_date) && availability === AVAILABLE_NOW) || isNil(from) || start_date >= from) &&
+          ((isNil(start_date) && availability === AVAILABLE_NOW) || isNil(to) || start_date <= to)) {
+          inRange = true
+        }
+      }
+    }
+  )
+  return inRange
+}
+
+export const bestRunLabel = (run: CourseRun) => {
+  if (!run) {
+    return AVAILABILITY_MAPPING[AVAILABLE_NOW].label
+  }
+  for (const range in AVAILABILITY_MAPPING) {
+    if (inDateRanges(run, [range])) {
+      return AVAILABILITY_MAPPING[range].label
+    }
+  }
+}
+
+export const dateOrNull = (dateString) => (
+  dateString ? moment(dateString, dateFormat) : null
+)
+
+export const bestRun = (runs: Array<CourseRun>) => {
+  const now = moment()
+
+  // Runs that are running right now
+  const currentRuns = runs.filter((run) => (
+    dateOrNull(run.best_start_date) <= now && (dateOrNull(run.best_end_date) > now || isNil(run.best_end_date))
+  ))
+  if (!(emptyOrNil(currentRuns))) {
+    return currentRuns[0]
+  }
+
+  // The next future run
+  const futureRuns = runs.filter((run) => (dateOrNull(run.best_start_date) > now)).sort()
+  if (!emptyOrNil(futureRuns)) {
+    return futureRuns[0]
+  }
+
+  // The most recent run that "ended"
+  const mostRecentRuns = runs.filter((run) => (dateOrNull(run.best_start_date)  <= now)).sort().reverse()
+  if (!emptyOrNil(mostRecentRuns)) {
+    return mostRecentRuns[0]
+  }
 }
 
 export const filterRunsByAvailability = (runs, availabilities) => (
-  runs.filter((run) => inDateRanges(run, availabilities))
+  runs.filter((run) => (availabilities ? inDateRanges(run, availabilities) : true))
 )
 
 export const resourceLabel = (resource: string) => {
@@ -47,17 +108,17 @@ export const resourceLabel = (resource: string) => {
     : concat(capitalize(resource), "s")
 }
 
-export const maxPrice = (resource: Object) => {
-  const prices = !emptyOrNil(resource.course_runs)
-    ? resource.course_runs[0].prices
+export const maxPrice = (courseRun: CourseRun) => {
+  const prices = !emptyOrNil(courseRun)
+    ? courseRun.prices
     : []
   const price = Math.max(...prices.map(price => price.price))
   return price > 0 ? `$${price}` : "Free"
 }
 
-export const minPrice = (resource: Object) => {
-  const prices = !emptyOrNil(resource.course_runs)
-    ? resource.course_runs[0].prices
+export const minPrice = (courseRun: CourseRun) => {
+  const prices = !emptyOrNil(courseRun)
+    ? courseRun.prices
     : []
   const price = Math.min(...prices.map(price => price.price))
   return price > 0 && price !== Infinity ? `$${price}` : "Free"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -102,7 +102,6 @@ export const compareRuns = (firstRun: CourseRun, secondRun: CourseRun) =>
 export const bestRun = (runs: Array<CourseRun>) => {
   // Runs that are running right now
   const currentRuns = runs.filter(
-    // $FlowFixMe: runStartDate and runEndDate will always return a Moment
     run => runStartDate(run).isSameOrBefore() && runEndDate(run).isAfter()
   )
   if (!emptyOrNil(currentRuns)) {
@@ -111,7 +110,6 @@ export const bestRun = (runs: Array<CourseRun>) => {
 
   // The next future run
   const futureRuns = runs
-    // $FlowFixMe: runStartDate always returns a Moment
     .filter(run => runStartDate(run).isAfter())
     .sort(compareRuns)
   if (!emptyOrNil(futureRuns)) {
@@ -120,7 +118,6 @@ export const bestRun = (runs: Array<CourseRun>) => {
 
   // The most recent run that "ended"
   const mostRecentRuns = runs
-    // $FlowFixMe: runStartDate always returns a Moment
     .filter(run => runStartDate(run).isSameOrBefore())
     .sort(compareRuns)
     .reverse()

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -96,7 +96,8 @@ export const bestRun = (runs: Array<CourseRun>) => {
   // Runs that are running right now
   const currentRuns = runs.filter(
     run =>
-      moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) <= 0 &&
+      moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) <=
+        0 &&
       moment(run.best_end_date || defaultEndDate, dateFormat).diff(now) > 0
   )
   if (!emptyOrNil(currentRuns)) {
@@ -106,7 +107,9 @@ export const bestRun = (runs: Array<CourseRun>) => {
   // The next future run
   const futureRuns = runs
     .filter(
-      run => moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) > 0
+      run =>
+        moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) >
+        0
     )
     .sort(compareRuns)
   if (!emptyOrNil(futureRuns)) {
@@ -116,7 +119,9 @@ export const bestRun = (runs: Array<CourseRun>) => {
   // The most recent run that "ended"
   const mostRecentRuns = runs
     .filter(
-      run => moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) <= 0
+      run =>
+        moment(run.best_start_date || defaultStartDate, dateFormat).diff(now) <=
+        0
     )
     .sort(compareRuns)
     .reverse()
@@ -131,8 +136,8 @@ export const filterRunsByAvailability = (
   availabilities: ?Array<string>
 ) =>
   runs
-    // $FlowFixMe
-    ? runs.filter(
+    ? // $FlowFixMe
+    runs.filter(
       run => (availabilities ? inDateRanges(run, availabilities) : true)
     )
     : []

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -1,5 +1,6 @@
 //@flow
 import { concat, isNil } from "ramda"
+import moment from "moment"
 
 import {
   COURSE_ARCHIVED,
@@ -8,10 +9,10 @@ import {
   COURSE_PRIOR,
   LR_TYPE_USERLIST
 } from "./constants"
-import { capitalize, emptyOrNil } from "./util"
 import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
-import moment from "moment"
+import { capitalize, emptyOrNil } from "./util"
 import { dateFormat } from "../factories/learning_resources"
+
 import type { CourseRun } from "../flow/discussionTypes"
 
 const defaultStartDate = "1970-01-01T00:00:00Z"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -8,14 +8,13 @@ import {
   COURSE_CURRENT,
   COURSE_PRIOR,
   DATE_FORMAT,
+  DEFAULT_END_DT,
+  DEFAULT_START_DT,
   LR_TYPE_USERLIST
 } from "./constants"
 import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
 import { capitalize, emptyOrNil } from "./util"
 import type { CourseRun } from "../flow/discussionTypes"
-
-const defaultStartDate = "1970-01-01T00:00:00Z"
-const defaultEndDate = "2500-01-01T00:00:00Z"
 
 export const availabilityFacetLabel = (availability: ?string) => {
   const facetKey = availability ? AVAILABILITY_MAPPING[availability] : null
@@ -83,20 +82,20 @@ export const bestRunLabel = (run: ?CourseRun) => {
   }
 }
 
-const runStartDate = (courseRun: CourseRun) =>
-  moment(courseRun.best_start_date || defaultStartDate, DATE_FORMAT)
-const runEndDate = (courseRun: CourseRun) =>
-  moment(courseRun.best_end_date || defaultEndDate, DATE_FORMAT)
+export const runStartDate = (courseRun: CourseRun) =>
+  moment(courseRun.best_start_date || DEFAULT_START_DT, DATE_FORMAT)
+
+export const runEndDate = (courseRun: CourseRun) =>
+  moment(courseRun.best_end_date || DEFAULT_END_DT, DATE_FORMAT)
 
 export const compareRuns = (firstRun: CourseRun, secondRun: CourseRun) =>
   runStartDate(firstRun).diff(runStartDate(secondRun), "hours")
 
 export const bestRun = (runs: Array<CourseRun>) => {
-  const now = moment()
-
   // Runs that are running right now
   const currentRuns = runs.filter(
-    run => runStartDate(run).isSameOrBefore(now) && runEndDate(run).isAfter(now)
+    // $FlowFixMe: runStartDate and runEndDate will always return a Moment
+    run => runStartDate(run).isSameOrBefore() && runEndDate(run).isAfter()
   )
   if (!emptyOrNil(currentRuns)) {
     return currentRuns[0]
@@ -104,7 +103,8 @@ export const bestRun = (runs: Array<CourseRun>) => {
 
   // The next future run
   const futureRuns = runs
-    .filter(run => runStartDate(run).isAfter(now))
+    // $FlowFixMe: runStartDate always returns a Moment
+    .filter(run => runStartDate(run).isAfter())
     .sort(compareRuns)
   if (!emptyOrNil(futureRuns)) {
     return futureRuns[0]
@@ -112,7 +112,8 @@ export const bestRun = (runs: Array<CourseRun>) => {
 
   // The most recent run that "ended"
   const mostRecentRuns = runs
-    .filter(run => runStartDate(run).isSameOrBefore(now))
+    // $FlowFixMe: runStartDate always returns a Moment
+    .filter(run => runStartDate(run).isSameOrBefore())
     .sort(compareRuns)
     .reverse()
   if (!emptyOrNil(mostRecentRuns)) {

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -8,6 +8,7 @@ import {
   COURSE_AVAILABLE_NOW,
   COURSE_CURRENT,
   COURSE_PRIOR,
+  DATE_FORMAT,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
@@ -20,16 +21,12 @@ import {
   maxPrice,
   resourceLabel,
   availabilityFacetLabel,
-  parseDateFilter,
+  availabilityFilterToMoment,
   inDateRanges,
   bestRunLabel,
   bestRun
 } from "./learning_resources"
-import {
-  dateFormat,
-  makeCourse,
-  makeCourseRun
-} from "../factories/learning_resources"
+import { makeCourse, makeCourseRun } from "../factories/learning_resources"
 
 describe("Course utils", () => {
   [
@@ -125,9 +122,9 @@ describe("Course run availability utils", () => {
     it(`parseDateFilter should return ${String(
       expected
     )} for filter ${filter}`, () => {
-      const parsedDate = parseDateFilter(filter)
+      const parsedDate = availabilityFilterToMoment(filter)
       assert.equal(
-        parsedDate ? parsedDate.format(dateFormat) : parsedDate,
+        parsedDate ? parsedDate.format(DATE_FORMAT) : parsedDate,
         expected
       )
     })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -107,8 +107,14 @@ describe("Course utils", () => {
 })
 
 describe("Course run availability utils", () => {
+  let clock
+
   beforeEach(() => {
-    sinon.useFakeTimers(new Date("2019-09-01T00:00:00Z"))
+    clock = sinon.useFakeTimers(new Date("2019-09-01T00:00:00Z"))
+  })
+
+  afterEach(() => {
+    clock.restore()
   })
 
   //

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import { makeCourse } from "../factories/learning_resources"
+import {dateFormat, makeCourse, makeCourseRun} from "../factories/learning_resources"
 import {
   COURSE_ARCHIVED,
   COURSE_AVAILABLE_NOW,
@@ -13,7 +13,7 @@ import {
   minPrice,
   maxPrice,
   resourceLabel,
-  availabilityFacetLabel
+  availabilityFacetLabel, parseDateFilter, inDateRanges, bestRunLabel
 } from "./learning_resources"
 import {
   LR_TYPE_BOOTCAMP,
@@ -21,7 +21,12 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST
 } from "./constants"
-import { AVAILABILITY_MAPPING } from "./search"
+import {AVAILABILITY_MAPPING, AVAILABLE_NOW} from "./search"
+import sinon from "sinon";
+import type {CourseRun} from "../flow/discussionTypes";
+import moment from "moment";
+import {isNil} from "ramda";
+import R from "ramda";
 
 describe("Course utils", () => {
   [
@@ -49,18 +54,19 @@ describe("Course utils", () => {
   ].forEach(([prices, expectedMax, expectedMin]) => {
     it(`minPrice, maxPrice should return ${expectedMin}, ${expectedMax} for price range ${prices.toString()}`, () => {
       const course = makeCourse()
-      course.course_runs[0].prices = []
+      const courseRun = course.course_runs[0]
+      courseRun.prices = []
       prices.forEach(price => {
         if (!isNaN(price)) {
           // $FlowFixMe: course.prices is definitely not null here
-          course.course_runs[0].prices.push({
+          courseRun.prices.push({
             mode:  "test",
             price: price
           })
         }
       })
-      assert.equal(minPrice(course), expectedMin)
-      assert.equal(maxPrice(course), expectedMax)
+      assert.equal(minPrice(courseRun), expectedMin)
+      assert.equal(maxPrice(courseRun), expectedMax)
     })
   })
 
@@ -93,4 +99,90 @@ describe("Course utils", () => {
       assert.equal(availabilityFacetLabel(searchType), label)
     })
   })
+
+})
+
+describe("Course run availability utils", () => {
+
+  beforeEach(() => {
+    sinon.useFakeTimers(new Date("2019-09-01T00:00:00Z"));
+  })
+
+  //
+  ;[
+    ["now", "2019-09-01T00:00:00Z"],
+    ["now+7d", "2019-09-08T00:00:00Z"],
+    ["now+6M", "2020-03-01T00:00:00Z"],
+    ["foo", null]
+  ].forEach(([filter, expected]) => {
+    it(`parseDateFilter should return ${String(expected)} for filter ${filter}`, () => {
+        const parsedDate = parseDateFilter(filter)
+        assert.equal(parsedDate ? parsedDate.format(dateFormat) : parsedDate, expected)
+      })
+  })
+
+  //
+  ;[
+    ["2019-08-01T00:00:00Z", "2019-08-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    ["2019-08-02T00:00:00Z", "2019-08-31T00:00:00Z", ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
+    ["2019-08-02T00:00:00Z", "2019-08-31T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.availableNow.label],
+    ["2019-09-02T00:00:00Z", "2019-10-31T00:00:00Z", ["nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
+    ["2019-08-01T00:00:00Z", null, ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    [null, "2019-08-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    [null, "2019-08-31T00:00:00Z", ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
+    [null, null, ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    [null, null, ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
+    ["2019-09-02T00:00:00Z", "2019-09-30T00:00:00Z", ["availableNow"], false, AVAILABILITY_MAPPING.nextWeek.label],
+    ["2019-09-02T00:00:00Z", null, ["availableNow"], false, AVAILABILITY_MAPPING.nextWeek.label],
+    [null, "2019-09-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    ["2019-09-02T00:00:00Z", "2019-09-30T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
+    ["2019-09-02T00:00:00Z", null, ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
+    [null, "2019-09-30T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.availableNow.label],
+    ["2020-08-02T00:00:00Z", null, ["nextYear"], true, AVAILABILITY_MAPPING.nextYear.label],
+    ["2030-08-02T00:00:00Z", null, ["nextYear"], false, null],
+  ].forEach(([start_date, end_date, availabilities, expected, label]) => {
+     const courseRun = makeCourseRun()
+     courseRun.best_start_date = start_date
+     courseRun.best_end_date = end_date
+
+     it(`inDateRanges should return ${String(expected)} for start_date ${String(start_date)}, end_date ${String(end_date)}, availabilities ${String(availabilities)}`, () => {
+       assert.equal(inDateRanges(courseRun, availabilities), expected)
+     })
+
+    it(`bestRunLabel should return ${label} for dates ${String(start_date)}-${String(end_date)}`, () => {
+      assert.equal(bestRunLabel(courseRun), label)
+    })
+  })
+
+
+  //;
+  [
+    [
+      ["2019-09-02", "2019-08-31", "2019-10-22"], ["2019-10-02", "2019-09-31", "2019-11-22"], "2019-08-31"
+    ],
+    [
+      ["2019-09-02", "2019-08-01", "2019-10-22"], ["2019-10-02", "2019-08-31", "2019-11-22"], "2019-09-02"
+    ],
+    [
+      ["2019-11-02", "2019-10-01", "2019-12-22"], ["2019-12-02", "2019-11-31", "2019-12-23"],  "2019-10-01"
+    ],
+    [
+      ["2019-11-02", "2019-10-01", "2019-10-22"], ["2019-12-02", null, "2019-11-22"],  "2019-10-01"
+    ],
+    [
+      ["2019-11-02", null, "2019-10-22"], ["2019-12-02", "2019-11-31", "2019-11-22"], "2019-10-22"
+    ]
+    ].forEach(([start_dates, end_dates, expected]) => {
+      it(`best run of 3 should have start_date ${expected}`, () => {
+        assert(true)
+        // const runs = R.times(makeCourseRun, 3)
+        // const setDates = (iter) => {
+        //   runs[iter].start_date = start_dates[iter]
+        //   runs[iter].end_date = end_dates[iter]
+        // }
+        // R.times(setDates, 3)
+        //assert.equal(bestRun(runs).start_date.format('YYYY-MM-dd'), expected)
+      })
+  })
+
 })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -9,6 +9,8 @@ import {
   COURSE_CURRENT,
   COURSE_PRIOR,
   DATE_FORMAT,
+  DEFAULT_END_DT,
+  DEFAULT_START_DT,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
@@ -24,9 +26,12 @@ import {
   availabilityFilterToMoment,
   inDateRanges,
   bestRunLabel,
-  bestRun
+  bestRun,
+  runStartDate,
+  runEndDate
 } from "./learning_resources"
 import { makeCourse, makeCourseRun } from "../factories/learning_resources"
+import moment from "moment"
 
 describe("Course utils", () => {
   [
@@ -300,6 +305,40 @@ describe("Course run availability utils", () => {
       times(setDates, 3)
       // $FlowFixMe: best_start_date won't be null for these tests
       assert.equal(bestRun(runs).best_start_date, `${expected}T00:00:00Z`)
+    })
+  })
+
+  //
+  ;[
+    ["2019-09-01T00:00:00Z", "2019-09-01T00:00:00Z"],
+    [null, DEFAULT_START_DT]
+  ].forEach(([startDate, expectedDate]) => {
+    it(`runStartDate() should return  ${expectedDate} for run with best_start_date ${String(
+      startDate
+    )}`, () => {
+      const run = makeCourseRun()
+      run.best_start_date = startDate
+      assert.equal(
+        runStartDate(run).format(DATE_FORMAT),
+        moment(expectedDate, DATE_FORMAT).format(DATE_FORMAT)
+      )
+    })
+  })
+
+  //
+  ;[
+    ["2019-09-01T00:00:00Z", "2019-09-01T00:00:00Z"],
+    [null, DEFAULT_END_DT]
+  ].forEach(([endDate, expectedDate]) => {
+    it(`runEndDate() should return  ${expectedDate} for run with best_end_date ${String(
+      endDate
+    )}`, () => {
+      const run = makeCourseRun()
+      run.best_end_date = endDate
+      assert.equal(
+        runEndDate(run).format(DATE_FORMAT),
+        moment(expectedDate, DATE_FORMAT).format(DATE_FORMAT)
+      )
     })
   })
 })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -1,7 +1,11 @@
 // @flow
 import { assert } from "chai"
 
-import {dateFormat, makeCourse, makeCourseRun} from "../factories/learning_resources"
+import {
+  dateFormat,
+  makeCourse,
+  makeCourseRun
+} from "../factories/learning_resources"
 import {
   COURSE_ARCHIVED,
   COURSE_AVAILABLE_NOW,
@@ -13,7 +17,11 @@ import {
   minPrice,
   maxPrice,
   resourceLabel,
-  availabilityFacetLabel, parseDateFilter, inDateRanges, bestRunLabel
+  availabilityFacetLabel,
+  parseDateFilter,
+  inDateRanges,
+  bestRunLabel,
+  bestRun
 } from "./learning_resources"
 import {
   LR_TYPE_BOOTCAMP,
@@ -21,12 +29,9 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST
 } from "./constants"
-import {AVAILABILITY_MAPPING, AVAILABLE_NOW} from "./search"
-import sinon from "sinon";
-import type {CourseRun} from "../flow/discussionTypes";
-import moment from "moment";
-import {isNil} from "ramda";
-import R from "ramda";
+import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
+import sinon from "sinon"
+import R from "ramda"
 
 describe("Course utils", () => {
   [
@@ -99,13 +104,11 @@ describe("Course utils", () => {
       assert.equal(availabilityFacetLabel(searchType), label)
     })
   })
-
 })
 
 describe("Course run availability utils", () => {
-
   beforeEach(() => {
-    sinon.useFakeTimers(new Date("2019-09-01T00:00:00Z"));
+    sinon.useFakeTimers(new Date("2019-09-01T00:00:00Z"))
   })
 
   //
@@ -115,74 +118,188 @@ describe("Course run availability utils", () => {
     ["now+6M", "2020-03-01T00:00:00Z"],
     ["foo", null]
   ].forEach(([filter, expected]) => {
-    it(`parseDateFilter should return ${String(expected)} for filter ${filter}`, () => {
-        const parsedDate = parseDateFilter(filter)
-        assert.equal(parsedDate ? parsedDate.format(dateFormat) : parsedDate, expected)
-      })
+    it(`parseDateFilter should return ${String(
+      expected
+    )} for filter ${filter}`, () => {
+      const parsedDate = parseDateFilter(filter)
+      assert.equal(
+        parsedDate ? parsedDate.format(dateFormat) : parsedDate,
+        expected
+      )
+    })
   })
 
   //
   ;[
-    ["2019-08-01T00:00:00Z", "2019-08-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
-    ["2019-08-02T00:00:00Z", "2019-08-31T00:00:00Z", ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
-    ["2019-08-02T00:00:00Z", "2019-08-31T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.availableNow.label],
-    ["2019-09-02T00:00:00Z", "2019-10-31T00:00:00Z", ["nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
-    ["2019-08-01T00:00:00Z", null, ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
-    [null, "2019-08-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
-    [null, "2019-08-31T00:00:00Z", ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
-    [null, null, ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
+    [
+      "2019-08-01T00:00:00Z",
+      "2019-08-31T00:00:00Z",
+      ["availableNow"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      "2019-08-02T00:00:00Z",
+      "2019-08-31T00:00:00Z",
+      ["nextWeek"],
+      false,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      "2019-08-02T00:00:00Z",
+      "2019-08-31T00:00:00Z",
+      ["availableNow", "nextWeek"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      "2019-09-02T00:00:00Z",
+      "2019-10-31T00:00:00Z",
+      ["nextWeek"],
+      true,
+      AVAILABILITY_MAPPING.nextWeek.label
+    ],
+    [
+      "2019-08-01T00:00:00Z",
+      null,
+      ["availableNow"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      null,
+      "2019-08-31T00:00:00Z",
+      ["availableNow"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      null,
+      "2019-08-31T00:00:00Z",
+      ["nextWeek"],
+      false,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      null,
+      null,
+      ["availableNow"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
     [null, null, ["nextWeek"], false, AVAILABILITY_MAPPING.availableNow.label],
-    ["2019-09-02T00:00:00Z", "2019-09-30T00:00:00Z", ["availableNow"], false, AVAILABILITY_MAPPING.nextWeek.label],
-    ["2019-09-02T00:00:00Z", null, ["availableNow"], false, AVAILABILITY_MAPPING.nextWeek.label],
-    [null, "2019-09-31T00:00:00Z", ["availableNow"], true, AVAILABILITY_MAPPING.availableNow.label],
-    ["2019-09-02T00:00:00Z", "2019-09-30T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
-    ["2019-09-02T00:00:00Z", null, ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.nextWeek.label],
-    [null, "2019-09-30T00:00:00Z", ["availableNow", "nextWeek"], true, AVAILABILITY_MAPPING.availableNow.label],
-    ["2020-08-02T00:00:00Z", null, ["nextYear"], true, AVAILABILITY_MAPPING.nextYear.label],
-    ["2030-08-02T00:00:00Z", null, ["nextYear"], false, null],
+    [
+      "2019-09-02T00:00:00Z",
+      "2019-09-30T00:00:00Z",
+      ["availableNow"],
+      false,
+      AVAILABILITY_MAPPING.nextWeek.label
+    ],
+    [
+      "2019-09-02T00:00:00Z",
+      null,
+      ["availableNow"],
+      false,
+      AVAILABILITY_MAPPING.nextWeek.label
+    ],
+    [
+      null,
+      "2019-09-31T00:00:00Z",
+      ["availableNow"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      "2019-09-02T00:00:00Z",
+      "2019-09-30T00:00:00Z",
+      ["availableNow", "nextWeek"],
+      true,
+      AVAILABILITY_MAPPING.nextWeek.label
+    ],
+    [
+      "2019-09-02T00:00:00Z",
+      null,
+      ["availableNow", "nextWeek"],
+      true,
+      AVAILABILITY_MAPPING.nextWeek.label
+    ],
+    [
+      null,
+      "2019-09-30T00:00:00Z",
+      ["availableNow", "nextWeek"],
+      true,
+      AVAILABILITY_MAPPING.availableNow.label
+    ],
+    [
+      "2020-08-02T00:00:00Z",
+      null,
+      ["nextYear"],
+      true,
+      AVAILABILITY_MAPPING.nextYear.label
+    ],
+    ["2030-08-02T00:00:00Z", null, ["nextYear"], false, null]
   ].forEach(([start_date, end_date, availabilities, expected, label]) => {
-     const courseRun = makeCourseRun()
-     courseRun.best_start_date = start_date
-     courseRun.best_end_date = end_date
+    const courseRun = makeCourseRun()
+    courseRun.best_start_date = start_date
+    courseRun.best_end_date = end_date
 
-     it(`inDateRanges should return ${String(expected)} for start_date ${String(start_date)}, end_date ${String(end_date)}, availabilities ${String(availabilities)}`, () => {
-       assert.equal(inDateRanges(courseRun, availabilities), expected)
-     })
+    it(`inDateRanges should return ${String(expected)} for start_date ${String(
+      start_date
+    )}, end_date ${String(end_date)}, availabilities ${String(
+      availabilities
+    )}`, () => {
+      assert.equal(inDateRanges(courseRun, availabilities), expected)
+    })
 
-    it(`bestRunLabel should return ${label} for dates ${String(start_date)}-${String(end_date)}`, () => {
+    it(`bestRunLabel should return ${label} for dates ${String(
+      start_date
+    )}-${String(end_date)}`, () => {
       assert.equal(bestRunLabel(courseRun), label)
     })
   })
 
-
-  //;
-  [
+  //
+  ;[
     [
-      ["2019-09-02", "2019-08-31", "2019-10-22"], ["2019-10-02", "2019-09-31", "2019-11-22"], "2019-08-31"
+      ["2019-09-02", "2019-08-31", "2019-10-22"],
+      ["2019-10-02", "2019-09-30", "2019-11-22"],
+      "2019-08-31"
     ],
     [
-      ["2019-09-02", "2019-08-01", "2019-10-22"], ["2019-10-02", "2019-08-31", "2019-11-22"], "2019-09-02"
+      ["2019-10-22", "2019-08-01", "2019-09-02"],
+      ["2019-10-02", "2019-08-31", "2019-11-22"],
+      "2019-08-01"
     ],
     [
-      ["2019-11-02", "2019-10-01", "2019-12-22"], ["2019-12-02", "2019-11-31", "2019-12-23"],  "2019-10-01"
+      ["2019-11-02", "2019-10-01", "2019-12-22"],
+      ["2019-12-02", "2019-11-30", "2019-12-23"],
+      "2019-10-01"
     ],
     [
-      ["2019-11-02", "2019-10-01", "2019-10-22"], ["2019-12-02", null, "2019-11-22"],  "2019-10-01"
+      ["2019-11-02", "2019-10-01", "2019-10-22"],
+      ["2019-12-02", null, "2019-11-22"],
+      "2019-10-01"
     ],
     [
-      ["2019-11-02", null, "2019-10-22"], ["2019-12-02", "2019-11-31", "2019-11-22"], "2019-10-22"
+      ["2019-11-02", null, "2019-10-22"],
+      ["2019-12-02", "2019-11-31", "2019-11-22"],
+      "2019-10-22"
     ]
-    ].forEach(([start_dates, end_dates, expected]) => {
-      it(`best run of 3 should have start_date ${expected}`, () => {
-        assert(true)
-        // const runs = R.times(makeCourseRun, 3)
-        // const setDates = (iter) => {
-        //   runs[iter].start_date = start_dates[iter]
-        //   runs[iter].end_date = end_dates[iter]
-        // }
-        // R.times(setDates, 3)
-        //assert.equal(bestRun(runs).start_date.format('YYYY-MM-dd'), expected)
-      })
+  ].forEach(([start_dates, end_dates, expected]) => {
+    it(`best run of 3 should have start_date ${expected}`, () => {
+      const runs = R.times(makeCourseRun, 3)
+      const setDates = iter => {
+        runs[iter].best_start_date = start_dates[iter]
+          ? `${start_dates[iter]  }T00:00:00Z`
+          : null
+        runs[iter].best_end_date = end_dates[iter]
+          ? `${end_dates[iter]  }T00:00:00Z`
+          : null
+      }
+      R.times(setDates, 3)
+      assert.equal(runs[0].best_start_date, `${start_dates[0]  }T00:00:00Z`)
+      assert.equal(runs[0].best_end_date, `${end_dates[0]  }T00:00:00Z`)
+      assert.equal(bestRun(runs).best_start_date, `${expected  }T00:00:00Z`)
+    })
   })
-
 })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -119,18 +119,23 @@ describe("Course run availability utils", () => {
 
   //
   ;[
-    ["now", "2019-09-01T00:00:00Z"],
-    ["now+7d", "2019-09-08T00:00:00Z"],
-    ["now+6M", "2020-03-01T00:00:00Z"],
+    ["now", "2019-09-01T"],
+    ["now+7d", "2019-09-08T"],
+    ["now+6M", "2020-03-01T"],
     ["foo", null]
   ].forEach(([filter, expected]) => {
     it(`parseDateFilter should return ${String(
       expected
-    )} for filter ${filter}`, () => {
-      const parsedDate = availabilityFilterToMoment(filter)
+    )} for filter ${filter} and ending=false`, () => {
+      const parsedStartDate = availabilityFilterToMoment(filter, false)
       assert.equal(
-        parsedDate ? parsedDate.format(DATE_FORMAT) : parsedDate,
-        expected
+        parsedStartDate ? parsedStartDate.format(DATE_FORMAT) : parsedStartDate,
+        expected ? `${expected}00:00:00Z` : null
+      )
+      const parsedEndDate = availabilityFilterToMoment(filter, true)
+      assert.equal(
+        parsedEndDate ? parsedEndDate.format(DATE_FORMAT) : parsedEndDate,
+        expected ? `${expected}23:59:59Z` : null
       )
     })
   })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -1,17 +1,19 @@
 // @flow
 import { assert } from "chai"
+import sinon from "sinon"
+import { times } from "ramda"
 
-import {
-  dateFormat,
-  makeCourse,
-  makeCourseRun
-} from "../factories/learning_resources"
 import {
   COURSE_ARCHIVED,
   COURSE_AVAILABLE_NOW,
   COURSE_CURRENT,
-  COURSE_PRIOR
+  COURSE_PRIOR,
+  LR_TYPE_BOOTCAMP,
+  LR_TYPE_COURSE,
+  LR_TYPE_PROGRAM,
+  LR_TYPE_USERLIST
 } from "./constants"
+import { AVAILABILITY_MAPPING } from "./search"
 import {
   availabilityLabel,
   minPrice,
@@ -24,14 +26,10 @@ import {
   bestRun
 } from "./learning_resources"
 import {
-  LR_TYPE_BOOTCAMP,
-  LR_TYPE_COURSE,
-  LR_TYPE_PROGRAM,
-  LR_TYPE_USERLIST
-} from "./constants"
-import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
-import sinon from "sinon"
-import R from "ramda"
+  dateFormat,
+  makeCourse,
+  makeCourseRun
+} from "../factories/learning_resources"
 
 describe("Course utils", () => {
   [
@@ -293,7 +291,7 @@ describe("Course run availability utils", () => {
     ]
   ].forEach(([startDates, endDates, expected]) => {
     it(`best run of 3 should have start_date ${expected}`, () => {
-      const runs = R.times(makeCourseRun, 3)
+      const runs = times(makeCourseRun, 3)
       const setDates = iter => {
         runs[iter].best_start_date = startDates[iter]
           ? `${startDates[iter]}T00:00:00Z`
@@ -302,7 +300,7 @@ describe("Course run availability utils", () => {
           ? `${endDates[iter]}T00:00:00Z`
           : null
       }
-      R.times(setDates, 3)
+      times(setDates, 3)
       // $FlowFixMe: best_start_date won't be null for these tests
       assert.equal(bestRun(runs).best_start_date, `${expected}T00:00:00Z`)
     })

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -238,22 +238,22 @@ describe("Course run availability utils", () => {
       AVAILABILITY_MAPPING.nextYear.label
     ],
     ["2030-08-02T00:00:00Z", null, ["nextYear"], false, null]
-  ].forEach(([start_date, end_date, availabilities, expected, label]) => {
+  ].forEach(([startDate, endDate, availabilities, expected, label]) => {
     const courseRun = makeCourseRun()
-    courseRun.best_start_date = start_date
-    courseRun.best_end_date = end_date
+    courseRun.best_start_date = startDate
+    courseRun.best_end_date = endDate
 
     it(`inDateRanges should return ${String(expected)} for start_date ${String(
-      start_date
-    )}, end_date ${String(end_date)}, availabilities ${String(
+      startDate
+    )}, end_date ${String(endDate)}, availabilities ${String(
       availabilities
     )}`, () => {
       assert.equal(inDateRanges(courseRun, availabilities), expected)
     })
 
-    it(`bestRunLabel should return ${label} for dates ${String(
-      start_date
-    )}-${String(end_date)}`, () => {
+    it(`bestRunLabel should return ${String(label)} for dates ${String(
+      startDate
+    )}-${String(endDate)}`, () => {
       assert.equal(bestRunLabel(courseRun), label)
     })
   })
@@ -266,8 +266,8 @@ describe("Course run availability utils", () => {
       "2019-08-31"
     ],
     [
-      ["2019-10-22", "2019-08-01", "2019-09-02"],
-      ["2019-10-02", "2019-08-31", "2019-11-22"],
+      ["2019-06-22", "2019-08-01", "2019-07-02"],
+      ["2019-08-02", "2019-08-31", "2019-08-22"],
       "2019-08-01"
     ],
     [
@@ -285,21 +285,20 @@ describe("Course run availability utils", () => {
       ["2019-12-02", "2019-11-31", "2019-11-22"],
       "2019-10-22"
     ]
-  ].forEach(([start_dates, end_dates, expected]) => {
+  ].forEach(([startDates, endDates, expected]) => {
     it(`best run of 3 should have start_date ${expected}`, () => {
       const runs = R.times(makeCourseRun, 3)
       const setDates = iter => {
-        runs[iter].best_start_date = start_dates[iter]
-          ? `${start_dates[iter]  }T00:00:00Z`
+        runs[iter].best_start_date = startDates[iter]
+          ? `${startDates[iter]}T00:00:00Z`
           : null
-        runs[iter].best_end_date = end_dates[iter]
-          ? `${end_dates[iter]  }T00:00:00Z`
+        runs[iter].best_end_date = endDates[iter]
+          ? `${endDates[iter]}T00:00:00Z`
           : null
       }
       R.times(setDates, 3)
-      assert.equal(runs[0].best_start_date, `${start_dates[0]  }T00:00:00Z`)
-      assert.equal(runs[0].best_end_date, `${end_dates[0]  }T00:00:00Z`)
-      assert.equal(bestRun(runs).best_start_date, `${expected  }T00:00:00Z`)
+      // $FlowFixMe: best_start_date won't be null for these tests
+      assert.equal(bestRun(runs).best_start_date, `${expected}T00:00:00Z`)
     })
   })
 })

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -3,11 +3,12 @@
 import bodybuilder from "bodybuilder"
 import R from "ramda"
 import {
-  LR_TYPE_COURSE,
+  DEFAULT_START_DT,
   LR_TYPE_BOOTCAMP,
+  LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST
-} from "../lib/constants"
+} from "./constants"
 import {
   SEARCH_FILTER_COMMENT,
   SEARCH_FILTER_POST,
@@ -349,7 +350,7 @@ export const buildSearchQuery = ({
               "date_range",
               "course_runs.best_start_date",
               {
-                missing: "1901-01-01T00:00:00Z",
+                missing: DEFAULT_START_DT,
                 keyed:   false,
                 ranges:  [
                   {

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -12,7 +12,6 @@ import {
 } from "../factories/search"
 import {
   AVAILABILITY_MAPPING,
-  AVAILABLE_NOW,
   buildSearchQuery,
   channelField,
   searchFields,
@@ -22,7 +21,11 @@ import {
   searchResultToProfile
 } from "./search"
 import * as searchFuncs from "./search"
-import { LR_TYPE_BOOTCAMP, LR_TYPE_COURSE } from "../lib/constants"
+import {
+  LR_TYPE_BOOTCAMP,
+  LR_TYPE_COURSE,
+  DEFAULT_START_DT
+} from "../lib/constants"
 
 describe("search functions", () => {
   let sandbox
@@ -409,7 +412,7 @@ describe("search functions", () => {
                     date_range: {
                       field:   "course_runs.best_start_date",
                       keyed:   false,
-                      missing: "1901-01-01T00:00:00Z",
+                      missing: DEFAULT_START_DT,
                       ranges:  [
                         {
                           key: "availableNow",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2162

#### What's this PR do?
- Sends the selected availability facets (if any) to the `LearningResourceCard` card component
- Adds functions for determining the best run/availability to display

#### How should this be manually tested?
- Select 'Available Now' facet only, all the results should show 'Available Now'
- Select 'In the next year' only, results should show a mix from 'In the next week' to 'In the next year'
- Select 'Available Now' and 'In the next year', results should show a mix from 'Available Now' to 'In the next year'.  
- Select 'Programs' and 'Learning Paths' facets, they should all be 'Available Now'

#### Screenshots

<img width="1589" alt="Screen Shot 2019-09-03 at 4 36 21 PM" src="https://user-images.githubusercontent.com/187676/64206876-71f0b880-ce69-11e9-9f13-e5048cb8df14.png">

<img width="1594" alt="Screen Shot 2019-09-03 at 4 37 10 PM" src="https://user-images.githubusercontent.com/187676/64206872-6e5d3180-ce69-11e9-9c81-36fb8c2c4ecc.png">


