### PR TITLE
hide 'my lists' button in course navbar when the user is anonymous

### DIFF
--- a/static/js/components/CourseToolbar.js
+++ b/static/js/components/CourseToolbar.js
@@ -10,6 +10,7 @@ import ResponsiveWrapper from "./ResponsiveWrapper"
 
 import { TABLET, DESKTOP } from "../lib/constants"
 import { COURSE_URL, userListIndexURL } from "../lib/url"
+import { userIsAnonymous } from "../lib/util"
 
 import type { Profile } from "../flow/discussionTypes"
 
@@ -61,10 +62,14 @@ export default class CourseToolbar extends React.Component<Props> {
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
               <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
-                <Link className="user-list-link" to={userListIndexURL}>
-                  <i className="material-icons">bookmark</i>
-                  My Lists
-                </Link>
+                {userIsAnonymous() ? (
+                  <div />
+                ) : (
+                  <Link className="user-list-link" to={userListIndexURL}>
+                    <i className="material-icons">bookmark</i>
+                    My Lists
+                  </Link>
+                )}
               </ResponsiveWrapper>
               <UserMenu
                 toggleShowUserMenu={toggleShowUserMenu}

--- a/static/js/components/CourseToolbar_test.js
+++ b/static/js/components/CourseToolbar_test.js
@@ -7,8 +7,9 @@ import { shallow } from "enzyme"
 
 import CourseToolbar from "./CourseToolbar"
 
-import { COURSE_URL } from "../lib/url"
+import { COURSE_URL, userListIndexURL } from "../lib/url"
 import { makeProfile } from "../factories/profiles"
+import * as util from "../lib/util"
 
 describe("CourseToolbar", () => {
   let sandbox
@@ -46,6 +47,21 @@ describe("CourseToolbar", () => {
         .at(1)
         .prop("to"),
       COURSE_URL
+    )
+  })
+
+  it("should include a link to the my lists page", () => {
+    const link = renderToolbar().find(".user-list-link")
+    assert.equal(link.prop("children")[1], "My Lists")
+    assert.equal(link.prop("to"), userListIndexURL)
+  })
+
+  it("should hide the my lists link when you're anonymous", () => {
+    sandbox.stub(util, "userIsAnonymous").returns(true)
+    assert.isNotOk(
+      renderToolbar()
+        .find(".user-list-link")
+        .exists()
     )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

we should be hiding the 'My Lists' button in the course navbar when the user is anonymous, so this does just that.

#### How should this be manually tested?

make sure that the button doesn't show up when you're anonymous, and that it doesn't show up when you aren't.

#### Screenshots (if appropriate)

![noooooo](https://user-images.githubusercontent.com/6207644/67885367-dc4a7000-fb1d-11e9-850c-21b4549352d9.png)
