### PR TITLE
Add course number to the search index and boost it in queries

### DIFF
--- a/search/serializers.py
+++ b/search/serializers.py
@@ -351,12 +351,20 @@ class ESCourseSerializer(ESModelSerializer):
 
     topics = ESTopicsField()
     course_runs = ESCourseRunSerializer(read_only=True, many=True, allow_null=True)
+    coursenum = serializers.SerializerMethodField()
+
+    def get_coursenum(self, course):
+        """
+        Extract the course number from the course id
+        """
+        return course.course_id.split("+")[-1]
 
     class Meta:
         model = Course
         fields = [
             "id",
             "course_id",
+            "coursenum",
             "short_description",
             "full_description",
             "platform",
@@ -386,6 +394,7 @@ class ESBootcampSerializer(ESCourseSerializer):
         fields = [
             "id",
             "course_id",
+            "coursenum",
             "short_description",
             "full_description",
             "title",

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -278,6 +278,7 @@ def test_es_course_serializer(offered_by):
             "object_type": COURSE_TYPE,
             "id": course.id,
             "course_id": course.course_id,
+            "coursenum": course.course_id.split("+")[-1],
             "short_description": course.short_description,
             "full_description": course.full_description,
             "platform": course.platform,

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -134,6 +134,7 @@ const COURSE_QUERY_FIELDS = [
   "topics",
   "platform",
   "course_id",
+  "coursenum^5",
   "offered_by"
 ]
 
@@ -142,6 +143,7 @@ const BOOTCAMP_QUERY_FIELDS = [
   "short_description.english",
   "full_description.english",
   "course_id",
+  "coursenum^5",
   "offered_by"
 ]
 

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -131,6 +131,11 @@ const COURSE_QUERY_FIELDS = [
   "title.english",
   "short_description.english",
   "full_description.english",
+  "year",
+  "semester",
+  "level",
+  "instructors",
+  "prices",
   "topics",
   "platform",
   "course_id",
@@ -142,16 +147,12 @@ const BOOTCAMP_QUERY_FIELDS = [
   "title.english",
   "short_description.english",
   "full_description.english",
+  "instructors",
+  "prices",
+  "topics",
   "course_id",
   "coursenum^5",
   "offered_by"
-]
-
-export const RESOURCE_QUERY_NESTED_FIELDS = [
-  "course_runs.year",
-  "course_runs.semester",
-  "course_runs.level",
-  "course_runs.instructors"
 ]
 
 const LIST_QUERY_FIELDS = [
@@ -416,32 +417,15 @@ export const buildSearchQuery = ({
     // One of the text fields must match
     const matchQuery = text
       ? {
-        should: [
-          {
-            multi_match: {
-              query:     text,
-              fields:    searchFields(type),
-              fuzziness: "AUTO"
-            }
-          }
-        ]
-      }
-      : {}
-
-    if (text && [LR_TYPE_BOOTCAMP, LR_TYPE_COURSE].includes(type)) {
-      matchQuery.should.push({
-        nested: {
-          path:  "course_runs",
-          query: {
-            multi_match: {
-              query:     text,
-              fields:    RESOURCE_QUERY_NESTED_FIELDS,
-              fuzziness: "AUTO"
-            }
+        must: {
+          multi_match: {
+            query:     text,
+            fields:    searchFields(type),
+            fuzziness: "AUTO"
           }
         }
-      })
-    }
+      }
+      : {}
 
     // If channelName is present add a filter for the type
     const channelClauses = channelName

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -131,11 +131,6 @@ const COURSE_QUERY_FIELDS = [
   "title.english",
   "short_description.english",
   "full_description.english",
-  "year",
-  "semester",
-  "level",
-  "instructors",
-  "prices",
   "topics",
   "platform",
   "course_id",
@@ -146,11 +141,15 @@ const BOOTCAMP_QUERY_FIELDS = [
   "title.english",
   "short_description.english",
   "full_description.english",
-  "instructors",
-  "prices",
-  "topics",
   "course_id",
   "offered_by"
+]
+
+export const RESOURCE_QUERY_NESTED_FIELDS = [
+  "course_runs.year",
+  "course_runs.semester",
+  "course_runs.level",
+  "course_runs.instructors"
 ]
 
 const LIST_QUERY_FIELDS = [
@@ -415,15 +414,32 @@ export const buildSearchQuery = ({
     // One of the text fields must match
     const matchQuery = text
       ? {
-        must: {
-          multi_match: {
-            query:     text,
-            fields:    searchFields(type),
-            fuzziness: "AUTO"
+        should: [
+          {
+            multi_match: {
+              query:     text,
+              fields:    searchFields(type),
+              fuzziness: "AUTO"
+            }
           }
-        }
+        ]
       }
       : {}
+
+    if (text && [LR_TYPE_BOOTCAMP, LR_TYPE_COURSE].includes(type)) {
+      matchQuery.should.push({
+        nested: {
+          path:  "course_runs",
+          query: {
+            multi_match: {
+              query:     text,
+              fields:    RESOURCE_QUERY_NESTED_FIELDS,
+              fuzziness: "AUTO"
+            }
+          }
+        }
+      })
+    }
 
     // If channelName is present add a filter for the type
     const channelClauses = channelName

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -12,9 +12,9 @@ import {
 } from "../factories/search"
 import {
   AVAILABILITY_MAPPING,
+  RESOURCE_QUERY_NESTED_FIELDS,
   buildSearchQuery,
   channelField,
-  RESOURCE_QUERY_NESTED_FIELDS,
   searchFields,
   searchResultToComment,
   searchResultToLearningResource,

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -641,6 +641,7 @@ describe("search functions", () => {
           "topics",
           "platform",
           "course_id",
+          "coursenum^5",
           "offered_by"
         ]
       ],

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -14,6 +14,7 @@ import {
   AVAILABILITY_MAPPING,
   buildSearchQuery,
   channelField,
+  RESOURCE_QUERY_NESTED_FIELDS,
   searchFields,
   searchResultToComment,
   searchResultToLearningResource,
@@ -289,13 +290,15 @@ describe("search functions", () => {
                       ]
                     }
                   },
-                  must: {
-                    multi_match: {
-                      fields:    fieldNames,
-                      query:     text,
-                      fuzziness: "AUTO"
+                  should: [
+                    {
+                      multi_match: {
+                        query:     text,
+                        fields:    fieldNames,
+                        fuzziness: "AUTO"
+                      }
                     }
-                  }
+                  ]
                 }
               }
             ]
@@ -528,13 +531,27 @@ describe("search functions", () => {
                           must: mustQuery
                         }
                       },
-                      must: {
-                        multi_match: {
-                          query:     text,
-                          fields:    fieldNames,
-                          fuzziness: "AUTO"
+                      should: [
+                        {
+                          multi_match: {
+                            query:     text,
+                            fields:    fieldNames,
+                            fuzziness: "AUTO"
+                          }
+                        },
+                        {
+                          nested: {
+                            path:  "course_runs",
+                            query: {
+                              multi_match: {
+                                query:     text,
+                                fields:    RESOURCE_QUERY_NESTED_FIELDS,
+                                fuzziness: "AUTO"
+                              }
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
                   }
                 ]
@@ -621,11 +638,6 @@ describe("search functions", () => {
           "title.english",
           "short_description.english",
           "full_description.english",
-          "year",
-          "semester",
-          "level",
-          "instructors",
-          "prices",
           "topics",
           "platform",
           "course_id",

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -12,7 +12,6 @@ import {
 } from "../factories/search"
 import {
   AVAILABILITY_MAPPING,
-  RESOURCE_QUERY_NESTED_FIELDS,
   buildSearchQuery,
   channelField,
   searchFields,
@@ -290,15 +289,13 @@ describe("search functions", () => {
                       ]
                     }
                   },
-                  should: [
-                    {
-                      multi_match: {
-                        query:     text,
-                        fields:    fieldNames,
-                        fuzziness: "AUTO"
-                      }
+                  must: {
+                    multi_match: {
+                      fields:    fieldNames,
+                      query:     text,
+                      fuzziness: "AUTO"
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -531,27 +528,13 @@ describe("search functions", () => {
                           must: mustQuery
                         }
                       },
-                      should: [
-                        {
-                          multi_match: {
-                            query:     text,
-                            fields:    fieldNames,
-                            fuzziness: "AUTO"
-                          }
-                        },
-                        {
-                          nested: {
-                            path:  "course_runs",
-                            query: {
-                              multi_match: {
-                                query:     text,
-                                fields:    RESOURCE_QUERY_NESTED_FIELDS,
-                                fuzziness: "AUTO"
-                              }
-                            }
-                          }
+                      must: {
+                        multi_match: {
+                          query:     text,
+                          fields:    fieldNames,
+                          fuzziness: "AUTO"
                         }
-                      ]
+                      }
                     }
                   }
                 ]
@@ -638,6 +621,11 @@ describe("search functions", () => {
           "title.english",
           "short_description.english",
           "full_description.english",
+          "year",
+          "semester",
+          "level",
+          "instructors",
+          "prices",
           "topics",
           "platform",
           "course_id",


### PR DESCRIPTION
Based off PR #2232 

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2220

#### What's this PR do?
- Adds a `coursenum` field to course and bootcamp search docs, based on course_id
- Makes that field searchable and boosts it.


#### How should this be manually tested?
- Import edx courses if you haven't already (`manage.py backpopulate_edx_data`)
- Recreate the index if you already imported the courses
- Search for "18.06", the first result should be "Linear Algebra"
- Search for "6.002x", the first result should be "Circuits and Electronics"
