### PR TITLE
add option to create new list from "add to list" dialog

### DIFF
--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -1,11 +1,12 @@
 // @flow
-import React, { useCallback } from "react"
+import React, { useState, useCallback } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { useRequest, useMutation } from "redux-query-react"
 import { createSelector } from "reselect"
 import { Checkbox } from "@rmwc/checkbox"
 
 import Dialog from "./Dialog"
+import UserListFormDialog from "./UserListFormDialog"
 
 import { DIALOG_ADD_TO_LIST, hideDialog } from "../actions/ui"
 import { capitalize, emptyOrNil } from "../lib/util"
@@ -48,6 +49,7 @@ export default function AddToListDialog() {
   )
 
   const resource = useSelector(learningResourceSelector)(objectId, objectType)
+  const [showUserListFormDialog, setShowUserListFormDialog] = useState(false)
 
   const userLists = useSelector(myUserListsSelector)
   const [{ isFinished: isFinishedList }] = useRequest(userListsRequest())
@@ -148,21 +150,32 @@ export default function AddToListDialog() {
               </div>
             ) : null
       )}
+      <button
+        className="create-new-list blue-btn"
+        onClick={() => setShowUserListFormDialog(true)}
+      >
+        Create New List
+      </button>
     </div>
   )
 
   return resource && isFinishedList && isFinishedResource ? (
-    <Dialog
-      id="list-add-dialog"
-      open={!emptyOrNil(resource)}
-      hideDialog={hide}
-      title="Add to List"
-      onAccept={hide}
-      hideCancel={true}
-      submitText="OK"
-      className="user-listitem-dialog"
-    >
-      {renderAddToListForm()}
-    </Dialog>
+    <React.Fragment>
+      <Dialog
+        id="list-add-dialog"
+        open={!emptyOrNil(resource)}
+        hideDialog={showUserListFormDialog ? null : hide}
+        title="Add to List"
+        onAccept={hide}
+        noButtons
+        submitText="OK"
+        className="user-listitem-dialog"
+      >
+        {renderAddToListForm()}
+      </Dialog>
+      {showUserListFormDialog ? (
+        <UserListFormDialog hide={() => setShowUserListFormDialog(false)} />
+      ) : null}
+    </React.Fragment>
   ) : null
 }

--- a/static/js/components/AddToListDialog_test.js
+++ b/static/js/components/AddToListDialog_test.js
@@ -4,8 +4,10 @@ import { assert } from "chai"
 import { times } from "ramda"
 import { Checkbox } from "@rmwc/checkbox"
 
-import IntegrationTestHelper from "../util/integration_test_helper"
+import UserListFormDialog from "./UserListFormDialog"
 import AddToListDialog from "./AddToListDialog"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeCourse, makeUserList } from "../factories/learning_resources"
 import { courseURL, userListApiURL } from "../lib/url"
 import { queryListResponse, shouldIf } from "../lib/test_utils"
@@ -22,9 +24,7 @@ describe("AddToListDialog", () => {
     })
     course = makeCourse()
     helper = new IntegrationTestHelper()
-    renderDialog = helper.configureReduxQueryRenderer(AddToListDialog, {
-      object: course
-    })
+    renderDialog = helper.configureReduxQueryRenderer(AddToListDialog)
     helper.handleRequestStub
       .withArgs(userListApiURL)
       .returns(queryListResponse(userLists))
@@ -39,7 +39,7 @@ describe("AddToListDialog", () => {
   })
 
   const render = async (object = course) => {
-    const { wrapper, store } = await renderDialog({ object }, [
+    const { wrapper, store } = await renderDialog({}, [
       setDialogData({ dialogKey: DIALOG_ADD_TO_LIST, data: object })
     ])
     return { wrapper, store }
@@ -95,5 +95,11 @@ describe("AddToListDialog", () => {
         inList
       )
     })
+  })
+
+  it("should have a button for making a new list", async () => {
+    const { wrapper } = await render(course)
+    wrapper.find(".create-new-list").simulate("click")
+    assert.ok(wrapper.find(UserListFormDialog).exists())
   })
 })

