### PR TITLE
Get rid of n+1 query on content_type.name

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -481,10 +481,17 @@ class SimpleUserListSerializer(
     Uses the SimpleUserListItemSerializer for items, which contains only essential attributes.
     """
 
-    items = SimpleUserListItemSerializer(many=True, allow_null=True, read_only=True)
+    items = serializers.SerializerMethodField()
     topics = WriteableSerializerMethodField()
     author_name = serializers.SerializerMethodField()
     object_type = serializers.CharField(read_only=True, source="list_type")
+
+    def get_items(self, instance):
+        """get items"""
+        return [
+            SimpleUserListItemSerializer(item).data
+            for item in instance.items.select_related("content_type")
+        ]
 
     def get_author_name(self, instance):
         """get author name for userlist"""


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Partially addresses #2459 

#### What's this PR do?
Gets rid of n+1 queries on 'UserListItem.content_type` when retrieving userlist API results

#### How should this be manually tested?
Make sure you have some userlists with items.
Try both:

http://od.odl.local:8063/api/v0/userlists
http://od.odl.local:8063/api/v0/userlists/<list_id>

and check the console, you should not see any warnings about n+1 queries
