### PR TITLE
add 'grid' style loader to the course search and course home pages

### DIFF
--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -6,8 +6,7 @@ import R from "ramda"
 
 import LearningResourceCard from "./LearningResourceCard"
 
-import { SEARCH_GRID_UI } from "../lib/search"
-import { PHONE, TABLET, DESKTOP } from "../lib/constants"
+import { SEARCH_GRID_UI, SEARCH_UI_GRID_WIDTHS } from "../lib/search"
 import { useDeviceCategory } from "../hooks/util"
 
 import type { LearningResource } from "../flow/discussionTypes"
@@ -18,18 +17,12 @@ type Props = {|
   setShowResourceDrawer: Function
 |}
 
-const carouselPageSizes = {
-  [PHONE]:   1,
-  [TABLET]:  2,
-  [DESKTOP]: 3
-}
-
 export default function CourseCarousel(props: Props) {
   const { title, courses, setShowResourceDrawer } = props
 
   const [index, setIndex] = useState(0)
   const deviceCategory = useDeviceCategory()
-  const pageSize = carouselPageSizes[deviceCategory]
+  const pageSize = SEARCH_UI_GRID_WIDTHS[deviceCategory]
   const canPageUp = index + pageSize < courses.length
   const canPageDown = index !== 0
 

--- a/static/js/components/Loading.js
+++ b/static/js/components/Loading.js
@@ -3,11 +3,18 @@ import React from "react"
 import R from "ramda"
 import ContentLoader from "react-content-loader"
 
-import { NotFound, NotAuthorized } from "../components/ErrorPages"
+import { NotFound, NotAuthorized } from "./ErrorPages"
 import Card from "./Card"
 import { Cell, Grid } from "./Grid"
+
 import { contentLoaderSpeed } from "../lib/constants"
 import { EMBEDLY_THUMB_HEIGHT } from "../lib/posts"
+import {
+  SEARCH_GRID_UI,
+  SEARCH_LIST_UI,
+  SEARCH_UI_GRID_WIDTHS
+} from "../lib/search"
+import { useDeviceCategory } from "../hooks/util"
 
 type LoadingProps = {
   loaded: boolean,
@@ -32,34 +39,55 @@ export const Loading = (props: SpinnerProps) => (
   </div>
 )
 
-const AnimatedEmptyCard = (i: number) => {
-  return (
-    <div className="post-content-loader" key={`loader-${i}`}>
-      <Card className="compact-post-summary">
-        <ContentLoader
-          speed={contentLoaderSpeed}
-          style={{ width: "100%", height: "137px" }}
-          width={1000}
-          height={137}
-          preserveAspectRatio="none"
-        >
-          <rect x="0" y="0" rx="5" ry="5" width="60%" height="20" />
-          <rect x="0" y="40" rx="5" ry="5" width="60%" height="16" />
-          <rect x="0" y="58" rx="5" ry="5" width="60%" height="16" />
-          <rect x="0" y="113" rx="5" ry="5" width="170" height="24" />
-          <rect
-            x="66%"
-            y="0"
-            rx="5"
-            ry="5"
-            width="34%"
-            height={EMBEDLY_THUMB_HEIGHT}
-          />
-        </ContentLoader>
-      </Card>
-    </div>
-  )
-}
+const AnimatedEmptyCard = () => (
+  <div className="post-content-loader">
+    <Card className="compact-post-summary">
+      <ContentLoader
+        speed={contentLoaderSpeed}
+        style={{ width: "100%", height: "137px" }}
+        width={1000}
+        height={137}
+        preserveAspectRatio="none"
+      >
+        <rect x="0" y="0" rx="5" ry="5" width="60%" height="20" />
+        <rect x="0" y="40" rx="5" ry="5" width="60%" height="16" />
+        <rect x="0" y="58" rx="5" ry="5" width="60%" height="16" />
+        <rect x="0" y="113" rx="5" ry="5" width="170" height="24" />
+        <rect
+          x="66%"
+          y="0"
+          rx="5"
+          ry="5"
+          width="34%"
+          height={EMBEDLY_THUMB_HEIGHT}
+        />
+      </ContentLoader>
+    </Card>
+  </div>
+)
+
+const AnimatedEmptyLRPortrait = () => (
+  <Card className="borderless lr-portrait-loader">
+    <ContentLoader
+      speed={contentLoaderSpeed}
+      style={{ width: "100%", height: "354px" }}
+      width={1000}
+      height={354}
+      preserveAspectRatio="none"
+    >
+      <rect x="0" y="0" rx="5" ry="5" width="100%" height="171" />
+      <rect x="60" y="190" rx="5" ry="5" width="250" height="13" />
+      <rect x="60" y="210" rx="5" ry="5" width="60%" height="24" />
+
+      <rect x="60" y="250" rx="5" ry="5" width="75%" height="15" />
+      <rect x="60" y="270" rx="5" ry="5" width="85%" height="15" />
+
+      <rect x="60" y="315" rx="25" ry="25" width="180" height="20" />
+      <rect x="280" y="315" rx="25" ry="25" width="250" height="20" />
+      <rect x="85%" y="315" rx="25" ry="25" width="10%" height="20" />
+    </ContentLoader>
+  </Card>
+)
 
 export const PostLoading = () => (
   <div className="card-list-loader">
@@ -74,15 +102,54 @@ export const PostLoading = () => (
         <rect x="0" y="0" rx="5" ry="5" width="100%" height="100%" />
       </ContentLoader>
     </div>
-    {R.times(AnimatedEmptyCard, emptyPostsToRender)}
+    {R.times(i => <AnimatedEmptyCard key={i} />, emptyPostsToRender)}
   </div>
 )
 
-export const CourseSearchLoading = () => (
-  <div className="card-list-loader">
-    {R.times(AnimatedEmptyCard, emptyPostsToRender)}
-  </div>
+type CSLProps = {
+  layout: string
+}
+
+export const CourseSearchLoading = ({ layout }: CSLProps) => (
+  <Grid className="card-list-loader">
+    {R.times(
+      i => (
+        <Cell width={layout === SEARCH_GRID_UI ? 4 : 12} key={i}>
+          {layout === SEARCH_LIST_UI ? (
+            <AnimatedEmptyCard />
+          ) : (
+            <AnimatedEmptyLRPortrait />
+          )}
+        </Cell>
+      ),
+      10
+    )}
+  </Grid>
 )
+
+export const CarouselLoading = () => {
+  const deviceCategory = useDeviceCategory()
+  const width = SEARCH_UI_GRID_WIDTHS[deviceCategory]
+
+  return (
+    <div className="course-carousel-loader">
+      <ContentLoader
+        speed={contentLoaderSpeed}
+        style={{ width: "100%", height: "30px" }}
+        width={1000}
+        height={30}
+        preserveAspectRatio="none"
+      >
+        <rect x="0" y="0" rx="5" ry="5" width="15%" height="22" />
+        <rect x="83%" y="0" rx="5" ry="5" width="8%" height="22" />
+        <rect x="92%" y="0" rx="5" ry="5" width="8%" height="22" />
+      </ContentLoader>
+      <div className="loader-row">
+        {R.times(i => <AnimatedEmptyLRPortrait key={i} />, width)}
+      </div>
+    </div>
+  )
+}
 
 export const SearchLoading = () => (
   <Grid className="main-content two-column search-page">

--- a/static/js/containers/CourseIndexPage.js
+++ b/static/js/containers/CourseIndexPage.js
@@ -16,6 +16,7 @@ import {
 } from "../components/PageBanner"
 import { Cell, Grid } from "../components/Grid"
 import CourseSearchbox from "../components/CourseSearchbox"
+import { CarouselLoading } from "../components/Loading"
 
 import { setShowResourceDrawer } from "../actions/ui"
 import {
@@ -126,7 +127,11 @@ export default function CourseIndexPage({ history }: Props) {
             />
           </Cell>
         ) : (
-          "loading"
+          <Cell width={12}>
+            <CarouselLoading />
+            <CarouselLoading />
+            <CarouselLoading />
+          </Cell>
         )}
       </Grid>
       <LearningResourceDrawer />

--- a/static/js/containers/CourseIndexPage_test.js
+++ b/static/js/containers/CourseIndexPage_test.js
@@ -152,4 +152,10 @@ describe("CourseIndexPage", () => {
     assert.equal(pathname, "/courses/search")
     assert.equal(search, "?q=search%20term")
   })
+
+  it("should have a loading state", async () => {
+    helper.handleRequestStub.withArgs(favoritesURL).returns({})
+    const { wrapper } = await render()
+    assert.equal(wrapper.find("CarouselLoading").length, 3)
+  })
 })

--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -336,7 +336,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { from, incremental, searchResultLayout, activeFacets } = this.state
 
     if ((processing || !loaded) && !incremental) {
-      return <CourseSearchLoading />
+      return <CourseSearchLoading layout={searchResultLayout} />
     }
 
     if (total === 0 && !processing && loaded) {

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -7,7 +7,10 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
-  LR_TYPE_USERLIST
+  LR_TYPE_USERLIST,
+  PHONE,
+  TABLET,
+  DESKTOP
 } from "./constants"
 import {
   SEARCH_FILTER_COMMENT,
@@ -495,3 +498,9 @@ export const mergeFacetResults = (...args: Array<FacetResult>) => ({
 
 export const SEARCH_GRID_UI = "grid"
 export const SEARCH_LIST_UI = "list"
+
+export const SEARCH_UI_GRID_WIDTHS = {
+  [PHONE]:   1,
+  [TABLET]:  2,
+  [DESKTOP]: 3
+}

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -107,9 +107,7 @@ export default class IntegrationTestHelper {
 
           callback(err, resStatus, resBody, resText, resHeaders)
         },
-        abort: () => {
-          throw new Error("Aborts currently unhandled")
-        }
+        abort: () => {}
       }))
 
     // there's a good reason for this I promise

--- a/static/scss/course-carousel.scss
+++ b/static/scss/course-carousel.scss
@@ -45,3 +45,18 @@
     }
   }
 }
