### PR TITLE
add sorting of items in a userlist / learning path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@mitodl/ckeditor-custom-build": "0.0.4",
     "@mitodl/mdl-react-components": "^0.0.3",
     "@trust/webcrypto": "^0.9.2",
+    "array-move": "^2.2.0",
     "autoprefixer": "^9.4.6",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.0",

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -39,13 +39,14 @@ import type {
 type Props = {|
   object: LearningResourceSummary,
   searchResultLayout?: string,
-  availabilities?: Array<string>
+  availabilities?: Array<string>,
+  reordering?: boolean
 |}
 
-const getClassName = searchResultLayout =>
+const getClassName = (searchResultLayout, reordering) =>
   `learning-resource-card ${
     searchResultLayout === SEARCH_LIST_UI ? "list-view" : ""
-  }`.trim()
+  } ${reordering ? "reordering" : ""}`.trim()
 
 const formatTopics = (topics: Array<CourseTopic>) =>
   topics.map((topic, i) => (
@@ -94,11 +95,11 @@ const CoverImage = ({ object, showResourceDrawer }) => (
 )
 
 export function LearningResourceCard(props: Props) {
-  const { searchResultLayout } = props
+  const { searchResultLayout, reordering } = props
 
   return (
     <Card
-      className={getClassName(searchResultLayout)}
+      className={getClassName(searchResultLayout, reordering)}
       borderless={searchResultLayout === SEARCH_GRID_UI}
     >
       <LearningResourceDisplay {...props} />
@@ -117,7 +118,7 @@ export function LearningResourceRow(props: Props) {
 }
 
 export function LearningResourceDisplay(props: Props) {
-  const { object, searchResultLayout, availabilities } = props
+  const { object, searchResultLayout, availabilities, reordering } = props
 
   const bestAvailableRun =
     bestRun(filterRunsByAvailability(object.runs, availabilities)) ||
@@ -150,6 +151,11 @@ export function LearningResourceDisplay(props: Props) {
     <React.Fragment>
       {searchResultLayout === SEARCH_GRID_UI ? (
         <CoverImage object={object} showResourceDrawer={showResourceDrawer} />
+      ) : null}
+      {reordering ? (
+        <div className="drag-handle">
+          <i className="material-icons">drag_indicator</i>
+        </div>
       ) : null}
       <div className="lr-info">
         <div className="row resource-type">

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -229,4 +229,20 @@ describe("LearningResourceCard", () => {
     )
     assert.isNotOk(wrapper.find(Card).exists())
   })
+
+  //
+  ;[true, false].forEach(reordering => {
+    it(`should set a classname and show UI when reordering=${String(
+      reordering
+    )}`, async () => {
+      const { wrapper } = await render({ reordering })
+      assert.equal(
+        wrapper.find(Card).prop("className"),
+        reordering
+          ? "learning-resource-card  reordering"
+          : "learning-resource-card"
+      )
+      assert.equal(wrapper.find(".drag-handle").exists(), reordering)
+    })
+  })
 })

--- a/static/js/components/SortableList.js
+++ b/static/js/components/SortableList.js
@@ -1,0 +1,11 @@
+// @flow
+import React from "react"
+import { sortableContainer, sortableElement } from "react-sortable-hoc"
+
+export const SortableItem = sortableElement(({ children }) => (
+  <React.Fragment>{children}</React.Fragment>
+))
+
+export const SortableContainer = sortableContainer(({ children }) => (
+  <React.Fragment>{children}</React.Fragment>
+))

--- a/static/js/components/widgets/WidgetList_test.js
+++ b/static/js/components/widgets/WidgetList_test.js
@@ -96,6 +96,8 @@ describe("WidgetList", () => {
       assert.equal(props.startEditInstance, startEditInstanceStub)
     })
   })
+
+  //
   ;[
     [true, true, true],
     [true, false, false],
@@ -136,6 +138,8 @@ describe("WidgetList", () => {
       sinon.assert.calledWith(setExpandedStub, [key], !expanded[key])
     })
   })
+
+  //
   ;[true, false].forEach(editing => {
     it(`${shouldIf(
       editing
@@ -151,6 +155,8 @@ describe("WidgetList", () => {
       wrapper.find(".add-widget").prop("onClick")()
       sinon.assert.calledWith(startAddInstanceStub)
     })
+
+    //
     ;[true, false].forEach(allExpanded => {
       it(`has a link to ${allExpanded ? "expand" : "collapse"} widgets`, () => {
         const widgetKeys = listResponse.widgets.map(getWidgetKey)

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -105,7 +105,7 @@ export const deleteUserListMutation = (userList: UserList) => ({
   }
 })
 
-export const userListMutation = (userList: UserList) => ({
+export const userListMutation = (userList: Object) => ({
   queryKey:  "userListMutation",
   body:      userList,
   url:       `${userListApiURL}/${userList.id}/`,

--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -1,9 +1,11 @@
 // @flow
-import React from "react"
-import { useRequest } from "redux-query-react"
+/* global SETTINGS: false */
+import React, { useState } from "react"
+import { useRequest, useMutation } from "redux-query-react"
 import { useSelector } from "react-redux"
 import { createSelector } from "reselect"
 import { memoize } from "lodash"
+import arrayMove from "array-move"
 
 import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import { Cell, Grid } from "../components/Grid"
@@ -15,10 +17,20 @@ import {
 } from "../components/PageBanner"
 import { LearningResourceCard } from "../components/LearningResourceCard"
 import AddToListDialog from "../components/AddToListDialog"
+import UserListFormDialog from "../components/UserListFormDialog"
+import { SortableItem, SortableContainer } from "../components/SortableList"
 
 import { SEARCH_LIST_UI } from "../lib/search"
-import { userListRequest, userListsSelector } from "../lib/queries/user_lists"
+import {
+  userListRequest,
+  userListsSelector,
+  userListMutation
+} from "../lib/queries/user_lists"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
+import {
+  readableLearningResources,
+  LR_TYPE_LEARNINGPATH
+} from "../lib/constants"
 
 const userListSelector = createSelector(userListsSelector, userLists =>
   memoize(userListID => (userLists ? userLists[userListID] : null))
@@ -28,12 +40,26 @@ type Props = {
   match: Object
 }
 
+const UL_PAGE_GRID_CLASSNAME = "main-content one-column narrow user-list-page"
+
 export default function UserListDetailPage(props: Props) {
   const { match } = props
   const userListId = match.params.id
 
   const [{ isFinished }] = useRequest(userListRequest(userListId))
   const userList = useSelector(userListSelector)(userListId)
+
+  const [{ isPending: listIsSaving }, updateUserList] = useMutation(
+    userListMutation
+  )
+
+  const [sorting, setIsSorting] = useState(false)
+  const [editing, setIsEditing] = useState(false)
+  const [temporaryList, setTemporaryList] = useState([])
+
+  const listItems = isFinished ? userList.items : []
+
+  const sortingItems = listIsSaving ? temporaryList : listItems
 
   return (
     <BannerPageWrapper>
@@ -43,22 +69,101 @@ export default function UserListDetailPage(props: Props) {
         </BannerContainer>
       </BannerPageHeader>
       {isFinished ? (
-        <Grid className="main-content one-column narrow user-list-page">
-          <Cell width={12}>
-            <h1 className="list-header">{userList.title}</h1>
-            {userList.short_description ? (
-              <p className="list-description">{userList.short_description}</p>
-            ) : null}
-          </Cell>
-          {userList.items.map((item, i) => (
-            <Cell width={12} key={i}>
-              <LearningResourceCard
-                object={item.content_data}
-                searchResultLayout={SEARCH_LIST_UI}
-              />
+        <React.Fragment>
+          <Grid className={UL_PAGE_GRID_CLASSNAME}>
+            <Cell width={12}>
+              <h1 className="list-header">{userList.title}</h1>
+              {userList.short_description ? (
+                <p className="list-description">{userList.short_description}</p>
+              ) : null}
             </Cell>
-          ))}
-        </Grid>
+            {userList.author === SETTINGS.user_id ? (
+              <Cell width={12} className="list-edit-controls">
+                {userList.items.length > 1 &&
+                userList.list_type === LR_TYPE_LEARNINGPATH ? (
+                    <button
+                      className="sort-list blue-btn"
+                      onClick={() => setIsSorting(!sorting)}
+                    >
+                      {sorting
+                        ? `Stop sorting ${
+                          readableLearningResources[userList.object_type]
+                        }`
+                        : `Reorder ${
+                          readableLearningResources[userList.object_type]
+                        }`}
+                    </button>
+                  ) : null}
+                <div className="count">
+                  {userList.items.length}{" "}
+                  {userList.items.length === 1 ? "item" : "items"}
+                </div>
+                <a
+                  href="#"
+                  className="edit-link"
+                  onClick={() => setIsEditing(true)}
+                >
+                  <i className="material-icons edit">edit</i>
+                  Edit
+                </a>
+              </Cell>
+            ) : null}
+          </Grid>
+          {sorting ? (
+            <SortableContainer
+              shouldCancelStart={() => listIsSaving}
+              onSortEnd={async ({ oldIndex, newIndex }) => {
+                const newList = arrayMove(userList.items, oldIndex, newIndex)
+                setTemporaryList(newList)
+                await updateUserList({
+                  id:    userList.id,
+                  items: newList.map((item, idx) => ({
+                    id:       item.id,
+                    position: idx
+                  }))
+                })
+                setTemporaryList([])
+              }}
+            >
+              <Grid
+                className={
+                  listIsSaving
+                    ? `${UL_PAGE_GRID_CLASSNAME} saving`
+                    : UL_PAGE_GRID_CLASSNAME
+                }
+              >
+                {sortingItems.map((item, i) => (
+                  <SortableItem key={`item-${item.id}`} index={i}>
+                    <Cell width={12}>
+                      <LearningResourceCard
+                        object={item.content_data}
+                        searchResultLayout={SEARCH_LIST_UI}
+                        reordering
+                      />
+                    </Cell>
+                  </SortableItem>
+                ))}
+              </Grid>
+            </SortableContainer>
+          ) : (
+            <Grid className={UL_PAGE_GRID_CLASSNAME}>
+              {userList.items.map((item, i) => (
+                <Cell width={12} key={i}>
+                  <LearningResourceCard
+                    object={item.content_data}
+                    searchResultLayout={SEARCH_LIST_UI}
+                  />
+                </Cell>
+              ))}
+            </Grid>
+          )}
+        </React.Fragment>
+      ) : null}
+      {editing ? (
+        <UserListFormDialog
+          userList={userList}
+          hide={() => setIsEditing(false)}
+        />
       ) : null}
       <LearningResourceDrawer />
       <AddToListDialog />

--- a/static/js/pages/UserListDetailPage_test.js
+++ b/static/js/pages/UserListDetailPage_test.js
@@ -1,14 +1,18 @@
 // @flow
+/* global SETTINGS: false */
 import { assert } from "chai"
 import R from "ramda"
+import arrayMove from "array-move"
 
 import UserListDetailPage from "./UserListDetailPage"
 import { LearningResourceCard } from "../components/LearningResourceCard"
+import { SortableContainer } from "../components/SortableList"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { makeUserList } from "../factories/learning_resources"
 import { userListApiURL } from "../lib/url"
-import { queryListResponse } from "../lib/test_utils"
+import { shouldIf } from "../lib/test_utils"
+import { LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST } from "../lib/constants"
 
 describe("UserListDetailPage tests", () => {
   let helper, userList, render
@@ -22,9 +26,6 @@ describe("UserListDetailPage tests", () => {
         status: 200,
         body:   userList
       })
-    helper.handleRequestStub
-      .withArgs(userListApiURL)
-      .returns(queryListResponse([]))
     render = helper.configureReduxQueryRenderer(UserListDetailPage, {
       match: {
         params: {
@@ -63,6 +64,86 @@ describe("UserListDetailPage tests", () => {
       ([card, item]) => {
         assert.deepEqual(card.props.object, item.content_data)
       }
+    )
+  })
+
+  //
+  ;[true, false].forEach(usersOwnList => {
+    it(`${shouldIf(usersOwnList)} show some editing controls if ${
+      usersOwnList ? "is" : "is not"
+    } the users own list`, async () => {
+      if (usersOwnList) {
+        // $FlowFixMe: flow thinks this is invalid for who knows what reason
+        userList.author = SETTINGS.user_id
+      }
+      const { wrapper } = await render()
+      assert.equal(wrapper.find(".list-edit-controls").exists(), usersOwnList)
+    })
+  })
+
+  it("should let the user edit their list", async () => {
+    // $FlowFixMe: flow thinks this is invalid for who knows what reason
+    userList.author = SETTINGS.user_id
+    const { wrapper } = await render()
+    wrapper.find(".edit-link").simulate("click")
+    const editor = wrapper.find("UserListFormDialog")
+    assert.ok(editor.exists())
+    assert.deepEqual(editor.prop("userList"), userList)
+    editor.prop("hide")()
+    wrapper.update()
+    assert.isNotOk(wrapper.find("UserListFormDialog").exists())
+  })
+
+  //
+  ;[[0, false], [1, false], [2, true], [3, true]].forEach(
+    ([listItems, shouldShowButton]) => {
+      it(`${shouldIf(
+        shouldShowButton
+      )} show the reorder button for LP with ${String(
+        listItems
+      )} items`, async () => {
+        // $FlowFixMe: flow thinks this is invalid for who knows what reason
+        userList.author = SETTINGS.user_id
+        userList.list_type = LR_TYPE_LEARNINGPATH
+        userList.items = userList.items.slice(0, listItems)
+        const { wrapper } = await render()
+        assert.equal(wrapper.find(".sort-list").exists(), shouldShowButton)
+      })
+    }
+  )
+
+  it("should hide the reorder button for a user list", async () => {
+    // $FlowFixMe: flow thinks this is invalid for who knows what reason
+    userList.author = SETTINGS.user_id
+    userList.list_type = LR_TYPE_USERLIST
+    const { wrapper } = await render()
+    assert.isNotOk(wrapper.find(".sort-list").exists())
+  })
+
+  it("should let the user reorder their learning path", async () => {
+    // $FlowFixMe: flow thinks this is invalid for who knows what reason
+    userList.author = SETTINGS.user_id
+    userList.list_type = LR_TYPE_LEARNINGPATH
+    const { wrapper } = await render()
+    wrapper.find(".sort-list").simulate("click")
+    wrapper.find("LearningResourceCard").forEach(card => {
+      assert.isTrue(card.prop("reordering"))
+    })
+
+    wrapper.find(SortableContainer).prop("onSortEnd")({
+      oldIndex: 1,
+      newIndex: 2
+    })
+    const [url, method, { body }] = helper.handleRequestStub.args[2]
+    assert.equal(method, "PATCH")
+    assert.equal(url, `${userListApiURL}/${userList.id}/`)
+    assert.deepEqual(body.id, userList.id)
+    assert.deepEqual(
+      body.items,
+      arrayMove(userList.items, 1, 2).map((item, idx) => ({
+        id:       item.id,
+        position: idx
+      }))
     )
   })
 })

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -28,6 +28,8 @@ import * as networkInterfaceFuncs from "../store/network_interface"
 import * as embedUtil from "../lib/embed"
 import { getQueries } from "../lib/redux_query"
 import * as storeLib from "../store/configureStore"
+import { topicApiURL, userListApiURL } from "../lib/url"
+import { queryListResponse } from "../lib/test_utils"
 
 import type { Sandbox } from "../flow/sinonTypes"
 
@@ -109,6 +111,11 @@ export default class IntegrationTestHelper {
         },
         abort: () => {}
       }))
+
+    this.handleRequestStub
+      .withArgs(userListApiURL)
+      .returns(queryListResponse([]))
+    this.handleRequestStub.withArgs(topicApiURL).returns(queryListResponse([]))
 
     // there's a good reason for this I promise
     this.realWarn = console.warn

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -4,6 +4,28 @@
   font-family: roboto;
   cursor: initial;
 
+  &.reordering {
+    cursor: pointer;
+
+    .card-contents {
+      padding-left: 8px;
+    }
+  }
+
+  .drag-handle {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-right: 10px;
+    border-right: 2px solid $font-grey-light;
+    cursor: pointer;
+
+    i {
+      font-size: 40px;
+      color: $font-grey-light;
+    }
+  }
+
   &.borderless {
     .lr-info {
       padding: 16px;

--- a/static/scss/user-list-page.scss
+++ b/static/scss/user-list-page.scss
@@ -1,4 +1,12 @@
 .user-list-page {
+  &.main-content.one-column.narrow {
+    min-height: 0;
+  }
+
+  &.saving {
+    opacity: 0.5;
+  }
+
   .first-row {
     display: flex;
     align-items: center;
@@ -15,5 +23,21 @@
 
   .list-description {
     font-size: 16px;
+  }
+
+  .list-edit-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .edit-link {
+      display: flex;
+      align-items: center;
+
+      i {
+        font-size: 20px;
+        margin-right: 5px;
+      }
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,6 +2612,11 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-move@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/array-move/-/array-move-2.2.0.tgz#28f39b915df05ce8b00c43100d20b5a6385f7606"
+  integrity sha512-n9Wlbjl9tb9c7qoKjminaLwyUR5y4UV+DXcCu428yUSvBD7WWmfskEB98zdrgMPKFDUrzfZtdJuZ3Pzi3k5IbA==
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

path of #2311

#### What's this PR do?

this adds an option to the user list detail page to both edit the list details (like the title and so on) and also to reorder the items in the list.

#### How should this be manually tested?

try out the functionality added and see if it breaks, haha. make sure the UX makes sense and is relatively clear to the user.


#### Screenshots (if appropriate)

![optionsdfasdfasdf](https://user-images.githubusercontent.com/6207644/69982321-2b5f3880-1502-11ea-9cb2-8ad9e2ba1278.png)
![optionsdf](https://user-images.githubusercontent.com/6207644/69982322-2b5f3880-1502-11ea-9391-71172cd2bece.png)
