### PR TITLE
add list view page

### DIFF
--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -8,7 +8,7 @@ import App from "./pages/App"
 import withTracker from "./util/withTracker"
 import ScrollToTop from "./components/ScrollToTop"
 
-import { getQueries } from "./lib/redux-query"
+import { getQueries } from "./lib/redux_query"
 
 import type { Store } from "redux"
 

--- a/static/js/components/CourseToolbar.js
+++ b/static/js/components/CourseToolbar.js
@@ -6,7 +6,10 @@ import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
 
 import MITLogoLink from "./MITLogoLink"
 import UserMenu from "./UserMenu"
-import { COURSE_URL } from "../lib/url"
+import ResponsiveWrapper from "./ResponsiveWrapper"
+
+import { TABLET, DESKTOP } from "../lib/constants"
+import { COURSE_URL, userListIndexURL } from "../lib/url"
 
 import type { Profile } from "../flow/discussionTypes"
 
@@ -57,6 +60,12 @@ export default class CourseToolbar extends React.Component<Props> {
               </div>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
+              <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
+                <Link className="user-list-link" to={userListIndexURL}>
+                  <i className="material-icons">bookmark</i>
+                  My Lists
+                </Link>
+              </ResponsiveWrapper>
               <UserMenu
                 toggleShowUserMenu={toggleShowUserMenu}
                 showUserMenu={showUserMenu}

--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -1,0 +1,61 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import R from "ramda"
+
+import Card from "./Card"
+
+import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+import {
+  CAROUSEL_IMG_WIDTH,
+  CAROUSEL_IMG_HEIGHT,
+  readableLearningResources
+} from "../lib/constants"
+
+import type { UserList } from "../flow/discussionTypes"
+
+const readableLength = (length: number) =>
+  length === 1 ? "1 Item" : `${String(length)} Items`
+
+const userListCoverImage = R.pathOr(null, [
+  "items",
+  0,
+  "content_data",
+  "image_src"
+])
+
+type Props = {
+  userList: UserList
+}
+
+export default function UserListCard(props: Props) {
+  const { userList } = props
+
+  return (
+    <Card className="user-list-card">
+      <div className="userlist-info">
+        <div className="platform">
+          {readableLearningResources[userList.object_type]}
+        </div>
+        <div className="ul-title">{userList.title}</div>
+        <div className="actions-and-count">
+          <div className="actions" />
+          <div className="count">{readableLength(userList.items.length)}</div>
+        </div>
+      </div>
+      {userList.items.length > 0 ? (
+        <img
+          src={embedlyThumbnail(
+            SETTINGS.embedlyKey,
+            userListCoverImage(userList) || defaultResourceImageURL(),
+            CAROUSEL_IMG_HEIGHT,
+            CAROUSEL_IMG_WIDTH
+          )}
+          height={CAROUSEL_IMG_HEIGHT}
+          alt={`cover image for ${userList.title}`}
+          className="cover-img"
+        />
+      ) : null}
+    </Card>
+  )
+}

--- a/static/js/components/UserListCard_test.js
+++ b/static/js/components/UserListCard_test.js
@@ -1,0 +1,72 @@
+// @flow
+import React from "react"
+import { assert } from "chai"
+import R from "ramda"
+import { shallow } from "enzyme"
+import sinon from "sinon"
+
+import UserListCard from "./UserListCard"
+
+import { makeUserList, makeUserListItem } from "../factories/learning_resources"
+import { LR_TYPE_COURSE, readableLearningResources } from "../lib/constants"
+import * as urlLib from "../lib/url"
+
+describe("UserListCard tests", () => {
+  const renderUserListCard = (props = {}) =>
+    shallow(<UserListCard userList={userList} {...props} />)
+
+  let userList, sandbox
+
+  beforeEach(() => {
+    userList = makeUserList()
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should print the list type (learning path || list)", () => {
+    assert.equal(
+      renderUserListCard()
+        .find(".platform")
+        .text(),
+      readableLearningResources[userList.object_type]
+    )
+  })
+
+  it("should put the title", () => {
+    assert.equal(
+      renderUserListCard()
+        .find(".ul-title")
+        .text(),
+      userList.title
+    )
+  })
+
+  //
+  ;[[0, "Items"], [1, "Item"], [2, "Items"], [10, "Items"]].forEach(
+    ([itemCount, expectedText]) => {
+      it(`should have a properly-formatted count of ${String(
+        itemCount
+      )} items`, () => {
+        userList.items = R.times(
+          () => makeUserListItem(LR_TYPE_COURSE),
+          itemCount
+        )
+        const text = renderUserListCard()
+          .find(".count")
+          .text()
+        assert.include(text, expectedText)
+      })
+    }
+  )
+
+  it("should render the image of the first list item", () => {
+    sandbox.stub(urlLib, "embedlyThumbnail").returns("南瓜")
+    const { src } = renderUserListCard()
+      .find("img")
+      .props()
+    assert.equal(src, "南瓜")
+  })
+})

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -1,14 +1,22 @@
 // @flow
 /* global SETTINGS:false */
 import React from "react"
-import { Link } from "react-router-dom"
+import { Link, Route } from "react-router-dom"
 
 import DropdownMenu from "./DropdownMenu"
 import ProfileImage, { PROFILE_IMAGE_SMALL } from "./ProfileImage"
 import { DropUpArrow, DropDownArrow } from "./Arrow"
+import ResponsiveWrapper from "./ResponsiveWrapper"
 
 import { isProfileComplete } from "../lib/util"
-import { profileURL, SETTINGS_URL, LOGIN_URL, REGISTER_URL } from "../lib/url"
+import {
+  profileURL,
+  userListIndexURL,
+  SETTINGS_URL,
+  LOGIN_URL,
+  REGISTER_URL
+} from "../lib/url"
+import { PHONE } from "../lib/constants"
 
 import type { Profile } from "../flow/discussionTypes"
 
@@ -33,6 +41,16 @@ export const LoggedInMenu = (props: DropdownMenuProps) => (
         <Link to={profileURL(SETTINGS.username)}>Profile</Link>
       </li>
     ) : null}
