### PR TITLE
Update indexing methods to reduce data sent to and from redis via celery 

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -1443,7 +1443,7 @@ class Api:
         with transaction.atomic():
             add_user_role(proxied_channel.channel, ROLE_CONTRIBUTORS, user)
             proxied_channel.contributor.add(user)
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
         return Redditor(self.reddit, name=contributor_name)
 
     def remove_contributor(self, contributor_name, channel_name):
@@ -1465,7 +1465,7 @@ class Api:
         with transaction.atomic():
             remove_user_role(proxied_channel.channel, ROLE_CONTRIBUTORS, user)
             proxied_channel.contributor.remove(user)
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
 
     def list_contributors(self, channel_name):
         """
@@ -1500,7 +1500,7 @@ class Api:
             except APIException as ex:
                 if ex.error_type != "ALREADY_MODERATOR":
                     raise
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
 
     def accept_invite(self, channel_name):
         """
@@ -1529,7 +1529,7 @@ class Api:
         with transaction.atomic():
             remove_user_role(proxied_channel.channel, ROLE_MODERATORS, user)
             proxied_channel.moderator.remove(user)
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
 
     def _list_moderators(self, *, channel_name, moderator_name):
         """
@@ -1602,7 +1602,7 @@ class Api:
                 channel.subscribe()
             except PrawForbidden as ex:
                 raise PermissionDenied() from ex
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
         return Redditor(self.reddit, name=subscriber_name)
 
     def remove_subscriber(self, subscriber_name, channel_name):
@@ -1630,7 +1630,7 @@ class Api:
                 # or maybe there's another unrelated 403 error from reddit, but we can't tell the difference,
                 # and the double removal case is probably more common.
                 pass
-        search_task_helpers.update_author(user)
+        search_task_helpers.update_author(user.id)
 
     def is_subscriber(self, subscriber_name, channel_name):
         """

--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -1078,7 +1078,7 @@ def test_add_contributor(mock_client, mock_update_author):
         ).group
         in contributor.groups.all()
     )
-    mock_update_author.assert_called_with(contributor)
+    mock_update_author.assert_called_with(contributor.id)
     assert isinstance(redditor, Redditor)
     assert redditor.name == contributor.username
 
@@ -1111,7 +1111,7 @@ def test_remove_contributor(mock_client, mock_update_author):
         ).group
         not in contributor.groups.all()
     )
-    mock_update_author.assert_called_with(contributor)
+    mock_update_author.assert_called_with(contributor.id)
 
 
 def test_list_contributors(mock_client):
@@ -1138,7 +1138,7 @@ def test_add_moderator(mock_client, mock_update_author):
         ).group
         in moderator.groups.all()
     )
-    mock_update_author.assert_called_with(moderator)
+    mock_update_author.assert_called_with(moderator.id)
 
 
 def test_add_moderator_no_user(mock_client):
@@ -1167,7 +1167,7 @@ def test_remove_moderator(mock_client, mock_update_author):
         ).group
         not in moderator.groups.all()
     )
-    mock_update_author.assert_called_with(moderator)
+    mock_update_author.assert_called_with(moderator.id)
 
 
 def test_list_moderator(mock_client):
@@ -1360,7 +1360,7 @@ def test_add_subscriber(mock_client, mock_update_author):
     assert ChannelSubscription.objects.filter(
         channel__name="channel", user=subscriber
     ).exists()
-    mock_update_author.assert_called_with(subscriber)
+    mock_update_author.assert_called_with(subscriber.id)
 
 
 def test_add_remove_subscriber_no_user(mock_client):
@@ -1385,7 +1385,7 @@ def test_remove_subscriber(mock_client, mock_update_author):
     assert not ChannelSubscription.objects.filter(
         channel__name="testchannel5", user=subscriber
     ).exists()
