### PR TITLE
Adjust resource item serializers

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -286,6 +286,14 @@ class LearningResourceRunSerializer(BaseCourseSerializer):
         fields = "__all__"
 
 
+class LearningResourceRunMixin(serializers.Serializer):
+    """
+    Mixin to serialize LearningResourceRuns for various models
+    """
+
+    runs = LearningResourceRunSerializer(read_only=True, many=True, allow_null=True)
+
+
 class SimpleCourseSerializer(BaseCourseSerializer):
     """
     Serializer for Course model, minus runs
@@ -312,12 +320,10 @@ class SimpleCourseSerializer(BaseCourseSerializer):
         extra_kwargs = {"raw_json": {"write_only": True}}
 
 
-class CourseSerializer(SimpleCourseSerializer):
+class CourseSerializer(SimpleCourseSerializer, LearningResourceRunMixin):
     """
     Serializer for Course model
     """
-
-    runs = LearningResourceRunSerializer(read_only=True, many=True, allow_null=True)
 
 
 class OCWSerializer(CourseSerializer):
@@ -371,12 +377,10 @@ class SimpleBootcampSerializer(BaseCourseSerializer):
         fields = "__all__"
 
 
-class BootcampSerializer(SimpleBootcampSerializer):
+class BootcampSerializer(SimpleBootcampSerializer, LearningResourceRunMixin):
     """
     Serializer for Bootcamp model
     """
-
-    runs = LearningResourceRunSerializer(read_only=True, many=True, allow_null=True)
 
 
 class SimpleUserListItemSerializer(
@@ -638,12 +642,10 @@ class SimpleProgramSerializer(
         fields = "__all__"
 
 
-class ProgramSerializer(SimpleProgramSerializer):
+class ProgramSerializer(SimpleProgramSerializer, LearningResourceRunMixin):
     """
     Serializer for Program model, with runs
     """
-
-    runs = LearningResourceRunSerializer(read_only=True, many=True, allow_null=True)
 
 
 class VideoSerializer(

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -209,7 +209,7 @@ class UserListViewSet(viewsets.ModelViewSet, FavoriteViewMixin):
     Viewset for User Lists & Learning Paths
     """
 
-    queryset = UserList.objects.prefetch_related("author", "topics", "offered_by").all()
+    queryset = UserList.objects.prefetch_related("author", "topics", "offered_by")
     serializer_class = UserListSerializer
     pagination_class = LargePagination
     permission_classes = (HasUserListPermissions,)

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -340,9 +340,8 @@ def test_user_list_endpoint_update_items(client, user, is_author, mock_user_list
         assert resp.data.get("topics") == [
             CourseTopicSerializer(instance=topics[0]).data
         ]
-        updated_items = sorted(
-            resp.data.get("items"), key=lambda item: item["position"]
-        )
+        updated_items = resp.data.get("items")
+
         assert (
             updated_items[0]["position"] == 33
             and updated_items[0]["id"] == list_items[1].id

--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -82,9 +82,12 @@ export default function AddToListDialog() {
   const [, toggleListItem] = useMutation((resource, list, remove) => {
     list.items = [
       {
-        content_type: resource.object_type,
-        object_id:    resource.id,
-        delete:       remove
+        content_type:
+          resource.object_type === LR_TYPE_LEARNINGPATH
+            ? LR_TYPE_USERLIST
+            : resource.object_type,
+        object_id: resource.id,
+        delete:    remove
       }
     ]
     return userListMutation(list)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2410 
Fixes #2421 
Also should improve performance

#### What's this PR do?
- Restricts usage of the SimpleUserListSerializer and SimpleUserListItemSerializers to the `content_data` field of UserListItemSerializer items.  This should fix the above issue while still streamlining the size of the api lists response (though not quite as much as before).
- Create 'simple' serializers for courses, bootcamps, and programs too that exclude runs, to be used for item.content_data
- Reduces n+1 queries

#### How should this be manually tested?
- Go directly to a URL for a specific list that contains 1+ lists.  Reload the page a few times. It should load every time.  On master branch it will occasionally fail to load, if the `api/v0/userlists` response comes after the `api/v0/userlists/<id>` response.
- "My Lists" should still display your lists
- Creating and editing lists should work as before
- Adding & removing resources to/from lists should work, including lists with and without topics

