### PR TITLE
only show/hide course search facet options when there are a lot of them

### DIFF
--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -11,9 +11,11 @@ type Props = {|
   title: string,
   currentlySelected: Array<string>,
   labelFunction?: Function,
-  onUpdate: Function,
-  displayCount?: number
+  onUpdate: Function
 |}
+
+const MAX_DISPLAY_COUNT = 5
+const FACET_COLLAPSE_THRESHOLD = 15
 
 function SearchFacet(props: Props) {
   const {
@@ -22,11 +24,8 @@ function SearchFacet(props: Props) {
     results,
     currentlySelected,
     labelFunction,
-    onUpdate,
-    displayCount
+    onUpdate
   } = props
-  const maxCount = displayCount || 5
-
   const [showFacetList, setShowFacetList] = useState(true)
   const [showAllFacets, setShowAllFacets] = useState(false)
 
@@ -46,52 +45,50 @@ function SearchFacet(props: Props) {
           const isChecked = R.contains(facet.key, currentlySelected || [])
 
           return (
-            <React.Fragment key={i}>
-              <div
-                className={`${
-                  showAllFacets || i < maxCount
-                    ? "facet-visible"
-                    : "facet-hidden"
-                } ${isChecked ? "checked" : ""}`}
-                onClick={() => {
-                  onUpdate({
-                    target: {
-                      name,
-                      value:   facet.key,
-                      checked: !isChecked
-                    }
-                  })
-                }}
-              >
-                <input
-                  type="checkbox"
-                  name={name}
-                  value={facet.key}
-                  checked={isChecked}
-                  onChange={onUpdate}
-                />
-                <div className="facet-label-div">
-                  <div className="facet-key">
-                    {labelFunction ? labelFunction(facet.key) : facet.key}
-                  </div>
-                  <div className="facet-count">{facet.doc_count}</div>
+            <div
+              key={i}
+              className={`${
+                showAllFacets ||
+                  i < MAX_DISPLAY_COUNT ||
+                  results.buckets.length < FACET_COLLAPSE_THRESHOLD
+                  ? "facet-visible"
+                  : "facet-hidden"
+              } ${isChecked ? "checked" : ""}`}
+              onClick={() => {
+                onUpdate({
+                  target: {
+                    name,
+                    value:   facet.key,
+                    checked: !isChecked
+                  }
+                })
+              }}
+            >
+              <input
+                type="checkbox"
+                name={name}
+                value={facet.key}
+                checked={isChecked}
+                onChange={onUpdate}
+              />
+              <div className="facet-label-div">
+                <div className="facet-key">
+                  {labelFunction ? labelFunction(facet.key) : facet.key}
                 </div>
+                <div className="facet-count">{facet.doc_count}</div>
               </div>
-              {(!showAllFacets &&
-                  i === maxCount &&
-                  maxCount < results.buckets.length) ||
-                (showAllFacets && i === results.buckets.length - 1) ? (
-                  <div
-                    className="facet-more-less"
-                    onClick={() => setShowAllFacets(!showAllFacets)}
-                  >
-                    {showAllFacets ? "View less" : "View more"}
-                  </div>
-                ) : null}
-            </React.Fragment>
+            </div>
           )
         })
         : null}
+      {results && results.buckets.length >= FACET_COLLAPSE_THRESHOLD ? (
+        <div
+          className="facet-more-less"
+          onClick={() => setShowAllFacets(!showAllFacets)}
+        >
+          {showAllFacets ? "View less" : "View more"}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -3,6 +3,7 @@ import React from "react"
 import { assert } from "chai"
 import { mount } from "enzyme"
 import * as sinon from "sinon"
+import R from "ramda"
 
 import SearchFacet from "./SearchFacet"
 
@@ -74,11 +75,26 @@ describe("SearchFacet", () => {
     sinon.assert.calledWith(labelStub, facet["key"])
   })
 
-  it("should have a button to show / hide all facets", () => {
-    const wrapper = renderSearchFacet({ displayCount: 1 })
-    assert.equal(wrapper.find(".facet-more-less").text(), "View more")
-    wrapper.find(".facet-more-less").simulate("click")
-    assert.equal(wrapper.find(".facet-more-less").text(), "View less")
+  //
+  ;[[2, false], [20, true]].forEach(([numBuckets, shouldShowExpansionUI]) => {
+    it(`${shouldIf(shouldShowExpansionUI)} show hide/show button when ${String(
+      numBuckets
+    )} buckets`, () => {
+      // $FlowFixMe: who cares it's a test
+      results.buckets = R.times(
+        () => ({ key: "Physics", doc_count: 32 }),
+        numBuckets
+      )
+
+      const wrapper = renderSearchFacet()
+      if (shouldShowExpansionUI) {
+        assert.equal(wrapper.find(".facet-more-less").text(), "View more")
+        wrapper.find(".facet-more-less").simulate("click")
+        assert.equal(wrapper.find(".facet-more-less").text(), "View less")
+      } else {
+        assert.isNotOk(wrapper.find(".facet-more-less").exists())
+      }
+    })
   })
 
   it("should have a button to show / hide the facet list", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2287

#### What's this PR do?

This PR fixes a small UI weirdness, which is that currently we show the show more / show less UI for any search facet where we have more than 5 options. Thus, if there are six options there is a strange case where clicking "show more" only causes you to see one more option...

Anyhow, this fixes the issue by changing things around so that we now only show this UI if the list of options is a bit longer, currently 15. Maybe we want just 10 instead? idk, up for debate. But anyhow, with this change that UI should only be shown for our longer option lists, namely the subjects, and shouldn't be used for any of the others.

#### How should this be manually tested?

Make sure that the behavior described above is there and that I haven't introduced any bugs, haha.


#### Screenshots (if appropriate)

![cccasdfasdfnfasdfasdf](https://user-images.githubusercontent.com/6207644/66857165-af5e6080-ef54-11e9-98c7-ea2516acef2d.png)
![cccasdfasdfnf](https://user-images.githubusercontent.com/6207644/66857166-af5e6080-ef54-11e9-8a7f-5f3b38ca62d7.png)

![cccasdfasdfnfasdfasdfmob](https://user-images.githubusercontent.com/6207644/66857170-b2f1e780-ef54-11e9-96fa-a4c4d923d4d9.png)
![cccasdfasdfnfasdfasdfmobexpfff](https://user-images.githubusercontent.com/6207644/66857184-b6856e80-ef54-11e9-824d-ae087896876e.png)

