### PR TITLE
display all learning reasourse offered bys

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -21,7 +21,6 @@ import {
   minPrice,
   getStartDate,
   getInstructorName,
-  getPreferredOfferedBy,
   isCoursewareResource,
   formatDurationClockTime,
   userListCoverImage,
@@ -109,7 +108,7 @@ const ExpandedLearningResourceDisplay = (props: Props) => {
   const url = selectedRun && selectedRun.url ? selectedRun.url : object.url
   const cost = selectedRun ? minPrice(selectedRun.prices, true) : null
 
-  const offeredBy = getPreferredOfferedBy(object.offered_by)
+  const offeredBy = object.offered_by.join(", ")
   const instructors =
     selectedRun && selectedRun.instructors
       ? selectedRun.instructors.map(instructor => getInstructorName(instructor))

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -13,7 +13,6 @@ import {
   bestRunLabel,
   bestRun,
   minPrice,
-  getPreferredOfferedBy,
   userListCoverImage
 } from "../lib/learning_resources"
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
@@ -169,9 +168,7 @@ export function LearningResourceDisplay(props: Props) {
           <>
             {object.offered_by.length ? (
               <Subtitle
-                content={offeredBySearchLink(
-                  getPreferredOfferedBy(object.offered_by)
-                )}
+                content={offeredBySearchLink(object.offered_by.join(", "))}
                 label="Offered by - "
               />
             ) : null}

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -15,8 +15,7 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_COURSE,
   LR_TYPE_BOOTCAMP,
-  platforms,
-  offeredBys
+  platforms
 } from "./constants"
 import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
 import { capitalize, emptyOrNil, formatPrice } from "./util"
@@ -210,12 +209,6 @@ export const getInstructorName = (instructor: CourseInstructor) => {
   }
   return ""
 }
-
-// prefer MicroMasters over MITx
-const findMicroMasters = R.find(R.equals(offeredBys.micromasters))
-
-export const getPreferredOfferedBy = (offeredBy: Array<string>): string =>
-  findMicroMasters(offeredBy) || R.head(offeredBy)
 
 export const filterItems = (
   results: Array<Object>,

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -16,8 +16,7 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
-  LR_TYPE_VIDEO,
-  offeredBys
+  LR_TYPE_VIDEO
 } from "./constants"
 import { AVAILABILITY_MAPPING } from "./search"
 import {
@@ -34,7 +33,6 @@ import {
   runEndDate,
   getStartDate,
   getInstructorName,
-  getPreferredOfferedBy,
   privacyIcon,
   filterItems,
   isCoursewareResource,
@@ -404,19 +402,6 @@ describe("Course run availability utils", () => {
   ].forEach(([input, expected]) => {
     it(`getInstructorName should return ${expected} when given ${input.toString()}`, () => {
       assert.equal(getInstructorName(input), expected)
-    })
-  })
-
-  //
-  ;[
-    [[offeredBys.micromasters, offeredBys.mitx], offeredBys.micromasters],
-    [[offeredBys.mitx, offeredBys.micromasters], offeredBys.micromasters],
-    [[offeredBys.micromasters], offeredBys.micromasters],
-    [[offeredBys.mitx], offeredBys.mitx],
-    [[offeredBys.mitx, offeredBys.xpro], offeredBys.mitx]
-  ].forEach(([input, expected]) => {
-    it(`getPreferredOfferedBy should return ${expected} when given ${input.toString()}`, () => {
-      assert.equal(getPreferredOfferedBy(input), expected)
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
<img width="1159" alt="Screen Shot 2019-12-26 at 6 57 03 PM" src="https://user-images.githubusercontent.com/1934992/71493975-ab32a700-2811-11ea-82d0-9261c35d86ea.png">
<img width="386" alt="Screen Shot 2019-12-26 at 6 57 36 PM" src="https://user-images.githubusercontent.com/1934992/71493982-aec62e00-2811-11ea-913d-b035b60f2ba3.png">

- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2500

#### What's this PR do?
This pr updates the ui to display all the offered by values if there are multiple

#### How should this be manually tested?
Find or create a learning resource with multiple offered by values. Verify that all the offered by values are displayed in the UI

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