-    mock_update_author.assert_called_with(subscriber)
+    mock_update_author.assert_called_with(subscriber.id)
 
 
 def test_is_subscriber(mock_client):

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -315,7 +315,7 @@ def parse_bootcamp_json_data(bootcamp_data, force_overwrite=False):
 
         load_offered_bys(run, [{"name": OfferedBy.bootcamps.value}])
 
-    index_func(bootcamp)
+    index_func(bootcamp.id)
 
 
 # pylint: disable=too-many-locals
@@ -495,6 +495,6 @@ def sync_ocw_data(*, force_overwrite, upload_to_s3):
     for course in Course.objects.filter(id__in=course_ids):
         # Probably quicker to do this as a bulk operation
         if course.published:
-            upsert_course(course)
+            upsert_course(course.id)
         else:
             delete_course(course)

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -139,7 +139,7 @@ def load_course(course_data):
     if not created and not course.published:
         search_task_helpers.delete_course(course)
     elif course.published:
-        search_task_helpers.upsert_course(course)
+        search_task_helpers.upsert_course(course.id)
 
     return course
 
@@ -196,7 +196,7 @@ def load_program(program_data):
     if not created and not program.published:
         search_task_helpers.delete_program(program)
     elif program.published:
-        search_task_helpers.upsert_program(program)
+        search_task_helpers.upsert_program(program.id)
 
     return program
 
@@ -312,7 +312,7 @@ def load_playlist_user_list(playlist):
         id__in=[item.id for item in items]
     ).delete()
 
-    search_task_helpers.upsert_user_list(user_list)
+    search_task_helpers.upsert_user_list(user_list.id)
 
     return user_list
 

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -229,7 +229,7 @@ def load_video(video_data):
         #       this gets addressed in load_channels after everything has been synced
         search_task_helpers.delete_video(video)
     elif video.published:
-        search_task_helpers.upsert_video(video)
+        search_task_helpers.upsert_video(video.id)
 
     return video
 

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -156,7 +156,7 @@ def test_load_program(
     if program_exists and not is_published:
         mock_upsert_tasks.delete_program.assert_called_with(result)
     elif is_published:
-        mock_upsert_tasks.upsert_program.assert_called_with(result)
+        mock_upsert_tasks.upsert_program.assert_called_with(result.id)
     else:
         mock_upsert_tasks.delete_program.assert_not_called()
         mock_upsert_tasks.upsert_program.assert_not_called()
@@ -215,7 +215,7 @@ def test_load_course(mock_upsert_tasks, course_exists, is_published):
     if course_exists and not is_published:
         mock_upsert_tasks.delete_course.assert_called_with(result)
     elif is_published:
-        mock_upsert_tasks.upsert_course.assert_called_with(result)
+        mock_upsert_tasks.upsert_course.assert_called_with(result.id)
     else:
         mock_upsert_tasks.delete_program.assert_not_called()
         mock_upsert_tasks.upsert_course.assert_not_called()
@@ -645,7 +645,7 @@ def test_load_playlist_user_list(
                 ).exists()
                 is True
             )
-        mock_upsert_tasks.upsert_user_list.assert_called_once_with(user_list)
+        mock_upsert_tasks.upsert_user_list.assert_called_once_with(user_list.id)
     else:
         if exists:
             mock_upsert_tasks.delete_user_list.assert_called_once_with(user_list)

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -383,7 +383,7 @@ def test_load_video(mock_upsert_tasks, video_exists, is_published):
     if video_exists and not is_published:
         mock_upsert_tasks.delete_video.assert_called_with(result)
     elif is_published:
-        mock_upsert_tasks.upsert_video.assert_called_with(result)
+        mock_upsert_tasks.upsert_video.assert_called_with(result.id)
     else:
         mock_upsert_tasks.delete_video.assert_not_called()
         mock_upsert_tasks.upsert_video.assert_not_called()

--- a/course_catalog/etl/youtube.py
+++ b/course_catalog/etl/youtube.py
@@ -563,7 +563,7 @@ def get_youtube_transcripts(videos):
             else:
                 video.transcript = parse_video_captions(caption)
                 video.save()
