### PR TITLE
some search page styling tweaks

### DIFF
--- a/static/js/containers/CourseSearchPage.js
+++ b/static/js/containers/CourseSearchPage.js
@@ -383,6 +383,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const anyFiltersActive =
       _.flatten(_.toArray(activeFacets.values())).length > 0
 
+    const facetColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 3 : 4
+    const resultsColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 9 : 8
+
     return (
       <BannerPageWrapper>
         <MetaTags>
@@ -393,11 +396,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
             <BannerImage src={COURSE_SEARCH_BANNER_URL} tall />
           </BannerContainer>
           <Grid>
-            <Cell width={4}>
-              <div className="course-catalog-title">
-                <div className="title">Course Catalog</div>
-              </div>
-            </Cell>
+            <Cell width={4} />
             <Cell width={4}>
               <CourseSearchbox
                 onChange={this.updateText}
@@ -417,8 +416,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
               : "two-column"
           } search-page`}
         >
-          <Cell width={3} />
-          <Cell width={9}>
+          <Cell width={facetColumnWidth} />
+          <Cell width={resultsColumnWidth}>
             <div className="layout-buttons">
               <div
                 onClick={() => this.setSearchUI(SEARCH_LIST_UI)}
@@ -443,7 +442,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
               )}
             </div>
           </Cell>
-          <Cell className="search-filters" width={3}>
+          <Cell className="search-filters" width={facetColumnWidth}>
             <div className="active-search-filters">
               {anyFiltersActive ? (
                 <div className="filter-section-title">
@@ -480,7 +479,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
               />
             ))}
           </Cell>
-          <Cell width={9}>{error ? null : this.renderResults()}</Cell>
+          <Cell width={resultsColumnWidth}>
+            {error ? null : this.renderResults()}
+          </Cell>
         </Grid>
         <LearningResourceDrawer />
       </BannerPageWrapper>

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -32,22 +32,22 @@
     .lr-info {
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
       min-width: 64%;
       width: 64%;
 
       .availability-price-favorite {
-        margin-top: 0;
+        margin-top: 12px;
       }
 
       .course-title {
         min-height: 0;
         margin: 0;
-        margin-bottom: 5px;
+        margin-top: 6px;
+        margin-bottom: 10px;
       }
 
       .subtitle {
-        margin-bottom: 0;
+        margin-bottom: 6px;
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

this does a few little tweaks to styling and layout on the course search page.

- removes the 'course catalog' text from the top banner
- changes the widths of the two columns on the course search page. in the 'list' view we do 4 columns for the facets and 8 for the results, and in the 'grid' view we do 3 columns for the facets and 9 for the results.
- restyles the 'list' view of the card so that the way that the text and spacing is done is more consistent for learning resources that have a one or two line title (among other things).

#### How should this be manually tested?

check out hte course search page and make sure everything works alright and looks good. if you switch between the list and grid views you should see that the proportion of space allocated to the facets vs the results changes (from 4/8 in the list view to 3/9 in the grid view).

#### Screenshots (if appropriate)

![listmobff](https://user-images.githubusercontent.com/6207644/65271038-64cefd00-daea-11e9-98b9-0f0925f12b42.png)
![gridmob](https://user-images.githubusercontent.com/6207644/65271039-64cefd00-daea-11e9-9520-58b114b5be4a.png)
![gridspacingfnffnn](https://user-images.githubusercontent.com/6207644/65271040-64cefd00-daea-11e9-8854-d911d4de9b2e.png)
![listspacingasdfasdfasdfnnn](https://user-images.githubusercontent.com/6207644/65271041-64cefd00-daea-11e9-87b8-44f0d42e6e33.png)
![listspacingasdfasdfasdf](https://user-images.githubusercontent.com/6207644/65271043-64cefd00-daea-11e9-8e94-0419a7f13be3.png)

