### PR TITLE
Log an error for YOUTUBE_DEVELOPER_KEY

### DIFF
--- a/course_catalog/etl/youtube.py
+++ b/course_catalog/etl/youtube.py
@@ -349,6 +349,7 @@ def extract(*, channel_ids=None):
         A generator that yields tuples with offered_by and video data
     """
     if not settings.YOUTUBE_DEVELOPER_KEY:
+        log.error("Missing YOUTUBE_DEVELOPER_KEY")
         return
 
     youtube_client = get_youtube_client()


### PR DESCRIPTION
#### What's this PR do?
We recently had the video import task fail silently on RC because YOUTUBE_DEVELOPER_KEY was missing. This pr adds an error log  

#### How should this be manually tested?
Remove YOUTUBE_DEVELOPER_KEY in your env file
run
```
from course_catalog.tasks import *
 get_youtube_data()
```

There should be en log message letting you know that YOUTUBE_DEVELOPER_KEY is not set
