### PR TITLE
Filter out unauthored lists on UserListsPage and AddToListDialog

### DIFF
--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -33,6 +33,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
     user_full_name = None
     user_email = None
     user_is_superuser = False
+    user_id = None
 
     if request.user.is_authenticated:
         user = request.user
@@ -40,6 +41,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         user_full_name = user.profile.name
         user_email = user.email
         user_is_superuser = user.is_superuser
+        user_id = user.id
 
     site = get_default_site()
 
@@ -68,6 +70,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "username": username,
         "user_full_name": user_full_name,
         "user_email": user_email,
+        "user_id": user_id,
         "is_admin": user_is_superuser,
         "authenticated_site": {
             "title": site.title,

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -42,6 +42,7 @@ def test_webpack_url(
         expected_user_values = {
             "user_email": test_user.email,
             "username": test_user.username,
+            "user_id": test_user.id,
             "user_full_name": test_user.profile.name,
             "is_admin": test_user.is_superuser,
         }
@@ -50,6 +51,7 @@ def test_webpack_url(
             "user_email": None,
             "username": None,
             "user_full_name": None,
+            "user_id": None,
             "is_admin": False,
         }
 

--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -25,19 +25,13 @@ import {
   favoriteUserListMutation,
   userListMutation,
   userListsRequest,
-  userListsSelector
+  myUserListsSelector
 } from "../lib/queries/user_lists"
 import { favoriteVideoMutation } from "../lib/queries/videos"
 import {
   learningResourceSelector,
   getResourceRequest
 } from "../lib/queries/learning_resources"
-
-const userListsFormSelector = createSelector(
-  userListsSelector,
-  userLists =>
-    userLists ? Object.keys(userLists).map(key => userLists[key]) : []
-)
 
 const uiDialogSelector = createSelector(
   state => state.ui,
@@ -55,7 +49,7 @@ export default function AddToListDialog() {
 
   const resource = useSelector(learningResourceSelector)(objectId, objectType)
 
-  const userLists = useSelector(userListsFormSelector)
+  const userLists = useSelector(myUserListsSelector)
   const [{ isFinished: isFinishedList }] = useRequest(userListsRequest())
 
   const inLists =

--- a/static/js/components/AddToListDialog_test.js
+++ b/static/js/components/AddToListDialog_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { assert } from "chai"
 import { times } from "ramda"
 import { Checkbox } from "@rmwc/checkbox"
@@ -12,9 +13,13 @@ import { DIALOG_ADD_TO_LIST, setDialogData } from "../actions/ui"
 
 describe("AddToListDialog", () => {
   let renderDialog, userLists, helper, course
+  SETTINGS.user_id = 92932
 
   beforeEach(() => {
-    userLists = times(makeUserList, 5)
+    userLists = times(makeUserList, 7)
+    userLists.forEach((userList, idx) => {
+      userList.author = idx < 5 ? SETTINGS.user_id : 121212
+    })
     course = makeCourse()
     helper = new IntegrationTestHelper()
     renderDialog = helper.configureReduxQueryRenderer(AddToListDialog, {
@@ -44,8 +49,8 @@ describe("AddToListDialog", () => {
     const { wrapper } = await render()
     const checkboxes = wrapper.find(Checkbox)
 
-    // Should be 1 checkbox for each list, plus 1 for favorites
-    assert.equal(checkboxes.length, userLists.length + 1)
+    // Should be 1 checkbox for each list, plus 1 for favorites, minus 2 for non-authored lists
+    assert.equal(checkboxes.length, userLists.length - 1)
 
     // 1st checkbox for Favorites
     const favoriteCheck = checkboxes.at(0)
@@ -66,8 +71,8 @@ describe("AddToListDialog", () => {
     const { wrapper } = await render(object)
     const checkboxes = wrapper.find(Checkbox)
 
-    // Should be 1 checkbox for each list, plus 1 for favorites, -1 for excluded list
-    assert.equal(checkboxes.length, userLists.length)
+    // Should be 1 checkbox for each list, plus 1 for favorites, -2 for non-authored lists, -1 for excluded list
+    assert.equal(checkboxes.length, userLists.length - 2)
 
     const userListCheck = checkboxes.at(1)
     assert.equal(userListCheck.find("label").text(), userLists[1].title)

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -67,7 +67,7 @@ export const makeRun = (): LearningResourceRun => {
         full_name:  casual.name
       }
     ],
-    prices: [{ mode: "audit", price: casual.number }]
+    prices: [{ mode: "audit", price: casual.integer(1, 1000) }]
   }
 }
 
@@ -113,9 +113,9 @@ export const makeUserListItem = (objectType: string) => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   id:           incrUserListItem.next().value,
   is_favorite:  casual.boolean,
-  object_id:    casual.number,
-  position:     casual.number,
-  program:      casual.number,
+  object_id:    casual.integer(1, 1000),
+  position:     casual.integer(1, 1000),
+  program:      casual.integer(1, 1000),
   content_type: objectType,
   content_data: makeLearningResource(objectType)
 })
@@ -164,7 +164,7 @@ export const makeUserList = (): UserList => ({
   profile_img:   casual.url,
   profile_name:  casual.name,
   privacy_level: casual.random_element(["public", "private"]),
-  author:        casual.number
+  author:        casual.integer(1, 1000)
 })
 
 const incrVideo = incrementer()

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -163,7 +163,8 @@ export const makeUserList = (): UserList => ({
   list_type:     "userlist",
   profile_img:   casual.url,
   profile_name:  casual.name,
-  privacy_level: casual.random_element(["public", "private"])
+  privacy_level: casual.random_element(["public", "private"]),
+  author:        casual.number
 })
 
 const incrVideo = incrementer()

--- a/static/js/factories/livestream.js
+++ b/static/js/factories/livestream.js
@@ -6,7 +6,7 @@ import type { LiveStreamEvent } from "../flow/livestreamTypes"
 export const makeLivestreamEvent = (
   isLive: boolean = false
 ): LiveStreamEvent => ({
-  ownerAccountId: casual.number,
-  id:             casual.number,
+  ownerAccountId: casual.integer(1, 1000),
+  id:             casual.integer(1, 1000),
   isLive
 })

--- a/static/js/factories/search.js
+++ b/static/js/factories/search.js
@@ -78,7 +78,7 @@ export const makePostResult = (): PostResult => ({
 })
 
 export const makeCourseResult = (): LearningResourceResult => ({
-  id:                casual.number,
+  id:                casual.integer(1, 1000),
   course_id:         `course_${String(casual.random)}`,
   title:             casual.title,
   url:               casual.url,
@@ -93,7 +93,7 @@ export const makeCourseResult = (): LearningResourceResult => ({
 })
 
 export const makeBootcampResult = (): LearningResourceResult => ({
-  id:                casual.number,
+  id:                casual.integer(1, 1000),
   course_id:         `course_${String(casual.random)}`,
   title:             casual.title,
   url:               casual.url,
@@ -107,7 +107,7 @@ export const makeBootcampResult = (): LearningResourceResult => ({
 })
 
 export const makeProgramResult = (): LearningResourceResult => ({
-  id:                casual.number,
+  id:                casual.integer(1, 1000),
   program_id:        `program_${String(casual.random)}`,
   title:             casual.title,
   url:               casual.url,
@@ -122,7 +122,7 @@ export const makeProgramResult = (): LearningResourceResult => ({
 })
 
 export const makeVideoResult = (): LearningResourceResult => ({
-  id:                casual.number,
+  id:                casual.integer(1, 1000),
   video_id:          `video_${String(casual.random)}`,
   title:             casual.title,
   url:               casual.url,

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -11,6 +11,7 @@ declare var SETTINGS: {
   },
   username: ?string,
   user_full_name: ?string,
+  user_id: ?number,
   profile_ui_enabled: boolean,
   authenticated_site: {
     title: string,

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -422,7 +422,8 @@ export type UserList = LearningResource & {
   items:              Array<UserListItem | UserListItemEdit>,
   list_type:          string,
   object_type:        string,
-  privacy_level:      string
+  privacy_level:      string,
+  author:             number
 }
 
 export type Video = LearningResource & {

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -23,6 +23,7 @@ const _createSettings = () => ({
   is_admin:               false,
   username:               "greatusername",
   user_full_name:         "Great User",
+  user_id:                0,
   profile_ui_enabled:     false,
   course_ui_enabled:      false,
   support_email:          "support@fake.url",

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import R from "ramda"
 import { createSelector } from "reselect"
 
@@ -32,6 +33,16 @@ export const userListsRequest = () => ({
 export const userListsSelector = createSelector(
   state => state.entities.userLists,
   userLists => userLists
+)
+
+export const myUserListsSelector = createSelector(
+  userListsSelector,
+  userLists =>
+    userLists
+      ? Object.keys(userLists)
+        .map(key => userLists[key])
+        .filter(userList => userList.author === SETTINGS.user_id)
+      : []
 )
 
 export const favoriteUserListMutation = (userList: UserList) => ({

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -8,7 +8,7 @@ import {
   deleteUserListMutation,
   userListMutation,
   userListsSelector,
-  myUserListsMapSelector
+  myUserListsSelector
 } from "./user_lists"
 import { makeUserList } from "../../factories/learning_resources"
 import { userListApiURL } from "../url"
@@ -126,7 +126,7 @@ describe("UserLists API", () => {
 
   it("myUserListsMapSelector should grab the right stuff", () => {
     assert.deepEqual(
-      myUserListsMapSelector(testState),
+      myUserListsSelector(testState),
       Object.keys(results)
         .map(key => results[key])
         .filter(result => result.author === author)

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -1,3 +1,5 @@
+// @flow
+/* global SETTINGS: false */
 import { assert } from "chai"
 import { mergeAll, times } from "ramda"
 
@@ -29,8 +31,8 @@ describe("UserLists API", () => {
   })
 
   it("userList request allows fetching a userList", () => {
-    const request = userListRequest("fake-id")
-    assert.equal(request.url, `${userListApiURL}/fake-id/`)
+    const request = userListRequest(45)
+    assert.equal(request.url, `${userListApiURL}/45/`)
     assert.deepEqual(request.transform({ id: "foobar" }), {
       userLists: {
         foobar: { id: "foobar" }
@@ -87,7 +89,6 @@ describe("UserLists API", () => {
 
   it("deleteUserListMutation should return what we expect", () => {
     const query = deleteUserListMutation(userList)
-    assert.isUndefined(query.body)
     assert.equal(query.queryKey, "deleteUserListMutation")
     assert.equal(query.url, `${userListApiURL}/${userList.id}/`)
     assert.deepEqual(query.options, {
@@ -119,11 +120,11 @@ describe("UserLists API", () => {
     })
   })
 
-  it("userListsSelector should grab the right stuff", () => {
+  it("userListsSelector should grab all userList entities from state", () => {
     assert.deepEqual(userListsSelector(testState), testState.entities.userLists)
   })
 
-  it("myUserListsMapSelector should grab the right stuff", () => {
+  it("myUserListsMapSelector should grab only user's userList entities", () => {
     author = results[0].author
     SETTINGS.user_id = author
     assert.deepEqual(

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -13,7 +13,7 @@ import {
 import { makeUserList } from "../../factories/learning_resources"
 import { userListApiURL } from "../url"
 import { LR_TYPE_USERLIST, LR_PUBLIC } from "../constants"
-import {constructIdMap, DEFAULT_POST_OPTIONS} from "../redux_query"
+import { constructIdMap, DEFAULT_POST_OPTIONS } from "../redux_query"
 
 describe("UserLists API", () => {
   let userList, results, testState, author

--- a/static/js/lib/queries/user_lists_test.js
+++ b/static/js/lib/queries/user_lists_test.js
@@ -20,7 +20,6 @@ describe("UserLists API", () => {
 
   beforeEach(() => {
     results = times(makeUserList, 5)
-    author = results[0].author
     userList = results[0]
     testState = {
       entities: {
@@ -125,6 +124,8 @@ describe("UserLists API", () => {
   })
 
   it("myUserListsMapSelector should grab the right stuff", () => {
+    author = results[0].author
+    SETTINGS.user_id = author
     assert.deepEqual(
       myUserListsSelector(testState),
       Object.keys(results)

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -42,7 +42,6 @@ export default function UserListsPage() {
   const [{ isFinished }] = useRequest(userListsRequest())
   const [{ isFinished: isFinishedFavorites }] = useRequest(favoritesRequest())
 
-
   const userLists = useSelector(myUserListsSelector)
   const favoritesUserList = useSelector(favoritesPseudoListSelector)
 

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -2,6 +2,7 @@
 import React, { useState } from "react"
 import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
+import { createSelector } from "reselect"
 
 import { Cell, Grid } from "../components/Grid"
 import {

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -16,7 +16,7 @@ import LoginTooltip from "../components/LoginTooltip"
 
 import {
   myUserListsSelector,
-  userListsRequest,
+  userListsRequest
 } from "../lib/queries/user_lists"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
 import { userIsAnonymous } from "../lib/util"

--- a/static/js/pages/UserListsPage.js
+++ b/static/js/pages/UserListsPage.js
@@ -2,7 +2,6 @@
 import React, { useState } from "react"
 import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
-import { createSelector } from "reselect"
 
 import { Cell, Grid } from "../components/Grid"
 import {
@@ -15,7 +14,10 @@ import UserListCard from "../components/UserListCard"
 import UserListFormDialog from "../components/UserListFormDialog"
 import LoginTooltip from "../components/LoginTooltip"
 
-import { userListsRequest, userListsSelector } from "../lib/queries/user_lists"
+import {
+  myUserListsSelector,
+  userListsRequest,
+} from "../lib/queries/user_lists"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
 import { userIsAnonymous } from "../lib/util"
 import {
@@ -23,12 +25,6 @@ import {
   favoritesListSelector
 } from "../lib/queries/learning_resources"
 import { FAVORITES_PSEUDO_LIST } from "../lib/constants"
-
-const userListsPageSelector = createSelector(
-  userListsSelector,
-  userLists =>
-    userLists ? Object.keys(userLists).map(key => userLists[key]) : null
-)
 
 const favoritesPseudoListSelector = createSelector(
   favoritesListSelector,
@@ -45,7 +41,8 @@ export default function UserListsPage() {
   const [{ isFinished }] = useRequest(userListsRequest())
   const [{ isFinished: isFinishedFavorites }] = useRequest(favoritesRequest())
 
-  const userLists = useSelector(userListsPageSelector)
+
+  const userLists = useSelector(myUserListsSelector)
   const favoritesUserList = useSelector(favoritesPseudoListSelector)
 
   return (

--- a/static/js/pages/UserListsPage_test.js
+++ b/static/js/pages/UserListsPage_test.js
@@ -47,13 +47,14 @@ describe("UserListsPage tests", () => {
       SETTINGS.user_id = authorId
       const { wrapper } = await render()
       const cards = wrapper.find("UserListCard")
-      assert.equal(cards.length, numLists)
+      // Expect <numLists> cards, plus 1 for favorites
+      assert.equal(cards.length, numLists + 1)
       userLists.slice(0, numLists).forEach((list, i) => {
         assert.equal(
           list,
           wrapper
             .find("UserListCard")
-            .at(i)
+            .at(i+1)
             .prop("userList")
         )
       })

--- a/static/js/pages/UserListsPage_test.js
+++ b/static/js/pages/UserListsPage_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { assert } from "chai"
 
 import UserListsPage from "./UserListsPage"
@@ -14,10 +15,15 @@ import * as util from "../lib/util"
 import { FAVORITES_PSEUDO_LIST } from "../lib/constants"
 
 describe("UserListsPage tests", () => {
+
   let helper, userLists, render, favorites
+  const userId = 92932
 
   beforeEach(() => {
     userLists = [makeUserList(), makeUserList(), makeUserList()]
+    userLists[0].author = userId
+    userLists[1].author = userId
+    userLists[2].author = userId + 1
     helper = new IntegrationTestHelper()
 
     helper.handleRequestStub
@@ -34,16 +40,23 @@ describe("UserListsPage tests", () => {
     helper.cleanup()
   })
 
-  it("should pass user lists down to user list card", async () => {
-    const { wrapper } = await render()
-    userLists.forEach((list, i) => {
-      assert.equal(
-        list,
-        wrapper
-          .find("UserListCard")
-          .at(i + 1)
-          .prop("userList")
-      )
+
+  //
+  ;[[userId, 2], [null, 0]].forEach(([authorId, numLists]) => {
+    it(`should pass ${numLists} user lists down to user list card`, async () => {
+      SETTINGS.user_id = authorId
+      const { wrapper } = await render()
+      const cards = wrapper.find("UserListCard")
+      assert.equal(cards.length, numLists)
+      userLists.slice(0, numLists).forEach((list, i) => {
+        assert.equal(
+          list,
+          wrapper
+            .find("UserListCard")
+            .at(i)
+            .prop("userList")
+        )
+      })
     })
   })
 

--- a/static/js/pages/UserListsPage_test.js
+++ b/static/js/pages/UserListsPage_test.js
@@ -15,7 +15,6 @@ import * as util from "../lib/util"
 import { FAVORITES_PSEUDO_LIST } from "../lib/constants"
 
 describe("UserListsPage tests", () => {
-
   let helper, userLists, render, favorites
   const userId = 92932
 
@@ -40,7 +39,6 @@ describe("UserListsPage tests", () => {
     helper.cleanup()
   })
 
-
   //
   ;[[userId, 2], [null, 0]].forEach(([authorId, numLists]) => {
     it(`should pass ${numLists} user lists down to user list card`, async () => {
@@ -54,7 +52,7 @@ describe("UserListsPage tests", () => {
           list,
           wrapper
             .find("UserListCard")
-            .at(i+1)
+            .at(i + 1)
             .prop("userList")
         )
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2382 

#### What's this PR do?
Filters out any lists in `state.entities.userLists` that are not authored by the current user

#### How should this be manually tested?
- As user A, search for user lists or learning paths and favorite 1+ that are authored by user B
- Go to the "My Lists" page, the recently favorited lists by user B should not show up here
- Click the star on any resource card to open the 'Add to List' dialog, only your own lists should show up here as well.
