### PR TITLE
Add instructors, topics, and program prices to micromasters ETL transform

### DIFF
--- a/course_catalog/etl/micromasters.py
+++ b/course_catalog/etl/micromasters.py
@@ -34,8 +34,17 @@ def transform(programs):
                     "platform": PlatformType.micromasters.value,
                     "title": program["title"],
                     "offered_by": OfferedBy.micromasters.value,
+                    "instructors": [
+                        {"full_name": instructor["name"]}
+                        for instructor in program["instructors"]
+                    ],
+                    "prices": [{"price": program["total_price"]}],
+                    "start_date": program["start_date"],
+                    "end_date": program["end_date"],
+                    "enrollment_start": program["enrollment_start"],
                 }
             ],
+            "topics": program["topics"],
             # all we need for course data is the relative positioning of courses by course_id
             "courses": [
                 {

--- a/course_catalog/etl/micromasters.py
+++ b/course_catalog/etl/micromasters.py
@@ -42,6 +42,9 @@ def transform(programs):
                     "start_date": program["start_date"],
                     "end_date": program["end_date"],
                     "enrollment_start": program["enrollment_start"],
+                    "best_start_date": program["enrollment_start"]
+                    or program["start_date"],
+                    "best_end_date": program["end_date"],
                 }
             ],
             "topics": program["topics"],

--- a/course_catalog/etl/micromasters_test.py
+++ b/course_catalog/etl/micromasters_test.py
@@ -109,6 +109,8 @@ def test_micromasters_transform(mock_micromasters_data):
                     "start_date": "2019-10-04T20:13:26.367297Z",
                     "end_date": None,
                     "enrollment_start": "2019-09-29T20:13:26.367297Z",
+                    "best_start_date": "2019-09-29T20:13:26.367297Z",
+                    "best_end_date": None,
                 }
             ],
             "topics": [{"name": "program"}, {"name": "first"}],
@@ -142,6 +144,8 @@ def test_micromasters_transform(mock_micromasters_data):
                     "start_date": None,
                     "end_date": "2019-10-04T20:14:50.271027Z",
                     "enrollment_start": None,
+                    "best_start_date": None,
+                    "best_end_date": "2019-10-04T20:14:50.271027Z",
                 }
             ],
             "topics": [{"name": "program"}, {"name": "second"}],

--- a/course_catalog/etl/micromasters_test.py
+++ b/course_catalog/etl/micromasters_test.py
@@ -20,6 +20,15 @@ def mock_micromasters_data():
                 {"edx_key": "2", "position_in_program": 2, "extra_field": "value"},
                 {"edx_key": "1", "position_in_program": 1, "extra_field": "value"},
             ],
+            "instructors": [
+                {"name": "Dr. Doofenshmirtz"},
+                {"name": "Joey Jo Jo Shabadoo"},
+            ],
+            "topics": [{"name": "program"}, {"name": "first"}],
+            "total_price": "123.45",
+            "start_date": "2019-10-04T20:13:26.367297Z",
+            "end_date": None,
+            "enrollment_start": "2019-09-29T20:13:26.367297Z",
         },
         {
             "id": 2,
@@ -31,6 +40,12 @@ def mock_micromasters_data():
                 {"edx_key": "3", "position_in_program": 1, "extra_field": "value"},
                 {"edx_key": "4", "position_in_program": 2, "extra_field": "value"},
             ],
+            "instructors": [{"name": "Mia"}, {"name": "Leah"}],
+            "topics": [{"name": "program"}, {"name": "second"}],
+            "start_date": None,
+            "end_date": "2019-10-04T20:14:50.271027Z",
+            "enrollment_start": None,
+            "total_price": "87.65",
         },
     ]
 
@@ -86,8 +101,17 @@ def test_micromasters_transform(mock_micromasters_data):
                     "platform": PlatformType.micromasters.value,
                     "title": "program title 1",
                     "offered_by": OfferedBy.micromasters.value,
+                    "instructors": [
+                        {"full_name": "Dr. Doofenshmirtz"},
+                        {"full_name": "Joey Jo Jo Shabadoo"},
+                    ],
+                    "prices": [{"price": "123.45"}],
+                    "start_date": "2019-10-04T20:13:26.367297Z",
+                    "end_date": None,
+                    "enrollment_start": "2019-09-29T20:13:26.367297Z",
                 }
             ],
+            "topics": [{"name": "program"}, {"name": "first"}],
         },
         {
             "program_id": 2,
@@ -113,7 +137,13 @@ def test_micromasters_transform(mock_micromasters_data):
                     "platform": PlatformType.micromasters.value,
                     "title": "program title 2",
                     "offered_by": OfferedBy.micromasters.value,
+                    "instructors": [{"full_name": "Mia"}, {"full_name": "Leah"}],
+                    "prices": [{"price": "87.65"}],
+                    "start_date": None,
+                    "end_date": "2019-10-04T20:14:50.271027Z",
+                    "enrollment_start": None,
                 }
             ],
+            "topics": [{"name": "program"}, {"name": "second"}],
         },
     ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2281 

#### What's this PR do?
Updates micromasters ETL transformation to handle new fields added

#### How should this be manually tested?
Make sure `MICROMASTERS_CATALOG_API_URL` is set properly.

Open a Django shell and run:

    from course_catalog.etl.pipelines import *
    programs = micromasters_etl()

Go to `/api/v0/catalog/` on your micromasters instance and then verify that:
 - `programs` in the shell matches the programs in the catalog API
 - For a program run `[topic.name for topic in program.topics.all()]` and verify that the topics match the catalog API
 - Run `[instructor.full_name for instructor in program.runs.first().instructors.all()]` for some `program` and verify that the instructors match the catalog API output
 - Run `program.runs.first().start_date` (and `end_date` and `enrollment_start`) and verify that they match
 - Finally, verify that `[price.price for price in program.runs.first().prices.all()]` has one result matching the price in the catalog API for that program.