### PR TITLE
change "/courses" urls to "/learn"

### DIFF
--- a/flow-typed/npm/react-router-dom_v5.x.x.js
+++ b/flow-typed/npm/react-router-dom_v5.x.x.js
@@ -170,5 +170,10 @@ declare module "react-router-dom" {
     parent?: Match
   ): null | Match;
 
+  declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
+  declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
+  declare export function useParams(): $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>;
+  declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
+
   declare export function generatePath(pattern?: string, params?: { +[string]: mixed }): string;
 }

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -84,6 +84,7 @@ urlpatterns = [
     url(r"^privacy-statement/", index, name="privacy-statement"),
     url(r"^search/", index, name="site-search"),
     url(r"^courses/", index, name="courses"),
+    url(r"^learn/", index, name="learn"),
     url(r"^terms-and-conditions/", index, name="terms-and-conditions"),
     # Hijack
     url(r"^hijack/", include("hijack.urls", namespace="hijack")),

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -43,7 +43,7 @@ export const LoggedInMenu = (props: DropdownMenuProps) => (
     ) : null}
     <ResponsiveWrapper onlyOn={[PHONE]}>
       <Route
-        path="/courses"
+        path="/learn"
         render={() => (
           <Link className="user-list-link" to={userListIndexURL}>
             My Lists

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -115,8 +115,8 @@ export const TERMS_OF_SERVICE_URL = "/terms-and-conditions"
 export const PRIVACY_POLICY_URL = "/privacy-statement"
 
 export const SITE_SEARCH_URL = "/search/"
-export const COURSE_URL = "/courses/"
-export const COURSE_SEARCH_URL = "/courses/search"
+export const COURSE_URL = "/learn/"
+export const COURSE_SEARCH_URL = "/learn/search"
 
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`
@@ -148,5 +148,5 @@ export const newVideosURL = "/api/v0/videos/new/"
 export const embedlyApiURL = "/api/v0/embedly"
 export const topicApiURL = "/api/v0/topics"
 
-export const userListIndexURL = "/courses/lists/"
-export const userListDetailURL = (id: number) => `/courses/lists/${id}`
+export const userListIndexURL = "/learn/lists/"
+export const userListDetailURL = (id: number) => `/learn/lists/${id}`

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -170,7 +170,7 @@ describe("url helper functions", () => {
       assert.equal(AUTH_REQUIRED_URL, "/auth_required/")
       assert.equal(FRONTPAGE_URL, "/")
       assert.equal(SITE_SEARCH_URL, "/search/")
-      assert.equal(COURSE_URL, "/courses/")
+      assert.equal(COURSE_URL, "/learn/")
     })
   })
 

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -1,14 +1,13 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { Route, Redirect, Switch } from "react-router-dom"
+import { Route, Redirect, Switch, useLocation } from "react-router-dom"
 import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 import qs from "query-string"
 
 import HomePage from "./HomePage"
 import SearchPage from "./SearchPage"
-import CourseSearchPage from "./CourseSearchPage"
 import ContentPolicyPage from "./policies/ContentPolicyPage"
 import PrivacyPolicyPage from "./policies/PrivacyPolicyPage"
 import TermsOfServicePage from "./policies/TermsOfServicePage"
@@ -30,10 +29,7 @@ import InactiveUserPage from "./auth/InactiveUserPage"
 import PasswordResetPage from "./auth/PasswordResetPage"
 import PasswordResetConfirmPage from "./auth/PasswordResetConfirmPage"
 import ChannelRouter from "./ChannelRouter"
-import CourseIndexPage from "./CourseIndexPage"
-import UserListsPage from "./UserListsPage"
-import UserListDetailPage from "./UserListDetailPage"
-import FavoritesDetailPage from "./FavoritesDetailPage"
+import LearnRouter from "./LearnRouter"
 
 import PrivateRoute from "../components/auth/PrivateRoute"
 import Snackbar from "../components/material/Snackbar"
@@ -85,6 +81,14 @@ type Props = {|
   ...OwnProps,
   dispatch: Dispatch<*>
 |}
+
+function CourseLearnRedirect() {
+  const { pathname, search } = useLocation()
+
+  const newPath = pathname.replace(/^\/courses/, "/learn").concat(search)
+
+  return <Redirect to={newPath} />
+}
 
 class App extends React.Component<Props> {
   toggleShowDrawer = () => {
@@ -187,7 +191,7 @@ class App extends React.Component<Props> {
         <MetaTags>
           <title>MIT Open Learning</title>
         </MetaTags>
-        <Route path={`${match.url}courses/`}>
+        <Route path={`${match.url}learn/`}>
           {({ match }) =>
             match ? (
               <CourseToolbar
@@ -315,31 +319,12 @@ class App extends React.Component<Props> {
             component={PrivacyPolicyPage}
           />
           {SETTINGS.course_ui_enabled ? (
-            <Switch>
-              <Route
-                exact
-                path={`${match.url}courses`}
-                component={CourseIndexPage}
-              />
-              <Route
-                exact
-                path={`${match.url}courses/search`}
-                component={CourseSearchPage}
-              />
-              <Route
-                path={`${match.url}courses/lists/favorites`}
-                component={FavoritesDetailPage}
-              />
-              <Route
-                path={`${match.url}courses/lists/:id`}
-                component={UserListDetailPage}
-              />
-              <Route
-                exact
-                path={`${match.url}courses/lists`}
-                component={UserListsPage}
-              />
-            </Switch>
+            <>
+              <Route path={`${match.url}courses`}>
+                <CourseLearnRedirect />
+              </Route>
+              <Route path={`${match.url}learn`} component={LearnRouter} />
+            </>
           ) : null}
         </div>
       </div>

--- a/static/js/pages/App_test.js
+++ b/static/js/pages/App_test.js
@@ -136,14 +136,14 @@ describe("App", () => {
   })
 
   //
-  ;[["/courses/", true], ["/", false]].forEach(([url, isCourseUrl]) => {
-    it(`${shouldIf(!isCourseUrl)} include a Drawer, ${shouldIf(
-      isCourseUrl
+  ;[["/learn/", true], ["/", false]].forEach(([url, isLearnUrl]) => {
+    it(`${shouldIf(!isLearnUrl)} include a Drawer, ${shouldIf(
+      isLearnUrl
     )} include CourseToolbar if url is ${url}`, async () => {
       const [wrapper] = await renderComponent(url, [])
-      assert.equal(wrapper.find("CourseToolbar").exists(), isCourseUrl)
-      assert.equal(wrapper.find("Toolbar").exists(), !isCourseUrl)
-      assert.equal(wrapper.find("Drawer").exists(), !isCourseUrl)
+      assert.equal(wrapper.find("CourseToolbar").exists(), isLearnUrl)
+      assert.equal(wrapper.find("Toolbar").exists(), !isLearnUrl)
+      assert.equal(wrapper.find("Drawer").exists(), !isLearnUrl)
     })
   })
 })

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -4,7 +4,6 @@ import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 import { Link } from "react-router-dom"
 
-import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import CourseCarousel from "../components/CourseCarousel"
 
 import {
@@ -16,7 +15,6 @@ import {
 import { Cell, Grid } from "../components/Grid"
 import CourseSearchbox from "../components/CourseSearchbox"
 import { CarouselLoading } from "../components/Loading"
-import AddToListDialog from "../components/AddToListDialog"
 import ResponsiveWrapper from "../components/ResponsiveWrapper"
 
 import {
@@ -124,8 +122,6 @@ export default function CourseIndexPage({ history }: Props) {
           </Cell>
         )}
       </Grid>
-      <LearningResourceDrawer />
-      <AddToListDialog />
     </BannerPageWrapper>
   )
 }

--- a/static/js/pages/CourseIndexPage_test.js
+++ b/static/js/pages/CourseIndexPage_test.js
@@ -2,7 +2,6 @@
 import { assert } from "chai"
 import R from "ramda"
 
-import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import CourseIndexPage from "./CourseIndexPage"
 import {
   BannerPageWrapper,
@@ -116,11 +115,6 @@ describe("CourseIndexPage", () => {
     })
   })
 
-  it("should render a LearningResourceDrawer", async () => {
-    const { wrapper } = await render()
-    assert.ok(wrapper.find(LearningResourceDrawer).exists())
-  })
-
   it("shouldnt render a featured carousel if featuredCourses is empty", async () => {
     helper.handleRequestStub
       .withArgs(featuredCoursesURL)
@@ -167,7 +161,7 @@ describe("CourseIndexPage", () => {
     const searchBox = wrapper.find("CourseSearchbox")
     searchBox.prop("onSubmit")({ target: { value: "search term" } })
     const { pathname, search } = helper.currentLocation
-    assert.equal(pathname, "/courses/search")
+    assert.equal(pathname, "/learn/search")
     assert.equal(search, "?q=search%20term")
   })
 

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -11,11 +11,9 @@ import { connectRequest } from "redux-query-react"
 import { compose } from "redux"
 import debounce from "lodash/debounce"
 
-import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import CanonicalLink from "../components/CanonicalLink"
 import { Cell, Grid } from "../components/Grid"
 import { Loading, CourseSearchLoading } from "../components/Loading"
-import AddToListDialog from "../components/AddToListDialog"
 import SearchFacet from "../components/SearchFacet"
 import SearchFilter from "../components/SearchFilter"
 import CourseSearchbox from "../components/CourseSearchbox"
@@ -501,8 +499,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
             {error ? null : this.renderResults()}
           </Cell>
         </Grid>
-        <LearningResourceDrawer />
-        <AddToListDialog />
       </BannerPageWrapper>
     )
   }

--- a/static/js/pages/FavoritesDetailPage.js
+++ b/static/js/pages/FavoritesDetailPage.js
@@ -3,7 +3,6 @@ import React from "react"
 import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 
-import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import { Cell, Grid } from "../components/Grid"
 import {
   BannerPageWrapper,
@@ -12,7 +11,6 @@ import {
   BannerImage
 } from "../components/PageBanner"
 import { LearningResourceCard } from "../components/LearningResourceCard"
-import AddToListDialog from "../components/AddToListDialog"
 
 import { SEARCH_LIST_UI } from "../lib/search"
 import { COURSE_SEARCH_BANNER_URL } from "../lib/url"
@@ -53,8 +51,6 @@ export default function FavoritesDetailPage() {
           )}
         </Grid>
       ) : null}
