### PR TITLE
add visual separation to items shown in the userlist drawer

### DIFF
--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -222,6 +222,8 @@
 .expanded-learning-resource-userlist {
   .learning-resource-card {
     margin: 20px;
+    border-bottom: 2px solid $pale-grey;
+    padding-bottom: 10px;
   }
 
   .user-list-header {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?

closes #2438 

#### What's this PR do?

adds a visual separator between items in the userlist when we display them in the drawer.

#### How should this be manually tested?

look at a userlist from the search page and make sure it looks alright


#### Screenshots (if appropriate)

![visualseparation](https://user-images.githubusercontent.com/6207644/70249328-3d331c80-174a-11ea-9cab-e650d2467aa1.png)
