### PR TITLE
fix a layout bug introduced in 2250

### DIFF
--- a/static/js/components/PageBanner.js
+++ b/static/js/components/PageBanner.js
@@ -19,6 +19,16 @@ const imageHeight = css`
   }
 `
 
+const imageWrapperHeight = css`
+  @media (max-width: ${PHONE_WIDTH}px) {
+    min-height: ${props =>
+    props.compactOnMobile ? shortMobileBannerHeight : bannerHeight};
+  }
+  @media (min-width: ${PHONE_WIDTH + 1}px) {
+    min-height: ${props => (props.tall ? tallBannerHeight : bannerHeight)};
+  }
+`
+
 export const BannerContainer = styled.div`
   position: absolute;
   width: 100%;
@@ -38,7 +48,7 @@ const StyledImage = styled.img`
 const PlaceholderDiv = styled.div`
   ${imageStylesheet}
   background-color: ${channelBannerBg};
-  ${imageHeight}
+  ${imageWrapperHeight}
 `
 
 type ImgProps = {
@@ -67,7 +77,7 @@ export const BannerPageWrapper = styled.div`
 
 export const BannerPageHeader = styled.div`
   margin-bottom: 20px;
-  ${imageHeight};
+  ${imageWrapperHeight};
 `
 
 export const Gradient = styled.div`

--- a/static/scss/course-searchbox.scss
+++ b/static/scss/course-searchbox.scss
@@ -3,7 +3,11 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100%;
+
+  height: 252px;
+  @include breakpoint(phone) {
+    height: 115px;
+  }
 
   label {
     font-size: 24px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots


#### What are the relevant tickets?

none, fix for a layout bug I introduced in #2250

#### What's this PR do?

I made this sad thing happen:

![yikessssss](https://user-images.githubusercontent.com/6207644/66238998-c71d2580-e6c6-11e9-9e32-3f3660df9381.png)

so I fixed it. the issue was that I changed some of the styling for the top banner components (which are shared between channel page, course search page, and post page) to accomodate the mobile UI for the course search page, but didn't realize that part of the display for the post page had been negatively impacted.

#### How should this be manually tested?

check out the branch and make sure it fixes the issue above, and that the display for the course search page isn't negatively affected by the fix.