### PR TITLE
upgrade babel-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,9 +4,6 @@
     "react": {
       "version": "16.4.0",
       "flowVersion": "0.75.0" // Flow version
-    },
-  },
-  rules: {
-      "no-unused-vars": 0
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mitodl/mdl-react-components": "^0.0.3",
     "@trust/webcrypto": "^0.9.2",
     "autoprefixer": "^9.4.6",
-    "babel-eslint": "^10.0.2",
+    "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.0",
     "babel-plugin-istanbul": "^4.1.6",
     "blueimp-canvas-to-blob": "^3.14.0",

--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -7,7 +7,7 @@ import R from "ramda"
 import LearningResourceCard from "./LearningResourceCard"
 
 import { SEARCH_GRID_UI } from "../lib/search"
-import { CAROUSEL_PAGE_SIZE, PHONE, TABLET, DESKTOP } from "../lib/constants"
+import { PHONE, TABLET, DESKTOP } from "../lib/constants"
 import { useDeviceCategory } from "../hooks/util"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"

--- a/static/js/components/CourseCarousel_test.js
+++ b/static/js/components/CourseCarousel_test.js
@@ -1,9 +1,6 @@
 // @flow
-import React from "react"
 import R from "ramda"
 import { assert } from "chai"
-import sinon from "sinon"
-import { mount } from "enzyme"
 
 import CourseCarousel from "./CourseCarousel"
 

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -6,12 +6,7 @@ import { mount } from "enzyme"
 
 import { LearningResourceCard } from "./LearningResourceCard"
 
-import {
-  availabilityLabel,
-  bestRun,
-  bestRunLabel,
-  minPrice
-} from "../lib/learning_resources"
+import { bestRun, bestRunLabel, minPrice } from "../lib/learning_resources"
 import { makeLearningResource } from "../factories/learning_resources"
 import {
   CAROUSEL_IMG_WIDTH,
@@ -99,8 +94,6 @@ describe("LearningResourceCard", () => {
   LR_TYPE_ALL.forEach(objectType => {
     it(`should render a readable platform name`, () => {
       const object = makeLearningResource(objectType)
-      const isCourse = objectType === LR_TYPE_COURSE
-      const isBootcamp = objectType === LR_TYPE_BOOTCAMP
       const platformName = render({
         object
       })

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -3,7 +3,6 @@ import React from "react"
 import { assert } from "chai"
 import { mount } from "enzyme"
 import * as sinon from "sinon"
-import Checkbox from "rmwc/Checkbox/index"
 
 import SearchFacet from "./SearchFacet"
 
@@ -12,7 +11,7 @@ import { makeSearchFacetResult } from "../factories/search"
 import { shouldIf } from "../lib/test_utils"
 
 describe("SearchFacet", () => {
-  let helper, onUpdateStub, dispatchStub, results, facet
+  let helper, onUpdateStub, results, facet
   const name = "topics"
   const title = "Search Topics"
 

--- a/static/js/containers/CourseIndexPage.js
+++ b/static/js/containers/CourseIndexPage.js
@@ -1,9 +1,7 @@
 // @flow
 import React, { useCallback } from "react"
-import { querySelectors } from "redux-query"
 import { useRequest } from "redux-query-react"
 import { useSelector, useDispatch } from "react-redux"
-import { compose } from "redux"
 import { Link } from "react-router-dom"
 import { createSelector } from "reselect"
 
@@ -33,8 +31,6 @@ import {
   favoritesSelector
 } from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
-
-import type { LearningResourceSummary } from "../flow/discussionTypes"
 
 type Props = {|
   history: Object

--- a/static/js/containers/CourseIndexPage_test.js
+++ b/static/js/containers/CourseIndexPage_test.js
@@ -1,7 +1,6 @@
 // @flow
 import { assert } from "chai"
 import R from "ramda"
-import sinon from "sinon"
 
 import LearningResourceDrawer from "./LearningResourceDrawer"
 import CourseIndexPage from "./CourseIndexPage"
@@ -17,23 +16,19 @@ import {
   favoritesURL,
   featuredCoursesURL,
   upcomingCoursesURL,
-  newCoursesURL,
-  courseURL
+  newCoursesURL
 } from "../lib/url"
-import { configureShallowRenderer, courseListResponse } from "../lib/test_utils"
+import { courseListResponse } from "../lib/test_utils"
 import {
   makeCourse,
   makeFavoritesResponse
 } from "../factories/learning_resources"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { wait } from "../lib/util"
 
 describe("CourseIndexPage", () => {
   let featuredCourses,
     upcomingCourses,
     newCourses,
-    setShowResourceDrawerStub,
-    renderCourseIndexPage,
     render,
     helper,
     courseLists,
@@ -78,15 +73,7 @@ describe("CourseIndexPage", () => {
     helper.handleRequestStub
       .withArgs(newCoursesURL)
       .returns(courseListResponse(newCourses))
-
-    setShowResourceDrawerStub = helper.sandbox.stub()
     render = helper.configureReduxQueryRenderer(CourseIndexPage)
-
-    renderCourseIndexPage = configureShallowRenderer(CourseIndexPage, {
-      setShowResourceDrawer: setShowResourceDrawerStub,
-      loaded:                true,
-      ...courseLists
-    })
   })
 
   afterEach(() => {
@@ -158,7 +145,6 @@ describe("CourseIndexPage", () => {
   })
 
   it("should have a search textbox which redirects you", async () => {
-    const pushStub = helper.sandbox.stub()
     const { wrapper } = await render()
     const searchBox = wrapper.find("CourseSearchbox")
     searchBox.prop("onSubmit")({ target: { value: "search term" } })

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -14,7 +14,6 @@ import debounce from "lodash/debounce"
 import LearningResourceDrawer from "./LearningResourceDrawer"
 
 import CanonicalLink from "../components/CanonicalLink"
-import Card from "../components/Card"
 import { Cell, Grid } from "../components/Grid"
 import { Loading, PostLoading } from "../components/Loading"
 import SearchFacet from "../components/SearchFacet"

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -4,7 +4,6 @@ import { assert } from "chai"
 import qs from "query-string"
 import sinon from "sinon"
 import _ from "lodash"
-import InfiniteScroll from "react-infinite-scroller"
 
 import ConnectedCourseSearchPage, { CourseSearchPage } from "./CourseSearchPage"
 
@@ -18,12 +17,10 @@ import {
   makeSearchFacetResult,
   makeSearchResponse
 } from "../factories/search"
-import { makeBootcamp } from "../factories/learning_resources"
 import { makeChannel } from "../factories/channels"
 import { LR_TYPE_COURSE, LR_TYPE_ALL } from "../lib/constants"
-import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
+import { SEARCH_GRID_UI } from "../lib/search"
 import { wait } from "../lib/util"
-import { favoritesURL } from "../lib/url"
 
 describe("CourseSearchPage", () => {
   let helper,

--- a/static/js/containers/HomePage_test.js
+++ b/static/js/containers/HomePage_test.js
@@ -2,7 +2,6 @@
 /* global SETTINGS: false */
 import { assert } from "chai"
 import sinon from "sinon"
-import { actionTypes } from "redux-query"
 
 import LiveStream from "../containers/LiveStream"
 import PostList from "../components/PostList"
@@ -14,8 +13,6 @@ import NewCoursesWidget from "../containers/NewCoursesWidget"
 
 import { makeChannelList } from "../factories/channels"
 import { makeChannelPostList } from "../factories/posts"
-import { actions } from "../actions"
-import { SET_CHANNEL_DATA } from "../actions/channel"
 import { SET_POST_DATA } from "../actions/post"
 import { POSTS_SORT_HOT, VALID_POST_SORT_TYPES } from "../lib/picker"
 import { REGISTER_URL, newPostURL } from "../lib/url"
@@ -88,28 +85,9 @@ describe("HomePage", () => {
   })
 
   describe("integration", () => {
-    let renderComponent
-
     beforeEach(() => {
-      renderComponent = helper.renderComponent.bind(helper)
       mockCourseAPIMethods(helper)
     })
-
-    const renderPage = async () => {
-      const [wrapper] = await renderComponent("/", [
-        actions.frontpage.get.requestType,
-        actions.frontpage.get.successType,
-        actions.subscribedChannels.get.requestType,
-        actions.subscribedChannels.get.successType,
-        actions.livestream.get.requestType,
-        actions.livestream.get.successType,
-        actionTypes.REQUEST_ASYNC,
-        actionTypes.REQUEST_ASYNC,
-        SET_POST_DATA,
-        SET_CHANNEL_DATA
-      ])
-      return wrapper.update()
-    }
 
     it("should fetch frontpage, set post data, render", async () => {
       const { wrapper } = await render()

--- a/static/js/containers/SearchPage_test.js
+++ b/static/js/containers/SearchPage_test.js
@@ -75,7 +75,7 @@ describe("SearchPage", () => {
   })
 
   it("renders search results", async () => {
-    const { wrapper, inner } = await renderPage()
+    const { inner } = await renderPage()
 
     sinon.assert.calledWith(helper.searchStub, {
       channelName: channel.name,
@@ -386,7 +386,7 @@ describe("SearchPage", () => {
   })
 
   it("calls updateVotedComments when upvote or downvote is triggered", async () => {
-    const { wrapper, inner } = await renderPage()
+    const { inner } = await renderPage()
     const comments = [makeComment(makePost()), makeComment(makePost())]
     helper.updateCommentStub.returns(Promise.resolve(comments[0]))
     await inner

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -18,7 +18,6 @@ import type {
   Bootcamp,
   Course,
   CourseRun,
-  LearningResource,
   Program,
   UserList
 } from "../flow/discussionTypes"

--- a/static/js/lib/queries/bootcamps.js
+++ b/static/js/lib/queries/bootcamps.js
@@ -4,7 +4,7 @@ import R from "ramda"
 import { bootcampURL } from "../url"
 import { DEFAULT_POST_OPTIONS } from "../redux_query"
 
-import type { LearningResource, Bootcamp } from "../../flow/discussionTypes"
+import type { Bootcamp } from "../../flow/discussionTypes"
 
 export const bootcampRequest = (bootcampId: string) => ({
   queryKey:  `bootcampRequest${bootcampId}`,

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -175,7 +175,7 @@ export default class IntegrationTestHelper {
   }
 
   stubComponent(module, displayName, name = "default") {
-    const Stubber = props => <div />
+    const Stubber = () => <div />
     Stubber.displayName = displayName
     this[`${displayName}Stub`] = this.sandbox
       .stub(module, name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,17 +1976,17 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-eslint@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
-  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
+babel-eslint@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
+  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
-    eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-generator@^6.18.0:
   version "6.26.0"
@@ -3723,7 +3723,7 @@ eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
 
-eslint-scope@3.7.1, eslint-scope@^3.7.1:
+eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
@@ -8382,7 +8382,7 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.1:
+resolve@^1.10.1, resolve@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

follow-on from #2168

#### What's this PR do?

when I upgraded eslint and some related packages there was, at the time, a bug in the latest version of babel-eslint that broke the parsing for the `no-unused-vars` rule. basically, it caused it to have tons of false positives, marking a lot of stuff that was fine incorrectly as an unused variable. because of this I had to disable the rule to get the build to pass.

Anyway, that issue has now been fixed in the latest version of the package, so I updated to that. this let me re-enable the rule. I also fixed all of the unused variable errors that we'd accumulated in the meantime while the rule was turned off, which was a surprisingly large amount!

#### How should this be manually tested?

tests should pass, code should look good.