--- a/static/js/components/Dialog.js
+++ b/static/js/components/Dialog.js
@@ -9,12 +9,11 @@ type Props = {
   onAccept?: ?Function,
   submitText?: string,
   cancelText?: string,
-  hideAccept?: boolean,
-  hideCancel?: boolean,
   title: string,
   id?: string,
   className?: string,
-  children?: any
+  children?: any,
+  noButtons?: boolean
 }
 
 export default function OurDialog(props: Props) {
@@ -22,22 +21,26 @@ export default function OurDialog(props: Props) {
     open,
     hideDialog,
     onCancel,
-    hideCancel,
     onAccept,
-    hideAccept,
     title,
     submitText,
     cancelText,
     id,
     className,
-    children
+    children,
+    noButtons
   } = props
   return (
     <Dialog open={open} onClose={hideDialog} id={id} className={className}>
-      <DialogTitle>{title}</DialogTitle>
+      <DialogTitle>
+        <span>{title}</span>
+        <i onClick={hideDialog} className="material-icons close">
+          close
+        </i>
+      </DialogTitle>
       <DialogContent>{children}</DialogContent>
-      <DialogActions>
-        {!hideCancel ? (
+      {noButtons ? null : (
+        <DialogActions>
           <button
             className="cancel"
             onClick={onCancel || hideDialog}
@@ -45,13 +48,11 @@ export default function OurDialog(props: Props) {
           >
             {cancelText || "Cancel"}
           </button>
-        ) : null}
-        {!hideAccept ? (
           <button className="submit" onClick={onAccept} type="button">
             {submitText || "Accept"}
           </button>
-        ) : null}
-      </DialogActions>
+        </DialogActions>
+      )}
     </Dialog>
   )
 }

--- a/static/js/components/Dialog_test.js
+++ b/static/js/components/Dialog_test.js
@@ -13,8 +13,6 @@ describe("Dialog", () => {
     onAccept,
     submitText,
     cancelText,
-    hideAccept,
-    hideCancel,
     title,
     id,
     className,
@@ -25,8 +23,6 @@ describe("Dialog", () => {
     hideDialog = sandbox.stub()
     onCancel = sandbox.stub()
     onAccept = sandbox.stub()
-    hideAccept = false
-    hideCancel = false
     title = "Dialog title"
     submitText = "Submit"
     cancelText = null
@@ -38,14 +34,11 @@ describe("Dialog", () => {
     sandbox.restore()
   })
 
-  const render = (props = {}) => {
-    const { children } = props
-    return shallow(
+  const render = (props = {}) =>
+    shallow(
       <Dialog
         open={open}
         hideDialog={hideDialog}
-        hideAccept={hideAccept}
-        hideCancel={hideCancel}
         // $FlowFixMe
         onCancel={onCancel}
         onAccept={onAccept}
@@ -58,10 +51,9 @@ describe("Dialog", () => {
         className={className}
         {...props}
       >
-        {children}
+        Some Text Here
       </Dialog>
     )
-  }
 
   it("passes some props to the inner Dialog component", () => {
     const props = render()
@@ -73,7 +65,7 @@ describe("Dialog", () => {
   })
 
   it("passes the title to DialogTitle", () => {
-    assert.equal(
+    assert.include(
       render()
         .find("DialogTitle")
         .dive()
@@ -92,13 +84,12 @@ describe("Dialog", () => {
   })
 
   it("passes children to the DialogContent", () => {
-    const children = "Some text here"
     assert.equal(
-      render({ children })
+      render()
         .find("DialogContent")
         .dive()
         .text(),
-      children
+      "Some Text Here"
     )
   })
 
@@ -166,20 +157,10 @@ describe("Dialog", () => {
       )
     })
 
-    it("hides the Accept button if hideAccept is true", () => {
-      hideAccept = true
+    it("hides the buttons if noButtons is true", () => {
       assert.isNotOk(
-        render()
-          .find(".submit")
-          .exists()
-      )
-    })
-
-    it("hides the Cancel button if hideCancel is true", () => {
-      hideCancel = true
-      assert.isNotOk(
-        render()
-          .find(".cancel")
+        render({ noButtons: true })
+          .find("DialogActions")
           .exists()
       )
     })

--- a/static/js/components/ProfileImage_test.js
+++ b/static/js/components/ProfileImage_test.js
@@ -91,7 +91,7 @@ describe("ProfileImage", () => {
 
     it("should have a description in the upload dialog", () => {
       const image = renderProfileImage({ editable: true })
-      assert.equal(image.find("DialogTitle").text(), "Upload a Profile Image")
+      assert.include(image.find("DialogTitle").text(), "Upload a Profile Image")
     })
 
     describe("save button", () => {

--- a/static/scss/dialog.scss
+++ b/static/scss/dialog.scss
@@ -1,0 +1,19 @@
+.mdc-dialog__container {
+  .mdc-dialog__title {
+    height: 60px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 0;
+    padding-top: 5px;
+
+    &::before {
+      content: none;
+    }
+
+    i {
+      font-size: 30px;
+      cursor: pointer;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -73,6 +73,7 @@
 @import "create-user-list-dialog";
 @import "user-list-page";
 @import "user-listitem-dialog";
+@import "dialog";
 
 body {
   font-family: $body-font;

--- a/static/scss/user-listitem-dialog.scss
+++ b/static/scss/user-listitem-dialog.scss
@@ -3,15 +3,23 @@
     padding: 5px !important;
   }
 
+  .mdc-dialog__surface {
+    width: 100%;
+  }
+
   .user-listitem-form {
     color: black;
     border-top: 2px solid $border-grey;
-    border-bottom: 2px solid $border-grey;
     padding-top: 20px;
     overflow: scroll;
+    min-width: 300px;
   }
 
   .privacy {
     width: 65px;
+  }
+
+  .create-new-list {
+    margin-top: 10px;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

closes #2357

#### What's this PR do?

this adds a button in the "add to list" dialog which lets you create a new list.

basically, it just opens the existing form we have for creating userlists.

#### How should this be manually tested?

Try it out and make sure there are no weird edges. you should be able to:

- add and remove a list from an existing list (i.e. no regression)
- clicking the 'Create New List' button should open the dialog
- canceling that dialog should just show you the 'add to list' dialog again
- you should be able to successfully create a new list
- that list should show up in the 'add to list' dialog immediately

I think that's about it. Just make sure it all makes sense and works properly.


#### Screenshots (if appropriate)

![flooofdfasdfasdf](https://user-images.githubusercontent.com/6207644/69363700-f976e800-0c5e-11ea-835b-f592cf116cd0.png)
![flooofdf](https://user-images.githubusercontent.com/6207644/69363701-fa0f7e80-0c5e-11ea-9098-b2d51e3ec177.png)
![sdfasjdfansdfn](https://user-images.githubusercontent.com/6207644/69363702-fa0f7e80-0c5e-11ea-94a9-437441b69beb.png)
