### PR TITLE
fix a small bug with learningResourceSelector

### DIFF
--- a/static/js/lib/queries/learning_resources.js
+++ b/static/js/lib/queries/learning_resources.js
@@ -136,18 +136,28 @@ export const learningResourceSelector = createSelector(
   state => state.entities.userLists,
   state => state.entities.videos,
   (courses, bootcamps, programs, userLists, videos) =>
-    memoize((objectId, objectType) => {
-      switch (objectType) {
-      case LR_TYPE_COURSE:
-        return courses ? courses[objectId] : null
-      case LR_TYPE_BOOTCAMP:
-        return bootcamps ? bootcamps[objectId] : null
-      case LR_TYPE_PROGRAM:
-        return programs ? programs[objectId] : null
-      case LR_TYPE_VIDEO:
-        return videos ? videos[objectId] : null
-      default:
-        return userLists ? userLists[objectId] : null
-      }
-    })
+    memoize(
+      (objectId, objectType) => {
+        switch (objectType) {
+        case LR_TYPE_COURSE:
+          return courses ? courses[objectId] : null
+        case LR_TYPE_BOOTCAMP:
+          return bootcamps ? bootcamps[objectId] : null
+        case LR_TYPE_PROGRAM:
+          return programs ? programs[objectId] : null
+        case LR_TYPE_VIDEO:
+          return videos ? videos[objectId] : null
+        default:
+          return userLists ? userLists[objectId] : null
+        }
+      },
+      // by default `_.memoize` only uses the first argument of the function it
+      // wraps as a cache key. since the first arg is the object ID, if we had
+      // two objects with the same ID but a different type we could return the
+      // wrong object.
+      //
+      // We're avoiding this by passing a function to `memoize` to create a
+      // custom cache key that takes the id and type in to account
+      (id, type) => `${id}_${type}`
+    )
 )

--- a/static/js/lib/queries/learning_resources_test.js
+++ b/static/js/lib/queries/learning_resources_test.js
@@ -2,7 +2,11 @@
 import { assert } from "chai"
 import R from "ramda"
 
-import { filterFavorites, similarResourcesRequest } from "./learning_resources"
+import {
+  filterFavorites,
+  similarResourcesRequest,
+  learningResourceSelector
+} from "./learning_resources"
 import {
   makeCourse,
   makeBootcamp,
@@ -13,7 +17,8 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_ALL,
   LR_TYPE_LEARNINGPATH,
-  LR_TYPE_USERLIST
+  LR_TYPE_USERLIST,
+  LR_TYPE_VIDEO
 } from "../constants"
 import { similarResourcesURL } from "../url"
 
@@ -61,5 +66,24 @@ describe("learning resource queries", () => {
         }
       })
     })
+  })
+
+  it("learningResourceSelector should return objects correctly", () => {
+    // this is a regression to ensure we're correctly figuring out when to hit
+    // the cache and when to skip it
+    const state = {
+      entities: {
+        courses: {
+          // $FlowFixMe
+          4: { id: 4, message: "im a course" }
+        },
+        videos: {
+          // $FlowFixMe
+          4: { id: 4, message: "🙃 🙃 🙃" }
+        }
+      }
+    }
+    const getter = learningResourceSelector(state)
+    assert.notDeepEqual(getter(4, LR_TYPE_COURSE), getter(4, LR_TYPE_VIDEO))
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

none

#### What's this PR do?

fixes a small bug with one of our selectors. basically, we sometimes return a getter wrapped with `_.memoize` to be able to access things in the store based on prop values. the problem with `learningResourceSelector` is that we return a memoized function of two arguments, `objectId` and `objectType`. But `_.memoize` only uses, by default, the first argument as the cache key for memoization, so if we did this:

```js
const getter = useSelector(learningResourceSelector)

const obj1 = getter(1, LR_TYPE_VIDEO)
const obj2 = getter(1, LR_TYPE_COURSE)
```

we'd be in a bad situation because `obj1` and `obj2` would be the same object :scream: 

this is because when we called `getter` the second time it would only look at the first argument to figure out whether to return a cached value or not, and it would return the same object as the first call. To get around this we can pass another function to generate a custom cache key, as described here: https://lodash.com/docs/4.17.15#memoize

#### How should this be manually tested?

make sure that the learning resource drawer works as normal. make sure the code changes make sense!

