### PR TITLE
Remove OCW courses from search if they are unpublished

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -1,7 +1,6 @@
 """
 course_catalog api functions
 """
-from collections import namedtuple
 from datetime import datetime
 import json
 import logging

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -159,19 +159,27 @@ def bootcamp_valid_data():
     }
 
 
-@pytest.mark.usefixtures("mock_index_functions")
-def test_deserializing_a_valid_ocw_course(ocw_valid_data):
+@pytest.mark.parametrize("published", [True, False])
+def test_deserializing_a_valid_ocw_course(
+    mock_course_index_functions, ocw_valid_data, published
+):
     """
     Verify that OCWSerializer successfully de-serialize a JSON object and create Course model instance
     """
-    digest_ocw_course(ocw_valid_data, timezone.now(), None, True)
+    digest_ocw_course(ocw_valid_data, timezone.now(), None, published)
     assert Course.objects.count() == 1
-    digest_ocw_course(ocw_valid_data, timezone.now() - timedelta(hours=1), None, True)
+    digest_ocw_course(
+        ocw_valid_data, timezone.now() - timedelta(hours=1), None, published
+    )
     assert Course.objects.count() == 1
 
     course = Course.objects.last()
     digest_ocw_course(
-        ocw_valid_data, timezone.now() + timedelta(hours=1), course, True, "PROD/RES"
+        ocw_valid_data,
+        timezone.now() + timedelta(hours=1),
+        course,
+        published,
+        "PROD/RES",
     )
     assert Course.objects.count() == 1
     assert (

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -221,6 +221,10 @@ class CourseRunSerializer(BaseCourseSerializer):
             "availability": data.get("availability"),
             "offered_by": data.get("offered_by"),
         }
