### PR TITLE
add entry for the favorites as a userlist

### DIFF
--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -34,10 +34,6 @@ const userListCoverImage = R.pathOr(null, [
   "image_src"
 ])
 
-type Props = {
-  userList: UserList
-}
-
 function ConfirmDeleteDialog(props) {
   const { userList, hide } = props
 
@@ -60,8 +56,13 @@ function ConfirmDeleteDialog(props) {
   )
 }
 
+type Props = {
+  userList: UserList,
+  hideUserListOptions?: boolean
+}
+
 export default function UserListCard(props: Props) {
-  const { userList } = props
+  const { userList, hideUserListOptions } = props
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
@@ -90,12 +91,14 @@ export default function UserListCard(props: Props) {
         </Link>
         <div className="actions-and-count">
           <div className="count">{readableLength(userList.items.length)}</div>
-          <i
-            className="material-icons grey-surround more_vert"
-            onClick={() => setShowMenu(true)}
-          >
-            more_vert
-          </i>
+          {hideUserListOptions ? null : (
+            <i
+              className="material-icons grey-surround more_vert"
+              onClick={() => setShowMenu(true)}
+            >
+              more_vert
+            </i>
+          )}
           {showMenu ? (
             <DropdownMenu closeMenu={() => setShowMenu(false)}>
               <li>

--- a/static/js/components/UserListCard_test.js
+++ b/static/js/components/UserListCard_test.js
@@ -86,6 +86,11 @@ describe("UserListCard tests", () => {
     assert.equal(src, "南瓜")
   })
 
+  it("should hide the dropdown menu if you pass the flag", async () => {
+    const { wrapper } = await renderUserListCard({ hideUserListOptions: true })
+    assert.isNotOk(wrapper.find(".more_vert").exists())
+  })
+
   it("should have a button to open a delete menu, which should confirm", async () => {
     const { wrapper } = await renderUserListCard()
     const dialog = getDeleteDialog(wrapper)

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -57,6 +57,7 @@ export const LR_TYPE_PROGRAM = "program"
 export const LR_TYPE_USERLIST = "userlist"
 export const LR_TYPE_LEARNINGPATH = "learningpath"
 export const LR_TYPE_VIDEO = "video"
+export const FAVORITES_PSEUDO_LIST = "favorites"
 export const LR_TYPE_ALL = [
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
@@ -67,12 +68,13 @@ export const LR_TYPE_ALL = [
 ]
 
 export const readableLearningResources = {
-  [LR_TYPE_COURSE]:       "Course",
-  [LR_TYPE_BOOTCAMP]:     "Bootcamp",
-  [LR_TYPE_PROGRAM]:      "Program",
-  [LR_TYPE_USERLIST]:     "User List",
-  [LR_TYPE_LEARNINGPATH]: "Learning Path",
-  [LR_TYPE_VIDEO]:        "Video"
+  [LR_TYPE_COURSE]:        "Course",
+  [LR_TYPE_BOOTCAMP]:      "Bootcamp",
+  [LR_TYPE_PROGRAM]:       "Program",
+  [LR_TYPE_USERLIST]:      "User List",
+  [LR_TYPE_LEARNINGPATH]:  "Learning Path",
+  [LR_TYPE_VIDEO]:         "Video",
+  [FAVORITES_PSEUDO_LIST]: "Favorites"
 }
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"

--- a/static/js/lib/queries/learning_resources.js
+++ b/static/js/lib/queries/learning_resources.js
@@ -73,6 +73,17 @@ export const favoritesSelector = createSelector(
   })
 )
 
+export const favoritesListSelector = createSelector(
+  favoritesSelector,
+  ({ courses, bootcamps, programs, userLists, videos }) => [
+    ...Object.values(courses),
+    ...Object.values(bootcamps),
+    ...Object.values(programs),
+    ...Object.values(userLists),
+    ...Object.values(videos)
+  ]
+)
+
 export const getResourceRequest = (objectId: ?number, objectType: ?string) => {
   if (!objectId) {
     return null

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -33,6 +33,7 @@ import ChannelRouter from "./ChannelRouter"
 import CourseIndexPage from "./CourseIndexPage"
 import UserListsPage from "./UserListsPage"
 import UserListDetailPage from "./UserListDetailPage"
+import FavoritesDetailPage from "./FavoritesDetailPage"
 
 import PrivateRoute from "../components/auth/PrivateRoute"
 import Snackbar from "../components/material/Snackbar"
@@ -324,6 +325,10 @@ class App extends React.Component<Props> {
                 exact
                 path={`${match.url}courses/search`}
                 component={CourseSearchPage}
+              />
+              <Route
+                path={`${match.url}courses/lists/favorites`}
+                component={FavoritesDetailPage}
               />
               <Route
                 path={`${match.url}courses/lists/:id`}

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -3,7 +3,6 @@ import React from "react"
 import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 import { Link } from "react-router-dom"
-import { createSelector } from "reselect"
 
 import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import CourseCarousel from "../components/CourseCarousel"
@@ -30,7 +29,7 @@ import {
 } from "../lib/queries/courses"
 import {
   favoritesRequest,
-  favoritesSelector
+  favoritesListSelector
 } from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
 import { PHONE, TABLET, DESKTOP } from "../lib/constants"
@@ -38,17 +37,6 @@ import { PHONE, TABLET, DESKTOP } from "../lib/constants"
 type Props = {|
   history: Object
 |}
-
-const favoritesListSelector = createSelector(
-  favoritesSelector,
-  ({ courses, bootcamps, programs, userLists, videos }) => [
-    ...Object.values(courses),
-    ...Object.values(bootcamps),
-    ...Object.values(programs),
-    ...Object.values(userLists),
-    ...Object.values(videos)
-  ]
-)
 
 export default function CourseIndexPage({ history }: Props) {
   const [{ isFinished: isFinishedFeatured }] = useRequest(

--- a/static/js/pages/FavoritesDetailPage.js
+++ b/static/js/pages/FavoritesDetailPage.js
@@ -1,0 +1,60 @@
+// @flow
+import React from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+
+import LearningResourceDrawer from "../components/LearningResourceDrawer"
+import { Cell, Grid } from "../components/Grid"
+import {
+  BannerPageWrapper,
+  BannerPageHeader,
+  BannerContainer,
+  BannerImage
+} from "../components/PageBanner"
+import LearningResourceCard from "../components/LearningResourceCard"
+import AddToListDialog from "../components/AddToListDialog"
+
+import { SEARCH_LIST_UI } from "../lib/search"
+import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
+import {
+  favoritesRequest,
+  favoritesListSelector
+} from "../lib/queries/learning_resources"
+
+export default function FavoritesDetailPage() {
+  const [{ isFinished }] = useRequest(favoritesRequest())
+  const favorites = useSelector(favoritesListSelector)
+
+  return (
+    <BannerPageWrapper>
+      <BannerPageHeader tall compactOnMobile>
+        <BannerContainer tall compactOnMobile>
+          <BannerImage src={COURSE_SEARCH_BANNER_URL} tall compactOnMobile />
+        </BannerContainer>
+      </BannerPageHeader>
+      {isFinished ? (
+        <Grid className="main-content one-column narrow user-list-page">
+          <Cell width={12}>
+            <h1 className="list-header">My Favorites</h1>
+          </Cell>
+          {favorites.length !== 0 ? (
+            favorites.map((item, i) => (
+              <Cell width={12} key={i}>
+                <LearningResourceCard
+                  object={item}
+                  searchResultLayout={SEARCH_LIST_UI}
+                />
+              </Cell>
+            ))
+          ) : (
+            <Cell width={12} className="empty-message">
+              You don't have any favorites.
+            </Cell>
+          )}
+        </Grid>
+      ) : null}
+      <LearningResourceDrawer />
+      <AddToListDialog />
+    </BannerPageWrapper>
+  )
+}

--- a/static/js/pages/FavoritesDetailPage_test.js
+++ b/static/js/pages/FavoritesDetailPage_test.js
@@ -1,0 +1,67 @@
+// @flow
+import { assert } from "chai"
+
+import FavoritesDetailPage from "./FavoritesDetailPage"
+import LearningResourceCard from "../components/LearningResourceCard"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeFavoritesResponse } from "../factories/learning_resources"
+import { queryListResponse } from "../lib/test_utils"
+import { userListApiURL, favoritesURL } from "../lib/url"
+
+describe("FavoritesDetailPage tests", () => {
+  let render, favorites, helper
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    favorites = makeFavoritesResponse()
+    helper.handleRequestStub
+      .withArgs(favoritesURL)
+      .returns(queryListResponse(favorites))
+    helper.handleRequestStub
+      .withArgs(userListApiURL)
+      .returns(queryListResponse([]))
+    render = helper.configureReduxQueryRenderer(FavoritesDetailPage)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should should show the title 'My Favorites'", async () => {
+    const { wrapper } = await render()
+    assert.equal(wrapper.find(".list-header").text(), "My Favorites")
+  })
+
+  it("should the items the user has favorited", async () => {
+    const { wrapper } = await render()
+    assert.deepEqual(
+      [...wrapper.find(LearningResourceCard)]
+        .map(card => card.props.object.id)
+        .sort(),
+      favorites.map(item => item.content_data.id).sort()
+    )
+  })
+
+  it("should have a drawer for showing istems, adding to lists", async () => {
+    const { wrapper } = await render()
+    assert.ok(wrapper.find("LearningResourceDrawer"))
+    assert.ok(wrapper.find("AddToListDialog"))
+  })
+
+  it("should show an empty message if there aren't any favorites", async () => {
+    favorites = []
+    helper.handleRequestStub
+      .withArgs(favoritesURL)
+      .returns(queryListResponse([]))
+
+    const { wrapper } = await render()
+    assert.equal(
+      wrapper
+        .find(".empty-message")
+        .at(0)
+        .text(),
+      "You don't have any favorites."
+    )
+  })
+})

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -18,6 +18,11 @@ import LoginTooltip from "../components/LoginTooltip"
 import { userListsRequest, userListsSelector } from "../lib/queries/user_lists"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
 import { userIsAnonymous } from "../lib/util"
+import {
+  favoritesRequest,
+  favoritesListSelector
+} from "../lib/queries/learning_resources"
+import { FAVORITES_PSEUDO_LIST } from "../lib/constants"
 
 const userListsPageSelector = createSelector(
   userListsSelector,
@@ -25,11 +30,23 @@ const userListsPageSelector = createSelector(
     userLists ? Object.keys(userLists).map(key => userLists[key]) : null
 )
 
+const favoritesPseudoListSelector = createSelector(
+  favoritesListSelector,
+  favorites => ({
+    title:     "My Favorites",
+    list_type: FAVORITES_PSEUDO_LIST,
+    items:     favorites,
+    id:        FAVORITES_PSEUDO_LIST
+  })
+)
+
 export default function UserListsPage() {
   const [showCreateListDialog, setShowCreateListDialog] = useState(false)
   const [{ isFinished }] = useRequest(userListsRequest())
+  const [{ isFinished: isFinishedFavorites }] = useRequest(favoritesRequest())
 
   const userLists = useSelector(userListsPageSelector)
+  const favoritesUserList = useSelector(favoritesPseudoListSelector)
 
   return (
     <BannerPageWrapper>
@@ -58,6 +75,11 @@ export default function UserListsPage() {
             </button>
           </LoginTooltip>
         </Cell>
+        {isFinishedFavorites ? (
+          <Cell width={12}>
+            <UserListCard userList={favoritesUserList} hideUserListOptions />
+          </Cell>
+        ) : null}
         {isFinished
           ? userLists.map((list, i) => (
             <Cell width={12} key={i}>

--- a/static/scss/user-list-page.scss
+++ b/static/scss/user-list-page.scss
@@ -8,4 +8,8 @@
       max-height: 36px;
     }
   }
+
+  .empty-message {
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2351

#### What's this PR do?

this adds two things:

- on the user lists page we now show the favorites as a userlist
- from there you can navigate to `/courses/lists/favorites`, which shows a list of your favorites

#### How should this be manually tested?

make sure that the above works. you should be able to also view, in the learning resource drawer, the items in the favorites list, and edit which lists they are members of, from `/courses/lists/favorites`.

#### Screenshots (if appropriate)

![fasdffnfnfnfffff](https://user-images.githubusercontent.com/6207644/68690506-20873880-0540-11ea-9a39-04b2db4a5fe9.png)
![fasdffnfnfnf](https://user-images.githubusercontent.com/6207644/68690507-20873880-0540-11ea-843e-919c8bb739ab.png)
![favrotiesitemsmsmsms](https://user-images.githubusercontent.com/6207644/68690508-20873880-0540-11ea-8263-192ca014b077.png)
![favrotiesthere](https://user-images.githubusercontent.com/6207644/68690509-20873880-0540-11ea-896e-e7d78b6c27a1.png)


#### What GIF best describes this PR or how it makes you feel?
(Optional)
