### PR TITLE
Display the most relevant course run, with dropdown, in course drawer

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -36,16 +36,13 @@ const getStartDate = (
         return moment(courseRun.start_date).format("DD MMMM YYYY")
       } else if (courseRun.best_start_date) {
         return moment(courseRun.best_start_date).format("DD MMMM YYYY")
-      } else {
-        return availabilityLabel(courseRun.availability)
       }
     }
-  } else {
-    return "Ongoing"
   }
+  return "Ongoing"
 }
 
-const getRunDateLabel = (object: Object, courseRun: CourseRun) =>
+const getTaughtInLabel = (object: Object, courseRun: CourseRun) =>
   object.platform === platforms.OCW
     ? `${capitalize(courseRun.semester || "")} ${courseRun.year || ""}`
     : getStartDate(true, object, courseRun)
@@ -80,12 +77,12 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
               <select value={runId} onChange={updateRun}>
                 {object.course_runs.map(run => (
                   <option value={run.id} key={run.id}>
-                    {getRunDateLabel(object, run)}
+                    {getTaughtInLabel(object, run)}
                   </option>
                 ))}
               </select>
             ) : (
-              <div>{getRunDateLabel(object, selectedRun)}</div>
+              <div>{getTaughtInLabel(object, selectedRun)}</div>
             )}
           </div>
         </div>

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -25,27 +25,16 @@ type Props = {
   setShowResourceDrawer: Function
 }
 
-const getStartDate = (
-  isCourse: boolean,
-  object: Object,
-  courseRun: ?CourseRun
-) => {
-  if (!isCourse || object.platform !== platforms.OCW) {
-    if (courseRun) {
-      if (courseRun.start_date) {
-        return moment(courseRun.start_date).format("DD MMMM YYYY")
-      } else if (courseRun.best_start_date) {
-        return moment(courseRun.best_start_date).format("DD MMMM YYYY")
-      }
-    }
+const getStartDate = (object: Object, courseRun: CourseRun) => {
+  if (object.platform === platforms.OCW) {
+    return `${capitalize(courseRun.semester || "")} ${courseRun.year || ""}`
+  } else if (courseRun.start_date) {
+    return moment(courseRun.start_date).format("MMMM DD, YYYY")
+  } else if (courseRun.best_start_date) {
+    return moment(courseRun.best_start_date).format("MMMM DD, YYYY")
   }
   return "Ongoing"
 }
-
-const getTaughtInLabel = (object: Object, courseRun: CourseRun) =>
-  object.platform === platforms.OCW
-    ? `${capitalize(courseRun.semester || "")} ${courseRun.year || ""}`
-    : getStartDate(true, object, courseRun)
 
 const ExpandedLearningResourceDisplay = (props: Props) => {
   const { object, objectType, runId, setShowResourceDrawer } = props
@@ -71,18 +60,21 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
       <div className="summary">
         <div className="course-info-row form centered">
           <i className="material-icons school">school</i>
-          <div className="course-info-label">As Taught In:</div>
+          <div className="course-info-label">
+            {// $FlowFixMe: only courses will access platform
+              object.platform === platforms.OCW ? "As Taught In" : "Start Date"}:
+          </div>
           <div className="select-semester-div">
             {object.course_runs.length > 1 ? (
               <select value={runId} onChange={updateRun}>
                 {object.course_runs.map(run => (
                   <option value={run.id} key={run.id}>
-                    {getTaughtInLabel(object, run)}
+                    {getStartDate(object, run)}
                   </option>
                 ))}
               </select>
             ) : (
-              <div>{getTaughtInLabel(object, selectedRun)}</div>
+              <div>{getStartDate(object, selectedRun)}</div>
             )}
           </div>
         </div>
@@ -135,13 +127,6 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
           ))}
         </div>
         <div className="course-subheader row">Info</div>
