### PR TITLE
restyling active search filter list

### DIFF
--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -35,7 +35,7 @@ function SearchFacet(props: Props) {
   return (
     <div className="facets">
       <div
-        className="facet-title"
+        className="filter-section-title"
         onClick={() => setShowFacetList(!showFacetList)}
       >
         {title}

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -44,7 +44,7 @@ describe("SearchFacet", () => {
   it("should render facets correctly", () => {
     const wrapper = renderSearchFacet()
     const checkbox = wrapper.find("input").at(0)
-    assert.include(wrapper.find(".facet-title").text(), title)
+    assert.include(wrapper.find(".filter-section-title").text(), title)
     assert.equal(checkbox.prop("name"), name)
     assert.equal(checkbox.prop("value"), facet["key"])
   })
@@ -75,7 +75,7 @@ describe("SearchFacet", () => {
   it("should have a button to show / hide the facet list", () => {
     const wrapper = renderSearchFacet()
     assert.ok(wrapper.find(".facet-visible").exists())
-    wrapper.find(".facet-title").simulate("click")
+    wrapper.find(".filter-section-title").simulate("click")
     assert.isNotOk(wrapper.find(".facet-visible").exists())
   })
 

--- a/static/js/components/SearchFilter.js
+++ b/static/js/components/SearchFilter.js
@@ -9,13 +9,13 @@ type Props = {|
 |}
 
 const SearchFilter = ({ title, value, clearFacet, labelFunction }: Props) => (
-  <div className={"search-filter-div"}>
+  <div className="active-search-filter">
+    <div className="remove-filter" onClick={clearFacet}>
+      <i className="material-icons">close</i>
+    </div>
     <div>
       {title}
       {value ? `: ${labelFunction ? labelFunction(value) : value}` : ""}
-    </div>
-    <div className="search-filter-close" onClick={clearFacet}>
-      <i className="material-icons">close</i>
     </div>
   </div>
 )

--- a/static/js/components/SearchFilter_test.js
+++ b/static/js/components/SearchFilter_test.js
@@ -1,27 +1,20 @@
 // @flow
 import React from "react"
+import sinon from "sinon"
 import _ from "lodash"
 import { assert } from "chai"
 import { shallow } from "enzyme"
-import * as sinon from "sinon"
 
 import SearchFilter from "./SearchFilter"
-import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("SearchFilter", () => {
-  let helper, onClickStub
+  let onClickStub
 
-  const renderSearchFilter = props => {
-    return shallow(<SearchFilter clearFacet={onClickStub} {...props} />)
-  }
+  const renderSearchFilter = props =>
+    shallow(<SearchFilter clearFacet={onClickStub} {...props} />)
 
   beforeEach(() => {
-    helper = new IntegrationTestHelper()
-    onClickStub = helper.sandbox.stub()
-  })
-
-  afterEach(() => {
-    helper.cleanup()
+    onClickStub = sinon.stub()
   })
 
   it("should render a search filter correctly", () => {
@@ -32,17 +25,14 @@ describe("SearchFilter", () => {
       value,
       labelFunction: _.upperCase
     })
-    const label = wrapper
-      .find(".search-filter-div")
-      .at(0)
-      .text()
+    const label = wrapper.text()
     assert.isTrue(label.includes(_.upperCase(value)))
     assert.isTrue(label.includes(title))
   })
 
   it("should trigger clearFacet function on click", async () => {
     const wrapper = renderSearchFilter({ title: "Platform", value: "ocw" })
-    wrapper.find(".search-filter-close").simulate("click")
+    wrapper.find(".remove-filter").simulate("click")
     sinon.assert.calledOnce(onClickStub)
   })
 })

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -365,6 +365,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { match } = this.props
     const { text, error, activeFacets, searchResultLayout } = this.state
 
+    const anyFiltersActive =
+      _.flatten(_.toArray(activeFacets.values())).length > 0
+
     return (
       <BannerPageWrapper>
         <MetaTags>
@@ -393,29 +396,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
           </Grid>
         </BannerPageHeader>
         <Grid className="main-content two-column-extrawide search-page">
-          <Cell width={12}>
-            <div className="search-filters-row">
-              {facetDisplayMap.map(([name, title, labelFunction]) =>
-                (activeFacets.get(name) || []).map((facet, i) => (
-                  <SearchFilter
-                    key={i}
-                    title={title}
-                    value={facet}
-                    clearFacet={() => this.toggleFacet(name, facet, false)}
-                    labelFunction={labelFunction}
-                  />
-                ))
-              )}
-              {_.flatten(_.toArray(activeFacets.values())).length > 0 ? (
-                <div
-                  className="search-filters-clear"
-                  onClick={this.clearAllFilters}
-                >
-                  Clear all filters
-                </div>
-              ) : null}
-            </div>
-          </Cell>
           <Cell width={3} />
           <Cell width={9}>
             <div className="layout-buttons">
@@ -437,7 +417,31 @@ export class CourseSearchPage extends React.Component<Props, State> {
               </div>
             </div>
           </Cell>
-          <Cell width={3}>
+          <Cell className="search-filters" width={3}>
+            <div className="active-search-filters">
+              {anyFiltersActive ? (
+                <div className="filter-section-title">
+                  Filters
+                  <span
+                    className="clear-all-filters"
+                    onClick={this.clearAllFilters}
+                  >
+                    Clear All
+                  </span>
+                </div>
+              ) : null}
+              {facetDisplayMap.map(([name, title, labelFunction]) =>
+                (activeFacets.get(name) || []).map((facet, i) => (
+                  <SearchFilter
+                    key={i}
+                    title={title}
+                    value={facet}
+                    clearFacet={() => this.toggleFacet(name, facet, false)}
+                    labelFunction={labelFunction}
+                  />
+                ))
+              )}
+            </div>
             {facetDisplayMap.map(([name, title, labelFunction], i) => (
               <SearchFacet
                 key={i}

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -329,7 +329,7 @@ describe("CourseSearchPage", () => {
     assert.equal(inner.state().text, text)
     assert.deepEqual(inner.state().activeFacets, activeFacets)
     assert.equal(wrapper.find("SearchFilter").length, 8)
-    wrapper.find(".search-filters-clear").simulate("click")
+    wrapper.find(".clear-all-filters").simulate("click")
     assert.equal(inner.state().text, null)
     assert.deepEqual(
       inner.state().activeFacets,

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -69,4 +69,4 @@ $body-font: "Source Sans Pro", helvetica, arial, sans-serif !important;
 $search-layout-active: #355b6b;
 $search-layout-inactive: #c2c0bf;
 
-$search-view-more: rgba(0, 0, 0, 0.85);
+$search-grey: rgba(0, 0, 0, 0.85);

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -58,11 +58,8 @@
   }
 }
 
-.facets {
-  margin-bottom: 20px;
-  width: 90%;
-
-  .facet-title {
+.search-filters {
+  .filter-section-title {
     font-size: 18px;
     font-weight: 600;
     margin-bottom: 10px;
@@ -71,98 +68,106 @@
     justify-content: space-between;
   }
 
-  .divider {
-    padding-top: 20px;
+  .facets,
+  .active-search-filters {
+    width: 90%;
   }
 
-  .mdc-form-field {
-    display: flex;
-    align-items: center;
-
-    label {
-      margin: 0;
-      width: 100%;
-    }
-  }
-
-  .facet-hidden {
-    display: none;
-  }
-
-  .facet-visible {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    height: 25px;
-    font-size: 14px;
-    margin-right: 6px;
-
-    input {
-      margin-right: 10px;
+  .active-search-filters {
+    .clear-all-filters {
+      font-size: 14px;
+      color: $search-grey;
+      font-weight: normal;
     }
 
-    .facet-label-div {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      width: 100%;
-    }
+    .active-search-filter {
+      margin: 0px 5px 9px 0px;
+      background-color: $bg-light-grey;
+      padding: 6px 10px;
+      font-size: 14px;
+      display: inline-flex;
+      align-items: center;
+      flex-wrap: nowrap;
+      white-space: nowrap;
+      border: 1px solid $font-grey-mid;
+      border-radius: 14px;
 
-    .facet-key {
-      color: black;
-    }
+      .remove-filter {
+        max-height: 18px;
+        margin-right: 5px;
+        cursor: pointer;
 
-    .facet-count {
-      color: $font-grey-mid;
-    }
-
-    &.checked {
-      font-size: 16px;
-      font-weight: bold;
-
-      .facet-key,
-      .facet-count {
-        color: $course-blue;
+        i {
+          font-size: 18px;
+        }
       }
     }
   }
 
-  .facet-more-less {
-    cursor: pointer;
-    color: $search-view-more;
-    font-size: 14px;
-    text-align: right;
+  .facets {
+    margin-bottom: 20px;
+
+    .divider {
+      padding-top: 20px;
+    }
+
+    .mdc-form-field {
+      display: flex;
+      align-items: center;
+
+      label {
+        margin: 0;
+        width: 100%;
+      }
+    }
+
+    .facet-hidden {
+      display: none;
+    }
+
+    .facet-visible {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      height: 25px;
+      font-size: 14px;
+      margin-right: 6px;
+
+      input {
+        margin-right: 10px;
+      }
+
+      .facet-label-div {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        width: 100%;
+      }
+
+      .facet-key {
+        color: black;
+      }
+
+      .facet-count {
+        color: $font-grey-mid;
+      }
+
+      &.checked {
+        font-size: 16px;
+        font-weight: bold;
+
+        .facet-key,
+        .facet-count {
+          color: $course-blue;
+        }
+      }
+    }
+
+    .facet-more-less {
+      cursor: pointer;
+      color: $search-grey;
+      font-size: 14px;
+      text-align: right;
+    }
   }
-}
-
-.search-filters-row {
-  flex-direction: row;
-  justify-content: space-between;
-}
-
-.search-filter-div {
-  margin: 0px 0px 5px 10px;
-  background-color: #ddeff7;
-  padding: 6px 10px;
-  font-size: 13px;
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: nowrap;
-  white-space: nowrap;
-}
-
-.search-filter-close {
-  display: flex;
-  cursor: pointer;
-
-  i {
-    transform: scale(0.75);
-  }
-}
-
-.search-filters-clear {
-  margin-left: 10px;
-  display: inline-flex;
-  cursor: pointer;
-  color: $link-blue;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2161

#### What's this PR do?

this restyles the display for the filters that the user currently has selected on the course search page. it basically moves the display into the left-hand column, adjusts some styling to match the new mockups, etc. nothing too major!

#### How should this be manually tested?

go to the course search page and make sure that the display matches what's shown in the mockups (see the linked issue).

#### Screenshots (if appropriate)

![filtersfwowownone](https://user-images.githubusercontent.com/6207644/64281891-2b12c980-cf22-11e9-8c10-ee27895db048.png)
![filtersfwowowo](https://user-images.githubusercontent.com/6207644/64281893-2b12c980-cf22-11e9-92e4-f24072e015e4.png)
