### PR TITLE
add ability to delete UserLists

### DIFF
--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -1,9 +1,12 @@
 // @flow
 /* global SETTINGS:false */
-import React from "react"
+import React, { useState } from "react"
 import R from "ramda"
+import { useMutation } from "redux-query-react"
 
 import Card from "./Card"
+import Dialog from "./Dialog"
+import DropdownMenu from "./DropdownMenu"
 
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
 import {
@@ -11,6 +14,7 @@ import {
   CAROUSEL_IMG_HEIGHT,
   readableLearningResources
 } from "../lib/constants"
+import { deleteUserListMutation } from "../lib/queries/user_lists"
 
 import type { UserList } from "../flow/discussionTypes"
 
@@ -28,19 +32,62 @@ type Props = {
   userList: UserList
 }
 
+function ConfirmDeleteDialog(props) {
+  const { userList, close } = props
+
+  const [, deleteUserList] = useMutation(deleteUserListMutation)
+
+  return (
+    <Dialog
+      title={`Delete this ${readableLearningResources[userList.list_type]}?`}
+      open={true}
+      hideDialog={close}
+      submitText="Delete"
+      onAccept={() => {
+        deleteUserList(userList)
+        close()
+      }}
+    >
+      Are you sure you want to delete this{" "}
+      {readableLearningResources[userList.list_type]}?
+    </Dialog>
+  )
+}
+
 export default function UserListCard(props: Props) {
   const { userList } = props
 
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [showMenu, setShowMenu] = useState(false)
+
   return (
     <Card className="user-list-card">
+      {showDeleteDialog ? (
+        <ConfirmDeleteDialog
+          userList={userList}
+          close={() => setShowDeleteDialog(false)}
+        />
+      ) : null}
       <div className="userlist-info">
         <div className="platform">
           {readableLearningResources[userList.list_type]}
         </div>
         <div className="ul-title">{userList.title}</div>
         <div className="actions-and-count">
-          <div className="actions" />
           <div className="count">{readableLength(userList.items.length)}</div>
+          <i
+            className="material-icons grey-surround more_vert"
+            onClick={() => setShowMenu(true)}
+          >
+            more_vert
+          </i>
+          {showMenu ? (
+            <DropdownMenu closeMenu={() => setShowMenu(false)}>
+              <li>
+                <div onClick={() => setShowDeleteDialog(true)}>Delete</div>
+              </li>
+            </DropdownMenu>
+          ) : null}
         </div>
       </div>
       {userList.items.length > 0 ? (

--- a/static/js/components/UserListCard_test.js
+++ b/static/js/components/UserListCard_test.js
@@ -1,47 +1,54 @@
 // @flow
-import React from "react"
 import { assert } from "chai"
 import R from "ramda"
-import { shallow } from "enzyme"
 import sinon from "sinon"
 
 import UserListCard from "./UserListCard"
+import DropdownMenu from "./DropdownMenu"
+import Dialog from "./Dialog"
 
+import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeUserList, makeUserListItem } from "../factories/learning_resources"
 import { LR_TYPE_COURSE, readableLearningResources } from "../lib/constants"
+import { userListApiURL } from "../lib/url"
 import * as urlLib from "../lib/url"
 
 describe("UserListCard tests", () => {
-  const renderUserListCard = (props = {}) =>
-    shallow(<UserListCard userList={userList} {...props} />)
-
-  let userList, sandbox
+  let userList, helper, renderUserListCard
 
   beforeEach(() => {
     userList = makeUserList()
-    sandbox = sinon.createSandbox()
+    helper = new IntegrationTestHelper()
+    renderUserListCard = helper.configureReduxQueryRenderer(UserListCard, {
+      userList
+    })
   })
 
   afterEach(() => {
-    sandbox.restore()
+    helper.cleanup()
   })
 
-  it("should print the list type (learning path || list)", () => {
+  const getDeleteDialog = wrapper => {
+    wrapper.find(".more_vert").simulate("click")
+    wrapper.update()
+    wrapper
+      .find(DropdownMenu)
+      .find("div")
+      .simulate("click")
+    return wrapper.find(Dialog)
+  }
+
+  it("should print the list type (learning path || list)", async () => {
+    const { wrapper } = await renderUserListCard()
     assert.equal(
-      renderUserListCard()
-        .find(".platform")
-        .text(),
-      readableLearningResources[userList.object_type]
+      wrapper.find(".platform").text(),
+      readableLearningResources[userList.list_type]
     )
   })
 
-  it("should put the title", () => {
-    assert.equal(
-      renderUserListCard()
-        .find(".ul-title")
-        .text(),
-      userList.title
-    )
+  it("should put the title", async () => {
+    const { wrapper } = await renderUserListCard()
+    assert.equal(wrapper.find(".ul-title").text(), userList.title)
   })
 
   //
@@ -49,24 +56,48 @@ describe("UserListCard tests", () => {
     ([itemCount, expectedText]) => {
       it(`should have a properly-formatted count of ${String(
         itemCount
-      )} items`, () => {
+      )} items`, async () => {
         userList.items = R.times(
           () => makeUserListItem(LR_TYPE_COURSE),
           itemCount
         )
-        const text = renderUserListCard()
-          .find(".count")
-          .text()
+        const { wrapper } = await renderUserListCard()
+        const text = wrapper.find(".count").text()
         assert.include(text, expectedText)
       })
     }
   )
 
-  it("should render the image of the first list item", () => {
-    sandbox.stub(urlLib, "embedlyThumbnail").returns("南瓜")
-    const { src } = renderUserListCard()
-      .find("img")
-      .props()
+  it("should render the image of the first list item", async () => {
+    helper.sandbox.stub(urlLib, "embedlyThumbnail").returns("南瓜")
+    const { wrapper } = await renderUserListCard()
+    const { src } = wrapper.find("img").props()
     assert.equal(src, "南瓜")
+  })
+
+  it("should have a button to open a delete menu, which should confirm", async () => {
+    const { wrapper } = await renderUserListCard()
+    const dialog = getDeleteDialog(wrapper)
+    const { submitText, title, hideDialog } = dialog.props()
+    assert.equal(submitText, "Delete")
+    assert.equal(
+      title,
+      `Delete this ${readableLearningResources[userList.list_type]}?`
+    )
+    hideDialog()
+    wrapper.update()
+    assert.isNotOk(wrapper.find("Dialog").exists())
+  })
+
+  it("should issue a DELETE request if the user confirms", async () => {
+    const { wrapper } = await renderUserListCard()
+    const { onAccept } = getDeleteDialog(wrapper).props()
+    await onAccept()
+
+    sinon.assert.calledWith(
+      helper.handleRequestStub,
+      `${userListApiURL}/${userList.id}/`,
+      "DELETE"
+    )
   })
 })

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -81,3 +81,15 @@ export const createUserListMutation = (params: Object) => ({
     ...DEFAULT_POST_OPTIONS
   }
 })
+
+export const deleteUserListMutation = (userList: UserList) => ({
+  queryKey: "deleteUserListMutation",
+  url:      `${userListApiURL}/${userList.id}/`,
+  update:   {
+    userLists: R.dissoc(userList.id)
+  },
+  options: {
+    method: "DELETE",
+    ...DEFAULT_POST_OPTIONS
+  }
+})

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -3,7 +3,8 @@ import { assert } from "chai"
 import {
   userListRequest,
   favoriteUserListMutation,
-  createUserListMutation
+  createUserListMutation,
+  deleteUserListMutation
 } from "./user_lists"
 import { makeUserList } from "../../factories/learning_resources"
 import { userListApiURL } from "../url"
@@ -72,5 +73,22 @@ describe("UserLists API", () => {
         [userList.id]: userList
       }
     })
+  })
+
+  it("deleteUserListMutation should return what we expect", () => {
+    const query = deleteUserListMutation(userList)
+    assert.isUndefined(query.body)
+    assert.equal(query.queryKey, "deleteUserListMutation")
+    assert.equal(query.url, `${userListApiURL}/${userList.id}/`)
+    assert.deepEqual(query.options, {
+      method: "DELETE",
+      ...DEFAULT_POST_OPTIONS
+    })
+    assert.deepEqual(
+      query.update.userLists({
+        [userList.id]: userList
+      }),
+      {}
+    )
   })
 })

--- a/static/scss/user-list-card.scss
+++ b/static/scss/user-list-card.scss
@@ -30,10 +30,15 @@
       display: flex;
       margin-top: auto;
       justify-content: space-between;
+      position: relative;
 
       .count {
         font-size: 14px;
         font-weight: 500;
+      }
+
+      i {
+        font-size: 20px;
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2353

#### What's this PR do?

this adds a dropdown menu to the UserListCard component. Currently in the dropdown there's only one option, 'Delete', which opens a confirm dialog to let you delete the list.

#### How should this be manually tested?

make sure that the above works as it should. you should be able to open and close the dialog, cancel, etc. when you actually confirm your list should be deleted, and it should disappear from the list of lists on the userlist index page.


#### Screenshots (if appropriate)

![deleteffffff2ff](https://user-images.githubusercontent.com/6207644/67957929-b62fd900-fbcc-11e9-886e-a39e06d51c84.png)
![deleteffffff2](https://user-images.githubusercontent.com/6207644/67957930-b62fd900-fbcc-11e9-9d2a-6e4b45787b95.png)
![deletefff](https://user-images.githubusercontent.com/6207644/67957931-b62fd900-fbcc-11e9-8a96-2dc87a4780dc.png)