-                upsert_video(video)
+                upsert_video(video.id)
                 consecutive_video_unavailable_failures = 0
                 break
             finally:

--- a/course_catalog/etl/youtube_test.py
+++ b/course_catalog/etl/youtube_test.py
@@ -522,7 +522,7 @@ def test_get_youtube_transcripts(mocker):
     mock_parse_call.assert_called_once_with(mock_caption)
     mock_video.save.assert_called_once()
 
-    mock_upsert_video.assert_called_once_with(mock_video)
+    mock_upsert_video.assert_called_once_with(mock_video.id)
 
 
 @pytest.mark.usefixtures("video_settings")
@@ -548,7 +548,7 @@ def test_get_youtube_transcripts_with_a_retry(mocker):
     mock_parse_call.assert_called_once_with(mock_caption)
     mock_video.save.assert_called_once()
 
-    mock_upsert_video.assert_called_once_with(mock_video)
+    mock_upsert_video.assert_called_once_with(mock_video.id)
 
 
 @pytest.mark.usefixtures("video_settings")

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -484,7 +484,7 @@ class UserListItemSerializer(SimpleUserListItemSerializer):
         view = self.context.get("view", None)
         if view is not None and view.kwargs.get("parent_lookup_user_list_id", None):
             # this was sent via userlistitems API, so update the search index
-            upsert_user_list(user_list)
+            upsert_user_list(user_list.id)
 
     def create(self, validated_data):
         user_list = validated_data["user_list"]
@@ -658,7 +658,7 @@ class UserListSerializer(SimpleUserListSerializer):
                 if topics_data is not None:
                     userlist.topics.set(CourseTopic.objects.filter(id__in=topics_data))
                 if instance.items.exists():
-                    upsert_user_list(userlist)
+                    upsert_user_list(userlist.id)
                 else:
                     delete_user_list(userlist)
                 return userlist

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -264,7 +264,7 @@ class UserListItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet, FavoriteVie
         instance.delete()
         user_list = instance.user_list
         if user_list.items.count() > 0:
-            upsert_user_list(user_list)
+            upsert_user_list(user_list.id)
         else:
             delete_user_list(user_list)
 

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -265,7 +265,7 @@ def test_user_list_endpoint_patch(client, user, mock_user_list_index, update_top
     assert resp.data["topics"][0]["id"] == (
         new_topic.id if update_topics else original_topic.id
     )
-    mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
+    mock_user_list_index.upsert_user_list.assert_called_once_with(userlist.id)
 
 
 @pytest.mark.parametrize("num_topics", [0, 2])
@@ -301,7 +301,7 @@ def test_user_list_endpoint_create_item(
         assert (
             sorted([topic["id"] for topic in resp.data.get("topics", [])]) == topic_ids
         )
-        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
+        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist.id)
 
 
 def test_user_list_endpoint_create_item_bad_data(client, user):
@@ -367,7 +367,7 @@ def test_user_list_endpoint_update_items(client, user, is_author, mock_user_list
             updated_items[1]["position"] == 44
             and updated_items[1]["id"] == list_items[0].id
         )
-        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
+        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist.id)
 
 
 def test_user_list_endpoint_update_items_wrong_list(client, user):