+    <ResponsiveWrapper onlyOn={[PHONE]}>
+      <Route
+        path="/courses"
+        render={() => (
+          <Link className="user-list-link" to={userListIndexURL}>
+            My Lists
+          </Link>
+        )}
+      />
+    </ResponsiveWrapper>
     <li>
       <a href="/logout">Sign Out</a>
     </li>

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -1,14 +1,15 @@
 // @flow
 import R from "ramda"
+import { createSelector } from "reselect"
 
-import { userListURL } from "../url"
-import { DEFAULT_POST_OPTIONS } from "../redux_query"
+import { userListApiURL } from "../url"
+import { DEFAULT_POST_OPTIONS, constructIdMap } from "../redux_query"
 
 import type { UserList } from "../../flow/discussionTypes"
 
 export const userListRequest = (userListId: string) => ({
   queryKey:  `userListRequest${userListId}`,
-  url:       `${userListURL}/${userListId}/`,
+  url:       `${userListApiURL}/${userListId}/`,
   transform: (userList: any) => ({
     userLists: { [userList.id]: userList }
   }),
@@ -17,10 +18,26 @@ export const userListRequest = (userListId: string) => ({
   }
 })
 
+export const userListsRequest = () => ({
+  queryKey:  "userListsRequest",
+  url:       userListApiURL,
+  transform: (body: ?{ results: Array<UserList> }) => ({
+    userLists: body ? constructIdMap(body.results) : {}
+  }),
+  update: {
+    userLists: R.merge
+  }
+})
+
+export const userListsSelector = createSelector(
+  state => state.entities.userLists,
+  userLists => userLists
+)
+
 export const favoriteUserListMutation = (userList: UserList) => ({
   queryKey: "userListMutation",
   body:     userList,
-  url:      `${userListURL}/${userList.id}/${
+  url:      `${userListApiURL}/${userList.id}/${
     userList.is_favorite ? "unfavorite" : "favorite"
   }/`,
   transform: () => {

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -2,7 +2,7 @@ import { assert } from "chai"
 
 import { userListRequest, favoriteUserListMutation } from "./user_lists"
 import { makeUserList } from "../../factories/learning_resources"
-import { userListURL } from "../url"
+import { userListApiURL } from "../url"
 
 describe("UserLists API", () => {
   let userList
@@ -13,7 +13,7 @@ describe("UserLists API", () => {
 
   it("userList request allows fetching a userList", () => {
     const request = userListRequest("fake-id")
-    assert.equal(request.url, `${userListURL}/fake-id/`)
+    assert.equal(request.url, `${userListApiURL}/fake-id/`)
     assert.deepEqual(request.transform({ id: "foobar" }), {
       userLists: {
         foobar: { id: "foobar" }
@@ -30,7 +30,7 @@ describe("UserLists API", () => {
       const mutation = favoriteUserListMutation(userList)
       assert.equal(
         mutation.url,
-        `${userListURL}/${userList.id}/${
+        `${userListApiURL}/${userList.id}/${
           isFavorite ? "unfavorite" : "favorite"
         }/`
       )

--- a/static/js/lib/redux-query.js
+++ b/static/js/lib/redux-query.js
@@ -1,4 +1,0 @@
-// @flow
-
-export const getQueries = (state: Object) => state.queries
-export const getEntities = (state: Object) => state.entities

--- a/static/js/lib/redux_query.js
+++ b/static/js/lib/redux_query.js
@@ -16,3 +16,6 @@ export const constructIdMap = (results: Array<Object>) => {
   })
   return map
 }
+
+export const getQueries = (state: Object) => state.queries
+export const getEntities = (state: Object) => state.entities

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -61,13 +61,13 @@ export const mockCourseAPIMethods = (
 ) => {
   helper.handleRequestStub
     .withArgs(upcomingCoursesURL)
-    .returns(courseListResponse(upcomingCourses || R.times(makeCourse, 10)))
+    .returns(queryListResponse(upcomingCourses || R.times(makeCourse, 10)))
   helper.handleRequestStub
     .withArgs(newCoursesURL)
-    .returns(courseListResponse(newCourses || R.times(makeCourse, 10)))
+    .returns(queryListResponse(newCourses || R.times(makeCourse, 10)))
 }
 
-export const courseListResponse = (list: Array<LearningResource>) => ({
+export const queryListResponse = (list: Array<LearningResource>) => ({
   status: 200,
   body:   {
     next:    null,

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -142,4 +142,6 @@ export const favoritesURL = "/api/v0/favorites"
 export const courseURL = "/api/v0/courses"
 export const bootcampURL = "/api/v0/bootcamps"
 export const programURL = "/api/v0/programs"
-export const userListURL = "/api/v0/userlists"
+export const userListApiURL = "/api/v0/userlists"
+
+export const userListIndexURL = "/courses/lists/"

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -31,6 +31,7 @@ import PasswordResetPage from "./auth/PasswordResetPage"
 import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
 import ChannelRouter from "./ChannelRouter"
 import CourseIndexPage from "./CourseIndexPage"
+import UserListPage from "./UserListPage"
 
 import PrivateRoute from "../components/auth/PrivateRoute"
 import Snackbar from "../components/material/Snackbar"
@@ -322,6 +323,11 @@ class App extends React.Component<Props> {
                 exact
                 path={`${match.url}courses/search`}
                 component={CourseSearchPage}
+              />
+              <Route
+                exact
+                path={`${match.url}courses/lists`}
+                component={UserListPage}
               />
             </Switch>
           ) : null}

--- a/static/js/pages/CourseIndexPage_test.js
+++ b/static/js/pages/CourseIndexPage_test.js
@@ -18,7 +18,7 @@ import {
   upcomingCoursesURL,
   newCoursesURL
 } from "../lib/url"
-import { courseListResponse } from "../lib/test_utils"
+import { queryListResponse } from "../lib/test_utils"
 import {
   makeCourse,
   makeFavoritesResponse
@@ -63,16 +63,16 @@ describe("CourseIndexPage", () => {
     }
     helper.handleRequestStub
       .withArgs(favoritesURL)
-      .returns(courseListResponse(favorites))
+      .returns(queryListResponse(favorites))
     helper.handleRequestStub
       .withArgs(featuredCoursesURL)
-      .returns(courseListResponse(featuredCourses))
+      .returns(queryListResponse(featuredCourses))
     helper.handleRequestStub
       .withArgs(upcomingCoursesURL)
-      .returns(courseListResponse(upcomingCourses))
+      .returns(queryListResponse(upcomingCourses))
     helper.handleRequestStub
       .withArgs(newCoursesURL)
-      .returns(courseListResponse(newCourses))
+      .returns(queryListResponse(newCourses))
     render = helper.configureReduxQueryRenderer(CourseIndexPage)
   })
 
@@ -108,7 +108,7 @@ describe("CourseIndexPage", () => {
   it("shouldnt render a featured carousel if featuredCourses is empty", async () => {
     helper.handleRequestStub
       .withArgs(featuredCoursesURL)
-      .returns(courseListResponse([]))
+      .returns(queryListResponse([]))
     const { wrapper } = await render()
     const carousels = wrapper.find("CourseCarousel")
     assert.lengthOf(carousels, 3)
@@ -122,7 +122,7 @@ describe("CourseIndexPage", () => {
   it("should hide the favorites carousel when empty", async () => {
     helper.handleRequestStub
       .withArgs(favoritesURL)
-      .returns(courseListResponse([]))
+      .returns(queryListResponse([]))
     const { wrapper } = await render()
     const carousels = wrapper.find("CourseCarousel")
     assert.lengthOf(carousels, 3)

--- a/static/js/pages/UserListPage.js
+++ b/static/js/pages/UserListPage.js
@@ -1,0 +1,51 @@
+// @flow
+import React from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+import { createSelector } from "reselect"
+
+import { Cell, Grid } from "../components/Grid"
+import {
+  BannerPageWrapper,
+  BannerPageHeader,
+  BannerContainer,
+  BannerImage
+} from "../components/PageBanner"
+import UserListCard from "../components/UserListCard"
+
+import { userListsRequest, userListsSelector } from "../lib/queries/user_lists"
+import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
+
+const userListsPageSelector = createSelector(
+  userListsSelector,
+  userLists =>
+    userLists ? Object.keys(userLists).map(key => userLists[key]) : null
+)
+
+export default function UserListPage() {
+  const [{ isFinished }] = useRequest(userListsRequest())
+
+  const userLists = useSelector(userListsPageSelector)
+
+  return (
+    <BannerPageWrapper>
+      <BannerPageHeader tall compactOnMobile>
+        <BannerContainer tall compactOnMobile>
+          <BannerImage src={COURSE_SEARCH_BANNER_URL} tall compactOnMobile />
+        </BannerContainer>
+      </BannerPageHeader>
+      <Grid className="main-content one-column narrow user-list-page">
+        <Cell width={12}>
+          <h1 className="my-lists">My Lists</h1>
+        </Cell>
+        {isFinished
+          ? userLists.map((list, i) => (
+            <Cell width={12} key={i}>
+              <UserListCard userList={list} />
+            </Cell>
+          ))
+          : null}
+      </Grid>
+    </BannerPageWrapper>
+  )
+}

--- a/static/js/pages/UserListPage_test.js
+++ b/static/js/pages/UserListPage_test.js
@@ -1,0 +1,40 @@
+// @flow
+import { assert } from "chai"
+
+import UserListPage from "./UserListPage"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeUserList } from "../factories/learning_resources"
+import { queryListResponse } from "../lib/test_utils"
+import { userListApiURL } from "../lib/url"
+
+describe("UserListPage tests", () => {
+  let helper, userLists, render
+
+  beforeEach(() => {
+    userLists = [makeUserList(), makeUserList(), makeUserList()]
+    helper = new IntegrationTestHelper()
+
+    helper.handleRequestStub
+      .withArgs(userListApiURL)
+      .returns(queryListResponse(userLists))
+    render = helper.configureReduxQueryRenderer(UserListPage)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should pass user lists down to user list card", async () => {
+    const { wrapper } = await render()
+    userLists.forEach((list, i) => {
+      assert.equal(
+        list,
+        wrapper
+          .find("UserListCard")
+          .at(i)
+          .prop("userList")
+      )
+    })
+  })
+})

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -9,7 +9,7 @@ import R from "ramda"
 import rootReducer from "../reducers"
 import { makeRequest } from "./network_interface"
 
-import { getQueries, getEntities } from "../lib/redux-query"
+import { getQueries, getEntities } from "../lib/redux_query"
 
 const persistConfig = {
   slicer: () => state => {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -26,7 +26,7 @@ import rootReducer from "../reducers"
 import * as utilFuncs from "../lib/util"
 import * as networkInterfaceFuncs from "../store/network_interface"
 import * as embedUtil from "../lib/embed"
-import { getQueries } from "../lib/redux-query"
+import { getQueries } from "../lib/redux_query"
 import * as storeLib from "../store/configureStore"
 
 import type { Sandbox } from "../flow/sinonTypes"

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -70,7 +70,8 @@ button.compact {
   }
 }
 
-button.blue-btn {
+button.blue-btn,
+a.blue-btn {
   color: white;
   background-color: $course-blue;
 }

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -17,6 +17,22 @@
       margin-left: 8px;
     }
   }
+
+  .user-menu-section {
+    max-width: 200px;
+    justify-content: space-between;
+    flex-grow: 1;
+
+    @include breakpoint(phone) {
+      justify-content: flex-end;
+      flex-grow: unset;
+    }
+
+    .user-list-link {
+      color: black;
+      display: flex;
+    }
+  }
 }
 
 .row {
@@ -256,6 +272,7 @@
 
     .results-count {
       margin-left: 50px;
+      margin-right: 20px;
       font-size: 14px;
       color: black;
 

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -69,6 +69,7 @@
 @import "course-searchbox";
 @import "course-filter-drawer";
 @import "truncated-text";
+@import "user-list-card";
 
 body {
   font-family: $body-font;
@@ -122,6 +123,10 @@ body {
       &.one-column {
         width: 80%;
         max-width: 950px;
+
+        &.narrow {
+          max-width: 560px;
+        }
 
         @include breakpoint(mobile) {
           width: 90%;

--- a/static/scss/user-list-card.scss
+++ b/static/scss/user-list-card.scss
@@ -1,0 +1,47 @@
+.user-list-card {
+  margin-bottom: 0;
+
+  .card-contents {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .userlist-info {
+    width: 100%;
+    margin-right: 16px;
+    display: flex;
+    flex-direction: column;
+
+    .platform {
+      font-size: 14px;
+      color: $font-grey-mid;
+      text-transform: uppercase;
+    }
+
+    .ul-title {
+      font-size: 16px;
+      color: black;
+      font-weight: bold;
+      margin-top: 5px;
+      margin-bottom: 20px;
+    }
+
+    .actions-and-count {
+      display: flex;
+      margin-top: auto;
+      justify-content: space-between;
+
+      .count {
+        font-size: 14px;
+        font-weight: 500;
+      }
+    }
+  }
+
+  .cover-img {
+    height: 100px;
+    width: 161px;
+    min-width: 161px;
+    border-radius: 3px;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2310

#### What's this PR do?

this adds a relatively basic page for showing the user lists (of all types) that a user currently has. it adds:

- a link from the search page
- the page itself
- a query for fetching it
- a UserListCard component for rendering basic info about the lists in a list format (a list of lists...)

#### How should this be manually tested?

go to `/courses/lists` and make sure there are no errors! if you don't have any user lists you'll have to make some in the admin or the console. then, they should show up here. in particular:

- you should see the basic information about them
- it should use the cover image for the first course on the list for the cover image for the list as a whole

#### Screenshots (if appropriate)

![mylistsmob](https://user-images.githubusercontent.com/6207644/67304927-927cdc80-f4c2-11e9-99b7-42360b53b05a.png)
![mylists](https://user-images.githubusercontent.com/6207644/67304928-927cdc80-f4c2-11e9-80d7-5b0b0ddc02db.png)
