### PR TITLE
hide empty facets

### DIFF
--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -31,7 +31,7 @@ function SearchFacet(props: Props) {
 
   const titleLineIcon = showFacetList ? "arrow_drop_down" : "arrow_drop_up"
 
-  return (
+  return results && results.buckets && results.buckets.length === 0 ? null : (
     <div className="facets">
       <div
         className="filter-section-title"
@@ -40,54 +40,58 @@ function SearchFacet(props: Props) {
         {title}
         <i className={`material-icons ${titleLineIcon}`}>{titleLineIcon}</i>
       </div>
-      {results && results.buckets && showFacetList
-        ? results.buckets.map((facet, i) => {
-          const isChecked = R.contains(facet.key, currentlySelected || [])
+      {showFacetList ? (
+        <React.Fragment>
+          {results && results.buckets
+            ? results.buckets.map((facet, i) => {
+              const isChecked = R.contains(facet.key, currentlySelected || [])
 
-          return (
-            <div
-              key={i}
-              className={`${
-                showAllFacets ||
-                  i < MAX_DISPLAY_COUNT ||
-                  results.buckets.length < FACET_COLLAPSE_THRESHOLD
-                  ? "facet-visible"
-                  : "facet-hidden"
-              } ${isChecked ? "checked" : ""}`}
-              onClick={() => {
-                onUpdate({
-                  target: {
-                    name,
-                    value:   facet.key,
-                    checked: !isChecked
-                  }
-                })
-              }}
-            >
-              <input
-                type="checkbox"
-                name={name}
-                value={facet.key}
-                checked={isChecked}
-                onChange={onUpdate}
-              />
-              <div className="facet-label-div">
-                <div className="facet-key">
-                  {labelFunction ? labelFunction(facet.key) : facet.key}
+              return (
+                <div
+                  key={i}
+                  className={`${
+                    showAllFacets ||
+                      i < MAX_DISPLAY_COUNT ||
+                      results.buckets.length < FACET_COLLAPSE_THRESHOLD
+                      ? "facet-visible"
+                      : "facet-hidden"
+                  } ${isChecked ? "checked" : ""}`}
+                  onClick={() => {
+                    onUpdate({
+                      target: {
+                        name,
+                        value:   facet.key,
+                        checked: !isChecked
+                      }
+                    })
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    name={name}
+                    value={facet.key}
+                    checked={isChecked}
+                    onChange={onUpdate}
+                  />
+                  <div className="facet-label-div">
+                    <div className="facet-key">
+                      {labelFunction ? labelFunction(facet.key) : facet.key}
+                    </div>
+                    <div className="facet-count">{facet.doc_count}</div>
+                  </div>
                 </div>
-                <div className="facet-count">{facet.doc_count}</div>
-              </div>
+              )
+            })
+            : null}
+          {results && results.buckets.length >= FACET_COLLAPSE_THRESHOLD ? (
+            <div
+              className="facet-more-less"
+              onClick={() => setShowAllFacets(!showAllFacets)}
+            >
+              {showAllFacets ? "View less" : "View more"}
             </div>
-          )
-        })
-        : null}
-      {results && results.buckets.length >= FACET_COLLAPSE_THRESHOLD ? (
-        <div
-          className="facet-more-less"
-          onClick={() => setShowAllFacets(!showAllFacets)}
-        >
-          {showAllFacets ? "View less" : "View more"}
-        </div>
+          ) : null}
+        </React.Fragment>
       ) : null}
     </div>
   )

--- a/static/js/components/SearchFacet_test.js
+++ b/static/js/components/SearchFacet_test.js
@@ -49,6 +49,13 @@ describe("SearchFacet", () => {
     assert.equal(checkbox.prop("value"), facet["key"])
   })
 
+  it("should return null when the buckets are empty", () => {
+    // $FlowFixMe
+    results.buckets = []
+    const wrapper = renderSearchFacet()
+    assert.isFalse(wrapper.isEmpty())
+  })
+
   it("checkbox should call onUpdate when clicked", () => {
     const wrapper = renderSearchFacet()
     const event = { target: { checked: true, name: name, value: facet["key"] } }
@@ -102,6 +109,15 @@ describe("SearchFacet", () => {
     assert.ok(wrapper.find(".facet-visible").exists())
     wrapper.find(".filter-section-title").simulate("click")
     assert.isNotOk(wrapper.find(".facet-visible").exists())
+  })
+
+  it("should hide the expansion UI when the facet is closed", () => {
+    // $FlowFixMe: who cares it's a test
+    results.buckets = R.times(() => ({ key: "Physics", doc_count: 32 }), 20)
+    const wrapper = renderSearchFacet()
+    assert.isOk(wrapper.find(".facet-more-less").exists())
+    wrapper.find(".filter-section-title").simulate("click")
+    assert.isNotOk(wrapper.find(".facet-more-less").exists())
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2298
closes #2318

#### What's this PR do?

this simply hides a search facet on the course search page if there aren't any options for that facet, so that the user isn't presented with an option they can't do anything with.

this also ensures that when a facet is collapsed we don't accidentally show the "View Less" / "View More" UI.

#### How should this be manually tested?

play around and make sure that the behavior described above works and there are no weird bug.



#### Screenshots (if appropriate)

![exampamob](https://user-images.githubusercontent.com/6207644/67224626-9c89d700-f3ff-11e9-8f60-d38d2f20e463.png)
![exampallthere](https://user-images.githubusercontent.com/6207644/67224627-9c89d700-f3ff-11e9-9bfb-a621f2b985f0.png)
![exampleasdf](https://user-images.githubusercontent.com/6207644/67224629-9c89d700-f3ff-11e9-8646-bb560941922a.png)
![example](https://user-images.githubusercontent.com/6207644/67224630-9c89d700-f3ff-11e9-9d96-4d0bee854149.png)
