### PR TITLE
Add CourseRun to Django Admin

### DIFF
--- a/course_catalog/admin.py
+++ b/course_catalog/admin.py
@@ -1,6 +1,7 @@
 """ admin for course catalog """
 
 from django.contrib import admin
+from django.contrib.contenttypes.admin import GenericTabularInline
 
 from course_catalog.models import (
     Course,
@@ -9,7 +10,46 @@ from course_catalog.models import (
     UserList,
     ProgramItem,
     UserListItem,
+    CourseRun,
 )
+
+
+class CourseRunAdmin(admin.ModelAdmin):
+    """CourseRun Admin"""
+
+    model = CourseRun
+
+    search_fields = ("course_run_id", "title", "course__course_id")
+    list_display = ("course_run_id", "title", "best_start_date", "best_end_date")
+    list_filter = ("semester", "year")
+
+
+class CourseRunInline(GenericTabularInline):
+    """Inline list items for course runs"""
+
+    model = CourseRun
+    extra = 0
+    show_change_link = True
+    fields = (
+        "course_run_id",
+        "best_start_date",
+        "best_end_date",
+        "enrollment_start",
+        "enrollment_end",
+        "start_date",
+        "end_date",
+        "semester",
+        "year",
+    )
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class CourseAdmin(admin.ModelAdmin):
@@ -17,6 +57,9 @@ class CourseAdmin(admin.ModelAdmin):
 
     model = Course
     search_fields = ("course_id", "title")
+    list_display = ("course_id", "title", "platform")
+    list_filter = ("platform",)
+    inlines = [CourseRunInline]
 
 
 class BootcampAdmin(admin.ModelAdmin):
@@ -24,6 +67,8 @@ class BootcampAdmin(admin.ModelAdmin):
 
     model = Bootcamp
     search_fields = ("course_id", "title")
+    list_display = ("course_id", "title")
+    inlines = [CourseRunInline]
 
 
 class UserListItemInline(admin.StackedInline):
@@ -67,6 +112,7 @@ class UserListAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Course, CourseAdmin)
+admin.site.register(CourseRun, CourseRunAdmin)
 admin.site.register(Bootcamp, BootcampAdmin)
 admin.site.register(Program, ProgramAdmin)
 admin.site.register(UserList, UserListAdmin)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Closes #2126 

#### What's this PR do?
Adds `CourseRun` inlines to `Course` in admin
Adds `CourseRun` section to admin

#### How should this be manually tested?
- View a `Course` and a `Bootcamp` in django admin, there should be a list of runs at the bottom.
- Go to `/admin/course_catalog/courserun/`

#### Screenshots (if appropriate)

<img width="1491" alt="Screen Shot 2019-09-05 at 1 33 23 PM" src="https://user-images.githubusercontent.com/187676/64365318-d040a700-cfe1-11e9-81c9-6c0eed23ad5f.png">

<img width="1509" alt="Screen Shot 2019-09-05 at 1 31 58 PM" src="https://user-images.githubusercontent.com/187676/64365310-ccad2000-cfe1-11e9-986a-6bdc915f1801.png">