-        <div className="course-info-row">
-          <i className="material-icons calendar_today">calendar_today</i>
-          <div className="course-info-label">Start date:</div>
-          <div className="course-info-value">
-            {getStartDate(isCourse, object, selectedRun)}
-          </div>
-        </div>
         <div className="course-info-row">
           <i className="material-icons attach_money">attach_money</i>
           <div className="course-info-label">Cost:</div>

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -72,11 +72,11 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
   return (
     <div className="expanded-course-summary">
       <div className="summary">
-        {isCourse ? (
-          <div className="course-info-row form centered">
-            <i className="material-icons school">school</i>
-            <div className="course-info-label">As Taught In:</div>
-            <div className="select-semester-div">
+        <div className="course-info-row form centered">
+          <i className="material-icons school">school</i>
+          <div className="course-info-label">As Taught In:</div>
+          <div className="select-semester-div">
+            {object.course_runs.length > 1 ? (
               <select value={runId} onChange={updateRun}>
                 {object.course_runs.map(run => (
                   <option value={run.id} key={run.id}>
@@ -84,9 +84,12 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
                   </option>
                 ))}
               </select>
-            </div>
+            ) : (
+              <div>{getRunDateLabel(object, selectedRun)}</div>
+            )}
           </div>
-        ) : null}
+        </div>
+
         {object.image_src ? (
           <div className="course-image-div">
             <img

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -96,21 +96,39 @@ describe("ExpandedLearningResourceDisplay", () => {
   })
 
   //
-  ;[["mitx", "01 september 2019"], ["ocw", "Fall 2019"]].forEach(
-    ([platform, expected]) => {
-      it(`should display the correct 'As Taught In' label and options for ${platform} courses`, () => {
-        course.platform = platform
-        const courseRun = course.course_runs[0]
-        courseRun.start_date = "2019-09-01T00:00:00Z"
-        courseRun.semester = "Fall"
-        courseRun.year = "2019"
-        const wrapper = render()
-        const selectOptions = wrapper.find("option")
-        assert.equal(selectOptions.length, course.course_runs.length)
-        assert.equal(selectOptions.at(0).text(), expected)
-      })
-    }
-  )
+  ;[
+    ["mitx", "september 01, 2019", "Start Date:"],
+    ["ocw", "Fall 2019", "As Taught In:"]
+  ].forEach(([platform, expectedValue, expectedLabel]) => {
+    it(`should display the correct date label and options for ${platform} courses`, () => {
+      course.platform = platform
+      const courseRun = course.course_runs[0]
+      courseRun.start_date = "2019-09-01T00:00:00Z"
+      courseRun.semester = "Fall"
+      courseRun.year = "2019"
+      const wrapper = render()
+      const selectOptions = wrapper.find("option")
+      assert.equal(selectOptions.length, course.course_runs.length)
+      assert.equal(selectOptions.at(0).text(), expectedValue)
+      const dateLabel = wrapper
+        .find(".form")
+        .at(0)
+        .find(".course-info-label")
+        .text()
+      assert.equal(dateLabel, expectedLabel)
+    })
+  })
+
+  it("should display 'Ongoing' for a course with no good dates", () => {
+    course.platform = "mitx"
+    course.course_runs = course.course_runs.splice(0, 1)
+    const courseRun = course.course_runs[0]
+    courseRun.start_date = null
+    courseRun.best_start_date = null
+    const wrapper = render()
+    const dateDiv = wrapper.find(".select-semester-div")
+    assert.equal(dateDiv.text(), "Ongoing")
+  })
 
   //
   ;[[1, false], [2, true]].forEach(([runs, showDropdown]) => {
@@ -124,46 +142,23 @@ describe("ExpandedLearningResourceDisplay", () => {
   })
 
   //
-  ;["mitx", "ocw"].forEach(platform => {
-    it(`should display the correct start date for ${platform} courses`, () => {
-      course.platform = platform
-      const wrapper = render()
-      const dateValue = wrapper
-        .find(".calendar_today")
-        .closest(".course-info-row")
-        .find(".course-info-value")
-        .text()
-      assert.equal(
-        dateValue,
-        course.platform === "ocw"
-          ? "Ongoing"
-          : // $FlowFixMe: run won't be null
-          moment(bestRun(course.course_runs).start_date).format(
-            "DD MMMM YYYY"
-          )
-      )
-    })
-  })
-
-  //
   ;[
-    ["2019-09-01T00:00:00Z", "2019-08-01T00:00:00Z", "01 september 2019"],
-    [null, "2019-08-01T00:00:00Z", "01 august 2019"],
+    ["2019-09-01T00:00:00Z", "2019-08-01T00:00:00Z", "september 01, 2019"],
+    [null, "2019-08-01T00:00:00Z", "august 01, 2019"],
     [null, null, "Ongoing"]
   ].forEach(([startDate, bestDate, expected]) => {
     it(`mitx run date should be ${expected} for start date ${String(
       startDate
     )}, best date ${String(bestDate)}`, () => {
       course.platform = "mitx"
-      course.course_runs = course.course_runs.slice(0, 1)
       const courseRun = course.course_runs[0]
       courseRun.start_date = startDate
       courseRun.best_start_date = bestDate
       const wrapper = render()
       const dateValue = wrapper
-        .find(".calendar_today")
-        .closest(".course-info-row")
-        .find(".course-info-value")
+        .find(".select-semester-div")
+        .find("option")
+        .at(0)
         .text()
       assert.equal(dateValue, expected)
     })

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -13,6 +13,7 @@ import {
 } from "../factories/learning_resources"
 import { LR_TYPE_COURSE, LR_TYPE_BOOTCAMP } from "../lib/constants"
 import { bestRun } from "../lib/learning_resources"
+import { shouldIf } from "../lib/test_utils"
 
 describe("ExpandedLearningResourceDisplay", () => {
   let course
@@ -111,10 +112,15 @@ describe("ExpandedLearningResourceDisplay", () => {
     }
   )
 
-  it(`should not display 'As Taught In' row for bootcamps`, () => {
-    const bootcamp = makeBootcamp()
-    const wrapper = render({ object: bootcamp, objectType: LR_TYPE_BOOTCAMP })
-    assert.isNotOk(wrapper.find(".form").exists())
+  //
+  ;[[1, false], [2, true]].forEach(([runs, showDropdown]) => {
+    it(`${shouldIf(
+      showDropdown
+    )} display a course run dropdown for a course with ${runs} run(s)`, () => {
+      course.course_runs = course.course_runs.slice(0, runs)
+      const wrapper = render()
+      assert.equal(wrapper.find("option").exists(), showDropdown)
+    })
   })
 
   //

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -145,6 +145,30 @@ describe("ExpandedLearningResourceDisplay", () => {
     })
   })
 
+  //
+  ;[
+    ["2019-09-01T00:00:00Z", "2019-08-01T00:00:00Z", "01 september 2019"],
+    [null, "2019-08-01T00:00:00Z", "01 august 2019"],
+    [null, null, "Ongoing"]
+  ].forEach(([startDate, bestDate, expected]) => {
+    it(`mitx run date should be ${expected} for start date ${String(
+      startDate
+    )}, best date ${String(bestDate)}`, () => {
+      course.platform = "mitx"
+      course.course_runs = course.course_runs.slice(0, 1)
+      const courseRun = course.course_runs[0]
+      courseRun.start_date = startDate
+      courseRun.best_start_date = bestDate
+      const wrapper = render()
+      const dateValue = wrapper
+        .find(".calendar_today")
+        .closest(".course-info-row")
+        .find(".course-info-value")
+        .text()
+      assert.equal(dateValue, expected)
+    })
+  })
+
   it("should display all instructors for the course", () => {
     const wrapper = render()
     const instructorText = wrapper

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -2,12 +2,10 @@
 import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
-import moment from "moment"
 
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
 import {
-  makeBootcamp,
   makeCourse,
   makeLearningResource
 } from "../factories/learning_resources"
@@ -27,7 +25,7 @@ describe("ExpandedLearningResourceDisplay", () => {
       <ExpandedLearningResourceDisplay
         object={course}
         objectType={LR_TYPE_COURSE}
-        runId={course.course_runs[0].id}
+        runId={course.course_runs[0] ? course.course_runs[0].id : 0}
         setShowResourceDrawer={null}
         {...props}
       />
@@ -224,5 +222,30 @@ describe("ExpandedLearningResourceDisplay", () => {
           : "Take Bootcamp"
       )
     })
+  })
+
+  it(`should still display without errors in case of a bad course with no runs`, () => {
+    course.course_runs = []
+    const wrapper = render()
+    assert.isNotOk(
+      wrapper
+        .find(".bar_chart")
+        .at(0)
+        .exists()
+    )
+    assert.isNotOk(
+      wrapper
+        .find(".school")
+        .at(1)
+        .exists()
+    )
+    assert.equal(
+      wrapper
+        .find(".language")
+        .closest(".course-info-row")
+        .find(".course-info-value")
+        .text(),
+      "English"
+    )
   })
 })

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -113,7 +113,8 @@ export const LearningResourceCard = ({
   const showResourceDrawer = () =>
     setShowResourceDrawer({
       objectId:   object.id,
-      objectType: object.object_type
+      objectType: object.object_type,
+      runId:      bestAvailableRun ? bestAvailableRun.id : null
     })
 
   return (

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -90,7 +90,11 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 
 type LearningResourceProps = {
   result: LearningResourceResult,
-  setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
+  setShowResourceDrawer?: ({
+    objectId: string,
+    objectType: string,
+    runId: ?number
+  }) => void,
   overrideObject?: Object,
   searchResultLayout?: string,
   availabilities?: Array<string>
@@ -123,7 +127,11 @@ type Props = {
   upvotedPost?: ?Post,
   votedComment?: ?CommentInTree,
   availabilities?: Array<string>,
-  setShowResourceDrawer?: ({ objectId: string, objectType: string }) => void,
+  setShowResourceDrawer?: ({
+    objectId: string,
+    objectType: string,
+    runId: ?number
+  }) => void,
   overrideObject?: Object,
   searchResultLayout?: string
 }

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -73,7 +73,11 @@ type OwnProps = {|
   match: Match,
   runSearch: (params: SearchParams) => Promise<*>,
   clearSearch: () => void,
-  setShowResourceDrawer: ({ objectId: string, objectType: string }) => void
+  setShowResourceDrawer: ({
+    objectId: string,
+    objectType: string,
+    runId: ?number
+  }) => void
 |}
 
 type StateProps = {|
@@ -487,12 +491,14 @@ const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
   },
   setShowResourceDrawer: ({
     objectId,
-    objectType
+    objectType,
+    runId
   }: {
     objectId: string,
-    objectType: string
+    objectType: string,
+    runId: ?number
   }) => {
-    dispatch(setShowResourceDrawer({ objectId, objectType }))
+    dispatch(setShowResourceDrawer({ objectId, objectType, runId }))
   },
   dispatch
 })

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -129,11 +129,16 @@ describe("CourseSearchPage", () => {
       .at(0)
       .prop("setShowResourceDrawer")({
         objectId:   searchCourse.course_id,
-        objectType: LR_TYPE_COURSE
+        objectType: LR_TYPE_COURSE,
+        runId:      23
       })
     assert.deepEqual(store.getLastAction(), {
       type:    SET_SHOW_RESOURCE_DRAWER,
-      payload: { objectId: searchCourse.course_id, objectType: LR_TYPE_COURSE }
+      payload: {
+        objectId:   searchCourse.course_id,
+        objectType: LR_TYPE_COURSE,
+        runId:      23
+      }
     })
   })
 

--- a/static/js/containers/LearningResourceDrawer.js
+++ b/static/js/containers/LearningResourceDrawer.js
@@ -13,7 +13,7 @@ import { createSelector } from "reselect"
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
 import { setShowResourceDrawer } from "../actions/ui"
-import { capitalize, getViewportWidth } from "../lib/util"
+import { getViewportWidth } from "../lib/util"
 import { courseRequest } from "../lib/queries/courses"
 import { bootcampRequest } from "../lib/queries/bootcamps"
 import { LR_TYPE_BOOTCAMP, LR_TYPE_COURSE } from "../lib/constants"

--- a/static/js/containers/LearningResourceDrawer.js
+++ b/static/js/containers/LearningResourceDrawer.js
@@ -13,7 +13,7 @@ import { createSelector } from "reselect"
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
 import { setShowResourceDrawer } from "../actions/ui"
-import { getViewportWidth } from "../lib/util"
+import { capitalize, getViewportWidth } from "../lib/util"
 import { courseRequest } from "../lib/queries/courses"
 import { bootcampRequest } from "../lib/queries/bootcamps"
 import { LR_TYPE_BOOTCAMP, LR_TYPE_COURSE } from "../lib/constants"
@@ -27,6 +27,7 @@ type Props = {
   object: Course | Bootcamp | null,
   objectId: number,
   objectType: string,
+  runId: number,
   setShowResourceDrawer: Function
 }
 
@@ -52,6 +53,7 @@ export class LearningResourceDrawer extends React.Component<Props> {
     const {
       object,
       objectType,
+      runId,
       showLearningDrawer,
       setShowResourceDrawer
     } = this.props
@@ -75,6 +77,8 @@ export class LearningResourceDrawer extends React.Component<Props> {
             <ExpandedLearningResourceDisplay
               object={object}
               objectType={objectType}
+              runId={runId}
+              setShowResourceDrawer={setShowResourceDrawer}
             />
             <div className="footer" />
           </DrawerContent>
@@ -110,11 +114,13 @@ export const mapStateToProps = (state: Object) => {
 
   const objectId = ui.courseDetail.objectId
   const objectType = ui.courseDetail.objectType
+  const runId = ui.courseDetail.runId
 
   return {
     showLearningDrawer: _.isFinite(state.ui.courseDetail.objectId),
     objectId,
     objectType,
+    runId,
     object:             getObject(state)
   }
 }

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -332,6 +332,7 @@ export type LearningResourceSummary = {
 }
 
 export type CourseRun = {
+  id:                 number,
   language:           ?string,
   semester:           ?string,
   year:               ?string,
@@ -344,7 +345,8 @@ export type CourseRun = {
   best_end_date:      ?string,
   instructors:        Array<CourseInstructor>,
   prices:             Array<CoursePrice>,
-  availability:       ?string
+  availability:       ?string,
+  url:                ?string
 }
 
 

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -58,6 +58,8 @@ export type PostResult = ResultCommon & {
 }
 
 export type LearningResourceRun = {
+  id:                  number,
+  url?:                ?string,
   language?:           ?string,
   semester?:           ?string,
   year?:               ?string,

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -10,7 +10,8 @@ import {
   DATE_FORMAT,
   DEFAULT_END_DT,
   DEFAULT_START_DT,
-  LR_TYPE_USERLIST
+  LR_TYPE_USERLIST,
+  platforms
 } from "./constants"
 import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
 import { capitalize, emptyOrNil } from "./util"
@@ -152,4 +153,15 @@ export const minPrice = (courseRun: ?CourseRun) => {
   const prices = courseRun && courseRun.prices ? courseRun.prices : []
   const price = Math.min(...prices.map(price => price.price))
   return price > 0 && price !== Infinity ? `$${price}` : "Free"
+}
+
+export const getStartDate = (object: Object, courseRun: CourseRun) => {
+  if (object.platform === platforms.OCW) {
+    return `${capitalize(courseRun.semester || "")} ${courseRun.year || ""}`
+  } else if (courseRun.start_date) {
+    return moment(courseRun.start_date).format("MMMM DD, YYYY")
+  } else if (courseRun.best_start_date) {
+    return moment(courseRun.best_start_date).format("MMMM DD, YYYY")
+  }
+  return "Ongoing"
 }

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -28,7 +28,8 @@ import {
   bestRunLabel,
   bestRun,
   runStartDate,
-  runEndDate
+  runEndDate,
+  getStartDate
 } from "./learning_resources"
 import { makeCourse, makeCourseRun } from "../factories/learning_resources"
 import moment from "moment"
@@ -344,6 +345,27 @@ describe("Course run availability utils", () => {
         runEndDate(run).format(DATE_FORMAT),
         moment(expectedDate, DATE_FORMAT).format(DATE_FORMAT)
       )
+    })
+  })
+
+  //
+  ;[
+    ["ocw", "2019-09-01", "2019-08-01", "Fall 2019"],
+    ["mitx", "2019-09-01", "2019-08-01", "september 01, 2019"],
+    ["mitx", null, "2019-08-01", "august 01, 2019"],
+    ["mitx", null, null, "Ongoing"]
+  ].forEach(([platform, startDt, bestDt, expected]) => {
+    it(`getStartDate should return ${expected} for ${platform} run with start_dt ${String(
+      startDt
+    )}, best_dt ${String(bestDt)}`, () => {
+      const course = makeCourse()
+      course.platform = platform
+      const courseRun = makeCourseRun()
+      courseRun.start_date = startDt
+      courseRun.best_start_date = bestDt
+      courseRun.semester = "Fall"
+      courseRun.year = "2019"
+      assert.equal(getStartDate(course, courseRun), expected)
     })
   })
 })

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -131,7 +131,8 @@ export const ui = (
       ...state,
       courseDetail: {
         objectId:   action.payload.objectId,
-        objectType: action.payload.objectType
+        objectType: action.payload.objectType,
+        runId:      action.payload.runId
       }
     }
   case SET_SNACKBAR_MESSAGE:

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -246,3 +246,12 @@
     }
   }
 }
+
+.select-semester-div {
+  margin-left: auto !important;
+  width: 50%;
+}
+
+.centered {
+  align-items: center;
+}

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -250,6 +250,7 @@
 .select-semester-div {
   margin-left: auto !important;
   width: 50%;
+  text-align: right;
 }
 
 .centered {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2124 

#### What's this PR do?
- Sends the most relevant course run id (if any, based on availability facets) to the drawer, where that run's info will be displayed (start date, price, instructors).  
- Adds a dropdown to the drawer allowing the user to select another course run (which will again update the drawer info shown).
- Does not restyle the dropdown to match the design, I'm assuming that restyling is a separate PR.

#### How should this be manually tested?
Do some course searches, with variations on the availability facets used.  Click on one of the search results to open the drawer.  The run shown in the drawer by default should be the best match for the availabilities selected.  There should be a dropdown at the top where you can choose different runs, and doing so should update the start date, instructors, and prices shown in the drawer.

OCW courses should have semester/year in the dropdown, MITx courses should have dates in the dropdown in a format like "September 10, 2019".
Bootcamps and any course with only 1 run should have a plain div with the date instead of a dropdown.


#### Screenshots (if appropriate)

OCW:
<img width="496" alt="Screen Shot 2019-09-11 at 8 55 09 AM" src="https://user-images.githubusercontent.com/187676/64701782-6b6ccd00-d477-11e9-99d8-6da51f8ff446.png">

OCW (1 run):
<img width="496" alt="Screen Shot 2019-09-11 at 9 36 33 AM" src="https://user-images.githubusercontent.com/187676/64701989-c1417500-d477-11e9-9070-a4c4b5038806.png">



MITx:
<img width="496" alt="Screen Shot 2019-09-11 at 9 33 25 AM" src="https://user-images.githubusercontent.com/187676/64702025-d0282780-d477-11e9-89c3-1fc79db67d97.png">



Bootcamp (1 run):
<img width="498" alt="Screen Shot 2019-09-11 at 8 56 41 AM" src="https://user-images.githubusercontent.com/187676/64702229-26956600-d478-11e9-8324-1986fa2f9265.png">



