### PR TITLE
Fix favoriting of lists and paths

### DIFF
--- a/course_catalog/permissions.py
+++ b/course_catalog/permissions.py
@@ -6,6 +6,10 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from course_catalog.constants import PrivacyLevel
 
+import logging
+
+log = logging.getLogger()
+
 
 class HasUserListPermissions(BasePermission):
     """Permission to view/modify UserLists"""
@@ -16,7 +20,8 @@ class HasUserListPermissions(BasePermission):
         return not request.user.is_anonymous
 
     def has_object_permission(self, request, view, obj):
-        if request.method in SAFE_METHODS:
+        log.error(view.action)
+        if request.method in SAFE_METHODS or view.action in ("favorite", "unfavorite"):
             return (
                 obj.privacy_level == PrivacyLevel.public.value
                 or request.user == obj.author

--- a/course_catalog/permissions.py
+++ b/course_catalog/permissions.py
@@ -6,10 +6,6 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from course_catalog.constants import PrivacyLevel
 
-import logging
-
-log = logging.getLogger()
-
 
 class HasUserListPermissions(BasePermission):
     """Permission to view/modify UserLists"""
@@ -20,7 +16,6 @@ class HasUserListPermissions(BasePermission):
         return not request.user.is_anonymous
 
     def has_object_permission(self, request, view, obj):
-        log.error(view.action)
         if request.method in SAFE_METHODS or view.action in ("favorite", "unfavorite"):
             return (
                 obj.privacy_level == PrivacyLevel.public.value

--- a/course_catalog/permissions_test.py
+++ b/course_catalog/permissions_test.py
@@ -48,3 +48,26 @@ def test_userlist_object_permissions(mocker, user, is_public, is_author):
     assert HasUserListPermissions().has_object_permission(
         request, mocker.MagicMock(), userlist
     ) is (is_public or is_author)
+
+
+@pytest.mark.parametrize("action", ["favorite", "unfavorite", ""])
+@pytest.mark.parametrize("is_public", [True, False])
+@pytest.mark.parametrize("is_author", [True, False])
+def test_userlist_favorite_permissions(mocker, user, is_public, is_author, action):
+    """
+    HasUserListPermissions.has_object_permission should return correct permission depending
+    on privacy level and author when favoriting or unfavoriting.
+    """
+    userlist = UserListFactory.create(
+        author=user,
+        privacy_level=PrivacyLevel.public.value
+        if is_public
+        else PrivacyLevel.private.value,
+    )
+
+    request = mocker.MagicMock(
+        method="POST", user=(user if is_author else UserFactory.create())
+    )
+    assert HasUserListPermissions().has_object_permission(
+        request, mocker.MagicMock(action=action), userlist
+    ) is ((is_public and "favorite" in action) or is_author)

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -392,6 +392,24 @@ def test_unautharized_favorites(client, factory, route_name):
     assert resp.status_code == 403
 
 
+@pytest.mark.parametrize(
+    "privacy_level", [PrivacyLevel.public.value, PrivacyLevel.private.value]
+)
+def test_favorite_lists_other_user(user_client, privacy_level):
+    """Test favoriting and unfavoriting someone else's list"""
+    is_public = privacy_level == PrivacyLevel.public.value
+    userlist = UserListFactory.create(privacy_level=privacy_level)
+    resp = user_client.post(
+        reverse("userlists-detail", args=[userlist.id]) + "favorite/"
+    )
+    assert resp.status_code == 200 if is_public else 403
+
+    resp = user_client.post(
+        reverse("userlists-detail", args=[userlist.id]) + "unfavorite/"
+    )
+    assert resp.status_code == 200 if is_public else 403
+
+
 def test_course_report(client):
     """Test ocw course report"""
     CourseFactory.create(

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -337,12 +337,18 @@ def test_user_list_endpoint_delete(client, user, is_author):
         (ProgramFactory, "programs-detail"),
         (BootcampFactory, "bootcamps-detail"),
         (VideoFactory, "videos-detail"),
+        (UserListFactory, "userlists-detail"),
     ],
 )
 def test_favorites(user_client, factory, route_name):
     """Test favoriting and unfavoriting"""
     # Test item is not favorited by default
-    item = factory.create()
+    kwargs = (
+        {"privacy_level": PrivacyLevel.public.value}
+        if route_name == "userlists-detail"
+        else {}
+    )
+    item = factory.create(**kwargs)
     path = reverse(route_name, args=[item.id])
     resp = user_client.get(path)
     assert resp.data.get("is_favorite") is False
@@ -379,11 +385,17 @@ def test_favorites(user_client, factory, route_name):
         (ProgramFactory, "programs-detail"),
         (BootcampFactory, "bootcamps-detail"),
         (VideoFactory, "videos-detail"),
+        (UserListFactory, "userlists-detail"),
     ],
 )
 def test_unautharized_favorites(client, factory, route_name):
     """Test favoriting and unfavoriting when not logged in"""
-    item = factory.create()
+    kwargs = (
+        {"privacy_level": PrivacyLevel.public.value}
+        if route_name == "userlists-detail"
+        else {}
+    )
+    item = factory.create(**kwargs)
     path = reverse(route_name, args=[item.id])
     resp = client.post(f"{path}favorite/")
     assert resp.status_code == 403

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -26,9 +26,10 @@ import {
   CAROUSEL_IMG_HEIGHT,
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
-  LR_TYPE_USERLIST,
   LR_TYPE_PROGRAM,
   LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH,
   readableLearningResources
 } from "../lib/constants"
 import { favoriteCourseMutation } from "../lib/queries/courses"
@@ -178,7 +179,9 @@ const mapDispatchToProps = dispatch => ({
     if (payload.object_type === LR_TYPE_PROGRAM) {
       dispatch(mutateAsync(favoriteProgramMutation(payload)))
     }
-    if (payload.object_type === LR_TYPE_USERLIST) {
+    if (
+      [LR_TYPE_USERLIST, LR_TYPE_LEARNINGPATH].includes(payload.object_type)
+    ) {
       dispatch(mutateAsync(favoriteUserListMutation(payload)))
     }
     if (payload.object_type === LR_TYPE_VIDEO) {

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -40,6 +40,7 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH,
   LR_TYPE_VIDEO
 } from "../lib/constants"
 import {
@@ -330,6 +331,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
       return userLists[result.id]
     case LR_TYPE_VIDEO:
       return videos[result.id]
+    case LR_TYPE_LEARNINGPATH:
+      return userLists[result.id]
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2340 

#### What's this PR do?
- Tweaks permissions so you can favorite another person's public lists and learning paths

#### How should this be manually tested?
- Create a public learning path and public list as user A and reindex so they're included in search results.
- Log in as user B and try to favorite then unfavorite both.  

