### PR TITLE
fix display of read more / read less on TruncatedText component

### DIFF
--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -32,6 +32,7 @@ import {
   LINK_TYPE_TEXT
 } from "../lib/channels"
 import * as urlLib from "../lib/url"
+import { mockHTMLElHeight } from "../lib/test_utils"
 
 describe("CompactPostDisplay", () => {
   let helper, post, openMenu
@@ -59,6 +60,7 @@ describe("CompactPostDisplay", () => {
     post = makePost()
     openMenu = () =>
       helper.store.dispatch(showDropdown(getPostDropdownMenuKey(post)))
+    mockHTMLElHeight(100, 50)
   })
 
   afterEach(() => {

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -24,6 +24,7 @@ import {
   videoApiURL,
   embedlyApiURL
 } from "../lib/url"
+import { mockHTMLElHeight } from "../lib/test_utils"
 
 describe("LearningResourceDrawer", () => {
   let course, helper, render
@@ -37,6 +38,7 @@ describe("LearningResourceDrawer", () => {
       "LearningResourceRow"
     )
     render = helper.configureReduxQueryRenderer(LearningResourceDrawer)
+    mockHTMLElHeight(100, 50)
   })
 
   afterEach(() => {

--- a/static/js/components/TruncatedText_test.js
+++ b/static/js/components/TruncatedText_test.js
@@ -6,8 +6,14 @@ import _ from "lodash"
 
 import TruncatedText from "./TruncatedText"
 
+import { mockHTMLElHeight } from "../lib/test_utils"
+
 describe("TruncatedText", () => {
   const render = (props = {}) => mount(<TruncatedText {...props} />)
+
+  beforeEach(() => {
+    mockHTMLElHeight(100, 50)
+  })
 
   it("displays text", () => {
     const props = {
@@ -60,5 +66,34 @@ describe("TruncatedText", () => {
       dotdotdotText,
       text.substring(0, estCharsPerLine * (lines + 2))
     )
+  })
+
+  it("should show expansion controls if flag is passed", () => {
+    const wrapper = render({
+      text:                  "foofofofofofof",
+      lines:                 1,
+      showExpansionControls: true
+    })
+    assert.ok(wrapper.find(".tt-expansion-control").exists())
+  })
+
+  it("should not show expansion controls if text is not hidden", () => {
+    mockHTMLElHeight(100, 100)
+    const wrapper = render({
+      text:                  "foofofofofofof",
+      lines:                 1,
+      showExpansionControls: true
+    })
+    assert.isNotOk(wrapper.find(".tt-expansion-control").exists())
+  })
+
+  it("should render an empty string ok", () => {
+    mockHTMLElHeight(0, 0)
+    const wrapper = render({
+      text:                  "",
+      lines:                 1,
+      showExpansionControls: true
+    })
+    assert.isNotOk(wrapper.find(".tt-expansion-control").exists())
   })
 })

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -88,3 +88,24 @@ export const changeFormikInput = (
     }
   })
 }
+
+export const mockHTMLElHeight = (
+  scrollHeight: number,
+  offsetHeight: number
+) => {
+  // $FlowFixMe
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get:          function() {
+      return scrollHeight || 0
+    }
+  })
+
+  // $FlowFixMe
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get:          function() {
+      return offsetHeight || 0
+    }
+  })
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

one part of #2466 

#### What's this PR do?

Currently when the `TruncatedText` component is used with the `showExpansionControls` prop we always show the 'read more' / 'read less' controls, regardless of whether any content has been hidden by the `Dotdotdot` component. This changes things so that we only show the expansion controls in the case where they can, you know, do something ^_^

In order to do this I had to figure out how to tell when the text was being truncated. Basically, this is being done with a div with `overflow: hidden` on it, and the `Dotdotdot` component doesn't have a way to pass in a callback or something to get out whether or not it's done the truncated.

So what I had to do was get a ref to the div used by `Dotdotdot` and then look at some of it's properties. Basically if the `scrollHeight`, which measures the height of the content, is higher than the `offsetHeight`, which represents the high of the element on screen, then there is some content which has been hidden. So in this case we show the expansion controls, and otherwise we can safely hide them. I had to do a very slight hack to make this work, basically to force our `TruncatedText` component to always do two render calls so that the `Dotdotdot` component has completed it's render. But things seem ok!

#### How should this be manually tested?

make sure that the behavior described above has been implemented and nothing works weirdly!

we use this in the compact post display and in the learning resource description.

basically, if the text is short you shouldn't see any controls in the learning resource description, and if it's long enough to overflow and get truncated you should see a 'read more / read less' control.

#### Screenshots (if appropriate)

![showmorefffshort](https://user-images.githubusercontent.com/6207644/70826152-33e22980-1db4-11ea-9caa-aa5958428af8.png)
![showmorefff](https://user-images.githubusercontent.com/6207644/70826153-33e22980-1db4-11ea-9a7f-e7ee33bc7202.png)
![showmore](https://user-images.githubusercontent.com/6207644/70826154-33e22980-1db4-11ea-99b3-5b189e078ad6.png)
