### PR TITLE
Show a filled-in star when a resource is in a user's list

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -79,6 +79,28 @@ class FavoriteSerializerMixin(serializers.Serializer):
             return False
 
 
+class ListsSerializerMixin(serializers.Serializer):
+    """
+    Mixin to serialize lists for various models
+    """
+
+    lists = serializers.SerializerMethodField()
+
+    def get_lists(self, obj):
+        """
+        Return a list of user's lists/path id's that a resource is in.
+        """
+        request = self.context.get("request")
+        if request and hasattr(request, "user") and isinstance(request.user, User):
+            return UserListItem.objects.filter(
+                user_list__author=request.user,
+                object_id=obj.id,
+                content_type=ContentType.objects.get_for_model(obj),
+            ).values_list("user_list", flat=True)
+        else:
+            return []
+
+
 class CourseInstructorSerializer(serializers.ModelSerializer):
     """
     Serializer for CourseInstructor model
@@ -117,7 +139,9 @@ class LearningResourceOfferorField(serializers.Field):
         return list(value.values_list("name", flat=True))
 
 
-class BaseCourseSerializer(FavoriteSerializerMixin, serializers.ModelSerializer):
+class BaseCourseSerializer(
+    FavoriteSerializerMixin, ListsSerializerMixin, serializers.ModelSerializer
+):
     """
     Serializer with common functions to be used by CourseSerializer and BootcampSerialzer
     """
@@ -439,7 +463,7 @@ class UserListItemSerializer(SimpleUserListItemSerializer):
         fields = "__all__"
 
 
-class SimpleUserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
+class SimpleUserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin):
     """
     Simplified serializer for UserList model
     """
@@ -550,7 +574,9 @@ class ProgramItemSerializer(serializers.ModelSerializer, FavoriteSerializerMixin
         fields = "__all__"
 
 
-class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
+class ProgramSerializer(
+    serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin
+):
     """
     Serializer for Program model
     """
@@ -566,7 +592,9 @@ class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
         fields = "__all__"
 
 
-class VideoSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
+class VideoSerializer(
+    serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin
+):
     """
     Serializer for Video model
     """

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -510,7 +510,10 @@ class UserListSerializer(SimpleUserListSerializer):
 
     def get_items(self, instance):
         """Returns the list of items"""
-        return [UserListItemSerializer(item).data for item in instance.items.all()]
+        return [
+            UserListItemSerializer(item, context=self.context).data
+            for item in instance.items.all()
+        ]
 
     def update(self, instance, validated_data):
         """Ensure that the list is authored by the requesting user before modifying"""

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -463,7 +463,9 @@ class UserListItemSerializer(SimpleUserListItemSerializer):
         fields = "__all__"
 
 
-class SimpleUserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin):
+class SimpleUserListSerializer(
+    serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin
+):
     """
     Simplified serializer for UserList model
     """

--- a/docs/learning_resources.md
+++ b/docs/learning_resources.md
@@ -58,6 +58,6 @@ and in tests for that code:
   - add the type to `favoritesListSelector`
   
 - pages/CourseSearchPage
-  - add the type to `getFavoriteObject`
+  - add the type to `getFavoriteOrListedObject`
   
  

--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -17,7 +17,7 @@ import {
   LR_TYPE_USERLIST,
   LR_TYPE_VIDEO
 } from "../lib/constants"
-import { filterItems, privacyIcon } from "../lib/learning_resources"
+import { privacyIcon } from "../lib/learning_resources"
 import { favoriteCourseMutation } from "../lib/queries/courses"
 import { favoriteBootcampMutation } from "../lib/queries/bootcamps"
 import { favoriteProgramMutation } from "../lib/queries/programs"
@@ -52,13 +52,7 @@ export default function AddToListDialog() {
   const userLists = useSelector(myUserListsSelector)
   const [{ isFinished: isFinishedList }] = useRequest(userListsRequest())
 
-  const inLists =
-    resource && isFinishedList && isFinishedResource
-      ? filterItems(userLists, "items", {
-        content_type: resource.object_type,
-        object_id:    resource.id
-      }).map(userList => userList.id)
-      : []
+  const inLists = resource && isFinishedResource ? resource.lists : []
 
   const dispatch = useDispatch()
   const hide = useCallback(
@@ -94,6 +88,14 @@ export default function AddToListDialog() {
     return userListMutation(list)
   })
 
+  const updateResource = (checked: boolean, userListId) => {
+    if (checked && !resource.lists.includes(userListId)) {
+      resource.lists.push(userListId)
+    } else {
+      resource.lists.pop(userListId)
+    }
+  }
+
   const renderAddToListForm = () => (
     <div className="user-listitem-form">
       <div className="flex-row">
@@ -125,6 +127,7 @@ export default function AddToListDialog() {
                     checked={inLists.includes(userList.id)}
                     onChange={(e: any) => {
                       toggleListItem(resource, userList, !e.target.checked)
+                      updateResource(e.target.checked, userList.id)
                     }}
                   >
                     {`${userList.title}`}

--- a/static/js/components/AddToListDialog_test.js
+++ b/static/js/components/AddToListDialog_test.js
@@ -84,7 +84,7 @@ describe("AddToListDialog", () => {
       inList ? "" : "not"
     } in it`, async () => {
       if (inList) {
-        userLists[0].items[0].object_id = course.id
+        course.lists.push(userLists[0].id)
       }
       const { wrapper } = await render(course)
       assert.equal(

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -28,7 +28,7 @@ import {
 } from "../lib/constants"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
 import { toQueryString, COURSE_SEARCH_URL } from "../lib/url"
-import { userIsAnonymous } from "../lib/util"
+import { emptyOrNil, userIsAnonymous } from "../lib/util"
 import { setShowResourceDrawer, DIALOG_ADD_TO_LIST } from "../actions/ui"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"
@@ -118,6 +118,7 @@ export default function LearningResourceCard(props: Props) {
   )
 
   const cost = bestAvailableRun ? minPrice(bestAvailableRun.prices) : null
+  const inLists = object ? object.lists : []
 
   return (
     <Card
@@ -165,7 +166,9 @@ export default function LearningResourceCard(props: Props) {
                 className="favorite"
                 src={
                   // $FlowFixMe
-                  object.is_favorite ? starSelectedURL : starUnselectedURL
+                  object.is_favorite || !emptyOrNil(inLists)
+                    ? starSelectedURL
+                    : starUnselectedURL
                 }
                 onClick={e => {
                   e.preventDefault()

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -85,7 +85,8 @@ export const makeCourse = (): Course => ({
   is_favorite:       casual.boolean,
   topics:            [{ name: casual.word }, { name: casual.word }],
   runs:              R.times(makeRun, 3),
-  object_type:       "course"
+  object_type:       "course",
+  lists:             []
 })
 
 const incrBootcamp = incrementer()
@@ -104,7 +105,8 @@ export const makeBootcamp = (): Bootcamp => ({
   offered_by:        [offeredBys.bootcamps],
   topics:            [{ name: casual.word }, { name: casual.word }],
   runs:              R.times(makeRun, 3),
-  object_type:       "bootcamp"
+  object_type:       "bootcamp",
+  lists:             []
 })
 
 const incrUserListItem = incrementer()
@@ -139,7 +141,8 @@ export const makeProgram = (): Program => ({
     makeUserListItem(LR_TYPE_COURSE)
   ],
   object_type: "program",
-  runs:        [makeRun()]
+  runs:        [makeRun()],
+  lists:       []
 })
 
 const incrUserList = incrementer()
@@ -164,7 +167,8 @@ export const makeUserList = (): UserList => ({
   profile_img:   casual.url,
   profile_name:  casual.name,
   privacy_level: casual.random_element(["public", "private"]),
-  author:        casual.integer(1, 1000)
+  author:        casual.integer(1, 1000),
+  lists:         []
 })
 
 const incrVideo = incrementer()
@@ -183,7 +187,8 @@ export const makeVideo = (): Video => ({
   topics:            [casual.word, casual.word],
   object_type:       LR_TYPE_VIDEO,
   offered_by:        [casual.random_element([offeredBys.mitx, offeredBys.ocw])],
-  runs:              []
+  runs:              [],
+  lists:             []
 })
 
 export const makeLearningResource = (objectType: string): Object => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -335,7 +335,8 @@ export type LearningResourceSummary = {
   topics:             Array<CourseTopic>,
   offered_by:         Array<string>,
   object_type:        string,
-  runs:               Array<LearningResourceRun>
+  runs:               Array<LearningResourceRun>,
+  lists:              Array<number>
 }
 
 export type LearningResourceRun = {
@@ -365,7 +366,8 @@ export type LearningResource = {
   topics:             Array<CourseTopic>,
   offered_by:         Array<string>,
   is_favorite:        boolean,
-  object_type:        string
+  object_type:        string,
+  lists:              Array<number>
 }
 
 

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -87,7 +87,8 @@ export type LearningResourceResult = {
   full_description?:   ?string,
   platform?:           string,
   topics:              Array<string>,
-  runs:         Array<LearningResourceRun>
+  runs:                Array<LearningResourceRun>,
+  lists?:               Array<number>
 }
 
 

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -77,6 +77,15 @@ export const readableLearningResources = {
   [FAVORITES_PSEUDO_LIST]: "Favorites"
 }
 
+export const resourceEntities = {
+  [LR_TYPE_COURSE]:       "courses",
+  [LR_TYPE_BOOTCAMP]:     "bootcamps",
+  [LR_TYPE_PROGRAM]:      "programs",
+  [LR_TYPE_USERLIST]:     "userLists",
+  [LR_TYPE_LEARNINGPATH]: "userLists",
+  [LR_TYPE_VIDEO]:        "videos"
+}
+
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 export const DEFAULT_START_DT = "1970-01-01T00:00:00Z"
 export const DEFAULT_END_DT = "2500-01-01T23:59:59Z"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -24,8 +24,11 @@ import { capitalize, emptyOrNil, formatPrice } from "./util"
 import type {
   LearningResourceRun,
   CourseInstructor,
-  CoursePrice
+  CoursePrice,
+  LearningResourceSummary,
+  UserList
 } from "../flow/discussionTypes"
+import type { LearningResourceResult } from "../flow/searchTypes"
 
 export const availabilityFacetLabel = (availability: ?string) => {
   const facetKey = availability ? AVAILABILITY_MAPPING[availability] : null
@@ -271,4 +274,17 @@ export const formatDurationClockTime = (value: string) => {
   values.push(`0${duration.seconds().toString()}`.slice(-2))
 
   return values.join(":")
+}
+
+export const filterListsByResource = (
+  resource: LearningResourceSummary | LearningResourceResult,
+  userLists: Array<UserList>
+) => {
+  return filterItems(userLists, "items", {
+    content_type:
+      resource.object_type === LR_TYPE_LEARNINGPATH
+        ? LR_TYPE_USERLIST
+        : resource.object_type,
+    object_id: resource.id
+  }).map(userList => userList.id)
 }

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -11,6 +11,7 @@ import {
   DATE_FORMAT,
   DEFAULT_END_DT,
   DEFAULT_START_DT,
+  LR_TYPE_ALL,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
@@ -43,7 +44,8 @@ import {
 import {
   makeCourse,
   makeRun,
-  makeUserList
+  makeUserList,
+  makeUserListItem
 } from "../factories/learning_resources"
 import moment from "moment"
 
@@ -429,6 +431,15 @@ describe("Course run availability utils", () => {
     const userLists = times(makeUserList, 5)
     const resource = userLists[3].items[1]
     assert.deepEqual(filterItems(userLists, "items", resource), [userLists[3]])
+  })
+
+  LR_TYPE_ALL.forEach(objectType => {
+    it(`filterListsByResource returns a list of userlists including a ${objectType} item`, () => {
+      const item = makeUserListItem(objectType)
+      const userLists = times(makeUserList, 2)
+      userLists[0].items.push(item)
+      assert.deepEqual(filterItems(userLists, "items", item), [userLists[0]])
+    })
   })
 
   //

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -113,7 +113,7 @@ export const userListMutation = (userList: UserList) => ({
     userLists: { [userList.id]: userList }
   }),
   update: {
-    userLists: R.merge
+    userLists: R.mergeDeepRight
   },
   options: {
     method: "PATCH",

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -124,7 +124,7 @@ describe("UserLists API", () => {
     assert.deepEqual(userListsSelector(testState), testState.entities.userLists)
   })
 
-  it("myUserListsMapSelector should grab only user's userList entities", () => {
+  it("myUserListsSelector should grab only user's userList entities", () => {
     author = results[0].author
     SETTINGS.user_id = author
     assert.deepEqual(

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -74,7 +74,7 @@ import type {
   LearningResourceResult
 } from "../flow/searchTypes"
 import {
-  userListsMapSelector,
+  myUserListsSelector,
   userListsRequest
 } from "../lib/queries/user_lists"
 import type { UserList } from "../flow/discussionTypes"
@@ -520,7 +520,7 @@ const mapStateToProps = (state): StateProps => {
     loaded:     search.loaded,
     processing: search.processing,
     favorites:  favoritesSelector(state),
-    lists:      userListsMapSelector(state)
+    lists:      myUserListsSelector(state)
   }
 }
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ codecov
 ddt
 django-debug-toolbar
 ipdb
-moto
+moto==1.3.13
 nplusone>=0.8.1
 pdbpp
 pip-tools


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2358

#### What's this PR do?
- Fills in the 'favorited' star on a `LearningResourceCard` if the resource is in one of the user's lists. 

#### How should this be manually tested?
- Click the 'star' icon on a resource (both on the search results page and the learning home page).  Add it to a list but don't favorite it.  The star should get filled in.  Remove it from the list and the star should revert back.
