### PR TITLE
fix course search "list" loader

### DIFF
--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -32,7 +32,7 @@ export const Loading = (props: SpinnerProps) => (
   </div>
 )
 
-const AnimatedEmptyPost = (i: number) => {
+const AnimatedEmptyCard = (i: number) => {
   return (
     <div className="post-content-loader" key={`loader-${i}`}>
       <Card className="compact-post-summary">
@@ -62,7 +62,7 @@ const AnimatedEmptyPost = (i: number) => {
 }
 
 export const PostLoading = () => (
-  <div className="post-loader">
+  <div className="card-list-loader">
     <div className="post-list-title">
       <ContentLoader
         speed={contentLoaderSpeed}
@@ -74,7 +74,13 @@ export const PostLoading = () => (
         <rect x="0" y="0" rx="5" ry="5" width="100%" height="100%" />
       </ContentLoader>
     </div>
-    {R.times(AnimatedEmptyPost, emptyPostsToRender)}
+    {R.times(AnimatedEmptyCard, emptyPostsToRender)}
+  </div>
+)
+
+export const CourseSearchLoading = () => (
+  <div className="card-list-loader">
+    {R.times(AnimatedEmptyCard, emptyPostsToRender)}
   </div>
 )
 

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -15,7 +15,7 @@ import LearningResourceDrawer from "./LearningResourceDrawer"
 
 import CanonicalLink from "../components/CanonicalLink"
 import { Cell, Grid } from "../components/Grid"
-import { Loading, PostLoading } from "../components/Loading"
+import { Loading, CourseSearchLoading } from "../components/Loading"
 import SearchFacet from "../components/SearchFacet"
 import SearchFilter from "../components/SearchFilter"
 import CourseSearchbox from "../components/CourseSearchbox"
@@ -336,7 +336,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { from, incremental, searchResultLayout, activeFacets } = this.state
 
     if ((processing || !loaded) && !incremental) {
-      return <PostLoading />
+      return <CourseSearchLoading />
     }
 
     if (total === 0 && !processing && loaded) {

--- a/static/js/containers/CourseSearchPage_test.js
+++ b/static/js/containers/CourseSearchPage_test.js
@@ -275,7 +275,10 @@ describe("CourseSearchPage", () => {
           }
         }
       )
-      assert.equal(inner.find("PostLoading").exists(), shouldShowPostloading)
+      assert.equal(
+        inner.find("CourseSearchLoading").exists(),
+        shouldShowPostloading
+      )
       assert.equal(inner.find(".results-count").exists(), !processing)
     })
   })

--- a/static/scss/channel.scss
+++ b/static/scss/channel.scss
@@ -7,7 +7,7 @@
   &.channel-page {
     margin-top: 0;
 
-    .post-loader {
+    .card-list-loader {
       margin-top: 20px;
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2167

#### What's this PR do?

basically this just deletes the little "top bar" that was previously shown in the course search. this was there because we were previously just using the same loader that we use for the post lists (e.g. on a channel or on the home page). I made a separate one just for the course search which doesn't have that top bar.

note that this only addresses getting the loader in shape for the 'list' view - I'll circle back with a separate PR to address the 'grid' view loader.


#### Screenshots (if appropriate)

![topbar](https://user-images.githubusercontent.com/6207644/65059407-f5b7a400-d943-11e9-97ec-2398fff14b66.gif)
