### PR TITLE
Added VideoResource indexing

### DIFF
--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -363,7 +363,6 @@ class VideoResourceFactory(LearningResourceFactory):
 
     full_description = factory.Faker("text")
     image_src = factory.Faker("image_url")
-    image_description = factory.Faker("text", max_nb_chars=300)
 
     last_modified = factory.Faker("past_datetime", tzinfo=pytz.utc)
 

--- a/search/api.py
+++ b/search/api.py
@@ -120,6 +120,19 @@ def gen_user_list_id(user_list_obj):
     return "user_list_{}".format(user_list_obj.id)
 
 
+def gen_video_id(video_obj):
+    """
+    Generates the Elasticsearch document id for a VideoResource
+
+    Args:
+        video_obj (VideoResource): The VideoResource object
+
+    Returns:
+        str: The Elasticsearch document id for this object
+    """
+    return "video_{}_{}".format(video_obj.platform, video_obj.video_id)
+
+
 def is_reddit_object_removed(reddit_obj):
     """
     Indicates whether or not a given reddit object is considered to be removed by moderators

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -12,6 +12,7 @@ from search.api import (
     is_reddit_object_removed,
     gen_post_id,
     gen_comment_id,
+    gen_video_id,
     find_related_documents,
     transform_aggregates,
 )
@@ -40,12 +41,20 @@ def gen_query_filters_mock(mocker):
 
 def test_gen_post_id():
     """Test that gen_post_id returns an expected id"""
-    return gen_post_id("1") == "p_1"
+    assert gen_post_id("1") == "p_1"
 
 
 def test_gen_comment_id():
     """Test that gen_comment_id returns an expected id"""
-    return gen_comment_id("1") == "c_1"
+    assert gen_comment_id("1") == "c_1"
+
+
+def test_gen_video_id(mocker):
+    """Test that gen_video_id returns an expected id"""
+    assert (
+        gen_video_id(mocker.Mock(platform="youtube", video_id="8gjuY2"))
+        == "video_youtube_8gjuY2"
+    )
 
 
 @pytest.mark.parametrize(

--- a/search/constants.py
+++ b/search/constants.py
@@ -8,6 +8,7 @@ BOOTCAMP_TYPE = "bootcamp"
 PROGRAM_TYPE = "program"
 USER_LIST_TYPE = "user_list"
 LEARNING_PATH_TYPE = "learning_path"
+VIDEO_TYPE = "video"
 
 VALID_OBJECT_TYPES = (
     POST_TYPE,
@@ -17,5 +18,6 @@ VALID_OBJECT_TYPES = (
     BOOTCAMP_TYPE,
     PROGRAM_TYPE,
     USER_LIST_TYPE,
+    VIDEO_TYPE,
 )
 GLOBAL_DOC_TYPE = "_doc"

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -13,6 +13,7 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
+  LR_TYPE_VIDEO,
   DATE_FORMAT
 } from "../lib/constants"
 
@@ -21,7 +22,8 @@ import type {
   Course,
   LearningResourceRun,
   Program,
-  UserList
+  UserList,
+  Video
 } from "../flow/discussionTypes"
 
 const incrCourse = incrementer()
@@ -164,6 +166,21 @@ export const makeUserList = (): UserList => ({
   privacy_level: casual.random_element(["public", "private"])
 })
 
+export const makeVideo = (): Video => ({
+  id:                casual.number,
+  video_id:          `video_${String(casual.random)}`,
+  title:             casual.title,
+  url:               casual.url,
+  is_favorite:       casual.boolean,
+  image_src:         "http://image.medium.url",
+  short_description: casual.description,
+  transcript:        casual.description,
+  topics:            [casual.word, casual.word],
+  object_type:       LR_TYPE_VIDEO,
+  offered_by:        [casual.random_element([offeredBys.mitx, offeredBys.ocw])],
+  runs:              []
+})
+
 export const makeLearningResource = (objectType: string): Object => {
   switch (objectType) {
   case LR_TYPE_COURSE:
@@ -182,6 +199,8 @@ export const makeLearningResource = (objectType: string): Object => {
       { object_type: LR_TYPE_LEARNINGPATH, list_type: LR_TYPE_LEARNINGPATH },
       makeUserList()
     )
+  case LR_TYPE_VIDEO:
+    return R.merge({ object_type: LR_TYPE_VIDEO }, makeVideo())
   }
 }
 

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -10,7 +10,8 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_ALL,
-  LR_TYPE_PROGRAM
+  LR_TYPE_PROGRAM,
+  LR_TYPE_VIDEO
 } from "../lib/constants"
 
 import type {
@@ -120,6 +121,19 @@ export const makeProgramResult = (): LearningResourceResult => ({
   runs: [makeRun()]
 })
 
+export const makeVideoResult = (): LearningResourceResult => ({
+  id:                casual.number,
+  video_id:          `video_${String(casual.random)}`,
+  title:             casual.title,
+  url:               casual.url,
+  image_src:         "http://image.medium.url",
+  short_description: casual.description,
+  topics:            [casual.word, casual.word],
+  object_type:       LR_TYPE_VIDEO,
+  offered_by:        [casual.random_element([offeredBys.mitx, offeredBys.ocw])],
+  runs:              []
+})
+
 export const makeLearningResourceResult = (objectType: string) => {
   switch (objectType) {
   case LR_TYPE_COURSE:
@@ -128,6 +142,8 @@ export const makeLearningResourceResult = (objectType: string) => {
     return makeBootcampResult()
   case LR_TYPE_PROGRAM:
     return makeProgramResult()
+  case LR_TYPE_VIDEO:
+    return makeVideoResult()
   }
 }
 

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -11,7 +11,8 @@ import {
   COMMENTS_OBJECT_TYPE,
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
-  LR_TYPE_PROGRAM
+  LR_TYPE_PROGRAM,
+  LR_TYPE_VIDEO
 } from "../lib/constants"
 
 export type FormImage = {
@@ -410,6 +411,13 @@ export type UserList = LearningResource & {
   items:              Array<UserListItem>,
   list_type:          string,
   object_type:        string
+}
+
+export type Video = LearningResource & {
+  image_src:          ?string,
+  object_type:        LR_TYPE_VIDEO,
+  transcript:         ?string,
+  url:                ?string,
 }
 
 export type CoursePrice = {

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -54,12 +54,14 @@ export const LR_TYPE_BOOTCAMP = "bootcamp"
 export const LR_TYPE_PROGRAM = "program"
 export const LR_TYPE_USERLIST = "user_list"
 export const LR_TYPE_LEARNINGPATH = "learning_path"
+export const LR_TYPE_VIDEO = "video"
 export const LR_TYPE_ALL = [
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
-  LR_TYPE_LEARNINGPATH
+  LR_TYPE_LEARNINGPATH,
+  LR_TYPE_VIDEO
 ]
 
 export const readableLearningResources = {
@@ -67,7 +69,8 @@ export const readableLearningResources = {
   [LR_TYPE_BOOTCAMP]:     "Bootcamp",
   [LR_TYPE_PROGRAM]:      "Program",
   [LR_TYPE_USERLIST]:     "User List",
-  [LR_TYPE_LEARNINGPATH]: "Learning Path"
+  [LR_TYPE_LEARNINGPATH]: "Learning Path",
+  [LR_TYPE_VIDEO]:        "Video"
 }
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -26,6 +26,7 @@ import * as searchFuncs from "./search"
 import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
+  LR_TYPE_VIDEO,
   DEFAULT_START_DT
 } from "../lib/constants"
 import { LR_TYPE_PROGRAM } from "./constants"
@@ -164,7 +165,7 @@ describe("search functions", () => {
   })
 
   //
-  ;[LR_TYPE_COURSE, LR_TYPE_BOOTCAMP].forEach(objectType => {
+  ;[LR_TYPE_COURSE, LR_TYPE_BOOTCAMP, LR_TYPE_VIDEO].forEach(objectType => {
     it(`takes an overrideObject with ${objectType}`, () => {
       const result = makeLearningResourceResult(objectType)
       const object = searchResultToLearningResource(result, {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2307 

#### What's this PR do?
- Adds `VideoResource` as an indexed object type
- Adds task helper methods for #2305 
- Refactored identical implementations of `index_profiles`, `index_bootcamps`, etc into a common `index_items`

#### How should this be manually tested?
Create one or more `VideoResource`s:

```python
from course_catalog.factories import VideoResourceFactory
from search.task_helpers import upsert_video
vr1 = VideoResourceFactory.create()
upsert_video(vr1)
vr2 = VideoResourceFactory.create()
```

Ensure the only first one shows up in the search page and facets work as expected.

Then you can reindex: `./manage.py recreate_index` and ensure both videos show up now.