@@ -415,7 +415,7 @@ def test_user_list_endpoint_delete_items(client, user, is_author, mock_user_list
         assert len(updated_items) == 1
         assert updated_items[0]["id"] == list_items[1].id
         assert UserListItem.objects.filter(id=list_items[0].id).exists() is False
-        mock_user_list_index.upsert_user_list.assert_called_with(userlist)
+        mock_user_list_index.upsert_user_list.assert_called_with(userlist.id)
 
         data = {
             "items": [
@@ -458,7 +458,7 @@ def test_user_list_items_endpoint_create_item(
     assert resp.status_code == (201 if is_author else 403)
     if resp.status_code == 201:
         assert resp.json().get("object_id") == course.id
-        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
+        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist.id)
 
 
 def test_user_list_items_endpoint_create_item_bad_data(client, user):
@@ -506,7 +506,7 @@ def test_user_list_items_endpoint_update_item(
     assert resp.status_code == (200 if is_author else 403)
     if resp.status_code == 200:
         assert resp.json()["position"] == 44444
-        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist)
+        mock_user_list_index.upsert_user_list.assert_called_once_with(userlist.id)
 
 
 def test_user_list_items_endpoint_update_items_wrong_list(client, user):
@@ -552,7 +552,7 @@ def test_user_list_items_endpoint_delete_items(
     )
     assert resp.status_code == (204 if is_author else 403)
     if resp.status_code == 204:
-        mock_user_list_index.upsert_user_list_view.assert_called_with(userlist)
+        mock_user_list_index.upsert_user_list_view.assert_called_with(userlist.id)
         client.delete(
             reverse("userlistitems-detail", args=[userlist.id, list_items[1].id]),
             format="json",

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -134,11 +134,11 @@ class Profile(models.Model):
         self.__previous_headline = self.headline
         self.__previous_bio = self.bio
         if is_new:
-            task_helpers.index_new_profile(self)
+            task_helpers.index_new_profile(self.id)
         elif update_author:
-            task_helpers.update_author(self.user)
+            task_helpers.update_author(self.user.id)
         if update_posts:
-            task_helpers.update_author_posts_comments(self)
+            task_helpers.update_author_posts_comments(self.id)
 
     def __str__(self):
         return "{}".format(self.name)

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -140,7 +140,7 @@ def test_update_user_profile(mock_index_functions, user, key, value):
         else:
             assert getattr(profile2, prop) == getattr(profile, prop)
 
-    mock_index_functions.update_author.call_count = (
+    assert mock_index_functions.update_author.call_count == (
         1 if key in ["name", "headline", "bio"] else 0
     )
     assert mock_index_functions.update_posts.call_count == (
@@ -213,11 +213,11 @@ def test_update_profile(mock_index_functions, user, key, value):
             assert getattr(profile2, prop) == getattr(profile, prop)
 
     if key in ("name", "image_file", "headline"):
-        mock_index_functions.update_posts.assert_called_once_with(profile2)
+        mock_index_functions.update_posts.assert_called_once_with(profile2.id)
     else:
         mock_index_functions.update_posts.assert_not_called()
         if key != "location":
-            mock_index_functions.update_author.assert_called_with(profile2.user)
+            mock_index_functions.update_author.assert_called_with(profile2.user.id)
 
 
 def test_serialize_profile_websites(user):

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -34,17 +34,14 @@ from search.serializers import (
     ESPostSerializer,
     ESCommentSerializer,
     ESProfileSerializer,
-    ESCourseSerializer,
     ESBootcampSerializer,
     ESUserListSerializer,
-    ESProgramSerializer,
 )
 from search import tasks
 from search.tasks import (
     create_document,
     create_post_document,
     update_document_with_partial,
-    upsert_document,
     increment_document_integer_field,
     update_field_values_by_query,
     delete_document,
@@ -387,21 +384,14 @@ def update_indexed_score(instance, instance_type, vote_action=None):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def upsert_course(course_obj):
+def upsert_course(course_id):
     """
-    Run a task to create or update a course Elasticsearch document
+    Run a task to create or update a course's Elasticsearch document
 
     Args:
-        course_obj(Course): the Course to update in ES
+        course_id (int): the primary key for the Course to update
     """
-
-    course_data = ESCourseSerializer(course_obj).data
-    upsert_document.delay(
-        gen_course_id(course_obj.platform, course_obj.course_id),
-        course_data,
-        COURSE_TYPE,
-        retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
-    )
+    tasks.upsert_course.delay(course_id)
 
 
 @if_feature_enabled(INDEX_UPDATES)
@@ -430,21 +420,14 @@ def index_new_bootcamp(bootcamp_obj):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def update_bootcamp(bootcamp_obj):
+def update_bootcamp(bootcamp_id):
     """
     Run a task to update all fields of a bootcamp Elasticsearch document
 
     Args:
-        bootcamp_obj(Bootcamp): the Bootcamp to update in ES
+        bootcamp_id (int): the primary key for Bootcamp to update in ES
     """
-
-    bootcamp_data = ESBootcampSerializer(bootcamp_obj).data
-    update_document_with_partial.delay(
-        gen_bootcamp_id(bootcamp_obj.course_id),
-        bootcamp_data,
-        BOOTCAMP_TYPE,
-        retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
-    )
+    tasks.upsert_bootcamp.delay(bootcamp_id)
 
 
 @if_feature_enabled(INDEX_UPDATES)
@@ -459,21 +442,14 @@ def delete_bootcamp(bootcamp_obj):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def upsert_program(program_obj):
+def upsert_program(program_id):
     """
     Run a task to create or update a program Elasticsearch document
 
     Args:
-        program_obj(Program): the Program to update in ES
+        program_id (int): the primary key for the Program to update in ES
     """
-
-    program_data = ESProgramSerializer(program_obj).data
-    upsert_document.delay(
-        gen_program_id(program_obj),
-        program_data,
-        PROGRAM_TYPE,
-        retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
-    )
+    tasks.upsert_program.delay(program_id)
 
 
 @if_feature_enabled(INDEX_UPDATES)
@@ -500,20 +476,14 @@ def index_new_user_list(user_list_obj):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def upsert_user_list(user_list_obj):
+def upsert_user_list(user_list_id):
     """
     Run a task to update all fields of a UserList Elasticsearch document
 
     Args:
-        user_list_obj(UserList): the UserList to update in ES
+        user_list_id (int): the primary key for the UserList to update in ES
     """
-    user_list_data = ESUserListSerializer(user_list_obj).data
-    upsert_document.delay(
-        gen_user_list_id(user_list_obj),
-        user_list_data,
-        USER_LIST_TYPE,
-        retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
-    )
+    tasks.upsert_user_list.delay(user_list_id)
 
 
 @if_feature_enabled(INDEX_UPDATES)

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -38,8 +38,8 @@ from search.serializers import (
     ESBootcampSerializer,
     ESUserListSerializer,
     ESProgramSerializer,
-    ESVideoSerializer,
 )
+from search import tasks
 from search.tasks import (
     create_document,
     create_post_document,
@@ -528,21 +528,14 @@ def delete_user_list(user_list_obj):
 
 
 @if_feature_enabled(INDEX_UPDATES)
-def upsert_video(video_obj):
+def upsert_video(video_id):
     """
     Run a task to create or update a video Elasticsearch document
 
     Args:
-        video_obj(Video): the Video to update in ES
+        video_id (int): the database primary key of the Video to update in ES
     """
-
-    video_data = ESVideoSerializer(video_obj).data
-    upsert_document.delay(
-        gen_video_id(video_obj),
-        video_data,
-        VIDEO_TYPE,
-        retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
-    )
+    tasks.upsert_video.delay(video_id)
 
 
 @if_feature_enabled(INDEX_UPDATES)

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -42,6 +42,8 @@ from search.task_helpers import (
     delete_video,
     upsert_user_list,
     delete_user_list,
+    index_new_bootcamp,
+    update_bootcamp,
 )
 from search.api import (
     gen_post_id,
@@ -528,3 +530,19 @@ def test_delete_user_list(mocker, list_type):
         gen_user_list_id(user_list),
         USER_LIST_TYPE,
     )
+
+
+def test_index_new_bootcamp(mocker):
+    """index_new_bootcamp should start a task to index a bootcamp document"""
+    patched = mocker.patch("search.task_helpers.tasks.index_new_bootcamp")
+    bootcamp_id = 345
+    index_new_bootcamp(bootcamp_id)
+    patched.delay.assert_called_once_with(bootcamp_id)
+
+
+def test_update_bootcamp(mocker):
+    """update_bootcamp should start a task to update the indexed document for the bootcamp"""
+    patched = mocker.patch("search.task_helpers.tasks.upsert_bootcamp")
+    bootcamp_id = 345
+    update_bootcamp(bootcamp_id)
+    patched.delay.assert_called_once_with(bootcamp_id)

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -514,16 +514,12 @@ def test_upsert_video(mocker):
     """
     Tests that upsert_video calls update_field_values_by_query with the right parameters
     """
-    patched_task = mocker.patch("search.task_helpers.upsert_document")
+    patched_task = mocker.patch("search.tasks.upsert_video")
     video = VideoFactory.create()
-    upsert_video(video)
+    upsert_video(video.id)
     assert patched_task.delay.called is True
-    assert patched_task.delay.call_args[1] == dict(retry_on_conflict=1)
-    assert patched_task.delay.call_args[0] == (
-        gen_video_id(video),
-        ESVideoSerializer(video).data,
-        VIDEO_TYPE,
-    )
+    assert patched_task.delay.call_args[1] == {}
+    assert patched_task.delay.call_args[0] == (video.id,)
 
 
 @pytest.mark.django_db

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -73,7 +73,7 @@ def enable_index_update_feature(settings):
 def mock_es_profile_serializer(mocker):
     """Mock ESProfileSerializer with canned serialized data"""
     mocker.patch(
-        "search.task_helpers.ESProfileSerializer.serialize",
+        "search.tasks.ESProfileSerializer.serialize",
         autospec=True,
         return_value=es_profile_serializer_data,
     )
@@ -168,8 +168,7 @@ def test_index_new_profile(mock_index_functions, mocker, user):
     fake_serialized_data = {"serialized": "profile"}
     patched_create_task = mocker.patch("search.indexing_api.create_document")
     patched_serialize_func = mocker.patch(
-        "search.task_helpers.ESProfileSerializer.serialize",
-        return_value=fake_serialized_data,
+        "search.tasks.ESProfileSerializer.serialize", return_value=fake_serialized_data
     )
     index_new_profile(user.profile.id)
     patched_serialize_func.assert_called_once_with(user.profile)

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -23,7 +23,6 @@ from search.constants import (
 from search.serializers import (
     ESCourseSerializer,
     ESProgramSerializer,
-    ESVideoSerializer,
     ESUserListSerializer,
 )
 from search.task_helpers import (

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -51,6 +51,7 @@ from search.tasks import (
     finish_recreate_index,
     increment_document_integer_field,
     update_field_values_by_query,
+    index_new_bootcamp,
     index_posts,
     start_recreate_index,
     wrap_retry_exception,
@@ -100,6 +101,16 @@ def test_update_document_with_partial_task(mocked_api):
     update_document_with_partial(*indexing_api_args)
     assert mocked_api.update_document_with_partial.call_count == 1
     assert mocked_api.update_document_with_partial.call_args[0] == indexing_api_args
+
+
+def test_index_new_bootcamp(mocked_api):
+    """index_new_bootcamp should call create_document with the serialized bootcamp document based on the primary key"""
+    bootcamp = BootcampFactory.create()
+    index_new_bootcamp(bootcamp.id)
+    data = ESBootcampSerializer(bootcamp).data
+    mocked_api.create_document.assert_called_once_with(
+        gen_bootcamp_id(bootcamp.course_id), data
+    )
 
 
 def test_upsert_bootcamp_task(mocked_api):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2518 

#### What's this PR do?
Converts create and update indexing methods to take a primary key value and pass it to the task to index, instead of serializing the data then sending it to the task. This should cut down on the amount of data in each task redis is keeping track of. 

#### How should this be manually tested?
- For videos, run youtube ETL task (backpopulate youtube data)
 - User list: create a user list and verify that 
 - Courses/programs: xpro integration (backpopulate xpro data)