### PR TITLE
allow specifying list name in config file

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -248,13 +248,13 @@ def load_videos(videos_data):
     return [load_video(video_data) for video_data in videos_data]
 
 
-def load_playlist_user_list(playlist):
+def load_playlist_user_list(playlist, user_list_title):
     """
     Load a playlist into a user list
 
     Args:
         playlist (Playlist): the playlist to generate a user list from
-
+        user_list_title (str or None): title for the user list
     Returns:
         UserList or None:
             the created/updated user list or None
@@ -292,7 +292,7 @@ def load_playlist_user_list(playlist):
             playlist.save()
 
     user_list = playlist.user_list
-    user_list.title = playlist.title
+    user_list.title = user_list_title if user_list_title else playlist.title
     user_list.save()
 
     video_content_type = ContentType.objects.get_for_model(Video)
@@ -334,6 +334,7 @@ def load_playlist(video_channel, playlist_data):
     videos_data = playlist_data.pop("videos", [])
     topics_data = playlist_data.pop("topics", [])
     offered_by_data = playlist_data.pop("offered_by", [])
+    user_list_title = playlist_data.pop("user_list_title", None)
 
     playlist, _ = Playlist.objects.update_or_create(
         platform=platform,
@@ -356,7 +357,7 @@ def load_playlist(video_channel, playlist_data):
             video_id__in=[video.id for video in videos]
         ).delete()
 
-    load_playlist_user_list(playlist)
+    load_playlist_user_list(playlist, user_list_title)
 
     from course_catalog import tasks
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2523

#### What's this PR do?
This PR allows us to set a custom title for the user list created for a youtube playlist in open-video-data 

#### How should this be manually tested?
Set
```
OPEN_VIDEO_DATA_BRANCH=format-change-custom-list-name
in your .env file.
```

Run
```
from course_catalog.etl import pipelines
pipelines.youtube_etl(channel_ids="UCPonD0FH2WNnEXyTsYiLWMw")
```
from the shell.  This should create three user lists. Two with the youtube list name, "Entrepreneurship 101: Who is Your Customer? - All Videos from Our MIT Online Course" and  "Entrepreneurship 102: What Can You Do for Your Customer? - All Videos from Our MIT Online Course", and one with a custom name "Custom List Name Bootcamps"

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
