### PR TITLE
Supported double-quoted search terms

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -31,6 +31,7 @@ from search.constants import (
 
 RELATED_POST_RELEVANT_FIELDS = ["plain_text", "post_title", "author_id", "channel_name"]
 SIMILAR_RESOURCE_RELEVANT_FIELDS = ["title", "short_description"]
+SUGGEST_FIELDS = ["title", "short_description"]
 
 
 def gen_post_id(reddit_obj_id):

--- a/search/api.py
+++ b/search/api.py
@@ -31,7 +31,6 @@ from search.constants import (
 
 RELATED_POST_RELEVANT_FIELDS = ["plain_text", "post_title", "author_id", "channel_name"]
 SIMILAR_RESOURCE_RELEVANT_FIELDS = ["title", "short_description"]
-SUGGEST_FIELDS = ["title", "short_description"]
 
 
 def gen_post_id(reddit_obj_id):

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -268,7 +268,7 @@ const _channelField = (type: ?string) => {
 }
 export { _channelField as channelField }
 import { channelField } from "./search"
-import { emptyOrNil } from "./util"
+import { emptyOrNil, isDoubleQuoted } from "./util"
 
 const getTypes = (type: ?(string | Array<string>)) => {
   if (type) {
@@ -577,12 +577,13 @@ export const buildLearnQuery = (
   facets: ?Map<string, Array<string>>
 ) => {
   for (const type of types) {
+    const queryType = isDoubleQuoted(text) ? "query_string" : "multi_match"
     const textQuery = emptyOrNil(text)
       ? {}
       : {
         should: [
           {
-            multi_match: {
+            [queryType]: {
               query:  text,
               fields: searchFields(type)
             }
@@ -592,7 +593,7 @@ export const buildLearnQuery = (
               nested: {
                 path:  "runs",
                 query: {
-                  multi_match: {
+                  [queryType]: {
                     query:  text,
                     fields: RESOURCE_QUERY_NESTED_FIELDS
                   }

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -1,6 +1,7 @@
 import { assert } from "chai"
 import sinon from "sinon"
 import _ from "lodash"
+import bodybuilder from "bodybuilder"
 
 import {
   makeBootcampResult,
@@ -20,7 +21,8 @@ import {
   searchResultToComment,
   searchResultToLearningResource,
   searchResultToPost,
-  searchResultToProfile
+  searchResultToProfile,
+  buildLearnQuery
 } from "./search"
 import * as searchFuncs from "./search"
 import {
@@ -786,6 +788,25 @@ describe("search functions", () => {
       it(`has the right searchFields for ${type}`, () => {
         assert.deepEqual(searchFields(type), fields)
       })
+    })
+  })
+  ;[
+    ['"mechanical engineering"', "query_string"],
+    ["'mechanical engineering\"", "multi_match"],
+    ["'mechanical engineering'", "multi_match"],
+    ["mechanical engineering", "multi_match"]
+  ].forEach(([text, queryType]) => {
+    it(`constructs a ${queryType} query on text ${text}`, () => {
+      const esQuery = buildLearnQuery(
+        bodybuilder(),
+        text,
+        [LR_TYPE_COURSE],
+        null
+      )
+      assert.deepEqual(
+        Object.keys(esQuery.query.bool.should[0].bool.should[0]),
+        [queryType]
+      )
     })
   })
 })

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -175,3 +175,6 @@ export const formatPrice = (price: ?string | number | Decimal): string => {
 
 export const sortBy = (property: string) =>
   R.sortWith([R.ascend(R.prop(property))])
+
+export const isDoubleQuoted = (text: ?string) =>
+  !emptyOrNil(R.match(/^".+"$/, text))

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -177,4 +177,4 @@ export const sortBy = (property: string) =>
   R.sortWith([R.ascend(R.prop(property))])
 
 export const isDoubleQuoted = (text: ?string) =>
-  !emptyOrNil(R.match(/^".+"$/, text))
+  !emptyOrNil(R.match(/^".+"$/, text || ""))

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -46,7 +46,8 @@ import {
   toArray,
   capitalize,
   getViewportWidth,
-  GRID_MOBILE_BREAKPOINT
+  GRID_MOBILE_BREAKPOINT,
+  isDoubleQuoted
 } from "../lib/util"
 import {
   mergeFacetResults,
@@ -398,7 +399,10 @@ export class CourseSearchPage extends React.Component<Props, State> {
     const resultsColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 9 : 8
     const suggestions =
       !emptyOrNil(suggest) && !emptyOrNil(text)
-        ? R.without([text], suggest)
+        ? R.without([text], suggest).map(
+          suggestion =>
+            isDoubleQuoted(text) ? `"${suggestion}"` : suggestion
+        )
         : []
 
     return (

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -131,6 +131,42 @@ describe("CourseSearchPage", () => {
       "Learning Resource"
     )
   })
+  ;[
+    ["mechical enginr", "mechanical engineer"],
+    ['"mechical enginr"', '"mechanical engineer"']
+  ].forEach(([text, suggestion]) => {
+    it(`renders suggestion ${suggestion} for query ${text}`, async () => {
+      const { inner } = await renderPage(
+        {
+          search: {
+            data: {
+              suggest: ["mechanical engineer"]
+            }
+          }
+        },
+        {
+          location: {
+            search: `q=${text}`
+          }
+        }
+      )
+      assert.equal(inner.state().text, text)
+      const suggestDiv = inner.find(".suggestion")
+      assert.isOk(suggestDiv.text().includes("Did you mean"))
+      assert.isOk(suggestDiv.text().includes(suggestion))
+      suggestDiv.find("a").simulate("click")
+      assert.equal(inner.state()["text"], suggestion)
+    })
+  })
+
+  it("renders suggestion and changes search text if clicked", async () => {
+    const { inner } = await renderPage()
+    const suggestDiv = inner.find(".suggestion")
+    assert.isOk(suggestDiv.text().includes("Did you mean"))
+    assert.isOk(suggestDiv.text().includes("test"))
+    suggestDiv.find("a").simulate("click")
+    assert.equal(inner.state()["text"], "test")
+  })
 
   it("renders suggestion and changes search text if clicked", async () => {
     const { inner } = await renderPage()

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -168,15 +168,6 @@ describe("CourseSearchPage", () => {
     assert.equal(inner.state()["text"], "test")
   })
 
-  it("renders suggestion and changes search text if clicked", async () => {
-    const { inner } = await renderPage()
-    const suggestDiv = inner.find(".suggestion")
-    assert.isOk(suggestDiv.text().includes("Did you mean"))
-    assert.isOk(suggestDiv.text().includes("test"))
-    suggestDiv.find("a").simulate("click")
-    assert.equal(inner.state()["text"], "test")
-  })
-
   //
   ;["", "a"].forEach(query => {
     it(`still runs a search if initial search text is '${query}'`, async () => {


### PR DESCRIPTION
Based on #2510, that one should be reviewed/merged first.

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2499

#### What's this PR do?
Supports quoted search terms

#### How should this be manually tested?
- Search for `mechanical engineer` without double quotes.  You should get X results back that match either` mechanical` or `engineer` or both
- Search for `"mechanical engineer"` with the double quotes.  You should get less than X results back that match `mechanical engineer`
- Search for `mechanical enginr` without quotes.  You should get Y results back that match `mechanical`
- Search for `"mechanical enginr"` with the double quotes.  You should get 0 results back and a suggestion `Did you mean "mechanical engineer"`
