### PR TITLE
Add all other playlists option to config

### DIFF
--- a/test_json/youtube/channels.list.0.json
+++ b/test_json/youtube/channels.list.0.json
@@ -2,14 +2,21 @@
  "kind": "youtube#channelListResponse",
  "etag": "\"j6xRRd8dTPVVptg711_CSPADRfg/4gZiPORgx3xKNcuJUNIzj3uUXr4\"",
  "pageInfo": {
-  "totalResults": 2,
-  "resultsPerPage": 2
+  "totalResults": 3,
+  "resultsPerPage": 3
  },
  "items": [
   {
    "kind": "youtube#channel",
    "etag": "\"j6xRRd8dTPVVptg711_CSPADRfg/Z_X_9N7zIPi2tpgNWKGk4eNPQl8\"",
    "id": "UCEBb1b_L6zDS3xTUrIALZOw",
+   "contentDetails": {
+     "relatedPlaylists": {
+      "uploads": "UUEBb1b_L6zDS3xTUrIALZOw",
+      "watchHistory": "HL",
+      "watchLater": "WL"
+     }
+   },
    "snippet": {
     "title": "MIT OpenCourseWare",
     "description": "Whether you’re a student, a teacher, or simply a curious person that wants to learn, MIT OpenCourseWare (OCW) offers a wealth of insight and inspiration. There's videos, and a whole lot more!\n\nOCW is a free and open online publication of material from thousands of MIT courses, covering the entire MIT curriculum, ranging from the introductory to the most advanced graduate courses. At the OCW website, you'll find that each course has a syllabus, instructional material like notes and reading lists, and learning activities like assignments and solutions. Some courses also have videos, online textbooks, or faculty insights on teaching.\n\nKnowledge is your reward. There's no signup or enrollment, and no start/end dates. it's self-paced learning at its best.\n\nGet the full picture at https://ocw.mit.edu. \n\nChannel banner photo by Nietnagel on Flickr (https://flic.kr/p/8WXxfK).",
@@ -43,6 +50,13 @@
    "kind": "youtube#channel",
    "etag": "\"j6xRRd8dTPVVptg711_CSPADRfg/me7-ZjpQJ4SIr1urL-sCPPLSMZw\"",
    "id": "UCTBMWu8yshnAmpzR3MoJFtw",
+   "contentDetails": {
+    "relatedPlaylists": {
+     "uploads": "UUTBMWu8yshnAmpzR3MoJFtw",
+     "watchHistory": "HL",
+     "watchLater": "WL"
+    }
+   },
    "snippet": {
     "title": "MITx Videos",
     "description": "MITx delivers massive open online courses, known as MOOCs, via edX, which MIT founded with Harvard University in 2012. MITx courses are developed and taught by MIT instructors with the aim of enhancing on-campus education, expanding access to quality educational opportunities worldwide, and advancing the understanding of teaching and learning through research. As of Fall 2017, more than 2 million learners worldwide have accessed MITx content.\n\nMITx courses on edX are open to any learner around the world for free. Verified identity certificates, which certify completion by the individual, are available for a fee.",
@@ -70,6 +84,45 @@
      "description": "MITx delivers massive open online courses, known as MOOCs, via edX, which MIT founded with Harvard University in 2012. MITx courses are developed and taught by MIT instructors with the aim of enhancing on-campus education, expanding access to quality educational opportunities worldwide, and advancing the understanding of teaching and learning through research. As of Fall 2017, more than 2 million learners worldwide have accessed MITx content.\n\nMITx courses on edX are open to any learner around the world for free. Verified identity certificates, which certify completion by the individual, are available for a fee."
     },
     "country": "US"
+   }
+  },
+  {
+   "kind": "youtube#channel", 
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/AdWwtJIn0M7S-6CK9hW2yRx6wMs\"", 
+   "id": "UCBpxspUNl1Th33XbugiHJzw", 
+   "contentDetails": {
+    "relatedPlaylists": {
+     "uploads": "UUBpxspUNl1Th33XbugiHJzw", 
+     "watchHistory": "HL", 
+     "watchLater": "WL"
+    }
+   },
+   "snippet": {
+    "title": "MITCSAIL", 
+    "description": "The Massachusetts Institute of Technology's Computer Science and Artificial Intelligence Laboratory (CSAIL) conducts research in all areas of computer science and AI, such as robotics, systems, theory, biology, machine learning, speech recognition, vision and graphics.  Here you'll find videos showcasing the exciting research being done at CSAIL.", 
+    "customUrl": "mitcsail",
+    "publishedAt": "2007-08-09T20:37:40.000Z", 
+    "thumbnails": {
+     "default": {
+      "url": "https://yt3.ggpht.com/a/AGF-l7__JUpDxR7gQD4wekOcG_Mz1Vrq9vwDMjuXZQ=s88-c-k-c0xffffffff-no-rj-mo", 
+      "width": 88,
+      "height": 88
+     }, 
+     "medium": {
+      "url": "https://yt3.ggpht.com/a/AGF-l7__JUpDxR7gQD4wekOcG_Mz1Vrq9vwDMjuXZQ=s240-c-k-c0xffffffff-no-rj-mo", 
+      "width": 240, 
+      "height": 240
+     }, 
+     "high": {
+      "url": "https://yt3.ggpht.com/a/AGF-l7__JUpDxR7gQD4wekOcG_Mz1Vrq9vwDMjuXZQ=s800-c-k-c0xffffffff-no-rj-mo", 
+      "width": 800, 
+      "height": 800
+     }
+    }
+   }, 
+   "localized": {
+    "title": "MITCSAIL",
+    "description": "The Massachusetts Institute of Technology's Computer Science and Artificial Intelligence Laboratory (CSAIL) conducts research in all areas of computer science and AI, such as robotics, systems, theory, biology, machine learning, speech recognition, vision and graphics.  Here you'll find videos showcasing the exciting research being done at CSAIL."
    }
   }
  ]

