### PR TITLE
Populate best date fields during xpro import

### DIFF
--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -75,6 +75,14 @@ def transform(programs):
                             "enrollment_end": _parse_datetime(
                                 course_run["enrollment_end"]
                             ),
+                            "best_start_date": _parse_datetime(
+                                course_run["enrollment_start"]
+                            )
+                            or _parse_datetime(course_run["start_date"]),
+                            "best_end_date": _parse_datetime(
+                                course_run["enrollment_end"]
+                            )
+                            or _parse_datetime(course_run["end_date"]),
                             "offered_by": OfferedBy.xpro.value,
                             "published": bool(course_run["current_price"]),
                             "prices": [{"price": course_run["current_price"]}]

--- a/course_catalog/etl/xpro_test.py
+++ b/course_catalog/etl/xpro_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from course_catalog.constants import OfferedBy
 from course_catalog.etl import xpro
+from course_catalog.etl.xpro import _parse_datetime
 from open_discussions.test_utils import any_instance_of
 
 
@@ -73,6 +74,14 @@ def test_xpro_transform(mock_xpro_data):
                             "end_date": any_instance_of(datetime, type(None)),
                             "enrollment_start": any_instance_of(datetime, type(None)),
                             "enrollment_end": any_instance_of(datetime, type(None)),
+                            "best_start_date": _parse_datetime(
+                                course_run_data["enrollment_start"]
+                                or course_run_data["start_date"]
+                            ),
+                            "best_end_date": _parse_datetime(
+                                course_run_data["enrollment_end"]
+                                or course_run_data["end_date"]
+                            ),
                             "offered_by": OfferedBy.xpro.value,
                             "published": bool(course_run_data["current_price"]),
                             "prices": [{"price": course_run_data["current_price"]}]
@@ -91,6 +100,4 @@ def test_xpro_transform(mock_xpro_data):
         }
         for program_data in mock_xpro_data
     ]
-    print(result)
-    print(expected)
     assert expected == result


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2248 

#### What's this PR do?
Populates best_start_date and best_end_date fields for xpro course runs during import.

#### How should this be manually tested?
- Set `XPRO_CATALOG_API_URL=http://docker.for.mac.host.internal:8053/api/programs/` (osx)
- Run `course_catalog.tasks.get_xpro_data`
- Verify that imported xPro course runs have correctly populated `best_start_date` and `best_end_date` fields
