### PR TITLE
refactor the 'new courses widget' to use hooks

### DIFF
--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -54,13 +54,17 @@ export const makeEvent = (name: string, value: any) => ({
   preventDefault: sinon.stub()
 })
 
-export const mockCourseAPIMethods = (helper: Object) => {
+export const mockCourseAPIMethods = (
+  helper: Object,
+  upcomingCourses: ?Array<LearningResource> = null,
+  newCourses: ?Array<LearningResource> = null
+) => {
   helper.handleRequestStub
     .withArgs(upcomingCoursesURL)
-    .returns(courseListResponse(R.times(makeCourse, 10)))
+    .returns(courseListResponse(upcomingCourses || R.times(makeCourse, 10)))
   helper.handleRequestStub
     .withArgs(newCoursesURL)
-    .returns(courseListResponse(R.times(makeCourse, 10)))
+    .returns(courseListResponse(newCourses || R.times(makeCourse, 10)))
 }
 
 export const courseListResponse = (list: Array<LearningResource>) => ({


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, just a quick little refactor.

#### What's this PR do?

just a little refactor to bring it in line with how we use the same APIs on the course home page (so we're not doing it two different ways in different places)

#### How should this be manually tested?

the new and upcoming courses widget on the home page should work as normal, code should look reasonable.