+
+.course-carousel-loader {
+  margin-top: 30px;
+
+  .loader-row {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .lr-portrait-loader {
+    &:not(:last-child) {
+      margin-right: 20px;
+    }
+  }
+}

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -33,7 +33,8 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      width: 100%;
+      min-width: 64%;
+      width: 64%;
 
       .availability-price-favorite {
         margin-top: 0;
@@ -125,4 +126,8 @@
       }
     }
   }
+}
+
+.lr-portrait-loader {
+  height: 354px;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2224
closes #2167

#### What's this PR do?

this implements a "grid" style loader for the course search page and also implements a "carousel" style loader for the course home page (to show while the couse information to populate the carousels is being fetched)

#### How should this be manually tested?

go the course home page. ensure that at all browser widths a carousel style loader is shown that mimics the size and placement of UI elements in the fully loaded page.

then go the course search page. ensure that if you switch to a grid view and change a facet you see a 'grid' loader that looks like the UI that eventually loads.



#### Screenshots (if appropriate)

carousel loader:

![carouselloader](https://user-images.githubusercontent.com/6207644/65254999-1e1dda80-dacb-11e9-979d-eb8888ed15d0.png)

search page:

![loaderasdfasdfasdf](https://user-images.githubusercontent.com/6207644/65255018-283fd900-dacb-11e9-98b3-2c8714c97e90.png)


mobile:

![carouselloadermob](https://user-images.githubusercontent.com/6207644/65255166-6f2dce80-dacb-11e9-87c0-b96fe5329fcb.png)

![carouselloadermobasdfsadffffasdfasdfasdfasdf](https://user-images.githubusercontent.com/6207644/65255207-7e148100-dacb-11e9-83bd-731027f59b7a.png)
