### PR TITLE
course search tweaks

### DIFF
--- a/static/js/components/CourseSearchbox.js
+++ b/static/js/components/CourseSearchbox.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react"
+import React, { useState } from "react"
 
 import { validationMessage } from "../lib/validation"
 
@@ -15,6 +15,8 @@ type Props = {
 export default function CourseSearchbox(props: Props) {
   const { onChange, value, onSubmit, validation, autoFocus, children } = props
 
+  const [text, setText] = useState("")
+
   return (
     <div className="course-searchbox">
       <div className="input-wrapper">
@@ -23,12 +25,23 @@ export default function CourseSearchbox(props: Props) {
           type="text"
           name="query"
           className="search-input"
-          onChange={onChange}
+          onChange={
+            onChange ||
+            (e => {
+              const { value } = e.target
+              setText(value)
+            })
+          }
           onKeyDown={event => (event.key === "Enter" ? onSubmit(event) : null)}
           placeholder="Search Learning Offerings"
           value={value}
         />
-        <i className="material-icons search-icon" onClick={onSubmit}>
+        <i
+          className="material-icons search-icon"
+          onClick={
+            onChange ? onSubmit : () => onSubmit({ target: { value: text } })
+          }
+        >
           search
         </i>
         {children}

--- a/static/js/components/CourseSearchbox_test.js
+++ b/static/js/components/CourseSearchbox_test.js
@@ -2,23 +2,28 @@
 import React from "react"
 import sinon from "sinon"
 import { assert } from "chai"
+import { mount } from "enzyme"
 
 import CourseSearchbox from "./CourseSearchbox"
 
-import { configureShallowRenderer } from "../lib/test_utils"
 import * as validationFuncs from "../lib/validation"
 
 describe("CourseSearchbox", () => {
-  let sandbox, renderSearchbox, onChangeStub, onSubmitStub
+  let sandbox, onChangeStub, onSubmitStub
+
+  const renderSearchbox = (props = {}) =>
+    mount(
+      <CourseSearchbox
+        onChange={onChangeStub}
+        onSubmit={onSubmitStub}
+        {...props}
+      />
+    )
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     onChangeStub = sandbox.stub()
     onSubmitStub = sandbox.stub()
-    renderSearchbox = configureShallowRenderer(CourseSearchbox, {
-      onChange: onChangeStub,
-      onSubmit: onSubmitStub
-    })
   })
 
   afterEach(() => {

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -47,7 +47,7 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
     objectRuns[0]
 
   const url = selectedRun && selectedRun.url ? selectedRun.url : object.url
-  const cost = selectedRun ? minPrice(selectedRun.prices) : null
+  const cost = selectedRun ? minPrice(selectedRun.prices, true) : null
 
   const offeredBy = getPreferredOfferedBy(object.offered_by)
   const instructors =

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -78,7 +78,9 @@ describe("ExpandedLearningResourceDisplay", () => {
           run.url = null
         }
         const wrapper = render({
-          object
+          object,
+          // $FlowFixMe: course run won't be null here
+          runId: run.id
         })
         const link = wrapper.find(".course-links").find("a")
         // $FlowFixMe: run won't be null
@@ -211,7 +213,9 @@ describe("ExpandedLearningResourceDisplay", () => {
     it(`should display all instructors for the ${objectType}`, () => {
       const object = makeLearningResource(objectType)
       const wrapper = render({
-        object
+        object,
+        // $FlowFixMe: course run won't be null here
+        runId: bestRun(object.runs).id
       })
       const instructorText = wrapper
         .find(".school")
@@ -239,7 +243,8 @@ describe("ExpandedLearningResourceDisplay", () => {
     )}`, () => {
       // $FlowFixMe: course run won't be null here
       bestRun(course.runs).language = langCode
-      const wrapper = render()
+      // $FlowFixMe: course run won't be null here
+      const wrapper = render({ runId: bestRun(course.runs).id })
       assert.equal(
         wrapper
           .find(".language")
@@ -275,15 +280,20 @@ describe("ExpandedLearningResourceDisplay", () => {
     it(`should display the cost for ${objectType}`, () => {
       const prices = [{ price: 25.5, mode: "" }]
       const object = makeLearningResource(objectType)
+      let run
       if (objectType === LR_TYPE_PROGRAM) {
         object.runs[0].prices = prices
+        run = object.runs[0]
       } else {
         // $FlowFixMe: bestRun result won't be null
         bestRun(object.runs).prices = prices
+        run = bestRun(object.runs)
       }
 
       const wrapper = render({
-        object
+        object,
+        // $FlowFixMe
+        runId: run.id
       })
       assert.equal(
         wrapper

--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -1,7 +1,8 @@
 // @flow
-import React, { useState, useEffect } from "react"
+import React from "react"
 
 import { isMobileGridWidth } from "../lib/util"
+import { useResponsive } from "../hooks/util"
 
 type GridProps = {
   children: any,
@@ -63,15 +64,7 @@ export const Cell = ({
   mobileWidth,
   className
 }: CellProps) => {
-  const [, setState] = useState(null)
-
-  useEffect(() => {
-    window.addEventListener("resize", setState)
-
-    return () => {
-      window.removeEventListener("resize", setState)
-    }
-  }, [])
+  useResponsive()
 
   return (
     <div

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -37,6 +37,7 @@ import { favoriteProgramMutation } from "../lib/queries/programs"
 import { favoriteUserListMutation } from "../lib/queries/user_lists"
 import { favoriteVideoMutation } from "../lib/queries/videos"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
+import { toQueryString, COURSE_SEARCH_URL } from "../lib/url"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"
 
@@ -62,7 +63,26 @@ const getClassName = searchResultLayout =>
   }`.trim()
 
 const formatTopics = (topics: Array<{ name: string }>) =>
-  topics.map(topic => topic.name).join("\u00A0\u00A0")
+  topics.map((topic, i) => (
+    <a
+      href={`${COURSE_SEARCH_URL}${toQueryString({
+        t: topic.name
+      })}`}
+      key={i}
+    >
+      {topic.name}
+    </a>
+  ))
+
+const offeredBySearchLink = offeredBy => (
+  <a
+    href={`${COURSE_SEARCH_URL}${toQueryString({
+      o: offeredBy
+    })}`}
+  >
+    {offeredBy}
+  </a>
+)
 
 const Subtitle = ({ label, content }) => (
   <div className="row subtitle">
@@ -125,7 +145,9 @@ export const LearningResourceCard = ({
         </div>
         {object.offered_by.length ? (
           <Subtitle
-            content={getPreferredOfferedBy(object.offered_by)}
+            content={offeredBySearchLink(
+              getPreferredOfferedBy(object.offered_by)
+            )}
             label="Offered by - "
           />
         ) : null}

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -21,7 +21,9 @@ import {
 import {
   embedlyThumbnail,
   starSelectedURL,
-  starUnselectedURL
+  starUnselectedURL,
+  toQueryString,
+  COURSE_SEARCH_URL
 } from "../lib/url"
 
 describe("LearningResourceCard", () => {
@@ -80,24 +82,30 @@ describe("LearningResourceCard", () => {
     )
   })
 
-  it("should render topics", () => {
-    const { content, label } = render()
+  it("should render topics as links", () => {
+    const subtitle = render()
       .find("Subtitle")
       .at(1)
-      .props()
-    course.topics.forEach(({ name }) => {
-      assert.include(content, name)
+    const links = subtitle.find("a")
+    course.topics.forEach(({ name }, i) => {
+      const link = links.at(i)
+      assert.equal(link.text(), name)
+      assert.equal(
+        link.prop("href"),
+        `${COURSE_SEARCH_URL}${toQueryString({
+          t: name
+        })}`
+      )
     })
-    assert.equal(label, "Subjects - ")
+    assert.equal(subtitle.prop("label"), "Subjects - ")
   })
 
   it("should render a single topic", () => {
     course.topics = [course.topics[0]]
-    const { content, label } = render()
+    const { label } = render()
       .find("Subtitle")
       .at(1)
       .props()
-    assert.include(content, course.topics[0].name)
     assert.equal(label, "Subject - ")
   })
 
@@ -121,9 +129,15 @@ describe("LearningResourceCard", () => {
       })
         .find("Subtitle")
         .at(0)
-
-      assert.equal(offeredBySubtitle.prop("content"), object.offered_by)
       assert.equal(offeredBySubtitle.prop("label"), "Offered by - ")
+      const link = offeredBySubtitle.find("a")
+      assert.equal(link.text(), object.offered_by)
+      assert.equal(
+        link.prop("href"),
+        `${COURSE_SEARCH_URL}${toQueryString({
+          o: object.offered_by
+        })}`
+      )
     })
   })
 

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -13,7 +13,6 @@ import { createSelector } from "reselect"
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
 import { setShowResourceDrawer } from "../actions/ui"
-import { getViewportWidth } from "../lib/util"
 import { courseRequest } from "../lib/queries/courses"
 import { bootcampRequest } from "../lib/queries/bootcamps"
 import { programRequest } from "../lib/queries/programs"
@@ -22,6 +21,7 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM
 } from "../lib/constants"
+import { useResponsive } from "../hooks/util"
 
 import type { Dispatch } from "redux"
 
@@ -35,58 +35,36 @@ type Props = {
   setShowResourceDrawer: Function
 }
 
-export class LearningResourceDrawer extends React.Component<Props> {
-  width: number
+export function LearningResourceDrawer(props: Props) {
+  const { object, runId, showLearningDrawer, setShowResourceDrawer } = props
 
-  constructor(props: Props) {
-    super(props)
-    this.width = getViewportWidth()
-  }
+  useResponsive()
 
-  componentDidMount() {
-    window.addEventListener("resize", () => this.onResize())
-  }
+  const onDrawerClose = () => setShowResourceDrawer({ objectId: null })
 
-  onResize() {
-    // this setState call forces a re-render of the component
-    // to ensure that the drawer is responsive
-    this.setState({})
-  }
-
-  render() {
-    const {
-      object,
-      runId,
-      showLearningDrawer,
-      setShowResourceDrawer
-    } = this.props
-
-    const onDrawerClose = () => setShowResourceDrawer({ objectId: null })
-
-    return object ? (
-      <Theme>
-        <Drawer
-          open={showLearningDrawer}
-          onClose={onDrawerClose}
-          dir="rtl"
-          className="align-right"
-          modal
-        >
-          <DrawerContent dir="ltr">
-            <div className="drawer-close" onClick={onDrawerClose}>
-              <i className="material-icons clear">clear</i>
-            </div>
-            <ExpandedLearningResourceDisplay
-              object={object}
-              runId={runId}
-              setShowResourceDrawer={setShowResourceDrawer}
-            />
-            <div className="footer" />
-          </DrawerContent>
-        </Drawer>
-      </Theme>
-    ) : null
-  }
+  return object ? (
+    <Theme>
+      <Drawer
+        open={showLearningDrawer}
+        onClose={onDrawerClose}
+        dir="rtl"
+        className="align-right"
+        modal
+      >
+        <DrawerContent dir="ltr">
+          <div className="drawer-close" onClick={onDrawerClose}>
+            <i className="material-icons clear">clear</i>
+          </div>
+          <ExpandedLearningResourceDisplay
+            object={object}
+            runId={runId}
+            setShowResourceDrawer={setShowResourceDrawer}
+          />
+          <div className="footer" />
+        </DrawerContent>
+      </Drawer>
+    </Theme>
+  ) : null
 }
 
 const getObject = createSelector(

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { assert } from "chai"
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 import sinon from "sinon"
 
 import {
@@ -46,12 +46,13 @@ describe("LearningResourceDrawer", () => {
   })
 
   const renderLearningResourceDrawer = (props = {}) =>
-    shallow(
+    mount(
       <LearningResourceDrawer
         dispatch={dispatchStub}
         showLearningDrawer={true}
         object={course}
         objectId={course.id}
+        runId={course.runs[0].run_id}
         objectType={LR_TYPE_COURSE}
         setShowResourceDrawer={setShowResourceDrawerStub}
         {...props}
@@ -65,15 +66,9 @@ describe("LearningResourceDrawer", () => {
   })
 
   it("should put an event listener on window resize", () => {
-    const onResizeStub = sandbox.stub(
-      LearningResourceDrawer.prototype,
-      "onResize"
-    )
     const addEventListenerStub = sandbox.stub(window, "addEventListener")
     renderLearningResourceDrawer()
-    assert.ok(addEventListenerStub.calledWith("resize"))
-    addEventListenerStub.args[0][1]()
-    assert.ok(onResizeStub.called)
+    assert.ok(addEventListenerStub.called)
   })
 
   it("should include an ExpandedLearningResourceDisplay", () => {

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -28,15 +28,14 @@ import type {
 
 const incrCourse = incrementer()
 const courseId: any = incrementer()
-const incrRun = incrementer()
+const incrRun: any = incrementer()
 
 const OFFERORS = R.values(offeredBys)
 
 export const makeRun = (): LearningResourceRun => {
   return {
-    // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
     run_id:            `courserun_${incrRun.next().value}`,
-    id:                casual.integer,
+    id:                incrRun.next().value,
     url:               casual.url,
     image_src:         "http://image.medium.url",
     short_description: casual.description,

--- a/static/js/hooks/util.js
+++ b/static/js/hooks/util.js
@@ -31,3 +31,15 @@ export const useDeviceCategory = () => {
   }
   return DESKTOP
 }
+
+export const useResponsive = () => {
+  const [, setState] = useState(null)
+
+  useEffect(() => {
+    window.addEventListener("resize", setState)
+
+    return () => {
+      window.removeEventListener("resize", setState)
+    }
+  }, [])
+}

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -167,12 +167,20 @@ export const maxPrice = (prices: Array<CoursePrice>) => {
   return price > 0 ? `${formatPrice(price)}` : "Free"
 }
 
-export const minPrice = (prices: Array<CoursePrice>) => {
+export const minPrice = (
+  prices: Array<CoursePrice>,
+  includeDollarSign: boolean = false
+) => {
   if (emptyOrNil(prices)) {
     return null
   }
   const price = Math.min(...prices.map(price => price.price))
-  return price > 0 && price !== Infinity ? `${formatPrice(price)}` : "Free"
+
+  if (price > 0 && price !== Infinity) {
+    return includeDollarSign ? `${formatPrice(price)}` : price
+  } else {
+    return "Free"
+  }
 }
 
 export const getStartDate = (

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -56,7 +56,7 @@ describe("Course utils", () => {
     [[0.0, 50.0, 25.0], "$50", "Free"],
     [[null, null], "Free", "Free"],
     [[null, 0], "Free", "Free"],
-    [[20.9, 100, 50], "$100", "$20.90"],
+    [[20.9, 100, 50], "$100", "20.90"],
     [[null, 100.23, 75], "$100.23", "Free"]
   ].forEach(([prices, expectedMax, expectedMin]) => {
     it(`minPrice, maxPrice should return ${expectedMin}, ${expectedMax} for price range ${prices.toString()}`, () => {
@@ -75,6 +75,17 @@ describe("Course utils", () => {
       assert.equal(minPrice(courseRun.prices), expectedMin)
       assert.equal(maxPrice(courseRun.prices), expectedMax)
     })
+  })
+
+  it("minPrice should return a dollar sign if you pass the flag", () => {
+    const courseRun = makeCourse().runs[0]
+    courseRun.prices = [
+      {
+        mode:  "test",
+        price: 100
+      }
+    ]
+    assert.equal(minPrice(courseRun.prices, true), "$100")
   })
 
   //

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -94,7 +94,7 @@ export default function CourseIndexPage({ history }: Props) {
           <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
             <div className="link-wrapper">
               <Link className="link-button" to={COURSE_SEARCH_URL}>
-                View All
+                Explore
               </Link>
             </div>
           </ResponsiveWrapper>
@@ -103,7 +103,7 @@ export default function CourseIndexPage({ history }: Props) {
       <ResponsiveWrapper onlyOn={[PHONE]}>
         <div className="wide-view-more">
           <Link className="link-button" to={COURSE_SEARCH_URL}>
-            View All
+            Explore
           </Link>
         </div>
       </ResponsiveWrapper>

--- a/static/scss/card.scss
+++ b/static/scss/card.scss
@@ -4,6 +4,10 @@
   border-radius: 5px;
   margin: 0 0 20px 0;
 
+  &:hover {
+    box-shadow: 3px 4px 12px 0 rgba(0, 0, 0, 0.36);
+  }
+
   .card-contents {
     margin: 0;
     padding: 20px;

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -2,6 +2,7 @@
   width: initial;
   margin-bottom: 0;
   font-family: roboto;
+  cursor: initial;
 
   &.borderless {
     .lr-info {
@@ -101,6 +102,16 @@
         text-overflow: ellipsis;
         width: 100%;
 
+        a {
+          color: black;
+          margin-right: 10px;
+
+          &:hover {
+            color: black;
+            text-decoration: underline;
+          }
+        }
+
         .grey {
           color: $font-grey-light;
         }
@@ -115,6 +126,7 @@
       .price {
         font-size: 12px;
         padding-right: 10px;
+        cursor: default;
 
         i {
           font-size: 12px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2294 

#### What's this PR do?

this does a series of tweaks to the course search page:

- remove extra dollar sign from course price (only on the card, not in the drawer)
- values in the card description for platform, topic, etc should be links to a search for that value (e.g. clicking the 'Math' subject on a course should take you to a search for the 'Math' subject')
- only the favorite button in the bottom row of the card should have a 'link' cursor
- cards all over the site should have a hover state, where a box-shadow shows up (see designs)
- course home page search 'magnifying glass' icon should redirect to search with the text the user has entered (currently this behavior happens when you hit the enter key but not when you click the little icon)
- change home page link text from "View All" to "Explore"

#### How should this be manually tested?

make sure that the above tweaks a good on mobile, desktop


#### Screenshots (if appropriate)
![topilinkffff](https://user-images.githubusercontent.com/6207644/67587567-27c9dc00-f722-11e9-936c-aec97b36417f.png)
![topilink](https://user-images.githubusercontent.com/6207644/67587568-27c9dc00-f722-11e9-88be-a50f98257cec.png)
![tweaks1fffjfjffff](https://user-images.githubusercontent.com/6207644/67587569-27c9dc00-f722-11e9-83fd-097cf6c5bd91.png)
![tweaks1fffjfj](https://user-images.githubusercontent.com/6207644/67587570-28627280-f722-11e9-8abf-267eca384335.png)
![tweaks1](https://user-images.githubusercontent.com/6207644/67587571-28627280-f722-11e9-9458-39153b8f506d.png)

