### PR TITLE
Prevent users from adding lists to each other

### DIFF
--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -122,7 +122,16 @@ export default function AddToListDialog() {
           (![LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(
             resource.object_type
           ) ||
-            resource.id !== userList.id) ? (
+            (resource.id !== userList.id &&
+              emptyOrNil(
+                resource.items.filter(
+                  item =>
+                    item.object_id === userList.id &&
+                    [LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(
+                      item.content_type
+                    )
+                )
+              ))) ? (
               <div className="flex-row" key={i}>
                 <div>
                   <Checkbox

--- a/static/js/components/AddToListDialog_test.js
+++ b/static/js/components/AddToListDialog_test.js
@@ -12,6 +12,7 @@ import { makeCourse, makeUserList } from "../factories/learning_resources"
 import { courseURL, userListApiURL } from "../lib/url"
 import { queryListResponse, shouldIf } from "../lib/test_utils"
 import { DIALOG_ADD_TO_LIST, setDialogData } from "../actions/ui"
+import { LR_TYPE_USERLIST } from "../lib/constants"
 
 describe("AddToListDialog", () => {
   let renderDialog, userLists, helper, course
@@ -76,6 +77,28 @@ describe("AddToListDialog", () => {
 
     const userListCheck = checkboxes.at(1)
     assert.equal(userListCheck.find("label").text(), userLists[1].title)
+  })
+
+  it("if list is in a resource's items, dont let user add that resource to the list", async () => {
+    const object = userLists[0]
+    object.items.push({
+      content_type: LR_TYPE_USERLIST,
+      object_id:    userLists[1].id
+    })
+    helper.handleRequestStub
+      .withArgs(`${userListApiURL}/${object.id}/`)
+      .returns({
+        status: 200,
+        body:   object
+      })
+    const { wrapper } = await render(object)
+    const checkboxes = wrapper.find(Checkbox)
+
+    // Should be 1 checkbox for each list, plus 1 for favorites, -2 for non-authored lists, -2 for excluded lists
+    assert.equal(checkboxes.length, userLists.length - 3)
+
+    const userListCheck = checkboxes.at(1)
+    assert.equal(userListCheck.find("label").text(), userLists[2].title)
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2414

#### What's this PR do?
Prevents users from adding lists to each other (List 1 in List 2 and List 2 in List 1)

#### How should this be manually tested?
- Create List 1
- Create List 2
- Click the List 2 'favorite' star and add it to List 1
- Click the List 1 star, List 2 should be excluded from the checkbox list
