### PR TITLE
Fix occasionally failing test for LearningResourceCard

### DIFF
--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -79,6 +79,7 @@ describe("LearningResourceCard", () => {
   })
 
   it("should render the topic", () => {
+    course.offered_by = "MITx"
     const { content, label } = render()
       .find("Subtitle")
       .at(1)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Makes sure 'offered_by' is not null when testing the topics section of the LearningResourceCard

#### How should this be manually tested?
Run `npm run-script coverage static/js/components/LearningResourceCard_test.js`, there should be no errors
