### PR TITLE
Simplified serializers for UserListView list response

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -79,28 +79,6 @@ class FavoriteSerializerMixin(serializers.Serializer):
             return False
 
 
-class ListsSerializerMixin(serializers.Serializer):
-    """
-    Mixin to serialize lists for various models
-    """
-
-    lists = serializers.SerializerMethodField()
-
-    def get_lists(self, obj):
-        """
-        Return a list of user's lists/path id's that a resource is in.
-        """
-        request = self.context.get("request")
-        if request and hasattr(request, "user") and isinstance(request.user, User):
-            return UserListItem.objects.filter(
-                author=request.user,
-                object_id=obj.id,
-                content_type=ContentType.objects.get_for_model(obj),
-            ).values_list("user_list", flat=True)
-        else:
-            return []
-
-
 class CourseInstructorSerializer(serializers.ModelSerializer):
     """
     Serializer for CourseInstructor model
@@ -139,7 +117,7 @@ class LearningResourceOfferorField(serializers.Field):
         return list(value.values_list("name", flat=True))
 
 
-class BaseCourseSerializer(FavoriteSerializerMixin, ListsSerializerMixin, serializers.ModelSerializer):
+class BaseCourseSerializer(FavoriteSerializerMixin, serializers.ModelSerializer):
     """
     Serializer with common functions to be used by CourseSerializer and BootcampSerialzer
     """
@@ -453,7 +431,7 @@ class UserListItemSerializer(SimpleUserListItemSerializer):
         fields = "__all__"
 
 
-class SimpleUserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin):
+class SimpleUserListSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
     """
     Simplified serializer for UserList model
     """
@@ -564,7 +542,7 @@ class ProgramItemSerializer(serializers.ModelSerializer, FavoriteSerializerMixin
         fields = "__all__"
 
 
-class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin):
+class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
     """
     Serializer for Program model
     """
@@ -580,7 +558,7 @@ class ProgramSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, Li
         fields = "__all__"
 
 
-class VideoSerializer(serializers.ModelSerializer, FavoriteSerializerMixin, ListsSerializerMixin):
+class VideoSerializer(serializers.ModelSerializer, FavoriteSerializerMixin):
     """
     Serializer for Video model
     """

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -353,9 +353,10 @@ class SimpleUserListItemSerializer(
 
     def get_content_data(self, instance):
         """Get the item content_data with image_src only"""
+        image_src = None
         if instance.item and instance.item.image_src:
-            return {"image_src": instance.item.image_src}
-        return {}
+            image_src = instance.item.image_src
+        return {"image_src": image_src}
 
     def validate(self, attrs):
         content_type = attrs.get("content_type", {}).get("name", None)

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -349,6 +349,13 @@ class SimpleUserListItemSerializer(
     """
 
     content_type = serializers.CharField(source="content_type.name")
+    content_data = serializers.SerializerMethodField()
+
+    def get_content_data(self, instance):
+        """Get the item content_data with image_src only"""
+        if instance.item and instance.item.image_src:
+            return {"image_src": instance.item.image_src}
+        return {}
 
     def validate(self, attrs):
         content_type = attrs.get("content_type", {}).get("name", None)
