### PR TITLE
display user list in LR drawer

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -473,6 +473,11 @@ class SimpleUserListSerializer(
     items = SimpleUserListItemSerializer(many=True, allow_null=True, read_only=True)
     topics = WriteableSerializerMethodField()
     object_type = serializers.CharField(read_only=True, default="userlist")
+    author_name = serializers.SerializerMethodField()
+
+    def get_author_name(self, instance):
+        """get author name for userlist"""
+        return instance.author.profile.name
 
     def validate_topics(self, topics):
         """Validator for topics"""
@@ -515,7 +520,7 @@ class SimpleUserListSerializer(
     class Meta:
         model = UserList
         fields = "__all__"
-        read_only_fields = ["author", "items"]
+        read_only_fields = ["author", "items", "author_name"]
 
 
 class UserListSerializer(SimpleUserListSerializer):

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -5,3 +5,4 @@ moment = require("moment")
 S = require("sanctuary")
 sinon = require("sinon")
 assert = require("chai").assert
+casual = require("casual-browserify")

--- a/static/js/components/CourseCarousel.js
+++ b/static/js/components/CourseCarousel.js
@@ -4,7 +4,7 @@ import React, { useState } from "react"
 import Carousel from "nuka-carousel"
 import R from "ramda"
 
-import LearningResourceCard from "./LearningResourceCard"
+import { LearningResourceCard } from "./LearningResourceCard"
 
 import { SEARCH_GRID_UI, SEARCH_UI_GRID_WIDTHS } from "../lib/search"
 import { useDeviceCategory } from "../hooks/util"

--- a/static/js/components/CourseCarousel_test.js
+++ b/static/js/components/CourseCarousel_test.js
@@ -16,7 +16,11 @@ describe("CourseCarousel", () => {
     helper = new IntegrationTestHelper()
     courses = R.times(makeCourse, 10)
     setShowResourceDrawerStub = helper.sandbox.stub()
-    helper.stubComponent(LRCardModule, "LearningResourceCard")
+    helper.stubComponent(
+      LRCardModule,
+      "LearningResourceCard",
+      "LearningResourceCard"
+    )
     render = helper.configureHOCRenderer(
       CourseCarousel,
       CourseCarousel,
@@ -45,7 +49,7 @@ describe("CourseCarousel", () => {
     const { wrapper } = await render()
     const carousel = wrapper.find("Carousel")
     R.zip(
-      carousel.find("LearningResourceCard").map(R.identity),
+      carousel.find("LearningResourceDisplay").map(R.identity),
       courses
     ).forEach(([el, course]) => {
       course.object_type = LR_TYPE_COURSE

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -8,11 +8,14 @@ import moment from "moment"
 
 import TruncatedText from "./TruncatedText"
 import Embedly from "./Embedly"
+import { LearningResourceRow } from "../components/LearningResourceCard"
 
 import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
   LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH,
   platforms
 } from "../lib/constants"
 import {
@@ -22,23 +25,36 @@ import {
   getInstructorName,
   getPreferredOfferedBy,
   isCoursewareResource,
-  formatDurationClockTime
+  formatDurationClockTime,
+  userListCoverImage
 } from "../lib/learning_resources"
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
 import { capitalize, emptyOrNil, languageName } from "../lib/util"
-
-import type { Bootcamp, Course, Program } from "../flow/discussionTypes"
+import { SEARCH_LIST_UI } from "../lib/search"
 
 const COURSE_IMAGE_DISPLAY_HEIGHT = 239
 const COURSE_IMAGE_DISPLAY_WIDTH = 440
 const entities = new AllHtmlEntities()
 
 type Props = {
-  object: Course | Bootcamp | Program,
+  object: any, // honestly we had like 10 FlowFixMe in this file before, I think this is just easier
   runId: number,
   setShowResourceDrawer: Function,
   embedly: ?Object
 }
+
+const getObjectImg = object =>
+  [LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(object.object_type)
+    ? userListCoverImage(object)
+    : object.image_src
+
+const courseInfoRow = (iconName, label, value) => (
+  <div className="course-info-row">
+    <i className={`material-icons ${iconName}`}>{iconName}</i>
+    <div className="course-info-label">{label}</div>
+    <div className="course-info-value">{value}</div>
+  </div>
+)
 
 const ExpandedLearningResourceDisplay = (props: Props) => {
   const { object, runId, setShowResourceDrawer, embedly } = props
@@ -66,159 +82,168 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
       : []
 
   return (
-    <div className="expanded-course-summary">
-      <div className="summary">
-        {selectedRun ? (
-          <div className="course-info-row form centered">
-            <i className="material-icons school">school</i>
-            <div className="course-info-label">
-              {// $FlowFixMe: only courses will access platform
-                object.platform === platforms.OCW
-                  ? "As Taught In"
-                  : "Start Date"}:
+    <React.Fragment>
+      <div className="expanded-course-summary">
+        <div className="summary">
+          {selectedRun ? (
+            <div className="course-info-row form centered">
+              <i className="material-icons school">school</i>
+              <div className="course-info-label">
+                {// $FlowFixMe: only courses will access platform
+                  object.platform === platforms.OCW
+                    ? "As Taught In"
+                    : "Start Date"}
+                :
+              </div>
+              <div className="select-semester-div">
+                {objectRuns.length > 1 ? (
+                  <select value={runId} onChange={updateRun}>
+                    {objectRuns.map(run => (
+                      <option value={run.id} key={run.id}>
+                        {getStartDate(object, run)}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <div>{getStartDate(object, selectedRun)}</div>
+                )}
+              </div>
             </div>
-            <div className="select-semester-div">
-              {objectRuns.length > 1 ? (
-                <select value={runId} onChange={updateRun}>
-                  {objectRuns.map(run => (
-                    <option value={run.id} key={run.id}>
-                      {getStartDate(object, run)}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <div>{getStartDate(object, selectedRun)}</div>
-              )}
-            </div>
+          ) : null}
+          <div className="course-image-div">
+            {object.object_type === LR_TYPE_VIDEO ? (
+              <Embedly embedly={embedly} />
+            ) : (
+              <img
+                src={embedlyThumbnail(
+                  SETTINGS.embedlyKey,
+                  getObjectImg(object) || defaultResourceImageURL(),
+                  COURSE_IMAGE_DISPLAY_HEIGHT,
+                  COURSE_IMAGE_DISPLAY_WIDTH
+                )}
+              />
+            )}
           </div>
-        ) : null}
-        <div className="course-image-div">
-          {object.object_type === LR_TYPE_VIDEO ? (
-            <Embedly embedly={embedly} />
-          ) : (
-            <img
-              src={embedlyThumbnail(
-                SETTINGS.embedlyKey,
-                object.image_src || defaultResourceImageURL(),
-                COURSE_IMAGE_DISPLAY_HEIGHT,
-                COURSE_IMAGE_DISPLAY_WIDTH
-              )}
+          {isCoursewareResource(object.object_type) && url ? (
+            <div className="course-links">
+              <div>
+                <a
+                  className="link-button"
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {`Take ${capitalize(object.object_type)}`}
+                  {offeredBy && object.object_type !== LR_TYPE_BOOTCAMP
+                    ? ` on ${offeredBy}`
+                    : null}
+                </a>
+              </div>
+            </div>
+          ) : null}
+          <div className="course-title">{object.title}</div>
+          <div className="course-description">
+            <TruncatedText
+              text={entities.decode(striptags(object.short_description))}
+              lines={5}
+              estCharsPerLine={100}
+              showExpansionControls
             />
-          )}
-        </div>
-        {isCoursewareResource(object.object_type) && url ? (
-          <div className="course-links">
-            <div>
-              <a
-                className="link-button"
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {`Take ${capitalize(object.object_type)}`}
-                {offeredBy && object.object_type !== LR_TYPE_BOOTCAMP
-                  ? ` on ${offeredBy}`
-                  : null}
-              </a>
-            </div>
           </div>
-        ) : null}
-        <div className="course-title">{object.title}</div>
-        <div className="course-description">
-          <TruncatedText
-            text={entities.decode(striptags(object.short_description))}
-            lines={5}
-            estCharsPerLine={100}
-            showExpansionControls
-          />
-        </div>
-        {!emptyOrNil(object.topics) ? (
-          <React.Fragment>
-            <div className="course-subheader row">Topics</div>
-            <div className="course-topics">
-              {object.topics.map((topic, i) => (
-                <div className="grey-surround facet" key={i}>
-                  {topic.name}
-                </div>
-              ))}
-            </div>
-          </React.Fragment>
-        ) : null}
-        <div className="course-subheader row">Info</div>
-        {cost ? (
-          <div className="course-info-row">
-            <i className="material-icons attach_money">attach_money</i>
-            <div className="course-info-label">Cost:</div>
-            <div className="course-info-value">{cost}</div>
-          </div>
-        ) : null}
-        {selectedRun && selectedRun.level ? (
-          <div className="course-info-row">
-            <i className="material-icons bar_chart">bar_chart</i>
-            <div className="course-info-label">Level:</div>
-            <div className="course-info-value">{selectedRun.level}</div>
-          </div>
-        ) : null}
-        {!emptyOrNil(instructors) ? (
-          <div className="course-info-row">
-            <i className="material-icons school">school</i>
-            <div className="course-info-label">Instructors:</div>
-            <div className="course-info-value">{R.join(", ", instructors)}</div>
-          </div>
-        ) : null}
-        {object.object_type === LR_TYPE_PROGRAM ? (
-          <div className="course-info-row">
-            <i className="material-icons menu_book">menu_book</i>
-            <div className="course-info-label">Number of Courses:</div>
-            <div className="course-info-value">
-              {
-                // $FlowFixMe: only programs will get to this code
-                object.items.length
-              }
-            </div>
-          </div>
-        ) : null}
-        {isCoursewareResource(object.object_type) ? (
-          <div className="course-info-row">
-            <i className="material-icons language">language</i>
-            <div className="course-info-label">Language:</div>
-            <div className="course-info-value">
-              {languageName(selectedRun ? selectedRun.language : "en")}
-            </div>
-          </div>
-        ) : null}
-        {object.object_type === LR_TYPE_VIDEO ? (
-          <React.Fragment>
-            {// $FlowFixMe: only videos will get to this code
-              object.duration ? (
-                <div className="course-info-row">
-                  <i className="material-icons restore">restore</i>
-                  <div className="course-info-label">Duration:</div>
-                  <div className="course-info-value">
-                    {// $FlowFixMe: only videos will get to this code
-                      formatDurationClockTime(object.duration)}
+          {!emptyOrNil(object.topics) ? (
+            <React.Fragment>
+              <div className="course-subheader row">Topics</div>
+              <div className="course-topics">
+                {object.topics.map((topic, i) => (
+                  <div className="grey-surround facet" key={i}>
+                    {topic.name}
                   </div>
-                </div>
-              ) : null}
-            {offeredBy ? (
-              <div className="course-info-row">
-                <i className="material-icons local_offer">local_offer</i>
-                <div className="course-info-label">Offered By:</div>
-                <div className="course-info-value">{offeredBy}</div>
+                ))}
               </div>
+            </React.Fragment>
+          ) : null}
+          <div className="course-subheader row">Info</div>
+          {cost ? courseInfoRow("attach_money", "Cost:", cost) : null}
+          {selectedRun && selectedRun.level
+            ? courseInfoRow("bar_chart", "Level:", selectedRun.level)
+            : null}
+          {!emptyOrNil(instructors)
+            ? courseInfoRow("school", "Instructors:", R.join(", ", instructors))
+            : null}
+          {object.object_type === LR_TYPE_PROGRAM
+            ? courseInfoRow(
+              "menu_book",
+              "Number of Courses:",
+              object.items.length
+            )
+            : null}
+          {isCoursewareResource(object.object_type)
+            ? courseInfoRow(
+              "language",
+              "Language:",
+              languageName(selectedRun ? selectedRun.language : "en")
+            )
+            : null}
+          {object.object_type === LR_TYPE_VIDEO ? (
+            <React.Fragment>
+              {// $FlowFixMe: only videos will get to this code
+                object.duration
+                  ? courseInfoRow(
+                    "restore",
+                    "Duration:",
+                    formatDurationClockTime(object.duration)
+                  )
+                  : null}
+              {offeredBy
+                ? courseInfoRow("local_offer", "Offered By:", offeredBy)
+                : null}
+              {courseInfoRow(
+                "calendar_today",
+                "Date Posted:",
+                moment(object.last_modified).format("MMM D, YYYY")
+              )}
+            </React.Fragment>
+          ) : null}
+          {[LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(
+            object.object_type
+          ) ? (
+              <React.Fragment>
+                {object.author_name
+                  ? courseInfoRow(
+                    "local_offer",
+                    "Created By:",
+                    object.author_name
+                  )
+                  : null}
+                {courseInfoRow(
+                  "lock",
+                  "Privacy:",
+                  capitalize(object.privacy_level)
+                )}
+                {courseInfoRow(
+                  "view_list",
+                  "Items in list:",
+                  object.items.length
+                )}
+              </React.Fragment>
             ) : null}
-            <div className="course-info-row">
-              <i className="material-icons calendar_today">calendar_today</i>
-              <div className="course-info-label">Date Posted:</div>
-              <div className="course-info-value">
-                {// $FlowFixMe: only videos will get to this code
-                  moment(object.last_modified).format("MMM D, YYYY")}
-              </div>
-            </div>
-          </React.Fragment>
-        ) : null}
+        </div>
       </div>
-    </div>
+      {[LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(object.object_type) ? (
+        <div className="expanded-learning-resource-userlist">
+          <div className="user-list-header">
+            Learning Resources in this List
+          </div>
+          {object.items.map((item, i) => (
+            <LearningResourceRow
+              key={i}
+              object={item.content_data}
+              searchResultLayout={SEARCH_LIST_UI}
+            />
+          ))}
+        </div>
+      ) : null}
+    </React.Fragment>
   )
 }
 

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
+import R from "ramda"
 
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
@@ -15,7 +16,8 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
   LR_TYPE_VIDEO,
-  LR_TYPE_USERLIST
+  LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH
 } from "../lib/constants"
 import { bestRun, getInstructorName } from "../lib/learning_resources"
 import { shouldIf } from "../lib/test_utils"
@@ -113,10 +115,26 @@ describe("ExpandedLearningResourceDisplay", () => {
     })
   })
 
-  it("should render course description using the TruncatedText", () => {
-    const wrapper = render()
-    const truncated = wrapper.find("TruncatedText")
-    assert.equal(truncated.props().text, course.short_description)
+  //
+  ;[
+    LR_TYPE_COURSE,
+    LR_TYPE_BOOTCAMP,
+    LR_TYPE_PROGRAM,
+    LR_TYPE_USERLIST,
+    LR_TYPE_LEARNINGPATH
+  ].forEach(objectType => {
+    it(`should render description using the TruncatedText for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({ object })
+      const truncated = wrapper.find("TruncatedText")
+      assert.equal(truncated.props().text, object.short_description)
+    })
+
+    it(`should render a title for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({ object })
+      assert.equal(wrapper.find(".course-title").text(), object.title)
+    })
   })
 
   it("should not render course links if urls are all null", () => {
@@ -308,6 +326,66 @@ describe("ExpandedLearningResourceDisplay", () => {
           .text(),
         "$25.50"
       )
+    })
+  })
+
+  //
+  ;[LR_TYPE_USERLIST, LR_TYPE_LEARNINGPATH].forEach(objectType => {
+    it(`should display the authors name for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({
+        object
+      })
+      assert.equal(
+        wrapper
+          .find(".local_offer")
+          .closest(".course-info-row")
+          .find(".course-info-value")
+          .text(),
+        object.author_name
+      )
+    })
+
+    it(`should display the privacy for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({
+        object
+      })
+      assert.equal(
+        wrapper
+          .find(".lock")
+          .closest(".course-info-row")
+          .find(".course-info-value")
+          .text(),
+        capitalize(object.privacy_level)
+      )
+    })
+
+    it(`should display the length for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({
+        object
+      })
+      assert.equal(
+        wrapper
+          .find(".view_list")
+          .closest(".course-info-row")
+          .find(".course-info-value")
+          .text(),
+        object.items.length
+      )
+    })
+
+    it(`should include a display of list items for ${objectType}`, () => {
+      const object = makeLearningResource(objectType)
+      const wrapper = render({
+        object
+      })
+      assert.ok(wrapper.find(".expanded-learning-resource-userlist").exists())
+      R.zip(
+        object.items.map(item => item.content_data),
+        wrapper.find("LearningResourceRow").map(el => el.prop("object"))
+      ).forEach(([obj1, obj2]) => assert.deepEqual(obj1, obj2))
     })
   })
 

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -90,7 +90,30 @@ const CoverImage = ({ object, showResourceDrawer }) => (
   </div>
 )
 
-export default function LearningResourceCard(props: Props) {
+export function LearningResourceCard(props: Props) {
+  const { searchResultLayout } = props
+
+  return (
+    <Card
+      className={getClassName(searchResultLayout)}
+      borderless={searchResultLayout === SEARCH_GRID_UI}
+    >
+      <LearningResourceDisplay {...props} />
+    </Card>
+  )
+}
+
+export function LearningResourceRow(props: Props) {
+  return (
+    <div className="learning-resource-card list-view">
+      <div className="card-contents">
+        <LearningResourceDisplay {...props} />
+      </div>
+    </div>
+  )
+}
+
+export function LearningResourceDisplay(props: Props) {
   const { object, searchResultLayout, availabilities } = props
 
   const bestAvailableRun =
@@ -121,10 +144,7 @@ export default function LearningResourceCard(props: Props) {
   const inLists = object ? object.lists : []
 
   return (
-    <Card
-      className={getClassName(searchResultLayout)}
-      borderless={searchResultLayout === SEARCH_GRID_UI}
-    >
+    <React.Fragment>
       {searchResultLayout === SEARCH_GRID_UI ? (
         <CoverImage object={object} showResourceDrawer={showResourceDrawer} />
       ) : null}
@@ -184,6 +204,6 @@ export default function LearningResourceCard(props: Props) {
       {searchResultLayout === SEARCH_GRID_UI ? null : (
         <CoverImage object={object} showResourceDrawer={showResourceDrawer} />
       )}
-    </Card>
+    </React.Fragment>
   )
 }

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -2,7 +2,11 @@
 import { assert } from "chai"
 import R from "ramda"
 
-import LearningResourceCard from "./LearningResourceCard"
+import {
+  LearningResourceCard,
+  LearningResourceRow
+} from "./LearningResourceCard"
+import Card from "./Card"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 
@@ -33,7 +37,7 @@ import { DIALOG_ADD_TO_LIST } from "../actions/ui"
 import { queryListResponse } from "../lib/test_utils"
 
 describe("LearningResourceCard", () => {
-  let course, userList, helper, render
+  let course, userList, helper, render, renderRow
 
   beforeEach(() => {
     course = makeLearningResource(LR_TYPE_COURSE)
@@ -43,6 +47,9 @@ describe("LearningResourceCard", () => {
       .withArgs(userListApiURL)
       .returns(queryListResponse([userList]))
     render = helper.configureReduxQueryRenderer(LearningResourceCard, {
+      object: course
+    })
+    renderRow = helper.configureReduxQueryRenderer(LearningResourceRow, {
       object: course
     })
   })
@@ -211,5 +218,15 @@ describe("LearningResourceCard", () => {
       wrapper.find(".price").text(),
       minPrice(bestRun(course.runs).prices)
     )
+  })
+
+  it("should render a LearningResourceRow", async () => {
+    const { wrapper } = await renderRow()
+    assert.ok(wrapper.find("LearningResourceDisplay").exists())
+    assert.deepEqual(
+      wrapper.find("LearningResourceDisplay").prop("object"),
+      course
+    )
+    assert.isNotOk(wrapper.find(Card).exists())
   })
 })

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -17,12 +17,15 @@ import { courseRequest } from "../lib/queries/courses"
 import { bootcampRequest } from "../lib/queries/bootcamps"
 import { programRequest } from "../lib/queries/programs"
 import { videoRequest } from "../lib/queries/videos"
+import { userListRequest } from "../lib/queries/user_lists"
 import { embedlyRequest, getEmbedlys } from "../lib/queries/embedly"
 import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH
 } from "../lib/constants"
 import { useResponsive } from "../hooks/util"
 
@@ -84,8 +87,9 @@ const getObject = createSelector(
   state => state.entities.bootcamps,
   state => state.entities.programs,
   state => state.entities.videos,
+  state => state.entities.userLists,
   state => state.queries,
-  (ui, courses, bootcamps, programs, videos, queries) => {
+  (ui, courses, bootcamps, programs, videos, userLists, queries) => {
     const { objectId, objectType } = ui.courseDetail
 
     switch (objectType) {
@@ -104,6 +108,12 @@ const getObject = createSelector(
     case LR_TYPE_VIDEO:
       return querySelectors.isFinished(queries, videoRequest(objectId))
         ? videos[objectId]
+        : null
+    }
+
+    if ([LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(objectType)) {
+      return querySelectors.isFinished(queries, userListRequest(objectId))
+        ? userLists[objectId]
         : null
     }
   }
@@ -160,6 +170,10 @@ const mapPropsToConfig = props => {
       videoRequest(objectId),
       ...(object && object.url ? [embedlyRequest(object.url)] : [])
     ]
+  case LR_TYPE_LEARNINGPATH:
+    return [userListRequest(objectId)]
+  case LR_TYPE_USERLIST:
+    return [userListRequest(objectId)]
   }
   return []
 }

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -8,12 +8,14 @@ import {
   mapStateToProps
 } from "./LearningResourceDrawer"
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
+import * as LRCardMod from "../components/LearningResourceCard"
 
 import {
   makeBootcamp,
   makeCourse,
   makeProgram,
-  makeVideo
+  makeVideo,
+  makeUserList
 } from "../factories/learning_resources"
 import { makeYoutubeVideo } from "../factories/embedly"
 import { shouldIf } from "../lib/test_utils"
@@ -21,34 +23,41 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST
 } from "../lib/constants"
 import { courseRequest } from "../lib/queries/courses"
 import { bootcampRequest } from "../lib/queries/bootcamps"
 import { programRequest } from "../lib/queries/programs"
 import { videoRequest } from "../lib/queries/videos"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("LearningResourceDrawer", () => {
-  let sandbox,
-    dispatchStub,
+  let dispatchStub,
     course,
     bootcamp,
     program,
     video,
-    setShowResourceDrawerStub
+    setShowResourceDrawerStub,
+    helper
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    dispatchStub = sandbox.stub()
+    helper = new IntegrationTestHelper()
+    dispatchStub = helper.sandbox.stub()
     course = makeCourse()
     bootcamp = makeBootcamp()
     program = makeProgram()
     video = makeVideo()
-    setShowResourceDrawerStub = sandbox.stub()
+    setShowResourceDrawerStub = helper.sandbox.stub()
+    helper.stubComponent(
+      LRCardMod,
+      "LearningResourceRow",
+      "LearningResourceRow"
+    )
   })
 
   afterEach(() => {
-    sandbox.restore()
+    helper.cleanup()
   })
 
   const renderLearningResourceDrawer = (props = {}) =>
@@ -72,7 +81,7 @@ describe("LearningResourceDrawer", () => {
   })
 
   it("should put an event listener on window resize", () => {
-    const addEventListenerStub = sandbox.stub(window, "addEventListener")
+    const addEventListenerStub = helper.sandbox.stub(window, "addEventListener")
     renderLearningResourceDrawer()
     assert.ok(addEventListenerStub.called)
   })
@@ -121,6 +130,17 @@ describe("LearningResourceDrawer", () => {
     const expandedDisplay = wrapper.find(ExpandedLearningResourceDisplay)
     assert.deepEqual(expandedDisplay.prop("object"), video)
     assert.deepEqual(expandedDisplay.prop("embedly"), embedly)
+  })
+
+  it("should include an ExpandedLearningResourceDisplay for a userList", () => {
+    const userList = makeUserList()
+    const wrapper = renderLearningResourceDrawer({
+      object:     userList,
+      objectId:   userList.id,
+      objectType: LR_TYPE_USERLIST
+    })
+    const expandedDisplay = wrapper.find(ExpandedLearningResourceDisplay)
+    assert.deepEqual(expandedDisplay.prop("object"), userList)
   })
 
   describe("mapStateToProps", () => {

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 
 import Card from "./Card"
 import CompactPostDisplay from "./CompactPostDisplay"
-import LearningResourceCard from "./LearningResourceCard"
+import { LearningResourceCard } from "./LearningResourceCard"
 import CommentTree from "./CommentTree"
 import ProfileImage, { PROFILE_IMAGE_SMALL } from "./ProfileImage"
 

--- a/static/js/components/SearchResult_test.js
+++ b/static/js/components/SearchResult_test.js
@@ -2,7 +2,7 @@ import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 
-import LearningResourceCard from "./LearningResourceCard"
+import { LearningResourceCard } from "./LearningResourceCard"
 import SearchResult from "./SearchResult"
 
 import {

--- a/static/js/components/UserListCard.js
+++ b/static/js/components/UserListCard.js
@@ -1,7 +1,6 @@
 // @flow
 /* global SETTINGS:false */
 import React, { useState } from "react"
-import R from "ramda"
 import { useMutation } from "redux-query-react"
 import { Link } from "react-router-dom"
 
@@ -21,18 +20,12 @@ import {
   readableLearningResources
 } from "../lib/constants"
 import { deleteUserListMutation } from "../lib/queries/user_lists"
+import { userListCoverImage } from "../lib/learning_resources"
 
 import type { UserList } from "../flow/discussionTypes"
 
 const readableLength = (length: number) =>
   length === 1 ? "1 Item" : `${String(length)} Items`
-
-const userListCoverImage = R.pathOr(null, [
-  "items",
-  0,
-  "content_data",
-  "image_src"
-])
 
 function ConfirmDeleteDialog(props) {
   const { userList, hide } = props

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -168,7 +168,8 @@ export const makeUserList = (): UserList => ({
   profile_name:  casual.name,
   privacy_level: casual.random_element(["public", "private"]),
   author:        casual.integer(1, 1000),
-  lists:         []
+  lists:         [],
+  author_name:   casual.name
 })
 
 const incrVideo = incrementer()

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -12,7 +12,9 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST,
+  LR_TYPE_LEARNINGPATH
 } from "../lib/constants"
 
 export type FormImage = {
@@ -421,11 +423,12 @@ export type Program = LearningResource & {
 export type UserList = LearningResource & {
   image_src:          ?string,
   image_description:  ?string,
-  items:              Array<UserListItem | UserListItemEdit>,
+  items:              Array<UserListItem>,
   list_type:          string,
-  object_type:        string,
+  object_type:        LR_TYPE_USERLIST | LR_TYPE_LEARNINGPATH,
   privacy_level:      string,
-  author:             number
+  author:             number,
+  author_name:        string
 }
 
 export type Video = LearningResource & {

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -288,3 +288,10 @@ export const filterListsByResource = (
     object_id: resource.id
   }).map(userList => userList.id)
 }
+
+export const userListCoverImage = R.pathOr(null, [
+  "items",
+  0,
+  "content_data",
+  "image_src"
+])

--- a/static/js/pages/FavoritesDetailPage.js
+++ b/static/js/pages/FavoritesDetailPage.js
@@ -11,7 +11,7 @@ import {
   BannerContainer,
   BannerImage
 } from "../components/PageBanner"
-import LearningResourceCard from "../components/LearningResourceCard"
+import { LearningResourceCard } from "../components/LearningResourceCard"
 import AddToListDialog from "../components/AddToListDialog"
 
 import { SEARCH_LIST_UI } from "../lib/search"

--- a/static/js/pages/FavoritesDetailPage_test.js
+++ b/static/js/pages/FavoritesDetailPage_test.js
@@ -2,7 +2,7 @@
 import { assert } from "chai"
 
 import FavoritesDetailPage from "./FavoritesDetailPage"
-import LearningResourceCard from "../components/LearningResourceCard"
+import { LearningResourceCard } from "../components/LearningResourceCard"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeFavoritesResponse } from "../factories/learning_resources"

--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -13,7 +13,7 @@ import {
   BannerContainer,
   BannerImage
 } from "../components/PageBanner"
-import LearningResourceCard from "../components/LearningResourceCard"
+import { LearningResourceCard } from "../components/LearningResourceCard"
 import AddToListDialog from "../components/AddToListDialog"
 
 import { SEARCH_LIST_UI } from "../lib/search"

--- a/static/js/pages/UserListDetailPage_test.js
+++ b/static/js/pages/UserListDetailPage_test.js
@@ -3,7 +3,7 @@ import { assert } from "chai"
 import R from "ramda"
 
 import UserListDetailPage from "./UserListDetailPage"
-import LearningResourceCard from "../components/LearningResourceCard"
+import { LearningResourceCard } from "../components/LearningResourceCard"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeUserList } from "../factories/learning_resources"

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -219,6 +219,19 @@
   }
 }
 
+.expanded-learning-resource-userlist {
+  .learning-resource-card {
+    margin: 20px;
+  }
+
+  .user-list-header {
+    background-color: $bg-light-grey;
+    font-size: 18px;
+    font-weight: 600;
+    padding: 18px 20px;
+  }
+}
+
 .facet {
   display: inline-flex;
   cursor: default;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #2266

#### What's this PR do?

this makes the learning resource drawer (which we use on the course search) able to display information about user lists and learning paths.

#### How should this be manually tested?

Go to the search page and click on a learning path or user list. The drawer should open with details about that user list.


#### Screenshots (if appropriate)
![listasdfasdf](https://user-images.githubusercontent.com/6207644/69261906-7a1ae300-0b90-11ea-9c12-46028eb888d9.png)
![list](https://user-images.githubusercontent.com/6207644/69261907-7a1ae300-0b90-11ea-8e8e-a2c563091edd.png)
