### PR TITLE
Video data transform

### DIFF
--- a/course_catalog/etl/pipelines.py
+++ b/course_catalog/etl/pipelines.py
@@ -1,7 +1,7 @@
 """ETL pipelines"""
 from toolz import compose, first, juxt
 
-from course_catalog.etl import micromasters, loaders, mitx, xpro, ocw, oll
+from course_catalog.etl import micromasters, loaders, mitx, xpro, ocw, oll, youtube
 from course_catalog.etl.utils import log_exceptions
 
 # A few notes on how this module works:
@@ -45,3 +45,5 @@ mitx_etl = compose(
 )
 
 oll_etl = compose(loaders.load_courses, oll.transform, oll.extract)
+
+youtube_etl = compose(loaders.load_videos, youtube.transform, youtube.extract)

--- a/course_catalog/etl/pipelines_test.py
+++ b/course_catalog/etl/pipelines_test.py
@@ -109,3 +109,19 @@ def test_oll_etl(mocker):
     mock_load_courses.assert_called_once_with(mock_transform.return_value)
 
     assert result == mock_load_courses.return_value
+
+
+def test_youtube_etl(mocker):
+    """Verify that youtube etl pipeline executes correctly"""
+    mock_extract = mocker.patch("course_catalog.etl.youtube.extract")
+    mock_transform = mocker.patch("course_catalog.etl.youtube.transform")
+    mock_load_videos = mocker.patch("course_catalog.etl.loaders.load_videos")
+
+    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_videos):
+        result = pipelines.youtube_etl()
+
+    mock_extract.assert_called_once_with()
+    mock_transform.assert_called_once_with(mock_extract.return_value)
+    mock_load_videos.assert_called_once_with(mock_transform.return_value)
+
+    assert result == mock_load_videos.return_value


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2304

#### What's this PR do?
This pr creates a transform function for normalizing youtube video data and adds a youtube pipeline

#### How should this be manually tested?
```
from course_catalog.etl import youtube
from toolz import compose

pipeline = compose(youtube.transform, youtube.extract)
g = pipeline()
next(g)
```
should step through the videos in the channels in YOUTUBE_CONFIG_FILE_LOCATION displaying normalized data for one video at a time

```
from course_catalog.etl.pipelines import *
youtube_etl()
```
should pull all the videos in the channels in YOUTUBE_CONFIG_FILE_LOCATION and save them in the database


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
