### PR TITLE
restyle reordering UI for learning paths

### DIFF
--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -165,49 +165,55 @@ export function LearningResourceDisplay(props: Props) {
         <div className="row course-title" onClick={showResourceDrawer}>
           <Dotdotdot clamp={2}>{object.title}</Dotdotdot>
         </div>
-        {object.offered_by.length ? (
-          <Subtitle
-            content={offeredBySearchLink(
-              getPreferredOfferedBy(object.offered_by)
-            )}
-            label="Offered by - "
-          />
-        ) : null}
-        {object.topics.length > 0 ? (
-          <Subtitle
-            content={formatTopics(object.topics)}
-            label={`${object.topics.length === 1 ? "Subject" : "Subjects"} - `}
-          />
-        ) : null}
-        <div className="row availability-price-favorite">
-          {cost ? (
-            <div className="price grey-surround">
-              <i className="material-icons attach_money">attach_money</i>
-              {cost}
+        {reordering ? null : (
+          <>
+            {object.offered_by.length ? (
+              <Subtitle
+                content={offeredBySearchLink(
+                  getPreferredOfferedBy(object.offered_by)
+                )}
+                label="Offered by - "
+              />
+            ) : null}
+            {object.topics.length > 0 ? (
+              <Subtitle
+                content={formatTopics(object.topics)}
+                label={`${
+                  object.topics.length === 1 ? "Subject" : "Subjects"
+                } - `}
+              />
+            ) : null}
+            <div className="row availability-price-favorite">
+              {cost ? (
+                <div className="price grey-surround">
+                  <i className="material-icons attach_money">attach_money</i>
+                  {cost}
+                </div>
+              ) : null}
+              <div className="availability grey-surround">
+                <i className="material-icons calendar_today">calendar_today</i>
+                {bestRunLabel(bestAvailableRun)}
+              </div>
+              <LoginTooltip>
+                <div
+                  className="favorite grey-surround"
+                  onClick={e => {
+                    e.preventDefault()
+                    if (!userIsAnonymous()) {
+                      showListDialog(object)
+                    }
+                  }}
+                >
+                  <i className={`material-icons ${bookmarkIconName}`}>
+                    {bookmarkIconName}
+                  </i>
+                </div>
+              </LoginTooltip>
             </div>
-          ) : null}
-          <div className="availability grey-surround">
-            <i className="material-icons calendar_today">calendar_today</i>
-            {bestRunLabel(bestAvailableRun)}
-          </div>
-          <LoginTooltip>
-            <div
-              className="favorite grey-surround"
-              onClick={e => {
-                e.preventDefault()
-                if (!userIsAnonymous()) {
-                  showListDialog(object)
-                }
-              }}
-            >
-              <i className={`material-icons ${bookmarkIconName}`}>
-                {bookmarkIconName}
-              </i>
-            </div>
-          </LoginTooltip>
-        </div>
+          </>
+        )}
       </div>
-      {searchResultLayout === SEARCH_GRID_UI ? null : (
+      {searchResultLayout === SEARCH_GRID_UI || reordering ? null : (
         <CoverImage object={object} showResourceDrawer={showResourceDrawer} />
       )}
     </React.Fragment>

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -263,6 +263,12 @@ describe("LearningResourceCard", () => {
           : "learning-resource-card"
       )
       assert.equal(wrapper.find(".drag-handle").exists(), reordering)
+      assert.equal(wrapper.find("Subtitle").exists(), !reordering)
+      assert.equal(
+        wrapper.find(".availability-price-favorite").exists(),
+        !reordering
+      )
+      assert.equal(wrapper.find(".cover-image").exists(), !reordering)
     })
   })
 })

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -10,6 +10,10 @@
     .card-contents {
       padding-left: 8px;
     }
+
+    .lr-info {
+      width: 100% !important;
+    }
   }
 
   .drag-handle {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2434

#### What's this PR do?

this just implements the visual parts of #2434, basically hiding more of the information in the learning resource cards when we're doing the reorder.

#### How should this be manually tested?

go and reorder your lists, make sure the UI looks like what's shown in the design.


#### Screenshots (if appropriate)

![reorderingtheitmesdf](https://user-images.githubusercontent.com/6207644/71105235-31ece180-218b-11ea-8a50-c0b9d3c665ef.png)
![reorderingtheitmes](https://user-images.githubusercontent.com/6207644/71105236-31ece180-218b-11ea-9db0-67681d0a8d3b.png)
