### PR TITLE
add a display of the userlist description to the userlist detail page

### DIFF
--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -46,6 +46,9 @@ export default function UserListDetailPage(props: Props) {
         <Grid className="main-content one-column narrow user-list-page">
           <Cell width={12}>
             <h1 className="list-header">{userList.title}</h1>
+            {userList.short_description ? (
+              <p className="list-description">{userList.short_description}</p>
+            ) : null}
           </Cell>
           {userList.items.map((item, i) => (
             <Cell width={12} key={i}>

--- a/static/js/pages/UserListDetailPage_test.js
+++ b/static/js/pages/UserListDetailPage_test.js
@@ -43,6 +43,20 @@ describe("UserListDetailPage tests", () => {
     assert.equal(wrapper.find(".list-header").text(), userList.title)
   })
 
+  it("should should show the description", async () => {
+    const { wrapper } = await render()
+    assert.equal(
+      wrapper.find(".list-description").text(),
+      userList.short_description
+    )
+  })
+
+  it("should not show the description if not there", async () => {
+    userList.short_description = undefined
+    const { wrapper } = await render()
+    assert.isNotOk(wrapper.find(".list-description").exists())
+  })
+
   it("should render the list items", async () => {
     const { wrapper } = await render()
     R.zip([...wrapper.find(LearningResourceCard)], userList.items).forEach(

--- a/static/scss/user-list-page.scss
+++ b/static/scss/user-list-page.scss
@@ -12,4 +12,8 @@
   .empty-message {
     font-style: italic;
   }
+
+  .list-description {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, just a quick thing that got left off

#### What's this PR do?

if the user has set a description on their userlist this adds a little display of that description on the detail page (`/courses/lists/${id}`).

#### How should this be manually tested?

create a userlist which does not have a description and confirm that the detail page doesn't render a `p.list-description`.

create one with a description (or edit the first one to have a description) and confirm you can see it on the detail page.


#### Screenshots (if appropriate)

![publiclistdescf](https://user-images.githubusercontent.com/6207644/68968035-96450b80-07af-11ea-84a7-2a9a71d5cf29.png)
![publiclistdesc](https://user-images.githubusercontent.com/6207644/68968036-96dda200-07af-11ea-99c5-2b105a7305eb.png)