--- a/test_json/youtube/playlistItems.list.2.json
+++ b/test_json/youtube/playlistItems.list.2.json
@@ -1,0 +1,56 @@
+{
+ "kind": "youtube#playlistItemListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/21857V67JkqsdWCpdRqjHex2ccw\"",
+ "nextPageToken": "CAUQAA",
+ "pageInfo": {
+  "totalResults": 5,
+  "resultsPerPage": 50
+ },
+ "items": [
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/UGM7YBWZ495od4_7pGU-Ku2n0CI\"",
+   "id": "VVVCcHhzcFVObDFUaDMzWGJ1Z2lISnp3LmhoRUpNcG91TVM4",
+   "contentDetails": {
+    "videoId": "hhEJMpouMS8",
+    "videoPublishedAt": "2019-12-06T15:31:06.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/_mzVr18QY1jaR8Okf-wmC5BbFbs\"",
+   "id": "VVVCcHhzcFVObDFUaDMzWGJ1Z2lISnp3LjBWS1htX3ZFcmlB",
+   "contentDetails": {
+    "videoId": "0VKXm_vEriA",
+    "videoPublishedAt": "2019-11-07T19:52:48.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/sPVzMafkUQzVkyn44Y2LDDIDv3E\"",
+   "id": "VVVCcHhzcFVObDFUaDMzWGJ1Z2lISnp3LmhJNVVES2FXSk9v",
+   "contentDetails": {
+    "videoId": "hI5UDKaWJOo",
+    "videoPublishedAt": "2019-10-30T11:51:59.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/DLIDkdmWTAIAVBQBYzDcRCZpIOU\"",
+   "id": "VVVCcHhzcFVObDFUaDMzWGJ1Z2lISnp3LkxNbU4yTGo2MWNN",
+   "contentDetails": {
+    "videoId": "LMmN2Lj61cM",
+    "videoPublishedAt": "2019-10-02T14:22:35.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/unlNatB7cTgY5eGZ9lauUS1nKVI\"",
+   "id": "VVVCcHhzcFVObDFUaDMzWGJ1Z2lISnp3LmZFZE4xVmNpSngw",
+   "contentDetails": {
+    "videoId": "fEdN1VciJx0",
+    "videoPublishedAt": "2019-09-10T12:03:23.000Z"
+   }
+  }
+ ]
+}

--- a/test_json/youtube/playlistItems.list.3.json
+++ b/test_json/youtube/playlistItems.list.3.json
@@ -1,0 +1,56 @@
+{
+ "kind": "youtube#playlistItemListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/f2zmvoTsdldYKPWlZ4Nax0qRsDo\"",
+ "nextPageToken": "CAUQAA",
+ "pageInfo": {
+  "totalResults": 5,
+  "resultsPerPage": 50
+ },
+ "items": [
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/Ulk5Uzwa1M7ArHXUOyakIQgdrBw\"",
+   "id": "UExjd2JOT04yaHFQNF9tR2dQdmVrY1NuZEZlenBEZFdjWS45NDk1REZENzhEMzU5MDQz",
+   "contentDetails": {
+    "videoId": "yZ9ApVHx7Ow",
+    "videoPublishedAt": "2018-11-29T14:59:15.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/PnD01kMPnc0tW5crjB7aGVqlIfA\"",
+   "id": "UExjd2JOT04yaHFQNF9tR2dQdmVrY1NuZEZlenBEZFdjWS5DQUNERDQ2NkIzRUQxNTY1",
+   "contentDetails": {
+    "videoId": "v759cZI4cqc",
+    "videoPublishedAt": "2018-02-05T15:37:23.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/yxtmwgWuTRwImmVwNP8dhsawpQM\"",
+   "id": "UExjd2JOT04yaHFQNF9tR2dQdmVrY1NuZEZlenBEZFdjWS41MzJCQjBCNDIyRkJDN0VD",
+   "contentDetails": {
+    "videoId": "novgMFIBcqg",
+    "videoPublishedAt": "2018-01-29T14:59:47.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/Vw174sf7ncWqq7XuRsy9Cqz7Jlo\"",
+   "id": "UExjd2JOT04yaHFQNF9tR2dQdmVrY1NuZEZlenBEZFdjWS4xMkVGQjNCMUM1N0RFNEUx",
+   "contentDetails": {
+    "videoId": "zvNUpQWft1I",
+    "videoPublishedAt": "2017-08-23T17:49:50.000Z"
+   }
+  },
+  {
+   "kind": "youtube#playlistItem",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/XWWOM4iO70fpaeSZLrLA6oCDH08\"",
+   "id": "UExjd2JOT04yaHFQNF9tR2dQdmVrY1NuZEZlenBEZFdjWS4wOTA3OTZBNzVEMTUzOTMy",
+   "contentDetails": {
+    "videoId": "45YLK7vbL3M",
+    "videoPublishedAt": "2017-08-04T17:42:31.000Z"
+   }
+  }
+ ]
+}

--- a/test_json/youtube/playlists.list.2.json
+++ b/test_json/youtube/playlists.list.2.json
@@ -1,0 +1,53 @@
+{
+ "kind": "youtube#playlistListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/S2QKCudzm4HavXjpQ4F8sK7ijD8\"",
+ "pageInfo": {
+  "totalResults": 1,
+  "resultsPerPage": 50
+ },
+ "items": [
+  {
+   "kind": "youtube#playlist",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/X_u2CFipu5FpmyfwuVqtUEcLBA8\"",
+   "id": "UUBpxspUNl1Th33XbugiHJzw",
+   "snippet": {
+    "publishedAt": "1970-01-01T00:00:00.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Uploads from MITCSAIL",
+    "description": "",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "localized": {
+     "title": "Uploads from MITCSAIL",
+     "description": ""
+    }
+   }
+  }
+ ]
+}

--- a/test_json/youtube/playlists.list.3.json
+++ b/test_json/youtube/playlists.list.3.json
@@ -1,0 +1,96 @@
+{
+ "kind": "youtube#playlistListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/aCYBJVV5pGOT8x5MQiMs_rk5vvM\"",
+ "pageInfo": {
+  "totalResults": 6,
+  "resultsPerPage": 50
+ },
+ "items": [
+  {
+   "kind": "youtube#playlist",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/n7ZKu2B5KrRd33yqT8hFcjPIwcA\"",
+   "id": "PLcwbNON2hqP5TFbkw0igt6Wz79WTaeFGi",
+   "snippet": {
+    "publishedAt": "2017-08-08T18:14:18.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Unwanted Playlist",
+    "description": "",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "localized": {
+     "title": "Unwanted Playlist",
+     "description": ""
+    }
+   }
+  },
+  {
+   "kind": "youtube#playlist",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/_MyZL8gb5BB4jmGsnU_WYt3bUvc\"",
+   "id": "PLcwbNON2hqP4_mGgPvekcSndFezpDdWcY",
+   "snippet": {
+    "publishedAt": "2017-08-08T18:12:13.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "3D Printing",
+    "description": "",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "localized": {
+     "title": "3D Printing",
+     "description": ""
+    }
+   }
+  }
+ ]
+}

--- a/test_json/youtube/videos.list.3.json
+++ b/test_json/youtube/videos.list.3.json
@@ -1,0 +1,330 @@
+{
+ "kind": "youtube#videoListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/d-4pSGseYYx31kCcinCBUiYDELk\"",
+ "pageInfo": {
+  "totalResults": 5,
+  "resultsPerPage": 50
+ },
+ "items": [
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/Txo97ZOGS4QOqWH6FFRbqQGsteE\"",
+   "id": "hhEJMpouMS8",
+   "snippet": {
+    "publishedAt": "2019-12-06T15:31:06.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Computational Mirrors: Revealing Hidden Video",
+    "description": "Paper: https://arxiv.org/abs/1912.02314\nProject page: http://compmirrors.csail.mit.edu/",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/hhEJMpouMS8/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "computer vision",
+     "computational mirror"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Computational Mirrors: Revealing Hidden Video",
+     "description": "Paper: https://arxiv.org/abs/1912.02314\nProject page: http://compmirrors.csail.mit.edu/"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M37S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/XKK9ZrKuPQ7GmNv5R-kPHbqB-3U\"",
+   "id": "0VKXm_vEriA",
+   "snippet": {
+    "publishedAt": "2019-11-07T19:52:48.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "\"What is AI?\" according to MIT computer scientists",
+    "description": "Artificial intelligence is everywhere nowadays, but what exactly does it mean?  We asked a group MIT computer science grad students and post-docs how they personally define AI.",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/0VKXm_vEriA/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/0VKXm_vEriA/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/0VKXm_vEriA/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/0VKXm_vEriA/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/0VKXm_vEriA/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "AI",
+     "artificial intelligence",
+     "computer science",
+     "cs"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "\"What is AI?\" according to MIT computer scientists",
+     "description": "Artificial intelligence is everywhere nowadays, but what exactly does it mean?  We asked a group MIT computer science grad students and post-docs how they personally define AI."
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M40S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/irk-skCT-O8F3ZwBOspO7UTmwwc\"",
+   "id": "hI5UDKaWJOo",
+   "snippet": {
+    "publishedAt": "2019-10-30T11:51:59.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "M-Blocks 2.0: Self-assembling Modular Robots",
+    "description": "More info:\nhttp://news.mit.edu/2019/self-transforming-robot-blocks-jump-spin-flip-identify-each-other-1030",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/hI5UDKaWJOo/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/hI5UDKaWJOo/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/hI5UDKaWJOo/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/hI5UDKaWJOo/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/hI5UDKaWJOo/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "robots",
+     "robotics",
+     "M-Blocks",
+     "self-assembly",
+     "modular",
+     "self-assembling",
+     "AI",
+     "artificial intelligence",
+     "CS"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "M-Blocks 2.0: Self-assembling Modular Robots",
+     "description": "More info:\nhttp://news.mit.edu/2019/self-transforming-robot-blocks-jump-spin-flip-identify-each-other-1030"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT2M20S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/DPH8VIFtrAM8dzhzrLbu95W9HJ0\"",
+   "id": "LMmN2Lj61cM",
+   "snippet": {
+    "publishedAt": "2019-10-02T14:22:35.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Better MRIs by Flattening Placental Images",
+    "description": "Paper: https://arxiv.org/abs/1903.05044\nMore info: http://news.mit.edu/2019/using-algorithms-to-build-placenta-map-1002",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/LMmN2Lj61cM/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/LMmN2Lj61cM/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/LMmN2Lj61cM/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/LMmN2Lj61cM/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/LMmN2Lj61cM/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "pregnancy",
+     "MRI",
+     "computer vision",
+     "placenta",
+     "medical imaging"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Better MRIs by Flattening Placental Images",
+     "description": "Paper: https://arxiv.org/abs/1903.05044\nMore info: http://news.mit.edu/2019/using-algorithms-to-build-placenta-map-1002"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/AvudGiSEsos_VOxppv_Bg6QlKaY\"",
+   "id": "fEdN1VciJx0",
+   "snippet": {
+    "publishedAt": "2019-09-10T12:03:23.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Photochromeleon: Creating Color-Changing Objects",
+    "description": "More info: http://news.mit.edu/2019/changing-colors-photochromeleon-mit-csail-0910\nPaper: http://groups.csail.mit.edu/hcie/files/research-projects/photochromeleon/2019-uist-photochromeleon-paper.pdf \nhttps://doi.org/10.1145/3332165.3347905",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/fEdN1VciJx0/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/fEdN1VciJx0/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/fEdN1VciJx0/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/fEdN1VciJx0/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/fEdN1VciJx0/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "color changing",
+     "3d printing",
+     "computer vision",
+     "chameleon",
+     "photochromeleon"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Photochromeleon: Creating Color-Changing Objects",
+     "description": "More info: http://news.mit.edu/2019/changing-colors-photochromeleon-mit-csail-0910\nPaper: http://groups.csail.mit.edu/hcie/files/research-projects/photochromeleon/2019-uist-photochromeleon-paper.pdf \nhttps://doi.org/10.1145/3332165.3347905"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT2M46S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  }
+ ]
+}

--- a/test_json/youtube/videos.list.4.json
+++ b/test_json/youtube/videos.list.4.json
@@ -1,0 +1,326 @@
+{
+ "kind": "youtube#videoListResponse",
+ "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/W-S9h00cHipvp8KJq_3fTgawkYc\"",
+ "pageInfo": {
+  "totalResults": 5,
+  "resultsPerPage": 5
+ },
+ "items": [
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/GyaKTm0kehfaK_XCBc2lkmdS1x0\"",
+   "id": "yZ9ApVHx7Ow",
+   "snippet": {
+    "publishedAt": "2018-11-29T14:59:15.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Reproducing Paintings with 3D Printing",
+    "description": "Paper: http://people.csail.mit.edu/liangs/papers/ToG18.pdf\nNews story: http://news.mit.edu/2018/mit-csail-repaint-system-reproducing-paintings-make-impression-1129",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/yZ9ApVHx7Ow/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "3D printing",
+     "art",
+     "painting",
+     "printing",
+     "reproduction",
+     "deep learning"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Reproducing Paintings with 3D Printing",
+     "description": "Paper: http://people.csail.mit.edu/liangs/papers/ToG18.pdf\nNews story: http://news.mit.edu/2018/mit-csail-repaint-system-reproducing-paintings-make-impression-1129"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M1S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/wItESDlBgGHviiXuBz6InZy-KTg\"",
+   "id": "v759cZI4cqc",
+   "snippet": {
+    "publishedAt": "2018-02-05T15:37:23.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Designing Printable Microstructures",
+    "description": "More info: http://news.mit.edu/2018/automating-materials-design-0202",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/v759cZI4cqc/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/v759cZI4cqc/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/v759cZI4cqc/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "3D printing",
+     "3-D printing",
+     "microstructures",
+     "design",
+     "manufacturing",
+     "computer science",
+     "CS"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Designing Printable Microstructures",
+     "description": "More info: http://news.mit.edu/2018/automating-materials-design-0202"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M24S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/r0o6UbKD0Jtx8Qqn_MvC-Ksff8Y\"",
+   "id": "novgMFIBcqg",
+   "snippet": {
+    "publishedAt": "2018-01-29T14:59:47.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Color-Changing 3D Printables",
+    "description": "Paper: http://groups.csail.mit.edu/hcie/files/research-projects/colorfab/2018-chi-colorfab-paper.pdf\nMore info: http://news.mit.edu/2018/changing-color-3-d-printed-objects-0129",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/novgMFIBcqg/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/novgMFIBcqg/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/novgMFIBcqg/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/novgMFIBcqg/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/novgMFIBcqg/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "3D printing",
+     "color",
+     "3D printable",
+     "color change",
+     "colorfab",
+     "CS",
+     "computer science"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Color-Changing 3D Printables",
+     "description": "Paper: http://groups.csail.mit.edu/hcie/files/research-projects/colorfab/2018-chi-colorfab-paper.pdf\nMore info: http://news.mit.edu/2018/changing-color-3-d-printed-objects-0129"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT1M31S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/eB10PfS3MDum3BnNHwouPymnIl4\"",
+   "id": "zvNUpQWft1I",
+   "snippet": {
+    "publishedAt": "2017-08-23T17:49:50.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "Robogami: 3D Printing Foldable Robots",
+    "description": "Paper: http://journals.sagepub.com/doi/10.1177/0278364917723465",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/zvNUpQWft1I/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/zvNUpQWft1I/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/zvNUpQWft1I/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/zvNUpQWft1I/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/zvNUpQWft1I/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "Massachusetts Institute of Technology",
+     "CSAIL",
+     "Robotics",
+     "robots",
+     "3D printing",
+     "origami",
+     "computer science"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "Robogami: 3D Printing Foldable Robots",
+     "description": "Paper: http://journals.sagepub.com/doi/10.1177/0278364917723465"
+    },
+    "defaultAudioLanguage": "en"
+   },
+   "contentDetails": {
+    "duration": "PT3M22S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "true",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  },
+  {
+   "kind": "youtube#video",
+   "etag": "\"p4VTdlkQv3HQeTEaXgvLePAydmU/ZuqnZ2qn5705q5vAnpMUknAOkFY\"",
+   "id": "45YLK7vbL3M",
+   "snippet": {
+    "publishedAt": "2017-08-04T17:42:31.000Z",
+    "channelId": "UCBpxspUNl1Th33XbugiHJzw",
+    "title": "InstantCAD: Making CAD Easier",
+    "description": "Paper & code: https://people.csail.mit.edu/aschulz/optCAD/index.html",
+    "thumbnails": {
+     "default": {
+      "url": "https://i.ytimg.com/vi/45YLK7vbL3M/default.jpg",
+      "width": 120,
+      "height": 90
+     },
+     "medium": {
+      "url": "https://i.ytimg.com/vi/45YLK7vbL3M/mqdefault.jpg",
+      "width": 320,
+      "height": 180
+     },
+     "high": {
+      "url": "https://i.ytimg.com/vi/45YLK7vbL3M/hqdefault.jpg",
+      "width": 480,
+      "height": 360
+     },
+     "standard": {
+      "url": "https://i.ytimg.com/vi/45YLK7vbL3M/sddefault.jpg",
+      "width": 640,
+      "height": 480
+     },
+     "maxres": {
+      "url": "https://i.ytimg.com/vi/45YLK7vbL3M/maxresdefault.jpg",
+      "width": 1280,
+      "height": 720
+     }
+    },
+    "channelTitle": "MITCSAIL",
+    "tags": [
+     "MIT",
+     "CSAIL",
+     "Massachusetts Institute of Technology",
+     "CAD",
+     "computer graphics",
+     "CS",
+     "computer science",
+     "computer-aided design",
+     "3D printing",
+     "design"
+    ],
+    "categoryId": "28",
+    "liveBroadcastContent": "none",
+    "localized": {
+     "title": "InstantCAD: Making CAD Easier",
+     "description": "Paper & code: https://people.csail.mit.edu/aschulz/optCAD/index.html"
+    }
+   },
+   "contentDetails": {
+    "duration": "PT1M10S",
+    "dimension": "2d",
+    "definition": "hd",
+    "caption": "false",
+    "licensedContent": false,
+    "projection": "rectangular"
+   }
+  }
+ ]
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2472

#### What's this PR do?
We will add a` id: wildcard option` to playlists to make it possible to download and make user lists for all playlists in a channel without listing each playlist in the config report individually. We will also add a ignore flag to ignore a playlist

For example:
```
channel_id: some_channel
playlists:
  - id: playlist1
    create_user_list: false
 - id: playlist2
    ignore: true
  -id: wildcard
   create_user_list: true
```
Will add all videos in the playlists in the channel except playlist2 to search and create user lists for every playlist except playlist1 and playlist2
#### How should this be manually tested?
Set
```
OPEN_VIDEO_DATA_BRANCH=format-change-2472
```
in your .env file.

Run 
```
from course_catalog.etl import pipelines
pipelines.youtube_etl(channel_ids="UCBpxspUNl1Th33XbugiHJzw")
```

This should add all the csail videos to search and create a UserList for every csail playlist except PLcwbNON2hqP5TFbkw0igt6Wz79WTaeFGi (Computer Vision)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
