### PR TITLE
fix a bug with the Cell component

### DIFF
--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -71,7 +71,7 @@ export const Cell = ({
     return () => {
       window.removeEventListener("resize", setState)
     }
-  })
+  }, [])
 
   return (
     <div


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

this fixes a little issue with the `Cell` component - basically, it uses a `setState` call and a `resize` event listener to ensure that the component is responsive. the issue, though, is that currently on master this event listener is added, and the old one remove, on, uh, every single render :woman_facepalming: 

so basically I fixed it to set the event listener on mount and remove it on unmount. checkout the docs for the `useEffect` hook for details: https://reactjs.org/docs/hooks-reference.html#useeffect

basically, the hook looks like this:

```js
useEffect(() => {
  someSideEffect()
}, [ props ])
```
where the second argument (the array) is an array of props which should re-trigger the effect when they change. so if you pass a `[]` as that argument that indicates the effect should only run once.

one other aspect of this hook: if you return a function from the callback function that the hook wraps this function is considered as a "cleanup" function, and is called at the end of the effect lifecycle.

#### How should this be manually tested?

you can add some log statements to see when these callbacks are being called, it should only be when a new `Cell` component is being rendered or being unmounted.
