### PR TITLE
Update get_active_aliases to reuse connection so verification doesn't thrash

### DIFF
--- a/search/connection.py
+++ b/search/connection.py
@@ -53,7 +53,7 @@ def get_conn(*, verify=True):
             _CONN_VERIFIED = False
         return _CONN
 
-    if len(get_active_aliases(VALID_OBJECT_TYPES)) == 0:
+    if len(get_active_aliases(_CONN, VALID_OBJECT_TYPES)) == 0:
         raise Exception("Unable to find any active indices to update")
 
     _CONN_VERIFIED = True
@@ -99,11 +99,12 @@ get_default_alias_name = partial(make_alias_name, False)
 get_reindexing_alias_name = partial(make_alias_name, True)
 
 
-def get_active_aliases(object_types):
+def get_active_aliases(conn, object_types):
     """
     Returns aliases which exist for specified object types
 
     Args:
+        conn(elasticsearch.client.Elasticsearch): An Elasticsearch client
         object_types(list of str): list of object types (post, comment, etc)
 
     Returns:
@@ -111,7 +112,6 @@ def get_active_aliases(object_types):
     """
     if not object_types:
         object_types = VALID_OBJECT_TYPES
-    conn = get_conn(verify=False)
     return [
         alias
         for alias_tuple in [

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -246,7 +246,7 @@ def create_document(doc_id, data):
         data (dict): Full ES document data
     """
     conn = get_conn(verify=True)
-    for alias in get_active_aliases([data["object_type"]]):
+    for alias in get_active_aliases(conn, [data["object_type"]]):
         conn.create(index=alias, doc_type=GLOBAL_DOC_TYPE, body=data, id=doc_id)
 
 
@@ -259,7 +259,7 @@ def delete_document(doc_id, object_type):
         object_type (str): The object type
     """
     conn = get_conn(verify=True)
-    for alias in get_active_aliases([object_type]):
+    for alias in get_active_aliases(conn, [object_type]):
         try:
             conn.delete(index=alias, doc_type=GLOBAL_DOC_TYPE, id=doc_id)
         except NotFoundError:
@@ -287,7 +287,7 @@ def update_field_values_by_query(query, field_dict, object_types=None):
     if not object_types:
         object_types = VALID_OBJECT_TYPES
     conn = get_conn(verify=True)
-    for alias in get_active_aliases(object_types):
+    for alias in get_active_aliases(conn, object_types):
         es_response = conn.update_by_query(  # pylint: disable=unexpected-keyword-arg
             index=alias,
             doc_type=GLOBAL_DOC_TYPE,
@@ -324,7 +324,7 @@ def _update_document_by_id(doc_id, body, object_type, *, retry_on_conflict=0):
         retry_on_conflict (int): Number of times to retry if there's a conflict (default=0)
     """
     conn = get_conn(verify=True)
-    for alias in get_active_aliases([object_type]):
+    for alias in get_active_aliases(conn, [object_type]):
         try:
             conn.update(
                 index=alias,
@@ -422,7 +422,7 @@ def index_items(serialize_bulk_items, object_type, ids):
         ids(list of int): List of item id's
     """
     conn = get_conn()
-    for alias in get_active_aliases([object_type]):
+    for alias in get_active_aliases(conn, [object_type]):
         _, errors = bulk(
             conn,
             serialize_bulk_items(ids),

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -62,7 +62,7 @@ def test_create_document(mocked_es, mocker, object_type):
         "search.indexing_api.get_active_aliases", return_value=[object_type]
     )
     create_document(doc_id, data)
-    mock_get_aliases.assert_called_once_with([object_type])
+    mock_get_aliases.assert_called_once_with(mocked_es.conn, [object_type])
     mocked_es.get_conn.assert_called_once_with(verify=True)
     mocked_es.conn.create.assert_any_call(
         index=object_type, doc_type=GLOBAL_DOC_TYPE, body=data, id=doc_id
@@ -117,7 +117,7 @@ def test_update_document_with_partial(mocked_es, mocker, object_type):
     )
     doc_id, data = ("doc_id", {"key1": "value1"})
     update_document_with_partial(doc_id, data, object_type)
-    mock_get_aliases.assert_called_once_with([object_type])
+    mock_get_aliases.assert_called_once_with(mocked_es.conn, [object_type])
     mocked_es.get_conn.assert_called_once_with(verify=True)
     mocked_es.conn.update.assert_called_once_with(
         index=object_type,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Improves efficiency of indexing by reusing verified connections. Prior to this, the connections were validated but immediately invalidated by a call to `get_active_aliases` which was in turn calling `get_conn` in a manner that it cleared the verified state. This code modifies `get_active_aliases` to instead accept a connection as an argument rather than getting its own. This way whether the connection is verified or not depends on the calling code.

#### How should this be manually tested?

- Run `./manage.py recreate_index`
- Create a post and a comment, ensure they show up in search
- Modify the post and comment and ensure their modified values are searchable