### PR TITLE
Import xPro program topics and instructors

### DIFF
--- a/course_catalog/admin.py
+++ b/course_catalog/admin.py
@@ -11,7 +11,32 @@ from course_catalog.models import (
     ProgramItem,
     UserListItem,
     LearningResourceRun,
+    CoursePrice,
+    CourseInstructor,
+    CourseTopic,
 )
+
+
+class CourseInstructorAdmin(admin.ModelAdmin):
+    """Instructor Admin"""
+
+    model = CourseInstructor
+    search_fields = ("full_name", "first_name", "last_name")
+
+
+class CoursePriceAdmin(admin.ModelAdmin):
+    """Price Admin"""
+
+    model = CoursePrice
+    search_fields = ("price",)
+    list_filter = ("mode",)
+
+
+class CourseTopicAdmin(admin.ModelAdmin):
+    """Topic Admin"""
+
+    model = CourseTopic
+    search_fields = ("name",)
 
 
 class LearningResourceRunAdmin(admin.ModelAdmin):
@@ -22,6 +47,8 @@ class LearningResourceRunAdmin(admin.ModelAdmin):
     search_fields = ("run_id", "title", "course__course_id")
     list_display = ("run_id", "title", "best_start_date", "best_end_date")
     list_filter = ("semester", "year")
+    exclude = ("course",)
+    autocomplete_fields = ("prices", "instructors", "topics")
 
 
 class LearningResourceRunInline(GenericTabularInline):
@@ -60,6 +87,7 @@ class CourseAdmin(admin.ModelAdmin):
     list_display = ("course_id", "title", "platform")
     list_filter = ("platform",)
     inlines = [LearningResourceRunInline]
+    autocomplete_fields = ("topics",)
 
 
 class BootcampAdmin(admin.ModelAdmin):
@@ -68,6 +96,7 @@ class BootcampAdmin(admin.ModelAdmin):
     model = Bootcamp
     search_fields = ("course_id", "title")
     list_display = ("course_id", "title")
+    autocomplete_fields = ("topics",)
     inlines = [LearningResourceRunInline]
 
 
@@ -98,7 +127,8 @@ class ProgramAdmin(admin.ModelAdmin):
     list_filter = ("offered_by",)
     list_display = ("title", "short_description", "offered_by")
     search_fields = ("title", "short_description")
-    inlines = [ProgramItemInline]
+    autocomplete_fields = ("topics",)
+    inlines = [ProgramItemInline, LearningResourceRunInline]
 
 
 class UserListAdmin(admin.ModelAdmin):
@@ -111,6 +141,9 @@ class UserListAdmin(admin.ModelAdmin):
     inlines = [UserListItemInline]
 
 
+admin.site.register(CourseTopic, CourseTopicAdmin)
+admin.site.register(CoursePrice, CoursePriceAdmin)
+admin.site.register(CourseInstructor, CourseInstructorAdmin)
 admin.site.register(Course, CourseAdmin)
 admin.site.register(LearningResourceRun, LearningResourceRunAdmin)
 admin.site.register(Bootcamp, BootcampAdmin)

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -100,6 +100,7 @@ def _transform_course(course):
                 course["courseruns"],
             )
         ),
+        "topics": course.get("topics", []),
         "runs": [_transform_run(course_run) for course_run in course["courseruns"]],
     }
 

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -134,6 +134,7 @@ def transform_programs(programs):
                 program["current_price"]
             ),  # a program is only considered published if it has a product/price
             "url": program["url"],
+            "topics": program.get("topics", []),
             "runs": [
                 {
                     "prices": [{"price": program["current_price"], "mode": ""}]
@@ -150,6 +151,10 @@ def transform_programs(programs):
                     "offered_by": OfferedBy.xpro.value,
                     "title": program["title"],
                     "short_description": program["description"],
+                    "instructors": [
+                        {"full_name": instructor["name"]}
+                        for instructor in program.get("instructors", [])
+                    ],
                 }
             ],
             "courses": [_transform_course(course) for course in program["courses"]],

--- a/course_catalog/etl/xpro_test.py
+++ b/course_catalog/etl/xpro_test.py
@@ -176,6 +176,7 @@ def test_xpro_transform_courses(mock_xpro_courses_data):
                     course_data["courseruns"],
                 )
             ),
