### PR TITLE
add history navigation to drawer

### DIFF
--- a/static/js/actions/ui.js
+++ b/static/js/actions/ui.js
@@ -22,10 +22,14 @@ export const setShowDrawerMobile = createAction<string, *>(
 export const SET_SHOW_DRAWER_HOVER = "SET_SHOW_DRAWER_HOVER"
 export const setShowDrawerHover = createAction<string, *>(SET_SHOW_DRAWER_HOVER)
 
-export const SET_SHOW_RESOURCE_DRAWER = "SET_SHOW_RESOURCE_DRAWER"
-export const setShowResourceDrawer = createAction<string, *>(
-  SET_SHOW_RESOURCE_DRAWER
-)
+export const PUSH_LR_HISTORY = "PUSH_LR_HISTORY"
+export const pushLRHistory = createAction<string, *>(PUSH_LR_HISTORY)
+
+export const POP_LR_HISTORY = "POP_LR_HISTORY"
+export const popLRHistory = createAction<string, *>(POP_LR_HISTORY)
+
+export const CLEAR_LR_HISTORY = "CLEAR_LR_HISTORY"
+export const clearLRHistory = createAction<string, *>(CLEAR_LR_HISTORY)
 
 export const SET_SNACKBAR_MESSAGE = "SET_SNACKBAR_MESSAGE"
 export const setSnackbarMessage = createAction<string, *>(SET_SNACKBAR_MESSAGE)

--- a/static/js/components/CourseCarousel_test.js
+++ b/static/js/components/CourseCarousel_test.js
@@ -10,12 +10,11 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 import * as LRCardModule from "./LearningResourceCard"
 
 describe("CourseCarousel", () => {
-  let courses, setShowResourceDrawerStub, helper, render
+  let courses, helper, render
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     courses = R.times(makeCourse, 10)
-    setShowResourceDrawerStub = helper.sandbox.stub()
     helper.stubComponent(
       LRCardModule,
       "LearningResourceCard",
@@ -26,9 +25,8 @@ describe("CourseCarousel", () => {
       CourseCarousel,
       {},
       {
-        title:                 "Greatest Courses Ever",
-        courses,
-        setShowResourceDrawer: setShowResourceDrawerStub
+        title: "Greatest Courses Ever",
+        courses
       }
     )
   })

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -30,7 +30,7 @@ import {
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
 import { toQueryString, COURSE_SEARCH_URL } from "../lib/url"
 import { emptyOrNil, userIsAnonymous } from "../lib/util"
-import { setShowResourceDrawer, DIALOG_ADD_TO_LIST } from "../actions/ui"
+import { pushLRHistory, DIALOG_ADD_TO_LIST } from "../actions/ui"
 
 import type {
   CourseTopic,
@@ -131,7 +131,7 @@ export function LearningResourceDisplay(props: Props) {
   const showResourceDrawer = useCallback(
     () =>
       dispatch(
-        setShowResourceDrawer({
+        pushLRHistory({
           objectId:   object.id,
           objectType: object.object_type,
           runId:      bestAvailableRun ? bestAvailableRun.id : null

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -63,7 +63,7 @@ describe("LearningResourceCard", () => {
     const { wrapper, store } = await render()
     wrapper.find(".cover-image").simulate("click")
     wrapper.find(".course-title").simulate("click")
-    const { objectId, objectType } = store.getState().ui.courseDetail
+    const { objectId, objectType } = store.getState().ui.LRDrawerHistory[0]
     assert.equal(objectId, course.id)
     assert.equal(objectType, LR_TYPE_COURSE)
   })

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -1,188 +1,123 @@
 // @flow
-import React from "react"
-import R from "ramda"
-import _ from "lodash"
-import { connect } from "react-redux"
-import { withRouter } from "react-router"
+import React, { useCallback } from "react"
+import { useDispatch, useSelector } from "react-redux"
 import { Drawer, DrawerContent } from "@rmwc/drawer"
 import { Theme } from "@rmwc/theme"
-import { querySelectors } from "redux-query"
-import { connectRequest } from "redux-query-react"
+import { useRequest } from "redux-query-react"
 import { createSelector } from "reselect"
 
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 
-import { setShowResourceDrawer } from "../actions/ui"
-import { courseRequest } from "../lib/queries/courses"
-import { bootcampRequest } from "../lib/queries/bootcamps"
-import { programRequest } from "../lib/queries/programs"
-import { videoRequest } from "../lib/queries/videos"
-import { userListRequest } from "../lib/queries/user_lists"
+import { pushLRHistory, popLRHistory, clearLRHistory } from "../actions/ui"
 import { embedlyRequest, getEmbedlys } from "../lib/queries/embedly"
-import {
-  LR_TYPE_BOOTCAMP,
-  LR_TYPE_COURSE,
-  LR_TYPE_PROGRAM,
-  LR_TYPE_VIDEO,
-  LR_TYPE_USERLIST,
-  LR_TYPE_LEARNINGPATH
-} from "../lib/constants"
+import { LR_TYPE_VIDEO } from "../lib/constants"
 import { useResponsive } from "../hooks/util"
+import {
+  learningResourceSelector,
+  getResourceRequest
+} from "../lib/queries/learning_resources"
 
-import type { Dispatch } from "redux"
-
-type Props = {
-  showLearningDrawer: boolean,
-  dispatch: Dispatch<*>,
-  object: Object | null,
-  objectId: number,
-  objectType: string,
-  runId: number,
-  setShowResourceDrawer: Function,
-  embedly: ?Object
-}
-
-export function LearningResourceDrawer(props: Props) {
-  const {
-    object,
-    runId,
-    showLearningDrawer,
-    setShowResourceDrawer,
-    embedly
-  } = props
-
-  useResponsive()
-
-  const onDrawerClose = () => setShowResourceDrawer({ objectId: null })
-
-  return object ? (
-    <Theme>
-      <Drawer
-        open={showLearningDrawer}
-        onClose={onDrawerClose}
-        dir="rtl"
-        className="align-right"
-        modal
-      >
-        <DrawerContent dir="ltr">
-          <div className="drawer-close" onClick={onDrawerClose}>
-            <i className="material-icons clear">clear</i>
-          </div>
-          <ExpandedLearningResourceDisplay
-            object={object}
-            runId={runId}
-            setShowResourceDrawer={setShowResourceDrawer}
-            embedly={embedly}
-          />
-          <div className="footer" />
-        </DrawerContent>
-      </Drawer>
-    </Theme>
-  ) : null
-}
-
-const getObject = createSelector(
+const getLRHistory = createSelector(
   state => state.ui,
-  state => state.entities.courses,
-  state => state.entities.bootcamps,
-  state => state.entities.programs,
-  state => state.entities.videos,
-  state => state.entities.userLists,
-  state => state.queries,
-  (ui, courses, bootcamps, programs, videos, userLists, queries) => {
-    const { objectId, objectType } = ui.courseDetail
+  ui => {
+    const mostRecentHistoryEntry =
+      ui.LRDrawerHistory[ui.LRDrawerHistory.length - 1]
 
-    switch (objectType) {
-    case LR_TYPE_COURSE:
-      return querySelectors.isFinished(queries, courseRequest(objectId))
-        ? courses[objectId]
-        : null
-    case LR_TYPE_BOOTCAMP:
-      return querySelectors.isFinished(queries, bootcampRequest(objectId))
-        ? bootcamps[objectId]
-        : null
-    case LR_TYPE_PROGRAM:
-      return querySelectors.isFinished(queries, programRequest(objectId))
-        ? programs[objectId]
-        : null
-    case LR_TYPE_VIDEO:
-      return querySelectors.isFinished(queries, videoRequest(objectId))
-        ? videos[objectId]
-        : null
-    }
+    const objectId = mostRecentHistoryEntry
+      ? mostRecentHistoryEntry.objectId
+      : undefined
+    const objectType = mostRecentHistoryEntry
+      ? mostRecentHistoryEntry.objectType
+      : undefined
+    const runId = mostRecentHistoryEntry
+      ? mostRecentHistoryEntry.runId
+      : undefined
 
-    if ([LR_TYPE_LEARNINGPATH, LR_TYPE_USERLIST].includes(objectType)) {
-      return querySelectors.isFinished(queries, userListRequest(objectId))
-        ? userLists[objectId]
-        : null
+    return {
+      objectId,
+      objectType,
+      runId,
+      numHistoryEntries: ui.LRDrawerHistory.length
     }
   }
 )
 
 const getEmbedlyForObject = createSelector(
-  getObject,
+  getLRHistory,
+  learningResourceSelector,
   getEmbedlys,
-  state => state.queries,
-  (object, embedlys, queries) => {
-    if (!object || object.object_type !== LR_TYPE_VIDEO || !object.url) {
+  (LRHistory, lrSelector, embedlys) => {
+    const { objectId, objectType } = LRHistory
+    const object = lrSelector(objectId, objectType)
+
+    if (
+      !object ||
+      object.object_type !== LR_TYPE_VIDEO ||
+      !object.url ||
+      !embedlys
+    ) {
       return null
     }
 
-    return querySelectors.isFinished(queries, embedlyRequest(object.url))
-      ? embedlys[object.url]
-      : null
+    return embedlys[object.url] || null
   }
 )
 
-export const mapStateToProps = (state: Object) => {
-  const { ui } = state
+export default function LearningResourceDrawer() {
+  useResponsive()
 
-  const objectId = ui.courseDetail.objectId
-  const objectType = ui.courseDetail.objectType
-  const runId = ui.courseDetail.runId
+  const { objectId, objectType, runId, numHistoryEntries } = useSelector(
+    getLRHistory
+  )
 
-  return {
-    showLearningDrawer: _.isFinite(state.ui.courseDetail.objectId),
-    objectId,
-    objectType,
-    runId,
-    object:             getObject(state),
-    embedly:            getEmbedlyForObject(state)
-  }
+  useRequest(getResourceRequest(objectId, objectType))
+
+  const object = useSelector(learningResourceSelector)(objectId, objectType)
+
+  useRequest(
+    objectType === LR_TYPE_VIDEO && object ? embedlyRequest(object.url) : null
+  )
+
+  const embedly = useSelector(getEmbedlyForObject)
+
+  const dispatch = useDispatch()
+  const clearHistory = useCallback(() => dispatch(clearLRHistory()), [dispatch])
+  const pushHistory = useCallback(object => dispatch(pushLRHistory(object)), [
+    dispatch
+  ])
+  const popHistory = useCallback(() => dispatch(popLRHistory()), [dispatch])
+
+  return (
+    <Theme>
+      <Drawer
+        open={numHistoryEntries > 0}
+        onClose={clearHistory}
+        dir="rtl"
+        className="align-right lr-drawer"
+        modal
+      >
+        <DrawerContent dir="ltr">
+          <div className="drawer-nav">
+            <div className="drawer-close" onClick={clearHistory}>
+              <i className="material-icons clear">clear</i>
+            </div>
+            {numHistoryEntries > 1 ? (
+              <div className="back" onClick={popHistory}>
+                <i className="material-icons arrow_back">arrow_back</i>
+              </div>
+            ) : null}
+          </div>
+          {object ? (
+            <ExpandedLearningResourceDisplay
+              object={object}
+              runId={runId}
+              setShowResourceDrawer={pushHistory}
+              embedly={embedly}
+            />
+          ) : null}
+          <div className="footer" />
+        </DrawerContent>
+      </Drawer>
+    </Theme>
+  )
 }
-
-const mapDispatchToProps = {
-  setShowResourceDrawer
-}
-
-const mapPropsToConfig = props => {
-  const { objectType, objectId, object } = props
-
-  switch (objectType) {
-  case LR_TYPE_COURSE:
-    return [courseRequest(objectId)]
-  case LR_TYPE_BOOTCAMP:
-    return [bootcampRequest(objectId)]
-  case LR_TYPE_PROGRAM:
-    return [programRequest(objectId)]
-  case LR_TYPE_VIDEO:
-    return [
-      videoRequest(objectId),
-      ...(object && object.url ? [embedlyRequest(object.url)] : [])
-    ]
-  case LR_TYPE_LEARNINGPATH:
-    return [userListRequest(objectId)]
-  case LR_TYPE_USERLIST:
-    return [userListRequest(objectId)]
-  }
-  return []
-}
-
-export default R.compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
-  withRouter,
-  connectRequest(mapPropsToConfig)
-)(LearningResourceDrawer)

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -14,7 +14,9 @@ import {
   HIDE_DROPDOWN,
   SET_DIALOG_DATA,
   SET_AUTH_USER_DETAIL,
-  SET_SHOW_RESOURCE_DRAWER
+  PUSH_LR_HISTORY,
+  POP_LR_HISTORY,
+  CLEAR_LR_HISTORY
 } from "../actions/ui"
 
 import type { Action } from "../flow/reduxTypes"
@@ -31,7 +33,7 @@ export type BannerState = {
   visible: boolean
 }
 
-export type CourseDetailState = {
+export type LRHistoryEntry = {
   objectId: ?number,
   objectType: ?string
 }
@@ -40,7 +42,7 @@ export type UIState = {
   showDrawerDesktop: boolean,
   showDrawerMobile: boolean,
   showDrawerHover: boolean,
-  courseDetail?: CourseDetailState,
+  LRDrawerHistory: Array<LRHistoryEntry>,
   snackbar: ?SnackbarState,
   banner: BannerState,
   dialogs: Map<string, any>,
@@ -53,16 +55,13 @@ const INITIAL_BANNER_STATE = {
   visible: false
 }
 
-const INITIAL_COURSE_STATE = {
-  objectId:   null,
-  objectType: null
-}
+const INITIAL_LR_DRAWER_STATE: Array<LRHistoryEntry> = []
 
 export const INITIAL_UI_STATE: UIState = {
   showDrawerDesktop: false,
   showDrawerMobile:  false,
   showDrawerHover:   false,
-  courseDetail:      INITIAL_COURSE_STATE,
+  LRDrawerHistory:   INITIAL_LR_DRAWER_STATE,
   snackbar:          null,
   banner:            INITIAL_BANNER_STATE,
   dialogs:           new Map(),
@@ -126,14 +125,27 @@ export const ui = (
     return { ...state, showDrawerMobile: action.payload }
   case SET_SHOW_DRAWER_HOVER:
     return { ...state, showDrawerHover: action.payload }
-  case SET_SHOW_RESOURCE_DRAWER:
+  case PUSH_LR_HISTORY:
     return {
       ...state,
-      courseDetail: {
+      LRDrawerHistory: state.LRDrawerHistory.concat({
         objectId:   action.payload.objectId,
         objectType: action.payload.objectType,
         runId:      action.payload.runId
-      }
+      })
+    }
+  case POP_LR_HISTORY:
+    return {
+      ...state,
+      LRDrawerHistory: state.LRDrawerHistory.slice(
+        0,
+        state.LRDrawerHistory.length - 1
+      )
+    }
+  case CLEAR_LR_HISTORY:
+    return {
+      ...state,
+      LRDrawerHistory: []
     }
   case SET_SNACKBAR_MESSAGE:
     return {

--- a/static/js/reducers/ui_test.js
+++ b/static/js/reducers/ui_test.js
@@ -15,6 +15,9 @@ import {
   HIDE_DROPDOWN,
   SET_BANNER_MESSAGE,
   HIDE_BANNER,
+  PUSH_LR_HISTORY,
+  POP_LR_HISTORY,
+  CLEAR_LR_HISTORY,
   setShowDrawerDesktop,
   setShowDrawerMobile,
   setShowDrawerHover,
@@ -25,7 +28,10 @@ import {
   showDropdown,
   hideDropdown,
   setBannerMessage,
-  hideBanner
+  hideBanner,
+  pushLRHistory,
+  popLRHistory,
+  clearLRHistory
 } from "../actions/ui"
 import { USER_MENU_DROPDOWN } from "../pages/App"
 
@@ -165,5 +171,43 @@ describe("ui reducer", () => {
       message: "",
       visible: false
     })
+  })
+
+  it("should let you push to the LR history", async () => {
+    const state = await dispatchThen(
+      pushLRHistory({ objectId: "HEY!", objectType: "best", runId: 1 }),
+      [PUSH_LR_HISTORY]
+    )
+    assert.deepEqual(state.LRDrawerHistory, [
+      { objectId: "HEY!", objectType: "best", runId: 1 }
+    ])
+  })
+
+  it("should let you pop an entry off the LR history", async () => {
+    await dispatchThen(
+      pushLRHistory({ objectId: "HEY!", objectType: "best", runId: 1 }),
+      [PUSH_LR_HISTORY]
+    )
+    await dispatchThen(
+      pushLRHistory({ objectId: "second one", objectType: "worst", runId: 1 }),
+      [PUSH_LR_HISTORY]
+    )
+    const state = await dispatchThen(popLRHistory(), [POP_LR_HISTORY])
+    assert.deepEqual(state.LRDrawerHistory, [
+      { objectId: "HEY!", objectType: "best", runId: 1 }
+    ])
+  })
+
+  it("should let you clear the LR history", async () => {
+    await dispatchThen(
+      pushLRHistory({ objectId: "HEY!", objectType: "best", runId: 1 }),
+      [PUSH_LR_HISTORY]
+    )
+    await dispatchThen(
+      pushLRHistory({ objectId: "second one", objectType: "worst", runId: 1 }),
+      [PUSH_LR_HISTORY]
+    )
+    const state = await dispatchThen(clearLRHistory(), [CLEAR_LR_HISTORY])
+    assert.deepEqual(state.LRDrawerHistory, [])
   })
 })

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -40,17 +40,28 @@
   justify-content: space-between;
 }
 
-.drawer-close {
-  float: right;
-  cursor: pointer;
-  text-align: right;
-  padding: 5px 10px;
-  width: 100%;
-  background-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.1),
-    rgba(0, 0, 0, 0) 25%
-  );
+.lr-drawer {
+  .drawer-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row-reverse;
+    background-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.1),
+      rgba(0, 0, 0, 0) 25%
+    );
+
+    .back,
+    .drawer-close {
+      cursor: pointer;
+      margin: 10px;
+    }
+
+    .drawer-close {
+      margin-right: 10px;
+    }
+  }
 }
 
 .course-catalog-title {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2440

#### What's this PR do?

This refactors how we control what is shown in the `LearningResourceDrawer`. Previously we basically set an object ID and object type, and then we'd use those to fetch the right object, and then we'd show it. This worked for opening and looking at one object, but it broke down a little when it came to navigating to a new object from the initial one. The specific problem is that if you click in you can't get back to the object you we're looking at before without closing the whole drawer and opening and navigating again.

We need to support this use-case well because the user can do this from a userlist or a learning path.

Anyhow, to fix this I changed it so it works on the basis of a history object, which we store in the `ui` reducer. It's just an array, and this is how it works:

- if the array is empty then nothing is on the history, so don't show the drawer
- if there is any item on the history, then show the drawer
- take the last item on the history and use that item ID and object type to fetch an object to display in the `ExpandedLearningResourceDisplay`

so I implemented 3 actions: push, pop, and clear. they do what you'd expect. overall it seems to work pretty well!

#### How should this be manually tested?

Make sure you can open the drawer for any resource. Initially, you should just see a 'close' button in the upper right of the drawer.

If you click on a user list, you should then be able to click on an item in that list, and it should then open in the drawer.

Then you should additionally see a 'back' button, which will take you back to the initial item.

#### Screenshots (if appropriate)

initial item:

![initialffff](https://user-images.githubusercontent.com/6207644/70276953-6a4df200-177f-11ea-9a17-12298282a115.png)

second item:

![initialfffffffdasdfasdf](https://user-images.githubusercontent.com/6207644/70276966-6e7a0f80-177f-11ea-8428-374b5cf12034.png)
