### PR TITLE
apply text style on hover to facet options

### DIFF
--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -162,7 +162,8 @@
         color: $font-grey-mid;
       }
 
-      &.checked {
+      &.checked,
+      &:hover {
         font-size: 16px;
         font-weight: bold;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

this just makes a small CSS tweak that @abdulkdawson requested. basically, we just want to apply the same style to our facet options on `:hover` that we currently applying when they're checked / selected.

#### How should this be manually tested?

If you go to the course search page and hover your cursor over an option it should turn blue, haha. that's it!


#### Screenshots (if appropriate)

![hovering_000](https://user-images.githubusercontent.com/6207644/66872876-fd835c00-ef74-11e9-80f5-265fff6c4f11.png)
