### PR TITLE
course search mobile view

### DIFF
--- a/static/js/components/CourseFilterDrawer.js
+++ b/static/js/components/CourseFilterDrawer.js
@@ -1,0 +1,45 @@
+// @flow
+import React, { useState } from "react"
+
+import { DESKTOP } from "../lib/constants"
+import { useDeviceCategory } from "../hooks/util"
+
+type Props = {
+  children: React$Node
+}
+
+export default function CourseFilterDrawer(props: Props) {
+  const { children } = props
+
+  const deviceCategory = useDeviceCategory()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  if (deviceCategory === DESKTOP) {
+    return children
+  }
+
+  const closeDrawer = () => setDrawerOpen(false)
+
+  return drawerOpen ? (
+    <div className="course-filter-drawer-open">
+      <div className="controls">
+        <i className="material-icons" onClick={closeDrawer}>
+          close
+        </i>
+      </div>
+      <div className="apply-filters">
+        <button onClick={closeDrawer} className="blue-btn">
+          Apply Filters
+        </button>
+      </div>
+      <div className="contents">{children}</div>
+    </div>
+  ) : (
+    <div className="controls">
+      <div onClick={() => setDrawerOpen(true)} className="filter-controls">
+        Filter Results
+        <i className="material-icons">arrow_drop_down</i>
+      </div>
+    </div>
+  )
+}

--- a/static/js/components/CourseFilterDrawer_test.js
+++ b/static/js/components/CourseFilterDrawer_test.js
@@ -1,0 +1,69 @@
+// @flow
+import React from "react"
+import { mount } from "enzyme"
+import { createSandbox } from "sinon"
+import { assert } from "chai"
+
+import CourseFilterDrawer from "./CourseFilterDrawer"
+
+import * as utilHooks from "../hooks/util"
+import { DESKTOP, PHONE, TABLET } from "../lib/constants"
+
+describe("CourseFilterDrawer", () => {
+  const render = (props = {}) =>
+    mount(
+      <CourseFilterDrawer {...props}>
+        <div className="child-child-child" />
+      </CourseFilterDrawer>
+    )
+
+  let sandbox, useDeviceCategoryStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    useDeviceCategoryStub = sandbox
+      .stub(utilHooks, "useDeviceCategory")
+      .returns(DESKTOP)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should render the children on desktop", () => {
+    const wrapper = render()
+    assert.ok(wrapper.find(".child-child-child"))
+  })
+
+  //
+  ;[TABLET, PHONE].forEach(deviceCategory => {
+    it(`should render an open control by default when ${deviceCategory}`, () => {
+      useDeviceCategoryStub.returns(deviceCategory)
+      const wrapper = render()
+      assert.ok(wrapper.find(".filter-controls").exists())
+      assert.isNotOk(wrapper.find(".child-child-child").exists())
+    })
+  })
+
+  //
+  ;[TABLET, PHONE].forEach(deviceCategory => {
+    it(`should open the drawer when you click the control when ${deviceCategory}`, () => {
+      useDeviceCategoryStub.returns(deviceCategory)
+      const wrapper = render()
+      wrapper.find(".filter-controls").simulate("click")
+      assert.ok(wrapper.find(".child-child-child").exists())
+    })
+  })
+
+  //
+  ;[TABLET, PHONE].forEach(deviceCategory => {
+    it(`should let you close the drawer once it's open when ${deviceCategory}`, () => {
+      useDeviceCategoryStub.returns(deviceCategory)
+      const wrapper = render()
+      wrapper.find(".filter-controls").simulate("click")
+      assert.ok(wrapper.find(".child-child-child").exists())
+      wrapper.find(".controls i").simulate("click")
+      assert.isNotOk(wrapper.find(".child-child-child").exists())
+    })
+  })
+})

