### PR TITLE
fix pluralization of 'subject' on learning resource card

### DIFF
--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -2,7 +2,6 @@
 /* global SETTINGS:false */
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
-import R from "ramda"
 import { mutateAsync } from "redux-query"
 import { connect } from "react-redux"
 
@@ -122,8 +121,11 @@ export const LearningResourceCard = ({
         {object.offered_by ? (
           <Subtitle content={object.offered_by} label="Offered by - " />
         ) : null}
-        {!R.isEmpty(object.topics) ? (
-          <Subtitle content={formatTopics(object.topics)} label="Subject - " />
+        {object.topics.length > 0 ? (
+          <Subtitle
+            content={formatTopics(object.topics)}
+            label={`${object.topics.length === 1 ? "Subject" : "Subjects"} - `}
+          />
         ) : null}
         <div className="row availability-price-favorite">
           <div className="price grey-surround">

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -78,7 +78,7 @@ describe("LearningResourceCard", () => {
     )
   })
 
-  it("should render the topic", () => {
+  it("should render topics", () => {
     course.offered_by = "MITx"
     const { content, label } = render()
       .find("Subtitle")
@@ -87,7 +87,29 @@ describe("LearningResourceCard", () => {
     course.topics.forEach(({ name }) => {
       assert.include(content, name)
     })
+    assert.equal(label, "Subjects - ")
+  })
+
+  it("should render a single topic", () => {
+    course.offered_by = "MITx"
+    course.topics = [course.topics[0]]
+    const { content, label } = render()
+      .find("Subtitle")
+      .at(1)
+      .props()
+    assert.include(content, course.topics[0].name)
     assert.equal(label, "Subject - ")
+  })
+
+  it("should not render topics if they aren't present", () => {
+    course.offered_by = "MITx"
+    course.topics = []
+    assert.notOk(
+      render()
+        .find("Subtitle")
+        .at(1)
+        .exists()
+    )
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2217

#### What's this PR do?

fixes the pluralization for "Subject" in the learning resource card. in particular:

- if there are no topics we don't show that line
- if there's one topic we say "Subject - "
- if there's multiple topics we say "Subjects - "

#### How should this be manually tested?

make sure that the above works as advertised

#### Screenshots (if appropriate)

![subjectasdfasdffasdfasdfasdf](https://user-images.githubusercontent.com/6207644/65438307-4707dd80-ddf3-11e9-9103-e10213060b77.png)

