### PR TITLE
Added transcripts to searchable fields

### DIFF
--- a/search/serializers.py
+++ b/search/serializers.py
@@ -488,6 +488,7 @@ class ESVideoSerializer(ESModelSerializer, LearningResourceSerializer):
             "video_id",
             "short_description",
             "full_description",
+            "transcript",
             "platform",
             "title",
             "image_src",

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -142,6 +142,7 @@ const VIDEO_QUERY_FIELDS = [
   "title.english^3",
   "short_description.english^2",
   "full_description.english",
+  "transcript.english^2",
   "topics",
   "platform",
   "video_id",

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -685,6 +685,7 @@ describe("search functions", () => {
           "title.english^3",
           "short_description.english^2",
           "full_description.english",
+          "transcript.english^2",
           "topics",
           "platform",
           "video_id",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2420 

#### What's this PR do?

- Adds `transcript` to the elasticsearch serializer
- Adds `transcript` to the fields the frontend queries the text search on

#### How should this be manually tested?

Update a video's transcript with some unqiue value:

```python
from course_catalog.models import *
v = Video.objects.first()
v.transcript = "uniqueword"
v.save()
```
- `./manage.py recreate_index`
- Go to the search page and search for your unique transcript value, you should see that as the only result