### PR TITLE
Support topics CRUD in UserList API

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -32,10 +32,6 @@ from course_catalog.utils import (
 from open_discussions.serializers import WriteableSerializerMethodField
 from search.task_helpers import upsert_user_list
 
-import logging
-
-log = logging.getLogger()
-
 
 class GenericForeignKeyFieldSerializer(serializers.ModelSerializer):
     """
@@ -480,7 +476,6 @@ class SimpleUserListSerializer(
 
     def validate_topics(self, topics):
         """Validator for topics"""
-        log.error(f"VALIDATING {topics}")
         if CourseTopic.objects.filter(
             id__in=[topic["id"] for topic in topics]
         ).count() != len(topics):
@@ -541,7 +536,6 @@ class UserListSerializer(SimpleUserListSerializer):
         if request and hasattr(request, "user") and isinstance(request.user, User):
             validated_data["author"] = request.user
             topics_data = [topic["id"] for topic in validated_data.pop("topics", [])]
-            log.error(f"TOPICS: {topics_data}")
             items_data = validated_data.pop("items", [])
             # iterate through any UserListItem objects that should be created/modified/deleted:
             with transaction.atomic():

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -476,10 +476,13 @@ class SimpleUserListSerializer(
 
     def validate_topics(self, topics):
         """Validator for topics"""
-        if CourseTopic.objects.filter(
-            id__in=[topic["id"] for topic in topics]
-        ).count() != len(topics):
-            raise ValidationError("One of your topics is not valid")
+        topic_ids = set([topic["id"] for topic in topics])
+        valid_topic_ids = set(
+            CourseTopic.objects.filter(id__in=topic_ids).values_list("id", flat=True)
+        )
+        missing = set(topic_ids).difference(valid_topic_ids)
+        if missing:
+            raise ValidationError(f"Invalid topic ids: {missing}")
         return {"topics": topics}
 
     def get_topics(self, instance):

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -476,11 +476,11 @@ class SimpleUserListSerializer(
 
     def validate_topics(self, topics):
         """Validator for topics"""
-        topic_ids = set([topic["id"] for topic in topics])
+        topic_ids = {topic["id"] for topic in topics}
         valid_topic_ids = set(
             CourseTopic.objects.filter(id__in=topic_ids).values_list("id", flat=True)
         )
-        missing = set(topic_ids).difference(valid_topic_ids)
+        missing = topic_ids.difference(valid_topic_ids)
         if missing:
             raise ValidationError(f"Invalid topic ids: {missing}")
         return {"topics": topics}
@@ -582,8 +582,10 @@ class UserListSerializer(SimpleUserListSerializer):
                             item.save()
                 userlist = super().update(instance, validated_data)
                 if topics_data is not None:
-                    userlist.topics.set(CourseTopic.objects.filter(
-                        id__in=[topic["id"] for topic in topics_data])
+                    userlist.topics.set(
+                        CourseTopic.objects.filter(
+                            id__in=[topic["id"] for topic in topics_data]
+                        )
                     )
                 upsert_user_list(userlist)
                 return userlist

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -476,7 +476,10 @@ class SimpleUserListSerializer(
 
     def validate_topics(self, topics):
         """Validator for topics"""
-        topic_ids = {topic["id"] for topic in topics}
+        try:
+            topic_ids = {topic["id"] for topic in topics}
+        except KeyError:
+            raise ValidationError("Topics must have id's")
         valid_topic_ids = set(
             CourseTopic.objects.filter(id__in=topic_ids).values_list("id", flat=True)
         )

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -152,17 +152,22 @@ def test_userlist_serializer_validation(list_type, valid):
     assert serializer.is_valid() is valid
 
 
-def test_userlist_serializer_validation_bad_topic():
+@pytest.mark.parametrize(
+    "data, error",
+    [[{"id": 9999}, "Invalid topic ids: {9999}"], [{}, "Topics must have id's"]],
+)
+def test_userlist_serializer_validation_bad_topic(data, error):
     """
     Test that the UserListSerializer invalidates a non-existent topic
     """
     data = {
         "title": "My List",
         "list_type": ListType.LEARNING_PATH.value,
-        "topics": [{"id": 9999}],
+        "topics": [data],
     }
     serializer = UserListSerializer(data=data)
     assert serializer.is_valid() is False
+    assert serializer.errors["topics"][0] == error
 
 
 @pytest.mark.parametrize(

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -142,9 +142,27 @@ def test_userlist_serializer_validation(list_type, valid):
     """
     Test that the UserListSerializer validates list_type correctly
     """
-    data = {"title": "My List", "list_type": list_type}
+    topics = CourseTopicFactory.create_batch(2)
+    data = {
+        "title": "My List",
+        "list_type": list_type,
+        "topics": [{"id": topic.id} for topic in topics],
+    }
     serializer = UserListSerializer(data=data)
-    assert serializer.is_valid() == valid
+    assert serializer.is_valid() is valid
+
+
+def test_userlist_serializer_validation_bad_topic():
+    """
+    Test that the UserListSerializer invalidates a non-existent topic
+    """
+    data = {
+        "title": "My List",
+        "list_type": ListType.LEARNING_PATH.value,
+        "topics": [{"id": 9999}],
+    }
+    serializer = UserListSerializer(data=data)
+    assert serializer.is_valid() is False
 
 
 @pytest.mark.parametrize(

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -202,7 +202,9 @@ def test_user_list_endpoint_create(client, is_anonymous, mock_user_list_index):
 def test_user_list_endpoint_patch(client, user, mock_user_list_index, update_topics):
     """Test userlist endpoint for updating a UserList"""
     [original_topic, new_topic] = CourseTopicFactory.create_batch(2)
-    userlist = UserListFactory.create(author=user, title="Title 1", topics=[original_topic])
+    userlist = UserListFactory.create(
+        author=user, title="Title 1", topics=[original_topic]
+    )
 
     client.force_login(user)
 
@@ -215,7 +217,9 @@ def test_user_list_endpoint_patch(client, user, mock_user_list_index, update_top
     )
     assert resp.status_code == 200
     assert UserList.objects.get(id=userlist.id).title == "Title 2"
-    assert resp.data["topics"][0]["id"] == (new_topic.id if update_topics else original_topic.id)
+    assert resp.data["topics"][0]["id"] == (
+        new_topic.id if update_topics else original_topic.id
+    )
     mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
 
 

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -21,6 +21,7 @@ from course_catalog.factories import (
     VideoFactory,
 )
 from course_catalog.models import UserList, UserListItem
+from course_catalog.serializers import CourseTopicSerializer
 from open_discussions.factories import UserFactory
 
 # pylint:disable=redefined-outer-name
@@ -213,8 +214,11 @@ def test_user_list_endpoint_patch(client, user, mock_user_list_index):
     mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
 
 
+@pytest.mark.parametrize("num_topics", [0, 2])
 @pytest.mark.parametrize("is_author", [True, False])
-def test_user_list_endpoint_create_item(client, user, is_author, mock_user_list_index):
+def test_user_list_endpoint_create_item(
+    client, user, is_author, mock_user_list_index, num_topics
+):
     """Test userlist endpoint for creating a UserListItem"""
     author = UserFactory.create()
     userlist = UserListFactory.create(
@@ -222,9 +226,20 @@ def test_user_list_endpoint_create_item(client, user, is_author, mock_user_list_
     )
     course = CourseFactory.create()
 
+    topics = sorted(
+        [
+            CourseTopicSerializer(instance=topic).data
+            for topic in CourseTopicFactory.create_batch(num_topics)
+        ],
+        key=lambda topic: topic["id"],
+    )
+
     client.force_login(author if is_author else user)
 
-    data = {"items": [{"content_type": "course", "object_id": course.id}]}
+    data = {
+        "items": [{"content_type": "course", "object_id": course.id}],
+        "topics": topics,
+    }
 
     resp = client.patch(
         reverse("userlists-detail", args=[userlist.id]), data=data, format="json"
@@ -233,6 +248,9 @@ def test_user_list_endpoint_create_item(client, user, is_author, mock_user_list_
     if resp.status_code == 200:
         assert len(resp.data.get("items")) == 1
         assert resp.data.get("items")[0]["object_id"] == course.id
+        assert (
+            sorted(resp.data.get("topics", []), key=lambda topic: topic["id"]) == topics
+        )
         mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
 
 
@@ -261,8 +279,9 @@ def test_user_list_endpoint_create_item_bad_data(client, user):
 def test_user_list_endpoint_update_items(client, user, is_author, mock_user_list_index):
     """Test userlist endpoint for updating UserListItem positions"""
     author = UserFactory.create()
+    topics = CourseTopicFactory.create_batch(3)
     userlist = UserListFactory.create(
-        author=author, privacy_level=PrivacyLevel.public.value
+        author=author, privacy_level=PrivacyLevel.public.value, topics=topics
     )
     list_items = sorted(
         UserListCourseFactory.create_batch(2, user_list=userlist),
@@ -275,7 +294,8 @@ def test_user_list_endpoint_update_items(client, user, is_author, mock_user_list
         "items": [
             {"id": list_items[0].id, "position": 44},
             {"id": list_items[1].id, "position": 33},
-        ]
+        ],
+        "topics": [{"id": topics[0].id}],
     }
 
     resp = client.patch(
@@ -283,6 +303,9 @@ def test_user_list_endpoint_update_items(client, user, is_author, mock_user_list
     )
     assert resp.status_code == (200 if is_author else 403)
     if resp.status_code == 200:
+        assert resp.data.get("topics") == [
+            CourseTopicSerializer(instance=topics[0]).data
+        ]
         updated_items = sorted(
             resp.data.get("items"), key=lambda item: item["position"]
         )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Partially addresses #2395 

#### What's this PR do?
Supports changing the topics in a list on creation/update via API

#### How should this be manually tested?
- Go to `http://od.odl.local:8063/api/v0/lists`
- Enter the following data and post it to create a new list with topics:
  ```
  {
      "topics": [{"id": <valid_topic_id>}, {"id": <valid_topic_id>}],
      "title": "A new list with topics",
      "short_description": "short description",
      "privacy_level": "private",
      "list_type": "userlist"
  }
  ```
- a new list should be created with the topics you selected
- Go to `http://od.odl.local:8063/api/v0/userlists/<new_userlist_id>/`
- Set the patch data to include a different topic or no topic at all, for example:
  ```
  {"topics": [{"id": <different_topic_id>}]}
  ```
  or
  ```
  {"topics": []}
  ```
- The userlist's topics should be updated when the data is patched.
- If you don't include "topics" in the request data at all, the current list topic(s) if any should remain unchanged.

