### PR TITLE
Search index updates for user lists

### DIFF
--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -1,8 +1,6 @@
 """
 Test course_catalog serializers
 """
-from types import SimpleNamespace
-
 import pytest
 
 from course_catalog import factories

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -1,6 +1,8 @@
 """
 Test course_catalog serializers
 """
+from types import SimpleNamespace
+
 import pytest
 
 from course_catalog import factories

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -33,6 +33,7 @@ from course_catalog.serializers import (
 from open_discussions.permissions import AnonymousAccessReadonlyPermission
 
 # pylint:disable=unused-argument
+from search.task_helpers import delete_user_list
 
 
 @api_view(["GET"])
@@ -212,6 +213,10 @@ class UserListViewSet(viewsets.ModelViewSet, FavoriteViewMixin):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    def perform_destroy(self, instance):
+        delete_user_list(instance)
+        instance.delete()
 
 
 class ProgramViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -500,19 +500,18 @@ def index_new_user_list(user_list_obj):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def update_user_list(user_list_obj):
+def upsert_user_list(user_list_obj):
     """
     Run a task to update all fields of a UserList Elasticsearch document
 
     Args:
         user_list_obj(UserList): the UserList to update in ES
     """
-
     user_list_data = ESUserListSerializer(user_list_obj).data
-    update_document_with_partial.delay(
+    upsert_document.delay(
         gen_user_list_id(user_list_obj),
         user_list_data,
-        USER_LIST_TYPE,
+        user_list_obj.list_type,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
     )
 
@@ -525,7 +524,7 @@ def delete_user_list(user_list_obj):
     Args:
         user_list_obj (course_catalog.models.UserList): A UserList object
     """
-    delete_document.delay(gen_user_list_id(user_list_obj), USER_LIST_TYPE)
+    delete_document.delay(gen_user_list_id(user_list_obj), user_list_obj.list_type)
 
 
 @if_feature_enabled(INDEX_UPDATES)

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -511,7 +511,7 @@ def upsert_user_list(user_list_obj):
     upsert_document.delay(
         gen_user_list_id(user_list_obj),
         user_list_data,
-        user_list_obj.list_type,
+        USER_LIST_TYPE,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
     )
 
@@ -524,7 +524,7 @@ def delete_user_list(user_list_obj):
     Args:
         user_list_obj (course_catalog.models.UserList): A UserList object
     """
-    delete_document.delay(gen_user_list_id(user_list_obj), user_list_obj.list_type)
+    delete_document.delay(gen_user_list_id(user_list_obj), USER_LIST_TYPE)
 
 
 @if_feature_enabled(INDEX_UPDATES)

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -2,16 +2,29 @@
 # pylint: disable=redefined-outer-name,unused-argument
 import pytest
 
-from course_catalog.factories import CourseFactory, ProgramFactory, VideoFactory
+from course_catalog.factories import (
+    CourseFactory,
+    ProgramFactory,
+    VideoFactory,
+    UserListFactory,
+)
 from open_discussions.features import INDEX_UPDATES
 from channels.constants import POST_TYPE, COMMENT_TYPE, VoteActions
 from channels.factories.models import CommentFactory
 from channels.utils import render_article_text
-from search.constants import PROFILE_TYPE, COURSE_TYPE, PROGRAM_TYPE, VIDEO_TYPE
+from search.constants import (
+    PROFILE_TYPE,
+    COURSE_TYPE,
+    PROGRAM_TYPE,
+    VIDEO_TYPE,
+    USER_LIST_TYPE,
+    LEARNING_PATH_TYPE,
+)
 from search.serializers import (
     ESCourseSerializer,
     ESProgramSerializer,
     ESVideoSerializer,
+    ESUserListSerializer,
 )
 from search.task_helpers import (
     reddit_object_persist,
@@ -35,6 +48,8 @@ from search.task_helpers import (
     upsert_program,
     upsert_video,
     delete_video,
+    upsert_user_list,
+    delete_user_list,
 )
 from search.api import (
     gen_post_id,
@@ -43,6 +58,7 @@ from search.api import (
     gen_course_id,
     gen_program_id,
     gen_video_id,
+    gen_user_list_id,
 )
 
 es_profile_serializer_data = {
@@ -519,3 +535,37 @@ def test_delete_video(mocker):
     delete_video(video)
     assert patched_delete_task.delay.called is True
     assert patched_delete_task.delay.call_args[0] == (gen_video_id(video), VIDEO_TYPE)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mock_index_functions")
+@pytest.mark.parametrize("list_type", [USER_LIST_TYPE, LEARNING_PATH_TYPE])
+def test_upsert_user_list(mocker, list_type):
+    """
+    Tests that upsert_user_list calls update_field_values_by_query with the right parameters
+    """
+    patched_task = mocker.patch("search.task_helpers.upsert_document")
+    user_list = UserListFactory.create(list_type=list_type)
+    upsert_user_list(user_list)
+    assert patched_task.delay.called is True
+    assert patched_task.delay.call_args[1] == dict(retry_on_conflict=1)
+    assert patched_task.delay.call_args[0] == (
+        gen_user_list_id(user_list),
+        ESUserListSerializer(user_list).data,
+        list_type,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mock_index_functions")
+@pytest.mark.parametrize("list_type", [USER_LIST_TYPE, LEARNING_PATH_TYPE])
+def test_delete_user_list(mocker, list_type):
+    """Tests that deleting a UserList triggers a delete on a UserList document"""
+    patched_delete_task = mocker.patch("search.task_helpers.delete_document")
+    user_list = UserListFactory.create(list_type=list_type)
+    delete_user_list(user_list)
+    assert patched_delete_task.delay.called is True
+    assert patched_delete_task.delay.call_args[0] == (
+        gen_user_list_id(user_list),
+        list_type,
+    )

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -552,7 +552,7 @@ def test_upsert_user_list(mocker, list_type):
     assert patched_task.delay.call_args[0] == (
         gen_user_list_id(user_list),
         ESUserListSerializer(user_list).data,
-        list_type,
+        USER_LIST_TYPE,
     )
 
 
@@ -567,5 +567,5 @@ def test_delete_user_list(mocker, list_type):
     assert patched_delete_task.delay.called is True
     assert patched_delete_task.delay.call_args[0] == (
         gen_user_list_id(user_list),
-        list_type,
+        USER_LIST_TYPE,
     )


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #2347 

#### What's this PR do?
- Updates the search index whenever user lists & learning paths are created, updated, or deleted.

#### How should this be manually tested?
Add, update, and delete both user lists and learning paths.  Verify that the changes are reflected in search.