@@ -392,7 +399,7 @@ class SimpleUserListItemSerializer(
 
     class Meta:
         model = UserListItem
-        fields = ("id", "object_id", "content_type", "is_favorite")
+        fields = ("id", "object_id", "content_type", "is_favorite", "content_data")
 
 
 class UserListItemSerializer(SimpleUserListItemSerializer):

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -15,6 +15,7 @@ from course_catalog.factories import (
     UserListFactory,
     LearningResourceRunFactory,
     ProgramItemCourseFactory,
+    UserListCourseFactory,
 )
 from course_catalog.models import FavoriteItem, UserListItem
 from course_catalog.serializers import (
@@ -26,6 +27,7 @@ from course_catalog.serializers import (
     LearningResourceRunSerializer,
     UserListItemSerializer,
     SimpleUserListSerializer,
+    SimpleUserListItemSerializer,
 )
 from open_discussions.factories import UserFactory
 
@@ -199,6 +201,21 @@ def test_userlistitem_serializer_validation(
     }
     serializer = UserListItemSerializer(data=data)
     assert serializer.is_valid() == (valid_type and object_exists)
+
+
+def test_simpleuserlistitem_serializer_content_data():
+    """
+    Test that the SimpleUserListItemSerializer includes content_data with an image_src
+    """
+    course = CourseFactory.create()
+    userlistitem = UserListCourseFactory.create(
+        content_object=course, user_list=UserListFactory.create()
+    )
+    expected_content_data = {"image_src": course.image_src}
+    item_serializer = SimpleUserListItemSerializer(instance=userlistitem)
+    assert item_serializer.data["content_data"] == expected_content_data
+    list_serializer = SimpleUserListSerializer(instance=userlistitem.user_list)
+    assert list_serializer.data["items"][0]["content_data"] == expected_content_data
 
 
 def test_favorites_serializer():

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -25,6 +25,7 @@ from course_catalog.serializers import (
     ProgramSerializer,
     LearningResourceRunSerializer,
     UserListItemSerializer,
+    SimpleUserListSerializer,
 )
 from open_discussions.factories import UserFactory
 
@@ -141,6 +142,24 @@ def test_userlist_serializer_validation(list_type, valid):
     """
     data = {"title": "My List", "list_type": list_type}
     serializer = UserListSerializer(data=data)
+    assert serializer.is_valid() == valid
+
+
+@pytest.mark.parametrize(
+    "list_type,valid",
+    [
+        [ListType.LIST.value, True],
+        [ListType.LEARNING_PATH.value, True],
+        ["bad_type", False],
+        [None, False],
+    ],
+)
+def test_simple_userlist_serializer_validation(list_type, valid):
+    """
+    Test that the SimpleUserListSerializer validates list_type correctly
+    """
+    data = {"title": "My List", "list_type": list_type}
+    serializer = SimpleUserListSerializer(data=data)
     assert serializer.is_valid() == valid
 
 

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -203,7 +203,8 @@ def test_userlistitem_serializer_validation(
     assert serializer.is_valid() == (valid_type and object_exists)
 
 
-def test_simpleuserlistitem_serializer_content_data():
+@pytest.mark.parametrize("is_null", [True, False])
+def test_simpleuserlistitem_serializer_content_data(is_null):
     """
     Test that the SimpleUserListItemSerializer includes content_data with an image_src
     """
@@ -212,6 +213,9 @@ def test_simpleuserlistitem_serializer_content_data():
         content_object=course, user_list=UserListFactory.create()
     )
     expected_content_data = {"image_src": course.image_src}
+    if is_null:
+        course.delete()
+        expected_content_data = {"image_src": None}
     item_serializer = SimpleUserListItemSerializer(instance=userlistitem)
     assert item_serializer.data["content_data"] == expected_content_data
     list_serializer = SimpleUserListSerializer(instance=userlistitem.user_list)

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -29,6 +29,7 @@ from course_catalog.serializers import (
     BootcampSerializer,
     FavoriteItemSerializer,
     VideoSerializer,
+    SimpleUserListSerializer,
 )
 from open_discussions.permissions import AnonymousAccessReadonlyPermission
 
@@ -187,15 +188,29 @@ class BootcampViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):
     permission_classes = (AnonymousAccessReadonlyPermission,)
 
 
+class UserListViewPagination(LimitOffsetPagination):
+    """
+    Pagination class for the UserList list view
+    on the frontend we have to fetch all the results,
+    for the same reason as favorites :/
+    """
+
+    default_limit = 1000
+    max_limit = 1000
+
+
 class UserListViewSet(viewsets.ModelViewSet, FavoriteViewMixin):
     """
     Viewset for User Lists & Learning Paths
     """
 
     queryset = UserList.objects.all().prefetch_related("items")
-    serializer_class = UserListSerializer
-    pagination_class = DefaultPagination
+    serializer_classes = {"list": SimpleUserListSerializer}
+    pagination_class = UserListViewPagination
     permission_classes = (HasUserListPermissions,)
+
+    def get_serializer_class(self):
+        return self.serializer_classes.get(self.action, UserListSerializer)
 
     def list(self, request, *args, **kwargs):
         """Override default list to only get lists authored by user"""

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -126,12 +126,15 @@ def test_user_list_endpoint_get(client, is_public, is_author, user):
     client.force_login(author if is_author else user)
     resp = client.get(reverse("userlists-list"))
     assert resp.data.get("count") == (1 if is_author else 0)
+    if is_author:
+        assert "content_data" not in resp.data.get("results")[0]
 
     resp = client.get(reverse("userlists-detail", args=[user_list.id]))
     assert resp.status_code == (403 if not (is_public or is_author) else 200)
     if resp.status_code == 200:
         assert resp.data.get("title") == user_list.title
         for item in resp.data.get("items"):
+            assert "content_data" in item
             if item.get("position") == 1:
                 assert item.get("id") == bootcamp_item.id
             else:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Partially address #2378

#### What's this PR do?
- When requesting a list of UserLists, returns a simplified response via a UserListItem serializer that contains only the essential properties needed to maintain existing functionality (favoriting, adding/remove items to list, etc).

#### How should this be manually tested?
- The 'My Lists' page should still work as before but load faster
- You should still be able to add/remove items in a list, un/favorite items, create/delete lists, view list details