-      <LearningResourceDrawer />
-      <AddToListDialog />
     </BannerPageWrapper>
   )
 }

--- a/static/js/pages/LearnRouter.js
+++ b/static/js/pages/LearnRouter.js
@@ -1,0 +1,37 @@
+// @flow
+import React from "react"
+import { Route } from "react-router-dom"
+
+import CourseSearchPage from "./CourseSearchPage"
+import CourseIndexPage from "./CourseIndexPage"
+import UserListsPage from "./UserListsPage"
+import UserListDetailPage from "./UserListDetailPage"
+import FavoritesDetailPage from "./FavoritesDetailPage"
+
+import LearningResourceDrawer from "../components/LearningResourceDrawer"
+import AddToListDialog from "../components/AddToListDialog"
+
+import type { Match } from "react-router"
+
+type Props = {
+  match: Match
+}
+
+export default function LearnRouter(props: Props) {
+  const { match } = props
+
+  return (
+    <>
+      <Route exact path={`${match.url}`} component={CourseIndexPage} />
+      <Route exact path={`${match.url}/search`} component={CourseSearchPage} />
+      <Route
+        path={`${match.url}/lists/favorites`}
+        component={FavoritesDetailPage}
+      />
+      <Route path={`${match.url}/lists/:id`} component={UserListDetailPage} />
+      <Route exact path={`${match.url}/lists`} component={UserListsPage} />
+      <LearningResourceDrawer />
+      <AddToListDialog />
+    </>
+  )
+}