+        is_published = data.get("is_published")
+        if is_published is not None:
+            course_fields["published"] = is_published
+
         self.instructors = [
             {
                 "first_name": person.get("given_name", person.get("first_name")),

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -2,25 +2,16 @@
 course_catalog tasks
 """
 import logging
-
 import json
 
 import requests
 import boto3
 from django.conf import settings
-from ocw_data_parser import OCWParser
 
 from open_discussions.celery import app
 from course_catalog.constants import PlatformType
-from course_catalog.models import Course, CourseRun
-from course_catalog.api import (
-    safe_load_json,
-    digest_ocw_course,
-    get_s3_object_and_read,
-    format_date,
-    generate_course_prefix_list,
-    parse_bootcamp_json_data,
-)
+from course_catalog.models import Course
+from course_catalog.api import sync_ocw_data, parse_bootcamp_json_data
 from course_catalog.etl import pipelines
 
 
@@ -50,111 +41,7 @@ def get_ocw_data(
     ):
         log.warning("Required settings missing for get_ocw_data")
         return
-    raw_data_bucket = boto3.resource(
-        "s3",
-        aws_access_key_id=settings.OCW_CONTENT_ACCESS_KEY,
-        aws_secret_access_key=settings.OCW_CONTENT_SECRET_ACCESS_KEY,
-    ).Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
-
-    # get all the courses prefixes we care about
-    ocw_courses = generate_course_prefix_list(raw_data_bucket)
-
-    # loop over each course
-    for course_prefix in sorted(ocw_courses):
-        loaded_raw_jsons_for_course = []
-        last_modified_dates = []
-        uid = None
-        is_published = True
-        log.info("Syncing: %s ...", course_prefix)
-        # Collect last modified timestamps for all course files of the course
-        for obj in raw_data_bucket.objects.filter(Prefix=course_prefix):
-            # the "1.json" metadata file contains a course's uid
-            if obj.key == course_prefix + "0/1.json":
-                try:
-                    first_json = safe_load_json(get_s3_object_and_read(obj), obj.key)
-                    uid = first_json.get("_uid")
-                    last_published_to_production = format_date(
-                        first_json.get("last_published_to_production", None)
-                    )
-                    last_unpublishing_date = format_date(
-                        first_json.get("last_unpublishing_date", None)
-                    )
-                    if last_published_to_production is None or (
-                        last_unpublishing_date
-                        and (last_unpublishing_date > last_published_to_production)
-                    ):
-                        is_published = False
-                except Exception:  # pylint: disable=broad-except
-                    log.exception(
-                        "Error encountered reading 1.json for %s", course_prefix
-                    )
-            # accessing last_modified from s3 object summary is fast (does not download file contents)
-            last_modified_dates.append(obj.last_modified)
-        if not uid:
-            # skip if we're unable to fetch course's uid
-            log.info("Skipping %s, no course_id", course_prefix)
-            continue
-        # get the latest modified timestamp of any file in the course
-        last_modified = max(last_modified_dates)
-
-        try:
-            # fetch JSON contents for each course file in memory (slow)
-            for obj in sorted(
-                raw_data_bucket.objects.filter(Prefix=course_prefix),
-                key=lambda x: int(x.key.split("/")[-1].split(".")[0]),
-            ):
-                loaded_raw_jsons_for_course.append(
-                    safe_load_json(get_s3_object_and_read(obj), obj.key)
-                )
-
-            # pass course contents into parser
-            parser = OCWParser("", "", loaded_raw_jsons_for_course)
-            course_json = parser.get_master_json()
-            course_json["uid"] = uid
-            course_json["course_id"] = "{}.{}".format(
-                course_json.get("department_number"),
-                course_json.get("master_course_number"),
-            )
-
-            # if course run synced before, update existing Course instance
-            courserun_instance = CourseRun.objects.filter(course_run_id=uid).first()
-
-            # Make sure that the data we are syncing is newer than what we already have
-            if (
-                courserun_instance
-                and last_modified <= courserun_instance.last_modified
-                and not force_overwrite
-            ):
-                log.info("Already synced. No changes found for %s", course_prefix)
-                continue
-
-            course_instance = Course.objects.filter(
-                course_id=course_json["course_id"]
-            ).first()
-            if upload_to_s3 and is_published:
-                # Upload all course media to S3 before serializing course to ensure the existence of links
-                parser.setup_s3_uploading(
-                    settings.OCW_LEARNING_COURSE_BUCKET_NAME,
-                    settings.OCW_LEARNING_COURSE_ACCESS_KEY,
-                    settings.OCW_LEARNING_COURSE_SECRET_ACCESS_KEY,
-                    # course_prefix now has trailing slash so [-2] below is the last
-                    # actual element and [-1] is an empty string
-                    course_prefix.split("/")[-2],
-                )
-                if settings.OCW_UPLOAD_IMAGE_ONLY:
-                    parser.upload_course_image()
-                else:
-                    parser.upload_all_media_to_s3(upload_master_json=True)
-
-            digest_ocw_course(
-                parser.get_master_json(),
-                last_modified,
-                course_instance,
-                is_published,
-                course_prefix,
-            )
-        except Exception:  # pylint: disable=broad-except
-            log.exception("Error encountered parsing OCW json for %s", course_prefix)
+    sync_ocw_data(force_overwrite=force_overwrite, upload_to_s3=upload_to_s3)
 
 
 @app.task

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -46,7 +46,7 @@ def mock_logger(mocker):
     """
     Mock log exception
     """
-    return mocker.patch("course_catalog.tasks.log.exception")
+    return mocker.patch("course_catalog.api.log.exception")
 
 
 @pytest.fixture
@@ -150,7 +150,7 @@ def test_get_ocw_overwrite(mocker, settings, mock_course_index_functions, overwr
     assert CourseInstructor.objects.count() == 1
     assert CourseTopic.objects.count() == 3
 
-    mock_digest = mocker.patch("course_catalog.tasks.digest_ocw_course")
+    mock_digest = mocker.patch("course_catalog.api.digest_ocw_course")
     get_ocw_data.delay(force_overwrite=overwrite)
     assert mock_digest.call_count == (1 if overwrite else 0)
 
@@ -170,7 +170,7 @@ def test_get_ocw_data_error_parsing(settings, mocker, mock_logger):
     Test that an error parsing ocw data is correctly logged
     """
     mocker.patch(
-        "course_catalog.tasks.OCWParser.setup_s3_uploading", side_effect=Exception
+        "course_catalog.api.OCWParser.setup_s3_uploading", side_effect=Exception
     )
     setup_s3(settings)
     get_ocw_data.delay()
@@ -185,7 +185,7 @@ def test_get_ocw_data_error_reading_s3(settings, mocker, mock_logger):
     """
     Test that an error reading from S3 is correctly logged
     """
-    mocker.patch("course_catalog.tasks.get_s3_object_and_read", side_effect=Exception)
+    mocker.patch("course_catalog.api.get_s3_object_and_read", side_effect=Exception)
     setup_s3(settings)
     get_ocw_data.delay()
     mock_logger.assert_called_once_with(
@@ -202,11 +202,9 @@ def test_get_ocw_data_upload_all_or_image(settings, mocker, image_only):
     """
     settings.OCW_UPLOAD_IMAGE_ONLY = image_only
     mock_upload_all = mocker.patch(
-        "course_catalog.tasks.OCWParser.upload_all_media_to_s3"
+        "course_catalog.api.OCWParser.upload_all_media_to_s3"
     )
-    mock_upload_image = mocker.patch(
-        "course_catalog.tasks.OCWParser.upload_course_image"
-    )
+    mock_upload_image = mocker.patch("course_catalog.api.OCWParser.upload_course_image")
     setup_s3(settings)
     get_ocw_data.delay()
     assert mock_upload_image.call_count == (1 if image_only else 0)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2125 

#### What's this PR do?
Updates indexing code to delete documents from the Elasticsearch index which are unpublished

#### How should this be manually tested?
First, start on master. Make sure you have up to date OCW data, or run `./manage.py backpopulate_ocw_data` if not. Go to `/courses/search?q=linear%20algebra` and there should be some Linear Algebra courses available. Click on each one from the top of the list until you get to one whose instructor is "Gilbert Strang". Click the "As Taught in" dropdown and verify that there are three years: 2002, 2005, and 2010. Select '2002' and click 'Take Course on OCW'. You should get a 404 page.

Run `./manage.py backpopulate_ocw_data --skip-s3 --overwrite`. This will take many hours and you may need to run it overnight. After it finishes, go back to the course search and look for the same course as before. It should now show only two years: 2005 and 2010.