### PR TITLE
Set DISABLE_SERVER_SIDE_CURSORS=True by default

### DIFF
--- a/app.json
+++ b/app.json
@@ -222,7 +222,6 @@
     },
     "OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS": {
       "description": "Disable server-side cursors",
-      "value": "True",
       "required": false
     },
     "OPEN_DISCUSSIONS_EMAIL_HOST": {

--- a/app.json
+++ b/app.json
@@ -220,6 +220,11 @@
     "OPEN_DISCUSSIONS_DB_DISABLE_SSL": {
       "value": "True"
     },
+    "OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS": {
+      "description": "Disable server-side cursors",
+      "value": "True",
+      "required": false
+    },
     "OPEN_DISCUSSIONS_EMAIL_HOST": {
       "description": "Outgoing e-mail settings"
     },

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -164,12 +164,16 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
         "DATABASE_URL", "sqlite:///{0}".format(os.path.join(BASE_DIR, "db.sqlite3"))
     )
 )
+DEFAULT_DATABASE_CONFIG["DISABLE_SERVER_SIDE_CURSORS"] = get_bool(
+    "OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS", True
+)
 DEFAULT_DATABASE_CONFIG["CONN_MAX_AGE"] = get_int("OPEN_DISCUSSIONS_DB_CONN_MAX_AGE", 0)
 
 if get_bool("OPEN_DISCUSSIONS_DB_DISABLE_SSL", False):
     DEFAULT_DATABASE_CONFIG["OPTIONS"] = {}
 else:
     DEFAULT_DATABASE_CONFIG["OPTIONS"] = {"sslmode": "require"}
+
 
 DATABASES = {"default": DEFAULT_DATABASE_CONFIG}
 

--- a/open_discussions/settings_test.py
+++ b/open_discussions/settings_test.py
@@ -180,3 +180,24 @@ class TestSettings(TestCase):
             "password-reset-confirm", kwargs=dict(uid=uid, token=token)
         )
         assert reverse_url == "/{}".format(template_generated_url)
+
+    def test_server_side_cursors_disabled(self):
+        """DISABLE_SERVER_SIDE_CURSORS should be true by default"""
+        with mock.patch.dict("os.environ", REQUIRED_SETTINGS):
+            settings_vars = self.reload_settings()
+            assert (
+                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+                is True
+            )
+
+    def test_server_side_cursors_enabled(self):
+        """DISABLE_SERVER_SIDE_CURSORS should be false if OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS is false"""
+        with mock.patch.dict(
+            "os.environ",
+            {**REQUIRED_SETTINGS, "OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS": "False"},
+        ):
+            settings_vars = self.reload_settings()
+            assert (
+                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+                is False
+            )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
- Fixes #2453 

#### What's this PR do?
Sets `DISABLE_SERVER_SIDE_CURSORS=True` by default unless overridden in .env

#### How should this be manually tested?
Nothing should break locally or on CI/RC, especially queries using `.iterator()`

```
from django.db import connections
connections["default"].settings_dict.get('DISABLE_SERVER_SIDE_CURSORS')
```
should return True by default, or False if `OPEN_DISCUSSIONS_DB_DISABLE_SS_CURSORS=False` in your .env file

#### Any background context you want to provide?
https://code.djangoproject.com/ticket/28062
