### PR TITLE
fix channel image upload dialog widths

### DIFF
--- a/static/js/components/CropperWrapper.js
+++ b/static/js/components/CropperWrapper.js
@@ -36,7 +36,7 @@ export default class CropperWrapper extends React.Component<Props> {
     return (
       <Cropper
         ref={cropper => (this.cropper = cropper)}
-        style={{ height: uploaderBodyHeight() }}
+        style={{ height: uploaderBodyHeight(), width: uploaderBodyHeight() }}
         className="photo-upload-dialog photo-active-item cropper"
         src={photo.preview}
         aspectRatio={width / height}

--- a/static/js/components/ImageUploaderForm.js
+++ b/static/js/components/ImageUploaderForm.js
@@ -97,7 +97,7 @@ export default class ImageUploaderForm extends React.Component<
   spinner = () => (
     <div
       className="photo-upload-dialog photo-active-item photo-dropzone dashed-border"
-      style={{ height: uploaderBodyHeight() }}
+      style={{ height: uploaderBodyHeight(), width: uploaderBodyHeight() }}
     >
       <div className="sk-fading-circle">
         <div className="sk-circle1 sk-circle" />
@@ -123,7 +123,7 @@ export default class ImageUploaderForm extends React.Component<
       <Dropzone
         onDrop={onDrop(this.startPhotoEdit)}
         className="photo-upload-dialog photo-active-item photo-dropzone dashed-border"
-        style={{ height: uploaderBodyHeight() }}
+        style={{ height: uploaderBodyHeight(), width: uploaderBodyHeight() }}
         accept="image/*"
         onDropRejected={() => this.setPhotoError("Please select a valid photo")}
       >
@@ -152,8 +152,8 @@ export default class ImageUploaderForm extends React.Component<
     return (
       <Dialog
         title={`Upload a ${description}`}
+        className="photo-upload-dialog"
         autoScrollBodyContent={true}
-        contentStyle={{ maxWidth: "620px" }}
         open={dialogOpen}
         onAccept={image && !processing ? onSubmit : null}
         onCancel={() => {

--- a/static/scss/profile-image.scss
+++ b/static/scss/profile-image.scss
@@ -87,6 +87,10 @@ $profile-image-small-size: 45px;
   h3 {
     border-bottom: none !important;
   }
+
+  .mdc-dialog__surface {
+    width: 100%;
+  }
 }
 
 .photo-dropzone {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2328

#### What's this PR do?

this just fixes the width of the image upload dialogs on the channel appearance settings page. there are two dialogs, one for setting the channel avatar and another for setting the channel banner.

#### How should this be manually tested?

go to a channel settings page and make sure the dialogs for uploading those two images are the right width and so on.

#### Screenshots (if appropriate)

![asdfffffffffasdvv](https://user-images.githubusercontent.com/6207644/69648535-86dc8280-1039-11ea-9d11-e06c8d57f2be.png)
![asdffff](https://user-images.githubusercontent.com/6207644/69648538-86dc8280-1039-11ea-905a-cc7e97aea45b.png)
![upload](https://user-images.githubusercontent.com/6207644/69648539-86dc8280-1039-11ea-8938-2f5aff552c6b.png)
