### PR TITLE
Search nested fields including instructors

### DIFF
--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -12,9 +12,9 @@ import {
 } from "../factories/search"
 import {
   AVAILABILITY_MAPPING,
+  RESOURCE_QUERY_NESTED_FIELDS,
   buildSearchQuery,
   channelField,
-  RESOURCE_QUERY_NESTED_FIELDS,
   searchFields,
   searchResultToComment,
   searchResultToLearningResource,

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -14,6 +14,7 @@ import {
   AVAILABILITY_MAPPING,
   buildSearchQuery,
   channelField,
+  RESOURCE_QUERY_NESTED_FIELDS,
   searchFields,
   searchResultToComment,
   searchResultToLearningResource,
@@ -289,13 +290,15 @@ describe("search functions", () => {
                       ]
                     }
                   },
-                  must: {
-                    multi_match: {
-                      fields:    fieldNames,
-                      query:     text,
-                      fuzziness: "AUTO"
+                  should: [
+                    {
+                      multi_match: {
+                        query:     text,
+                        fields:    fieldNames,
+                        fuzziness: "AUTO"
+                      }
                     }
-                  }
+                  ]
                 }
               }
             ]
@@ -528,13 +531,27 @@ describe("search functions", () => {
                           must: mustQuery
                         }
                       },
-                      must: {
-                        multi_match: {
-                          query:     text,
-                          fields:    fieldNames,
-                          fuzziness: "AUTO"
+                      should: [
+                        {
+                          multi_match: {
+                            query:     text,
+                            fields:    fieldNames,
+                            fuzziness: "AUTO"
+                          }
+                        },
+                        {
+                          nested: {
+                            path:  "course_runs",
+                            query: {
+                              multi_match: {
+                                query:     text,
+                                fields:    RESOURCE_QUERY_NESTED_FIELDS,
+                                fuzziness: "AUTO"
+                              }
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
                   }
                 ]
@@ -621,11 +638,6 @@ describe("search functions", () => {
           "title.english",
           "short_description.english",
           "full_description.english",
-          "year",
-          "semester",
-          "level",
-          "instructors",
-          "prices",
           "topics",
           "platform",
           "course_id",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2221

#### What's this PR do?
Modifies the ES query to properly search nested fields.

#### How should this be manually tested?
Search for the names of certain professors who teach courses, using full name or just last name.  The top results should include courses with runs taught by them.

