### PR TITLE
Dont publish/index blacklisted courses

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,6 +43,10 @@
       "description": "S3 Bucket name.",
       "required": false
     },
+    "BLACKLISTED_COURSES_URL": {
+      "description": "URL of a text file containing blacklisted course ids",
+      "required": false
+    },
     "BOOTCAMPS_URL": {
       "description": "URL to retrieve bootcamps data",
       "required": false

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -208,7 +208,7 @@ def load_program(program_data, blacklist):
 
 def load_programs(programs_data):
     """Load a list of programs"""
-    blacklist = []  # load_course_blacklist()
+    blacklist = load_course_blacklist()
     return [load_program(program_data, blacklist) for program_data in programs_data]
 
 

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -683,7 +683,7 @@ def test_load_courses(mocker, mock_blacklist):
     )
     load_courses(course_data)
     assert mock_load_course.call_count == len(course_data)
-    assert mock_blacklist.called_once()
+    mock_blacklist.assert_called_once()
 
 
 def test_load_programs(mocker, mock_blacklist):
@@ -694,4 +694,4 @@ def test_load_programs(mocker, mock_blacklist):
     )
     load_programs(program_data)
     assert mock_load_program.call_count == len(program_data)
-    assert mock_blacklist.called_once()
+    mock_blacklist.assert_called_once()

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -22,6 +22,8 @@ from course_catalog.etl.loaders import (
     load_playlists,
     load_video_channels,
     load_playlist_user_list,
+    load_courses,
+    load_programs,
 )
 from course_catalog.etl.xpro import _parse_datetime
 from course_catalog.factories import (
@@ -671,3 +673,25 @@ def test_load_playlist_user_list(
             mock_upsert_tasks.delete_user_list.assert_called_once_with(user_list)
         else:
             mock_upsert_tasks.delete_user_list.assert_not_called()
+
+
+def test_load_courses(mocker, mock_blacklist):
+    """Test that load_courses calls the expected functions"""
+    course_data = [{"a": "b"}, {"a": "c"}]
+    mock_load_course = mocker.patch(
+        "course_catalog.etl.loaders.load_course", autospec=True
+    )
+    load_courses(course_data)
+    assert mock_load_course.call_count == len(course_data)
+    assert mock_blacklist.called_once()
+
+
+def test_load_programs(mocker, mock_blacklist):
+    """Test that load_programs calls the expected functions"""
+    program_data = [{"a": "b"}, {"a": "c"}]
+    mock_load_program = mocker.patch(
+        "course_catalog.etl.loaders.load_program", autospec=True
+    )
+    load_programs(program_data)
+    assert mock_load_program.call_count == len(program_data)
+    assert mock_blacklist.called_once()

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -136,7 +136,6 @@ def test_get_ocw_data(
     mock_blacklist.assert_called_once()
     assert Course.objects.first().published is not blacklisted
 
-    # mocker.patch("course_catalog.api.load_course_blacklist", return_value=[])
     get_ocw_data.delay()
     assert Course.objects.count() == 1
     assert CoursePrice.objects.count() == 1

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from urllib.parse import urljoin
 
 import pytz
+import requests
 from django.conf import settings
 
 from course_catalog.constants import ocw_edx_mapping, semester_mapping, PlatformType
@@ -158,3 +159,19 @@ def get_list_items_by_resource(user, object_type, object_id):
         .filter(content_type__model=object_type)
         .filter(object_id=object_id)
     ]
+
+
+def load_course_blacklist():
+    """
+    Get a list of blacklisted course ids
+
+    Returns:
+        list of str: list of course ids
+
+    """
+    blacklist_url = settings.BLACKLISTED_COURSES_URL
+    if blacklist_url is not None:
+        response = requests.get(blacklist_url)
+        response.raise_for_status()
+        return [str(line, "utf-8") for line in response.iter_lines()]
+    return []

--- a/course_catalog/utils_test.py
+++ b/course_catalog/utils_test.py
@@ -7,7 +7,11 @@ import pytest
 import pytz
 
 from course_catalog.constants import PlatformType
-from course_catalog.utils import get_course_url, semester_year_to_date
+from course_catalog.utils import (
+    get_course_url,
+    semester_year_to_date,
+    load_course_blacklist,
+)
 
 
 @pytest.mark.parametrize(
@@ -87,3 +91,22 @@ def test_semester_year_to_date(semester, year, ending, expected):
         assert semester_year_to_date(
             semester, year, ending=ending
         ) == datetime.strptime(expected, "%Y-%m-%d").replace(tzinfo=pytz.UTC)
+
+
+@pytest.mark.parametrize("url", [None, "http://test.me"])
+def test_load_blacklist(url, settings, mocker):
+    """Test that a list of course ids is returned if a URL is set"""
+    settings.BLACKLISTED_COURSES_URL = url
+    file_content = [b"MITX_Test1_FAKE", b"MITX_Test2_Fake", b"OCW_Test_Fake"]
+    mock_request = mocker.patch(
+        "requests.get",
+        autospec=True,
+        return_value=mocker.Mock(iter_lines=mocker.Mock(return_value=file_content)),
+    )
+    blacklist = load_course_blacklist()
+    if url is None:
+        mock_request.assert_not_called()
+        assert blacklist == []
+    else:
+        mock_request.assert_called_once_with(url)
+        assert blacklist == [str(id, "utf-8") for id in file_content]

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -831,6 +831,10 @@ MAX_S3_GET_ITERATIONS = get_int("MAX_S3_GET_ITERATIONS", 3)
 OCW_BASE_URL = get_string("OCW_BASE_URL", "http://ocw.mit.edu/")
 MITX_BASE_URL = get_string("MITX_BASE_URL", "https://www.edx.org/course/")
 MITX_ALT_URL = get_string("MITX_ALT_URL", "https://courses.edx.org/courses/")
+BLACKLISTED_COURSES_URL = get_string(
+    "BLACKLISTED_COURSES_URL",
+    "https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/courses.txt",
+)
 
 # Base URL for bootcamps data
 BOOTCAMPS_URL = get_string(

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -330,6 +330,7 @@ def test_start_recreate_index(
     """
     settings.INDEXING_API_USERNAME = user.username
     settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE = 2
+    mock_blacklist = mocker.patch("search.tasks.load_course_blacklist", return_value=[])
     UserFactory.create_batch(
         4, is_active=False
     )  # these should not show up in the indexing
@@ -370,6 +371,7 @@ def test_start_recreate_index(
         }
     )
     assert mocked_celery.group.call_count == 1
+    mock_blacklist.assert_called_once()
 
     # Celery's 'group' function takes a generator as an argument. In order to make assertions about the items
     # in that generator, 'list' is being called to force iteration through all of those items.


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2492 

#### What's this PR do?
- Retrieves a list of blacklisted ids from a URL and sets those courses as `published=False` during import, skips them during a full recreate_index.

#### How should this be manually tested?
- Make a gist with a text file containing a list of some edx course id's you've already imported, one per line.
- Set `BLACKLISTED_COURSES_URL` to the raw URL for that file in your .env file
- Run `recreate_index`.  Those courses should be removed from the index.
- Delete those course and import them again (`backpopulate_edx_data`).  They should be assigned `published=False`
