### PR TITLE
Don't show any results if no text matches are found

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -151,7 +151,7 @@ export const RESOURCE_QUERY_NESTED_FIELDS = [
   "runs.year",
   "runs.semester",
   "runs.level",
-  "runs.instructors"
+  "runs.instructors^5"
 ]
 
 const LIST_QUERY_FIELDS = [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2293 

#### What's this PR do?
Modifies ES search query so that it returns no results if a text query like 'sdhfjsdhfksdjfhsk' has no matches.

#### How should this be manually tested?
Make sure search returns expected matches:
- "6.002x" returns "Circuits and Electronics" MITx course as 1st result
- "Aerospace Engineering" returns a course with that in the title as 1st result
- "Capozzola" returns a MITx course with Christopher Capozzola as instructor
- "sjdkfjslfkjsldfkjsdlfks" returns nothing

#### Any background context you want to provide?
The text clauses had to be added to the ES query twice: in the original location (which adjusts the result scores based on closeness of match but doesn't exclude non-matching results), and in the "filter -> must" query (which excludes non-matching results but does not score the results returned).
Also boosted some additional fields (title, short description, instructors).