--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -7,7 +7,6 @@ import { createSelector } from "reselect"
 import { memoize } from "lodash"
 import arrayMove from "array-move"
 
-import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import { Cell, Grid } from "../components/Grid"
 import {
   BannerPageWrapper,
@@ -16,7 +15,6 @@ import {
   BannerImage
 } from "../components/PageBanner"
 import { LearningResourceCard } from "../components/LearningResourceCard"
-import AddToListDialog from "../components/AddToListDialog"
 import UserListFormDialog from "../components/UserListFormDialog"
 import { SortableItem, SortableContainer } from "../components/SortableList"
 
@@ -165,8 +163,6 @@ export default function UserListDetailPage(props: Props) {
           hide={() => setIsEditing(false)}
         />
       ) : null}
-      <LearningResourceDrawer />
-      <AddToListDialog />
     </BannerPageWrapper>
   )
 }

--- a/static/js/pages/UserListDetailPage_test.js
+++ b/static/js/pages/UserListDetailPage_test.js
@@ -134,7 +134,7 @@ describe("UserListDetailPage tests", () => {
       oldIndex: 1,
       newIndex: 2
     })
-    const [url, method, { body }] = helper.handleRequestStub.args[2]
+    const [url, method, { body }] = helper.handleRequestStub.args[1]
     assert.equal(method, "PATCH")
     assert.equal(url, `${userListApiURL}/${userList.id}/`)
     assert.deepEqual(body.id, userList.id)


### PR DESCRIPTION
#### What are the relevant tickets?

closes #2360 

#### What's this PR do?

this changes all the `/courses` URLs to be `/learn`, so from `/courses/search` to `/learn/search`, `/learn/lists`, etc.

I also pulled all the relevant routes into a separate new component call the `LearnRouter`. this means we can also mount components for all those subpages, so we can render like our dialogs and stuff at that one place instead of all over the place.

This will hopefully in the future, after refactoring the search state, let us pull the learn banner out to one place as well.

#### How should this be manually tested?

Extensively test all the course search sub-site and any places that links to it. I am pretty sure I got all of the links, but I could have missed something when grepping. so just click around and try to find any broken / weird links. To clarify, though, I also added a redirect from `/courses/` to `/learn`, so a link that is pointing to the wrong thing will still "work". but just make sure that the URLs for links are correct.

also! test that the redirect works. it should preserve any sub-path and any search params when redirecting, so `/courses/search?foo=bar` should redirect to `/learn/search?foo=bar` and so on.