### PR TITLE
add the ability to edit user lists

### DIFF
--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom"
 import Card from "./Card"
 import Dialog from "./Dialog"
 import DropdownMenu from "./DropdownMenu"
+import UserListFormDialog from "./UserListFormDialog"
 
 import {
   defaultResourceImageURL,
@@ -38,7 +39,7 @@ type Props = {
 }
 
 function ConfirmDeleteDialog(props) {
-  const { userList, close } = props
+  const { userList, hide } = props
 
   const [, deleteUserList] = useMutation(deleteUserListMutation)
 
@@ -46,11 +47,11 @@ function ConfirmDeleteDialog(props) {
     <Dialog
       title={`Delete this ${readableLearningResources[userList.list_type]}?`}
       open={true}
-      hideDialog={close}
+      hideDialog={hide}
       submitText="Delete"
       onAccept={() => {
         deleteUserList(userList)
-        close()
+        hide()
       }}
     >
       Are you sure you want to delete this{" "}
@@ -63,6 +64,7 @@ export default function UserListCard(props: Props) {
   const { userList } = props
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [showEditDialog, setShowEditDialog] = useState(false)
   const [showMenu, setShowMenu] = useState(false)
 
   return (
@@ -70,7 +72,13 @@ export default function UserListCard(props: Props) {
       {showDeleteDialog ? (
         <ConfirmDeleteDialog
           userList={userList}
-          close={() => setShowDeleteDialog(false)}
+          hide={() => setShowDeleteDialog(false)}
+        />
+      ) : null}
+      {showEditDialog ? (
+        <UserListFormDialog
+          userList={userList}
+          hide={() => setShowEditDialog(false)}
         />
       ) : null}
       <div className="userlist-info">
@@ -92,6 +100,9 @@ export default function UserListCard(props: Props) {
             <DropdownMenu closeMenu={() => setShowMenu(false)}>
               <li>
                 <div onClick={() => setShowDeleteDialog(true)}>Delete</div>
+              </li>
+              <li>
+                <div onClick={() => setShowEditDialog(true)}>Edit</div>
               </li>
             </DropdownMenu>
           ) : null}

--- a/static/js/components/UserListCard_test.js
+++ b/static/js/components/UserListCard_test.js
@@ -6,6 +6,7 @@ import sinon from "sinon"
 import UserListCard from "./UserListCard"
 import DropdownMenu from "./DropdownMenu"
 import Dialog from "./Dialog"
+import UserListFormDialog from "./UserListFormDialog"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeUserList, makeUserListItem } from "../factories/learning_resources"
@@ -28,15 +29,19 @@ describe("UserListCard tests", () => {
     helper.cleanup()
   })
 
-  const getDeleteDialog = wrapper => {
+  const getDialog = R.curry((index, Component, wrapper) => {
     wrapper.find(".more_vert").simulate("click")
     wrapper.update()
     wrapper
       .find(DropdownMenu)
       .find("div")
+      .at(index)
       .simulate("click")
-    return wrapper.find(Dialog)
-  }
+    return wrapper.find(Component)
+  })
+
+  const getDeleteDialog = getDialog(0, Dialog)
+  const getEditDialog = getDialog(1, UserListFormDialog)
 
   it("should print the list type (learning path || list)", async () => {
     const { wrapper } = await renderUserListCard()
@@ -92,7 +97,7 @@ describe("UserListCard tests", () => {
     )
     hideDialog()
     wrapper.update()
-    assert.isNotOk(wrapper.find("Dialog").exists())
+    assert.isNotOk(wrapper.find(Dialog).exists())
   })
 
   it("should issue a DELETE request if the user confirms", async () => {
@@ -105,5 +110,14 @@ describe("UserListCard tests", () => {
       `${userListApiURL}/${userList.id}/`,
       "DELETE"
     )
+  })
+
+  it("should let you open a dialog to edit the UserList", async () => {
+    const { wrapper } = await renderUserListCard()
+    const dialog = getEditDialog(wrapper)
+    assert.deepEqual(dialog.prop("userList"), userList)
+    dialog.prop("hide")()
+    wrapper.update()
+    assert.isNotOk(wrapper.find(Dialog).exists())
   })
 })

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -421,7 +421,8 @@ export type UserList = LearningResource & {
   image_description:  ?string,
   items:              Array<UserListItem | UserListItemEdit>,
   list_type:          string,
-  object_type:        string
+  object_type:        string,
+  privacy_level:      string
 }
 
 export type Video = LearningResource & {

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -12,7 +12,7 @@ import {
   BannerImage
 } from "../components/PageBanner"
 import UserListCard from "../components/UserListCard"
-import CreateUserListDialog from "../components/CreateUserListDialog"
+import UserListFormDialog from "../components/UserListFormDialog"
 import LoginTooltip from "../components/LoginTooltip"
 
 import { userListsRequest, userListsSelector } from "../lib/queries/user_lists"
@@ -39,7 +39,7 @@ export default function UserListsPage() {
         </BannerContainer>
       </BannerPageHeader>
       {showCreateListDialog ? (
-        <CreateUserListDialog hide={() => setShowCreateListDialog(false)} />
+        <UserListFormDialog hide={() => setShowCreateListDialog(false)} />
       ) : null}
       <Grid className="main-content one-column narrow user-list-page">
         <Cell width={12} className="first-row">

--- a/static/js/pages/UserListsPage_test.js
+++ b/static/js/pages/UserListsPage_test.js
@@ -41,19 +41,19 @@ describe("UserListsPage tests", () => {
 
   it("should hide and show the create list dialog", async () => {
     const { wrapper } = await render()
-    assert.isNotOk(wrapper.find("CreateUserListDialog").exists())
+    assert.isNotOk(wrapper.find("UserListFormDialog").exists())
     wrapper.find(".blue-btn").simulate("click")
-    assert.ok(wrapper.find("CreateUserListDialog").exists())
-    wrapper.find("CreateUserListDialog").prop("hide")()
+    assert.ok(wrapper.find("UserListFormDialog").exists())
+    wrapper.find("UserListFormDialog").prop("hide")()
     wrapper.update()
-    assert.isNotOk(wrapper.find("CreateUserListDialog").exists())
+    assert.isNotOk(wrapper.find("UserListFormDialog").exists())
   })
 
   it("should not open create list dialog for anonymous users", async () => {
     helper.sandbox.stub(util, "userIsAnonymous").returns(true)
     const { wrapper } = await render()
-    assert.isNotOk(wrapper.find("CreateUserListDialog").exists())
+    assert.isNotOk(wrapper.find("UserListFormDialog").exists())
     wrapper.find(".blue-btn").simulate("click")
-    assert.isNotOk(wrapper.find("CreateUserListDialog").exists())
+    assert.isNotOk(wrapper.find("UserListFormDialog").exists())
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2370

#### What's this PR do?

adds the ability to edit the list metadata (title, description, etc).

#### How should this be manually tested?

go to the lists index page. if you click on the little 'three dots' menu you should see an "Edit" button. this should let you edit the list with no problems. List creation should be as normal.

#### Screenshots (if appropriate)

different dialog title when creating:
![editmenuffffffasdfasdf](https://user-images.githubusercontent.com/6207644/68404627-dc192880-014c-11ea-81cc-2cc828f31724.png)

versus when saving:
![editmenuffff](https://user-images.githubusercontent.com/6207644/68404628-dc192880-014c-11ea-8773-4f69f5aa719d.png)

the menu option for opening the dialog:
![editmenu](https://user-images.githubusercontent.com/6207644/68404629-dc192880-014c-11ea-8987-c52807620c09.png)