--- a/static/js/components/CourseSearchbox.js
+++ b/static/js/components/CourseSearchbox.js
@@ -8,11 +8,12 @@ type Props = {
   value?: string,
   onSubmit: Function,
   validation?: ?string,
-  autoFocus?: boolean
+  autoFocus?: boolean,
+  children?: React$Node
 }
 
 export default function CourseSearchbox(props: Props) {
-  const { onChange, value, onSubmit, validation, autoFocus } = props
+  const { onChange, value, onSubmit, validation, autoFocus, children } = props
 
   return (
     <div className="course-searchbox">
@@ -30,6 +31,7 @@ export default function CourseSearchbox(props: Props) {
         <i className="material-icons search-icon" onClick={onSubmit}>
           search
         </i>
+        {children}
       </div>
       {validationMessage(validation)}
     </div>

--- a/static/js/components/CourseSearchbox_test.js
+++ b/static/js/components/CourseSearchbox_test.js
@@ -1,4 +1,5 @@
 // @flow
+import React from "react"
 import sinon from "sinon"
 import { assert } from "chai"
 
@@ -72,5 +73,12 @@ describe("CourseSearchbox", () => {
     const validationStub = sandbox.stub(validationFuncs, "validationMessage")
     renderSearchbox({ validation: "NO!!!!!" })
     sinon.assert.calledWith(validationStub, "NO!!!!!")
+  })
+
+  it("should render children if they are passed", () => {
+    const wrapper = renderSearchbox({
+      children: <div className="child">hey!</div>
+    })
+    assert.ok(wrapper.find(".child").exists())
   })
 })

--- a/static/js/components/PageBanner.js
+++ b/static/js/components/PageBanner.js
@@ -1,15 +1,23 @@
 // @flow
 import React from "react"
-import styled from "styled-components"
+import styled, { css } from "styled-components"
 
-import { isMobileWidth } from "../lib/util"
+import { PHONE_WIDTH } from "../lib/constants"
 
 const bannerHeight = "200px"
 const tallBannerHeight = "252px"
+const shortMobileBannerHeight = "115px"
 const channelBannerBg = "#20316d"
 
-const imageHeight = props =>
-  props.tall && !isMobileWidth() ? tallBannerHeight : bannerHeight
+const imageHeight = css`
+  @media (max-width: ${PHONE_WIDTH}px) {
+    height: ${props =>
+    props.compactOnMobile ? shortMobileBannerHeight : bannerHeight};
+  }
+  @media (min-width: ${PHONE_WIDTH + 1}px) {
+    height: ${props => (props.tall ? tallBannerHeight : bannerHeight)};
+  }
+`
 
 export const BannerContainer = styled.div`
   position: absolute;
@@ -24,24 +32,30 @@ const imageStylesheet = `
 
 const StyledImage = styled.img`
   ${imageStylesheet} object-fit: cover;
-  height: ${imageHeight};
+  ${imageHeight};
 `
 
 const PlaceholderDiv = styled.div`
   ${imageStylesheet}
   background-color: ${channelBannerBg};
-  height: ${imageHeight}
+  ${imageHeight}
 `
 
 type ImgProps = {
   src: ?string,
   alt?: string,
-  tall?: boolean
+  tall?: boolean,
+  compactOnMobile?: boolean
 }
 
-export const BannerImage = ({ src, alt, tall }: ImgProps) =>
+export const BannerImage = ({ src, alt, tall, compactOnMobile }: ImgProps) =>
   src ? (
-    <StyledImage src={src} tall={tall} alt={alt || ""} />
+    <StyledImage
+      src={src}
+      tall={tall}
+      alt={alt || ""}
+      compactOnMobile={compactOnMobile}
+    />
   ) : (
     <PlaceholderDiv />
   )
@@ -53,7 +67,7 @@ export const BannerPageWrapper = styled.div`
 
 export const BannerPageHeader = styled.div`
   margin-bottom: 20px;
-  min-height: ${imageHeight};
+  ${imageHeight};
 `
 
 export const Gradient = styled.div`
@@ -63,8 +77,8 @@ export const Gradient = styled.div`
     rgba(0, 0, 0, 0.5)
   );
   position: absolute;
-  height: ${imageHeight}
   width: 100%;
   display: block;
   top: 0;
+  ${imageHeight};
 `

--- a/static/js/components/ResponsiveWrapper.js
+++ b/static/js/components/ResponsiveWrapper.js
@@ -1,0 +1,15 @@
+// @flow
+import { useDeviceCategory } from "../hooks/util"
+
+type Props = {
+  children: React$Node,
+  onlyOn: Array<string>
+}
+
+export default function ResponsiveWrapper(props: Props) {
+  const { children, onlyOn } = props
+
+  const deviceCategory = useDeviceCategory()
+
+  return onlyOn.includes(deviceCategory) ? children : null
+}

--- a/static/js/components/ResponsiveWrapper_test.js
+++ b/static/js/components/ResponsiveWrapper_test.js
@@ -1,0 +1,61 @@
+// @flow
+import React from "react"
+import { mount } from "enzyme"
+import { createSandbox } from "sinon"
+import { assert } from "chai"
+
+import ResponsiveWrapper from "./ResponsiveWrapper"
+
+import * as utilHooks from "../hooks/util"
+import { DESKTOP, PHONE, TABLET } from "../lib/constants"
+import { shouldIf } from "../lib/test_utils"
+
+describe("ResponsiveWrapper", () => {
+  const render = (props = { onlyOn: [] }) =>
+    mount(
+      <ResponsiveWrapper {...props}>
+        <div className="child-child-child" />
+      </ResponsiveWrapper>
+    )
+
+  let sandbox, useDeviceCategoryStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    useDeviceCategoryStub = sandbox
+      .stub(utilHooks, "useDeviceCategory")
+      .returns(DESKTOP)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  //
+  ;[PHONE, DESKTOP, TABLET].forEach(deviceCategory => {
+    it(`should not show any children when ${deviceCategory} and no onlyOn`, () => {
+      useDeviceCategoryStub.returns(deviceCategory)
+      const wrapper = render()
+      assert.isNotOk(wrapper.find(".child-child-child").exists())
+    })
+  })
+
+  //
+  ;[PHONE, DESKTOP, TABLET].forEach(deviceCategory => {
+    [
+      [[PHONE], deviceCategory === PHONE],
+      [[DESKTOP], deviceCategory === DESKTOP],
+      [[TABLET], deviceCategory === TABLET]
+    ].forEach(([onlyOn, shouldShowChildren]) => {
+      it(`${shouldIf(
+        shouldShowChildren
+      )} show children when ${deviceCategory} and onlyOn is ${JSON.stringify(
+        onlyOn
+      )}`, () => {
+        useDeviceCategoryStub.returns(deviceCategory)
+        const wrapper = render()
+        assert.isNotOk(wrapper.find(".child-child-child").exists())
+      })
+    })
+  })
+})

--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -53,6 +53,15 @@ function SearchFacet(props: Props) {
                     ? "facet-visible"
                     : "facet-hidden"
                 } ${isChecked ? "checked" : ""}`}
+                onClick={() => {
+                  onUpdate({
+                    target: {
+                      name,
+                      value:   facet.key,
+                      checked: !isChecked
+                    }
+                  })
+                }}
               >
                 <input
                   type="checkbox"

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -58,6 +58,16 @@ describe("SearchFacet", () => {
     sinon.assert.calledWith(onUpdateStub, event)
   })
 
+  it("whole thing should call onUpdate when clicked", () => {
+    renderSearchFacet()
+      .find(".facet-visible")
+      .at(0)
+      .simulate("click")
+    sinon.assert.calledWith(onUpdateStub, {
+      target: { checked: true, name: name, value: facet["key"] }
+    })
+  })
+
   it("checkbox should call the label function if assigned", () => {
     const labelStub = helper.sandbox.stub()
     renderSearchFacet({ labelFunction: labelStub })

--- a/static/js/hooks/util.js
+++ b/static/js/hooks/util.js
@@ -2,7 +2,13 @@
 import { useState, useEffect } from "react"
 
 import { getViewportWidth } from "../lib/util"
-import { PHONE, TABLET, DESKTOP } from "../lib/constants"
+import {
+  PHONE,
+  PHONE_WIDTH,
+  TABLET,
+  TABLET_WIDTH,
+  DESKTOP
+} from "../lib/constants"
 
 export const useDeviceCategory = () => {
   const [width, setWidth] = useState(getViewportWidth())
@@ -17,10 +23,10 @@ export const useDeviceCategory = () => {
     }
   }, [])
 
-  if (width <= 580) {
+  if (width <= PHONE_WIDTH) {
     return PHONE
   }
-  if (width <= 800) {
+  if (width <= TABLET_WIDTH) {
     return TABLET
   }
   return DESKTOP

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -66,3 +66,5 @@ export const DEFAULT_END_DT = "2500-01-01T23:59:59Z"
 export const PHONE = "PHONE"
 export const TABLET = "TABLET"
 export const DESKTOP = "DESKTOP"
+export const PHONE_WIDTH = 580
+export const TABLET_WIDTH = 839

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -16,6 +16,7 @@ import {
 import { Cell, Grid } from "../components/Grid"
 import CourseSearchbox from "../components/CourseSearchbox"
 import { CarouselLoading } from "../components/Loading"
+import ResponsiveWrapper from "../components/ResponsiveWrapper"
 
 import { setShowResourceDrawer } from "../actions/ui"
 import {
@@ -31,6 +32,7 @@ import {
   favoritesSelector
 } from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
+import { PHONE, TABLET, DESKTOP } from "../lib/constants"
 
 type Props = {|
   history: Object
@@ -75,28 +77,35 @@ export default function CourseIndexPage({ history }: Props) {
 
   return (
     <BannerPageWrapper>
-      <BannerPageHeader tall>
-        <BannerContainer tall>
-          <BannerImage src={COURSE_BANNER_URL} tall />
+      <BannerPageHeader tall compactOnMobile>
+        <BannerContainer tall compactOnMobile>
+          <BannerImage src={COURSE_BANNER_URL} tall compactOnMobile />
         </BannerContainer>
-        <Grid>
-          <Cell width={4} />
-          <Cell className="course-searchbox-container" width={4}>
-            <CourseSearchbox
-              onSubmit={e => {
-                const { value } = e.target
-                const newLocation = `${COURSE_SEARCH_URL}${toQueryString({
-                  q: value
-                })}`
-                history.push(newLocation)
-              }}
-            />
-            <Link className="link-button" to={COURSE_SEARCH_URL}>
-              View All
-            </Link>
-          </Cell>
-        </Grid>
+        <CourseSearchbox
+          onSubmit={e => {
+            const { value } = e.target
+            const newLocation = `${COURSE_SEARCH_URL}${toQueryString({
+              q: value
+            })}`
+            history.push(newLocation)
+          }}
+        >
+          <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
+            <div className="link-wrapper">
+              <Link className="link-button" to={COURSE_SEARCH_URL}>
+                View All
+              </Link>
+            </div>
+          </ResponsiveWrapper>
+        </CourseSearchbox>
       </BannerPageHeader>
+      <ResponsiveWrapper onlyOn={[PHONE]}>
+        <div className="wide-view-more">
+          <Link className="link-button" to={COURSE_SEARCH_URL}>
+            View All
+          </Link>
+        </div>
+      </ResponsiveWrapper>
       <Grid className="main-content one-column">
         {loaded ? (
           <Cell width={12}>

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -82,7 +82,7 @@ export default class IntegrationTestHelper {
     })
     this.getViewportWidthStub = this.sandbox
       .stub(utilFuncs, "getViewportWidth")
-      .returns(700)
+      .returns(1000)
     this.embedlyPlatformStub = this.sandbox.stub(
       embedUtil,
       "loadEmbedlyPlatform"

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -70,6 +70,11 @@ button.compact {
   }
 }
 
+button.blue-btn {
+  color: white;
+  background-color: $course-blue;
+}
+
 .grey-surround {
   display: flex;
   align-items: center;

--- a/static/scss/course-filter-drawer.scss
+++ b/static/scss/course-filter-drawer.scss
@@ -1,0 +1,34 @@
+.course-filter-drawer-open {
+  position: fixed;
+  top: $toolbar-height-mobile;
+  height: calc(100% - #{$toolbar-height-mobile});
+  left: 0;
+  background: white;
+  width: 100%;
+  overflow: scroll;
+
+  .contents {
+    margin: 0 20px;
+  }
+
+  .controls {
+    display: flex;
+    justify-content: flex-end;
+
+    i {
+      margin-right: 18px;
+      margin-top: 18px;
+      font-size: 33px;
+      cursor: pointer;
+    }
+  }
+
+  .apply-filters {
+    margin: 25px;
+
+    button {
+      width: 100%;
+      font-size: 20px;
+    }
+  }
+}

--- a/static/scss/course-searchbox.scss
+++ b/static/scss/course-searchbox.scss
@@ -1,5 +1,9 @@
 .course-searchbox {
-  padding-top: 78px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 
   label {
     font-size: 24px;
@@ -12,6 +16,9 @@
     position: relative;
     height: 55px;
     color: $font-grey-mid;
+    margin: 0 20px;
+    max-width: 500px;
+    width: calc(100% - 40px);
 
     i.material-icons {
       position: absolute;
@@ -27,6 +34,16 @@
       font-size: 20px;
       border-radius: 7px;
       border: none;
+    }
+
+    .link-wrapper {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 22px;
+
+      a.link-button {
+        margin-right: 0;
+      }
     }
   }
 }

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -238,6 +238,10 @@
 
     .option {
       height: 40px;
+
+      &:first-child {
+        padding-right: 20px;
+      }
     }
 
     i {
@@ -254,6 +258,10 @@
       margin-left: 50px;
       font-size: 14px;
       color: black;
+
+      @include breakpoint(phone) {
+        margin-left: auto;
+      }
     }
   }
 }
@@ -271,4 +279,15 @@
 .bordered {
   padding-bottom: 5px;
   border-bottom: 1px solid black;
+}
+
+.wide-view-more {
+  display: flex;
+  justify-content: center;
+
+  a {
+    max-width: 424px;
+    margin: 0 20px;
+    width: 100%;
+  }
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -66,6 +66,7 @@
 @import "course-index-page";
 @import "channel-member-page";
 @import "course-searchbox";
+@import "course-filter-drawer";
 
 body {
   font-family: $body-font;

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -22,6 +22,10 @@
         margin-left: 16px;
         width: 46%;
 
+        @include breakpoint(phone) {
+          display: none;
+        }
+
         img {
           height: 130px;
           border-radius: 3px;
@@ -34,6 +38,10 @@
       flex-direction: column;
       min-width: 64%;
       width: 64%;
+
+      @include breakpoint(phone) {
+        width: 100%;
+      }
 
       .availability-price-favorite {
         margin-top: 12px;

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -59,6 +59,12 @@
 }
 
 .search-filters {
+  .filter-controls {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
   .filter-section-title {
     font-size: 18px;
     font-weight: 600;
@@ -70,7 +76,9 @@
 
   .facets,
   .active-search-filters {
-    width: 90%;
+    @include breakpoint(desktop) {
+      width: 90%;
+    }
   }
 
   .active-search-filters {
@@ -132,9 +140,11 @@
       height: 25px;
       font-size: 14px;
       margin-right: 6px;
+      cursor: pointer;
 
       input {
         margin-right: 10px;
+        cursor: pointer;
       }
 
       .facet-label-div {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes  #2103

#### What's this PR do?

this PR implements mobile view for the course search and course home page. in particular, there are two main things I'm doing here:

- fixing the facets, so that only mobile you have to click a little button to open them (they take over the screen when they're open)
- fix the display of the search bar and the top banner on mobile


#### How should this be manually tested?

test it out at a bunch of screen widths, both on the course home page and on the course search page, to make sure things look ok and that they are working well. I think it should all be good as far as the responsive stuff.

#### Screenshots (if appropriate)

![hompe](https://user-images.githubusercontent.com/6207644/65714134-85f29900-e068-11e9-9188-84187cd1a20d.png)
![searchfilters](https://user-images.githubusercontent.com/6207644/65714136-85f29900-e068-11e9-8197-0e58f5f579a0.png)
![search](https://user-images.githubusercontent.com/6207644/65714137-868b2f80-e068-11e9-90ca-421a117fd4c9.png)