+            "topics": course_data.get("topics", []),
             "runs": [
                 {
                     "run_id": course_run_data["courseware_id"],

--- a/course_catalog/etl/xpro_test.py
+++ b/course_catalog/etl/xpro_test.py
@@ -83,6 +83,7 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
             "offered_by": OfferedBy.xpro.value,
             "published": bool(program_data["current_price"]),
             "url": program_data["url"],
+            "topics": program_data.get("topics", []),
             "runs": [
                 {
                     "run_id": program_data["readable_id"],
@@ -97,6 +98,10 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
                     "prices": [{"price": program_data["current_price"], "mode": ""}]
                     if program_data["current_price"]
                     else [],
+                    "instructors": [
+                        {"full_name": instructor["name"]}
+                        for instructor in program_data.get("instructors", [])
+                    ],
                     "title": program_data["title"],
                     "short_description": program_data["description"],
                     "offered_by": OfferedBy.xpro.value,
@@ -116,6 +121,7 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
                             course_data["courseruns"],
                         )
                     ),
+                    "topics": course_data.get("topics", []),
                     "runs": [
                         {
                             "run_id": course_run_data["courseware_id"],

--- a/course_catalog/models.py
+++ b/course_catalog/models.py
@@ -21,6 +21,9 @@ class CourseInstructor(TimestampedModel):
     last_name = models.CharField(max_length=128, null=True, blank=True)
     full_name = models.CharField(max_length=256, null=True, blank=True)
 
+    def __str__(self):
+        return self.full_name or " ".join((self.first_name, self.last_name))
+
 
 class CourseTopic(TimestampedModel):
     """
@@ -28,6 +31,9 @@ class CourseTopic(TimestampedModel):
     """
 
     name = models.CharField(max_length=128, unique=True)
+
+    def __str__(self):
+        return self.name
 
 
 class CoursePrice(TimestampedModel):
@@ -38,6 +44,9 @@ class CoursePrice(TimestampedModel):
     price = models.DecimalField(decimal_places=2, max_digits=6)
     mode = models.CharField(max_length=128)
     upgrade_deadline = models.DateTimeField(null=True)
+
+    def __str__(self):
+        return "${:,.2f}".format(self.price)
 
 
 class LearningResource(TimestampedModel):

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -47,27 +47,10 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
   const url = selectedRun && selectedRun.url ? selectedRun.url : object.url
   const cost = selectedRun ? minPrice(selectedRun.prices) : null
 
-  let instructors = []
-  if (object.object_type === LR_TYPE_PROGRAM) {
-    instructors = Array.from(
-      new Set(
-        R.flatten(
-          // $FlowFixMe: programs have items
-          object.items.map(item =>
-            item.content_data.runs.map(objectRun =>
-              objectRun.instructors.map(instructor =>
-                getInstructorName(instructor)
-              )
-            )
-          )
-        )
-      )
-    )
-  } else if (selectedRun && selectedRun.instructors) {
-    instructors = selectedRun.instructors.map(instructor =>
-      getInstructorName(instructor)
-    )
-  }
+  const instructors =
+    selectedRun && selectedRun.instructors
+      ? selectedRun.instructors.map(instructor => getInstructorName(instructor))
+      : []
 
   return (
     <div className="expanded-course-summary">

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -206,37 +206,22 @@ describe("ExpandedLearningResourceDisplay", () => {
     })
   })
 
-  it("should display all instructors for the course", () => {
-    const wrapper = render()
-    const instructorText = wrapper
-      .find(".school")
-      .at(1)
-      .closest(".course-info-row")
-      .find(".course-info-value")
-      .text()
-    // $FlowFixMe: course run won't be null here
-    bestRun(course.runs).instructors.forEach(instructor => {
-      assert.ok(instructorText.includes(getInstructorName(instructor)))
-    })
-  })
-
-  it("should display all instructors for the program", () => {
-    const object = makeLearningResource(LR_TYPE_PROGRAM)
-    // $FlowFixMe
-    const wrapper = render({
-      object
-    })
-    const instructorText = wrapper
-      .find(".school")
-      .at(1)
-      .closest(".course-info-row")
-      .find(".course-info-value")
-      .text()
-    object.items.forEach(item => {
-      item.content_data.runs.forEach(courseRun => {
-        courseRun.instructors.forEach(instructor => {
-          assert.ok(instructorText.includes(getInstructorName(instructor)))
-        })
+  //
+  ;[LR_TYPE_PROGRAM, LR_TYPE_COURSE, LR_TYPE_BOOTCAMP].forEach(objectType => {
+    it(`should display all instructors for the ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({
+        object
+      })
+      const instructorText = wrapper
+        .find(".school")
+        .at(1)
+        .closest(".course-info-row")
+        .find(".course-info-value")
+        .text()
+      // $FlowFixMe: course run won't be null here
+      bestRun(object.runs).instructors.forEach(instructor => {
+        assert.ok(instructorText.includes(getInstructorName(instructor)))
       })
     })
   })

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -184,7 +184,7 @@ export const getStartDate = (
 
 export const getInstructorName = (instructor: CourseInstructor) => {
   if (instructor.full_name) {
-    return `Prof. ${instructor.full_name}`
+    return instructor.full_name // Assume full name contains title if any
   } else if (instructor.first_name && instructor.last_name) {
     return `Prof. ${instructor.first_name} ${instructor.last_name}`
   } else if (instructor.last_name) {

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -376,10 +376,7 @@ describe("Course run availability utils", () => {
       { first_name: "Joe", last_name: "Smith", full_name: "" },
       "Prof. Joe Smith"
     ],
-    [
-      { first_name: "Joe", last_name: "", full_name: "Joe Smith" },
-      "Prof. Joe Smith"
-    ]
+    [{ first_name: "Joe", last_name: "", full_name: "Joe Smith" }, "Joe Smith"]
   ].forEach(([input, expected]) => {
     it(`getInstructorName should return ${expected} when given ${input.toString()}`, () => {
       assert.equal(getInstructorName(input), expected)

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -428,7 +428,10 @@ export const buildSearchQuery = ({
       }
       : {}
 
-    if (text && [LR_TYPE_BOOTCAMP, LR_TYPE_COURSE].includes(type)) {
+    if (
+      text &&
+      [LR_TYPE_BOOTCAMP, LR_TYPE_COURSE, LR_TYPE_PROGRAM].includes(type)
+    ) {
       matchQuery.should.push({
         nested: {
           path:  "runs",

--- a/test_json/xpro_programs.json
+++ b/test_json/xpro_programs.json
@@ -10,6 +10,7 @@
     "start_date": "2019-09-01T00:00:00Z",
     "end_date": "2019-12-01T00:00:00Z",
     "enrollment_start": "2019-08-01T00:00:00Z",
+    "topics": ["Engineering", "Planning"],
     "courses": [
       {
         "id": 18,
@@ -18,7 +19,8 @@
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB1",
         "courseruns": [],
-        "next_run_id": null
+        "next_run_id": null,
+        "topics": ["Engineering"]
       },
       {
         "id": 20,
@@ -26,6 +28,7 @@
         "description": "<p>Course 3 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program. This course may be taken individually, without enrolling in the professional certificate program.</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB3",
+        "topics": [],
         "courseruns": [
           {
             "title": "SEED Model-Based Systems Engineering: Documentation and Analysis - Fall 2020",
@@ -50,6 +53,7 @@
         "description": "<p>Course 2 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program. This course may be taken individually, without enrolling in the professional certificate program.</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB2",
+        "topics": ["Planning"],
         "courseruns": [
           {
             "title": "SEED Models in Engineering - Spring 2020",
@@ -75,7 +79,8 @@
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB4",
         "courseruns": [],
-        "next_run_id": null
+        "next_run_id": null,
+        "topics": []
       }
     ]
   },
@@ -90,6 +95,7 @@
     "start_date": "2019-09-10T00:00:00Z",
     "end_date": "2019-12-10T00:00:00Z",
     "enrollment_start": null,
+    "topics": ["Education", "Computer Science"],
     "courses": [
       {
         "id": 30,
@@ -97,6 +103,7 @@
         "description": "<p>An introductory course to Digital Learning</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+DgtlLearn1",
+        "topics": ["Education", "Computer Science"],
         "courseruns": [
           {
             "title": "SEED Digital Learning 100 - August 2020",
@@ -144,7 +151,8 @@
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+DgtlLearn2",
         "courseruns": [],
-        "next_run_id": null
+        "next_run_id": null,
+        "topics": ["Education", "Computer Science"]
       },
       {
         "id": 32,
@@ -153,7 +161,8 @@
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+DgtlLearn3",
         "courseruns": [],
-        "next_run_id": null
+        "next_run_id": null,
+        "topics": []
       }
     ]
   }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2256 

#### What's this PR do?
- Imports xPro program topics and instructors
- Makes program instructors searchable
- Enables autocomplete for topics, instructors fields in django admin

#### How should this be manually tested?
- Set `XPRO_CATALOG_API_URL` to an instance of xpro with programs that have instructors and prices.
- Run `course_catalog.tasks.get_xpro_data()`
- Verify that the imported xpro programs have the correct topics, and the program runs have correct instructors and prices.
- Go to `courses/search` filter by program, and search for a particular instructor you know is in a program.  That program should be at the top of results.
- Click on one of those programs, the instructors and topics should be shown in the drawer.
