### PR TITLE
mock out HTML height attrs globally

### DIFF
--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -79,3 +79,6 @@ afterEach(function() {
 import chai from "chai"
 import chaiAsPromised from "chai-as-promised"
 chai.use(chaiAsPromised)
+
+import { mockHTMLElHeight } from "./lib/test_utils"
+mockHTMLElHeight(100, 100)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

fixes an issue with mocking out the HTMLElement `scrollHeight` and `offsetHeight` attributes. Basically, these attributes are checked by the `TruncatedText` component to see whether there's overflow and therefore determine when it makes sense to show a `show more / show less` button. Issue is that these values weren't being mocked globally, but instead piecemeal in certain test files. Other files actually required the values to be mocked, and were indirectly getting the mock because of execution order of the tests but, if those files were run separately, the mock wouldn't be there and it would cause an `InvarientViolation`.

One such file is `static/js/components/ExpandedLearningResourceDisplay_test.js`

to fix I just added a call to the mock function to our `global_init.js` file, which is called at the beginning of our test suite no matter which files are run.

#### How should this be manually tested?

check out master and confirm that you get a big ol error on the test file above. then check out this branch and confirm that it's fixed.
