### PR TITLE
add userlist detail page

### DIFF
--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -9,16 +9,15 @@ import LearningResourceCard from "./LearningResourceCard"
 import { SEARCH_GRID_UI, SEARCH_UI_GRID_WIDTHS } from "../lib/search"
 import { useDeviceCategory } from "../hooks/util"
 
-import type { LearningResource } from "../flow/discussionTypes"
+import type { LearningResourceSummary } from "../flow/discussionTypes"
 
 type Props = {|
   title: string,
-  courses: Array<LearningResource>,
-  setShowResourceDrawer: Function
+  courses: Array<LearningResourceSummary>
 |}
 
 export default function CourseCarousel(props: Props) {
-  const { title, courses, setShowResourceDrawer } = props
+  const { title, courses } = props
 
   const [index, setIndex] = useState(0)
   const deviceCategory = useDeviceCategory()
@@ -70,7 +69,6 @@ export default function CourseCarousel(props: Props) {
           <LearningResourceCard
             key={idx}
             object={course}
-            setShowResourceDrawer={setShowResourceDrawer}
             searchResultLayout={SEARCH_GRID_UI}
           />
         ))}

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -90,11 +90,6 @@ const ProfileSearchResult = ({ result }: ProfileProps) => {
 
 type LearningResourceProps = {
   result: LearningResourceResult,
-  setShowResourceDrawer?: ({
-    objectId: string,
-    objectType: string,
-    runId: ?number
-  }) => void,
   overrideObject?: Object,
   searchResultLayout?: string,
   availabilities?: Array<string>
@@ -102,7 +97,6 @@ type LearningResourceProps = {
 
 const LearningResourceSearchResult = ({
   result,
-  setShowResourceDrawer,
   overrideObject,
   searchResultLayout,
   availabilities
@@ -112,7 +106,6 @@ const LearningResourceSearchResult = ({
   return (
     <LearningResourceCard
       object={searchResultToLearningResource(result, overrideObject)}
-      setShowResourceDrawer={setShowResourceDrawer}
       searchResultLayout={searchResultLayout}
       availabilities={availabilities}
     />

--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -3,12 +3,17 @@
 import React, { useState } from "react"
 import R from "ramda"
 import { useMutation } from "redux-query-react"
+import { Link } from "react-router-dom"
 
 import Card from "./Card"
 import Dialog from "./Dialog"
 import DropdownMenu from "./DropdownMenu"
 
-import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+import {
+  defaultResourceImageURL,
+  embedlyThumbnail,
+  userListDetailURL
+} from "../lib/url"
 import {
   CAROUSEL_IMG_WIDTH,
   CAROUSEL_IMG_HEIGHT,
@@ -72,7 +77,9 @@ export default function UserListCard(props: Props) {
         <div className="platform">
           {readableLearningResources[userList.list_type]}
         </div>
-        <div className="ul-title">{userList.title}</div>
+        <Link to={userListDetailURL(userList.id)} className="ul-title">
+          {userList.title}
+        </Link>
         <div className="actions-and-count">
           <div className="count">{readableLength(userList.items.length)}</div>
           <i

--- a/static/js/components/UserListCard_test.js
+++ b/static/js/components/UserListCard_test.js
@@ -48,7 +48,13 @@ describe("UserListCard tests", () => {
 
   it("should put the title", async () => {
     const { wrapper } = await renderUserListCard()
-    assert.equal(wrapper.find(".ul-title").text(), userList.title)
+    assert.equal(
+      wrapper
+        .find(".ul-title")
+        .at(0)
+        .text(),
+      userList.title
+    )
   })
 
   //

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -146,3 +146,4 @@ export const userListApiURL = "/api/v0/userlists"
 export const videoApiURL = "/api/v0/videos"
 
 export const userListIndexURL = "/courses/lists/"
+export const userListDetailURL = (id: number) => `/courses/lists/${id}`

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -31,7 +31,8 @@ import PasswordResetPage from "./auth/PasswordResetPage"
 import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
 import ChannelRouter from "./ChannelRouter"
 import CourseIndexPage from "./CourseIndexPage"
-import UserListPage from "./UserListPage"
+import UserListsPage from "./UserListsPage"
+import UserListDetailPage from "./UserListDetailPage"
 
 import PrivateRoute from "../components/auth/PrivateRoute"
 import Snackbar from "../components/material/Snackbar"
@@ -325,9 +326,13 @@ class App extends React.Component<Props> {
                 component={CourseSearchPage}
               />
               <Route
+                path={`${match.url}courses/lists/:id`}
+                component={UserListDetailPage}
+              />
+              <Route
                 exact
                 path={`${match.url}courses/lists`}
-                component={UserListPage}
+                component={UserListsPage}
               />
             </Switch>
           ) : null}

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -1,7 +1,7 @@
 // @flow
-import React, { useCallback } from "react"
+import React from "react"
 import { useRequest } from "redux-query-react"
-import { useSelector, useDispatch } from "react-redux"
+import { useSelector } from "react-redux"
 import { Link } from "react-router-dom"
 import { createSelector } from "reselect"
 
@@ -20,7 +20,6 @@ import { CarouselLoading } from "../components/Loading"
 import AddToListDialog from "../components/AddToListDialog"
 import ResponsiveWrapper from "../components/ResponsiveWrapper"
 
-import { setShowResourceDrawer } from "../actions/ui"
 import {
   featuredCoursesRequest,
   featuredCoursesSelector,
@@ -72,12 +71,6 @@ export default function CourseIndexPage({ history }: Props) {
     isFinishedNew &&
     isFinishedFavorites
 
-  const dispatch = useDispatch()
-  const setShowResourceDrawerFunc = useCallback(
-    args => dispatch(setShowResourceDrawer(args)),
-    [dispatch]
-  )
-
   return (
     <BannerPageWrapper>
       <BannerPageHeader tall compactOnMobile>
@@ -113,29 +106,19 @@ export default function CourseIndexPage({ history }: Props) {
         {loaded ? (
           <Cell width={12}>
             {favorites.length !== 0 ? (
-              <CourseCarousel
-                title="Your Favorites"
-                courses={favorites}
-                setShowResourceDrawer={setShowResourceDrawerFunc}
-              />
+              <CourseCarousel title="Your Favorites" courses={favorites} />
             ) : null}
             {featuredCourses.length !== 0 ? (
               <CourseCarousel
                 title="Featured Courses"
                 courses={featuredCourses}
-                setShowResourceDrawer={setShowResourceDrawerFunc}
               />
             ) : null}
             <CourseCarousel
               title="Upcoming Courses"
               courses={upcomingCourses}
-              setShowResourceDrawer={setShowResourceDrawerFunc}
             />
-            <CourseCarousel
-              title="New Courses"
-              courses={newCourses}
-              setShowResourceDrawer={setShowResourceDrawerFunc}
-            />
+            <CourseCarousel title="New Courses" courses={newCourses} />
           </Cell>
         ) : (
           <Cell width={12}>

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -29,7 +29,6 @@ import {
 import CourseFilterDrawer from "../components/CourseFilterDrawer"
 
 import { actions } from "../actions"
-import { setShowResourceDrawer } from "../actions/ui"
 import { clearSearch } from "../actions/search"
 import {
   availabilityFacetLabel,
@@ -81,12 +80,7 @@ type OwnProps = {|
   isModerator: boolean,
   match: Match,
   runSearch: (params: SearchParams) => Promise<*>,
-  clearSearch: () => void,
-  setShowResourceDrawer: ({
-    objectId: string,
-    objectType: string,
-    runId: ?number
-  }) => void
+  clearSearch: () => void
 |}
 
 type StateProps = {|
@@ -353,13 +347,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 
   renderResults = () => {
-    const {
-      results,
-      processing,
-      loaded,
-      total,
-      setShowResourceDrawer
-    } = this.props
+    const { results, processing, loaded, total } = this.props
     const { from, incremental, searchResultLayout, activeFacets } = this.state
 
     if ((processing || !loaded) && !incremental) {
@@ -390,7 +378,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
                 }
                 toggleFacet={this.toggleFacet}
                 availabilities={activeFacets.get("availability")}
-                setShowResourceDrawer={setShowResourceDrawer}
                 searchResultLayout={searchResultLayout}
               />
             </Cell>
@@ -533,17 +520,6 @@ const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
   clearSearch: async () => {
     dispatch(actions.search.clear())
     await dispatch(clearSearch())
-  },
-  setShowResourceDrawer: ({
-    objectId,
-    objectType,
-    runId
-  }: {
-    objectId: string,
-    objectType: string,
-    runId: ?number
-  }) => {
-    dispatch(setShowResourceDrawer({ objectId, objectType, runId }))
   },
   dispatch
 })

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -9,7 +9,6 @@ import ConnectedCourseSearchPage, { CourseSearchPage } from "./CourseSearchPage"
 
 import SearchFacet from "../components/SearchFacet"
 
-import { SET_SHOW_RESOURCE_DRAWER } from "../actions/ui"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { shouldIf } from "../lib/test_utils"
 import {
@@ -18,7 +17,7 @@ import {
   makeSearchResponse
 } from "../factories/search"
 import { makeChannel } from "../factories/channels"
-import { LR_TYPE_COURSE, LR_TYPE_ALL } from "../lib/constants"
+import { LR_TYPE_ALL } from "../lib/constants"
 import { SEARCH_LIST_UI } from "../lib/search"
 import { wait } from "../lib/util"
 
@@ -121,26 +120,6 @@ describe("CourseSearchPage", () => {
         .prop("title"),
       "Learning Resource"
     )
-  })
-
-  it("passes a setShowResourceDrawer to search results", async () => {
-    const { inner, store } = await renderPage()
-    inner
-      .find("SearchResult")
-      .at(0)
-      .prop("setShowResourceDrawer")({
-        objectId:   searchCourse.course_id,
-        objectType: LR_TYPE_COURSE,
-        runId:      23
-      })
-    assert.deepEqual(store.getLastAction(), {
-      type:    SET_SHOW_RESOURCE_DRAWER,
-      payload: {
-        objectId:   searchCourse.course_id,
-        objectType: LR_TYPE_COURSE,
-        runId:      23
-      }
-    })
   })
 
   //

--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -1,0 +1,64 @@
+// @flow
+import React from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+import { createSelector } from "reselect"
+import { memoize } from "lodash"
+
+import LearningResourceDrawer from "../components/LearningResourceDrawer"
+import { Cell, Grid } from "../components/Grid"
+import {
+  BannerPageWrapper,
+  BannerPageHeader,
+  BannerContainer,
+  BannerImage
+} from "../components/PageBanner"
+import LearningResourceCard from "../components/LearningResourceCard"
+import AddToListDialog from "../components/AddToListDialog"
+
+import { SEARCH_LIST_UI } from "../lib/search"
+import { userListRequest, userListsSelector } from "../lib/queries/user_lists"
+import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
+
+const userListSelector = createSelector(userListsSelector, userLists =>
+  memoize(userListID => (userLists ? userLists[userListID] : null))
+)
+
+type Props = {
+  match: Object
+}
+
+export default function UserListDetailPage(props: Props) {
+  const { match } = props
+  const userListId = match.params.id
+
+  const [{ isFinished }] = useRequest(userListRequest(userListId))
+  const userList = useSelector(userListSelector)(userListId)
+
+  return (
+    <BannerPageWrapper>
+      <BannerPageHeader tall compactOnMobile>
+        <BannerContainer tall compactOnMobile>
+          <BannerImage src={COURSE_SEARCH_BANNER_URL} tall compactOnMobile />
+        </BannerContainer>
+      </BannerPageHeader>
+      {isFinished ? (
+        <Grid className="main-content one-column narrow user-list-page">
+          <Cell width={12}>
+            <h1 className="list-header">{userList.title}</h1>
+          </Cell>
+          {userList.items.map((item, i) => (
+            <Cell width={12} key={i}>
+              <LearningResourceCard
+                object={item.content_data}
+                searchResultLayout={SEARCH_LIST_UI}
+              />
+            </Cell>
+          ))}
+        </Grid>
+      ) : null}
+      <LearningResourceDrawer />
+      <AddToListDialog />
+    </BannerPageWrapper>
+  )
+}

--- a/static/js/pages/UserListDetailPage_test.js
+++ b/static/js/pages/UserListDetailPage_test.js
@@ -1,0 +1,54 @@
+// @flow
+import { assert } from "chai"
+import R from "ramda"
+
+import UserListDetailPage from "./UserListDetailPage"
+import LearningResourceCard from "../components/LearningResourceCard"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeUserList } from "../factories/learning_resources"
+import { userListApiURL } from "../lib/url"
+import { queryListResponse } from "../lib/test_utils"
+
+describe("UserListDetailPage tests", () => {
+  let helper, userList, render
+
+  beforeEach(() => {
+    userList = makeUserList()
+    helper = new IntegrationTestHelper()
+    helper.handleRequestStub
+      .withArgs(`${userListApiURL}/${userList.id}/`)
+      .returns({
+        status: 200,
+        body:   userList
+      })
+    helper.handleRequestStub
+      .withArgs(userListApiURL)
+      .returns(queryListResponse([]))
+    render = helper.configureReduxQueryRenderer(UserListDetailPage, {
+      match: {
+        params: {
+          id: userList.id
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should should show the title", async () => {
+    const { wrapper } = await render()
+    assert.equal(wrapper.find(".list-header").text(), userList.title)
+  })
+
+  it("should render the list items", async () => {
+    const { wrapper } = await render()
+    R.zip([...wrapper.find(LearningResourceCard)], userList.items).forEach(
+      ([card, item]) => {
+        assert.deepEqual(card.props.object, item.content_data)
+      }
+    )
+  })
+})

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -25,7 +25,7 @@ const userListsPageSelector = createSelector(
     userLists ? Object.keys(userLists).map(key => userLists[key]) : null
 )
 
-export default function UserListPage() {
+export default function UserListsPage() {
   const [showCreateListDialog, setShowCreateListDialog] = useState(false)
   const [{ isFinished }] = useRequest(userListsRequest())
 

--- a/static/js/pages/UserListsPage_test.js
+++ b/static/js/pages/UserListsPage_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 
-import UserListPage from "./UserListPage"
+import UserListsPage from "./UserListsPage"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeUserList } from "../factories/learning_resources"
@@ -9,7 +9,7 @@ import { queryListResponse } from "../lib/test_utils"
 import { userListApiURL } from "../lib/url"
 import * as util from "../lib/util"
 
-describe("UserListPage tests", () => {
+describe("UserListsPage tests", () => {
   let helper, userLists, render
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe("UserListPage tests", () => {
     helper.handleRequestStub
       .withArgs(userListApiURL)
       .returns(queryListResponse(userLists))
-    render = helper.configureReduxQueryRenderer(UserListPage)
+    render = helper.configureReduxQueryRenderer(UserListsPage)
   })
 
   afterEach(() => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2364

#### What's this PR do?

this adds a user list detail page, a `/courses/lists/:id/`, which displays the learning resources in a list. here's what I implemented:

- add a link from the user list index to this detail page
- add a learning resource drawer to the detail page so you can inspect the items in your list
- add the user list membership dialog too, so you can edit the lists a learning resource is in from that page as well
- make the learningresourcecard self-contained as far as it's "open drawer" callback is concerned

that's about it.

#### How should this be manually tested?

make sure that the above works as advertised. you should also confirm that the learning resource drawer still opens normally from the search and from the homepage, as it did before.

#### Screenshots (if appropriate)

![listdetailview](https://user-images.githubusercontent.com/6207644/68242776-1cf32f00-ffdf-11e9-92f1-2c83dc9f3d74.png)
![lpdrawer](https://user-images.githubusercontent.com/6207644/68242801-2bd9e180-ffdf-11e9-98ed-04d6c5f89c3c.png)
