### PR TITLE
Fix search result subject display

### DIFF
--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -311,17 +311,17 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const { bootcamps, courses, programs, userLists, videos } = entities
     switch (result.object_type) {
     case LR_TYPE_COURSE:
-      return courses ? courses[result.id] || result : result
+      return courses ? courses[result.id] || null : null
     case LR_TYPE_BOOTCAMP:
-      return bootcamps ? bootcamps[result.id] || result : result
+      return bootcamps ? bootcamps[result.id] || null : null
     case LR_TYPE_PROGRAM:
-      return programs ? programs[result.id] || result : result
+      return programs ? programs[result.id] || null : null
     case LR_TYPE_USERLIST:
-      return userLists ? userLists[result.id] || result : result
+      return userLists ? userLists[result.id] || null : null
     case LR_TYPE_VIDEO:
-      return videos ? videos[result.id] || result : result
+      return videos ? videos[result.id] || null : null
     case LR_TYPE_LEARNINGPATH:
-      return userLists ? userLists[result.id] || result : result
+      return userLists ? userLists[result.id] || null : null
     }
   }
 

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -530,6 +530,22 @@ describe("CourseSearchPage", () => {
   })
 
   LR_TYPE_ALL.forEach(resourceType => {
+    it(`overrideObject ${resourceType} is null if not in entities`, async () => {
+      const resource = makeLearningResourceResult(resourceType)
+      searchResponse.hits.hits[0] = resource
+      helper.searchStub.returns(Promise.resolve(searchResponse))
+      const { inner } = await renderPage()
+      assert.equal(
+        inner
+          .find("SearchResult")
+          .at(0)
+          .prop("overrideObject"),
+        null
+      )
+    })
+  })
+
+  LR_TYPE_ALL.forEach(resourceType => {
     it(`overrides ${resourceType} search results for is_favorite and lists with values from entities`, async () => {
       const resource = makeLearningResourceResult(resourceType)
       // Conditional to prevent flow from whining about an undefined resource


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2487 

#### What's this PR do?
Returns null instead of the search result as the overrideObject in the CourseSearchPage's 'getFavoriteOrListedObject' function if the object can't be found in react state.

#### How should this be manually tested?
Run some course searches when logged out and logged in, the subjects should display on the result cards, and when logged in any of your favorite/listed items should still be starred.
