### PR TITLE
Fixed routing for /learn/lists/favorites

### DIFF
--- a/static/js/pages/LearnRouter.js
+++ b/static/js/pages/LearnRouter.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { Route } from "react-router-dom"
+import { Route, Switch } from "react-router-dom"
 
 import CourseSearchPage from "./CourseSearchPage"
 import CourseIndexPage from "./CourseIndexPage"
@@ -24,11 +24,13 @@ export default function LearnRouter(props: Props) {
     <>
       <Route exact path={`${match.url}`} component={CourseIndexPage} />
       <Route exact path={`${match.url}/search`} component={CourseSearchPage} />
-      <Route
-        path={`${match.url}/lists/favorites`}
-        component={FavoritesDetailPage}
-      />
-      <Route path={`${match.url}/lists/:id`} component={UserListDetailPage} />
+      <Switch>
+        <Route
+          path={`${match.url}/lists/favorites`}
+          component={FavoritesDetailPage}
+        />
+        <Route path={`${match.url}/lists/:id`} component={UserListDetailPage} />
+      </Switch>
       <Route exact path={`${match.url}/lists`} component={UserListsPage} />
       <LearningResourceDrawer />
       <AddToListDialog />


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a routing condition where the url `/learn/lists/favorites` also matches on `/learn/lists/:id`, the latter of which fails because "favorites" is an invalid list id

#### How should this be manually tested?
Go to `/learn/lists/favorites` on master, confirm the page fail to load. Do this on this branch, the page should load