### PR TITLE
share learning resources

### DIFF
--- a/static/js/components/CommentTree.js
+++ b/static/js/components/CommentTree.js
@@ -161,6 +161,7 @@ export default class CommentTree extends React.Component<Props, State> {
             <ShareTooltip
               hideSocialButtons={isPrivateChannel}
               url={absolutizeURL(commentPermalink(comment.id))}
+              objectType="comment"
             >
               <div className="comment-action-button share-button">share</div>
             </ShareTooltip>

--- a/static/js/components/CommentTree_test.js
+++ b/static/js/components/CommentTree_test.js
@@ -107,7 +107,8 @@ describe("CommentTree", () => {
         wrapper.find(ShareTooltip).map(R.identity),
         flattenCommentTree(comments)
       ).forEach(([toolTip, comment]) => {
-        const { url, hideSocialButtons } = toolTip.props()
+        const { url, hideSocialButtons, objectType } = toolTip.props()
+        assert.equal(objectType, "comment")
         assert.equal(url, absolutizeURL(permalinkFunc(comment.id)))
         assert.equal(hideSocialButtons, isPrivateChannel)
       })

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -8,6 +8,7 @@ import moment from "moment"
 
 import TruncatedText from "./TruncatedText"
 import Embedly from "./Embedly"
+import ShareTooltip from "./ShareTooltip"
 
 import { LearningResourceRow } from "./LearningResourceCard"
 import { PaginatedUserListItems } from "./UserListItems"
@@ -15,8 +16,10 @@ import {
   LR_TYPE_BOOTCAMP,
   LR_TYPE_PROGRAM,
   LR_TYPE_VIDEO,
+  LR_PRIVATE,
   platforms,
-  platformLogos
+  platformLogos,
+  readableLearningResources
 } from "../lib/constants"
 import {
   bestRun,
@@ -28,7 +31,11 @@ import {
   hasCourseList,
   isUserList
 } from "../lib/learning_resources"
-import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+import {
+  defaultResourceImageURL,
+  embedlyThumbnail,
+  learningResourcePermalink
+} from "../lib/url"
 import { capitalize, emptyOrNil, languageName } from "../lib/util"
 import { SEARCH_LIST_UI, searchResultToLearningResource } from "../lib/search"
 
@@ -276,6 +283,21 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
           </div>
         </div>
       </div>
+      {isUserList(object.object_type) &&
+      object.privacy_level === LR_PRIVATE ? null : (
+          <div className="elr-share">
+            <ShareTooltip
+              url={learningResourcePermalink(object)}
+              objectType={readableLearningResources[object.object_type]}
+              placement="topLeft"
+            >
+              <div className="share-contents">
+                <i className="material-icons reply">reply</i>
+              Share
+              </div>
+            </ShareTooltip>
+          </div>
+        )}
       {hasCourseList(object.object_type) && !emptyOrNil(object.items) ? (
         <ListItemsSection
           title="Learning Resources in this Program"

--- a/static/js/components/ShareTooltip.js
+++ b/static/js/components/ShareTooltip.js
@@ -15,7 +15,8 @@ import { setSnackbarMessage } from "../actions/ui"
 type HelperProps = {
   url: string,
   hideSocialButtons?: boolean,
-  setSnackbarMessage: Function
+  setSnackbarMessage: Function,
+  objectType?: string
 }
 
 export class ShareTooltipHelper extends React.Component<HelperProps> {
@@ -37,11 +38,13 @@ export class ShareTooltipHelper extends React.Component<HelperProps> {
   }
 
   render() {
-    const { url, hideSocialButtons } = this.props
+    const { url, hideSocialButtons, objectType } = this.props
 
     return (
       <div className="tooltip">
-        <div className="tooltip-text">Share a link to this post:</div>
+        <div className="tooltip-text">
+          {`Share a link to this ${objectType || "post"}:`}
+        </div>
         <input ref={this.input} readOnly value={url} />
         <div className="bottom-row">
           {hideSocialButtons ? null : (
@@ -74,13 +77,14 @@ const ConnectedShareTooltipHelper = connect(
 type Props = {
   url: string,
   hideSocialButtons?: boolean,
-  children: Array<React$Element<any>> | React$Element<any>
+  children: Array<React$Element<any>> | React$Element<any>,
+  placement?: string
 }
 
-export default function ShareTooltip({ children, ...props }: Props) {
+export default function ShareTooltip({ children, placement, ...props }: Props) {
   return (
     <Tooltip
-      placement="top"
+      placement={placement || "top"}
       trigger={["click"]}
       overlay={() => <ConnectedShareTooltipHelper {...props} />}
     >

--- a/static/js/components/ShareTooltip_test.js
+++ b/static/js/components/ShareTooltip_test.js
@@ -78,6 +78,24 @@ describe("ShareTooltip", () => {
     })
   })
 
+  it("should have a little flavor text ", () => {
+    const wrapper = renderShareTooltipHelper()
+    assert.equal(
+      wrapper.find(".tooltip-text").text(),
+      "Share a link to this post:"
+    )
+  })
+
+  it("should accept an optional object type prop", () => {
+    const wrapper = renderShareTooltipHelper({
+      objectType: "thingamajig"
+    })
+    assert.equal(
+      wrapper.find(".tooltip-text").text(),
+      "Share a link to this thingamajig:"
+    )
+  })
+
   it("should hide buttons, if hideSocialButtons === true", () => {
     const wrapper = renderShareTooltipHelper({ hideSocialButtons: true })
     ;[FacebookShareButton, LinkedinShareButton, TwitterShareButton].forEach(

--- a/static/js/hooks/learning_resources.js
+++ b/static/js/hooks/learning_resources.js
@@ -1,0 +1,13 @@
+// @flow
+import { useLocation } from "react-router-dom"
+import qs from "query-string"
+
+export function useLRDrawerParams() {
+  const { search } = useLocation()
+  const { drawerObjectID, drawerObjectType } = qs.parse(search)
+
+  return {
+    objectId:   drawerObjectID,
+    objectType: drawerObjectType
+  }
+}

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -161,3 +161,11 @@ export const similarResourcesURL = "/api/v0/similar/"
 
 export const userListIndexURL = "/learn/lists/"
 export const userListDetailURL = (id: number) => `/learn/lists/${id}`
+
+export const learningResourcePermalink = (object: Object) =>
+  absolutizeURL(
+    `${COURSE_URL}${toQueryString({
+      drawerObjectID:   object.id,
+      drawerObjectType: object.object_type
+    })}`
+  )

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -27,9 +27,12 @@ import {
   getNextParam,
   channelSearchURL,
   SITE_SEARCH_URL,
-  COURSE_URL
+  COURSE_URL,
+  learningResourcePermalink
 } from "./url"
 import { makePost } from "../factories/posts"
+import { makeLearningResource } from "../factories/learning_resources"
+import { LR_TYPE_ALL } from "../lib/constants"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {
@@ -294,6 +297,20 @@ describe("url helper functions", () => {
     it("should return the channel search URL", () => {
       const channelName = "name"
       assert.equal(channelSearchURL(channelName), `/c/${channelName}/search/`)
+    })
+  })
+
+  describe("learningResourcePermalink", () => {
+    LR_TYPE_ALL.forEach(objectType => {
+      it(`learningResourcePermalink should return a good link for ${objectType}`, () => {
+        const object = makeLearningResource(objectType)
+        assert.equal(
+          learningResourcePermalink(object),
+          `${window.location.origin}/learn/?drawerObjectID=${
+            object.id
+          }&drawerObjectType=${object.object_type}`
+        )
+      })
     })
   })
 })

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -1,7 +1,7 @@
 // @flow
-import React from "react"
+import React, { useEffect } from "react"
 import { useRequest } from "redux-query-react"
-import { useSelector } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
 import { Link } from "react-router-dom"
 
 import CourseCarousel from "../components/CourseCarousel"
@@ -32,6 +32,8 @@ import {
 } from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
 import { PHONE, TABLET, DESKTOP } from "../lib/constants"
+import { useLRDrawerParams } from "../hooks/learning_resources"
+import { pushLRHistory } from "../actions/ui"
 
 type Props = {|
   history: Object
@@ -60,6 +62,20 @@ export default function CourseIndexPage({ history }: Props) {
     isFinishedNew &&
     isFinishedFavorites &&
     isFinishedVideos
+
+  const dispatch = useDispatch()
+  const { objectId, objectType } = useLRDrawerParams()
+
+  useEffect(() => {
+    if (objectId && objectType) {
+      dispatch(
+        pushLRHistory({
+          objectId,
+          objectType
+        })
+      )
+    }
+  }, [])
 
   return (
     <BannerPageWrapper>

--- a/static/js/pages/CourseIndexPage_test.js
+++ b/static/js/pages/CourseIndexPage_test.js
@@ -26,6 +26,8 @@ import {
   makeVideo
 } from "../factories/learning_resources"
 import IntegrationTestHelper from "../util/integration_test_helper"
+import { LR_TYPE_COURSE } from "../lib/constants"
+import * as lrHooks from "../hooks/learning_resources"
 
 describe("CourseIndexPage", () => {
   let featuredCourses,
@@ -35,7 +37,8 @@ describe("CourseIndexPage", () => {
     render,
     helper,
     courseLists,
-    favorites
+    favorites,
+    paramsStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -88,6 +91,11 @@ describe("CourseIndexPage", () => {
       .withArgs(userListApiURL.toString())
       .returns(queryListResponse([]))
     render = helper.configureReduxQueryRenderer(CourseIndexPage)
+
+    paramsStub = helper.sandbox.stub(lrHooks, "useLRDrawerParams").returns({
+      objectId:   null,
+      objectType: null
+    })
   })
 
   afterEach(() => {
@@ -169,5 +177,19 @@ describe("CourseIndexPage", () => {
     helper.handleRequestStub.withArgs(favoritesURL).returns({})
     const { wrapper } = await render()
     assert.equal(wrapper.find("CarouselLoading").length, 4)
+  })
+
+  it("should open the drawer if sharing URL params present", async () => {
+    paramsStub.returns({
+      objectId:   1,
+      objectType: LR_TYPE_COURSE
+    })
+    const { store } = await render()
+    const [entry] = store.getState().ui.LRDrawerHistory
+    assert.deepEqual(entry, {
+      objectId:   1,
+      objectType: LR_TYPE_COURSE,
+      runId:      undefined
+    })
   })
 })

--- a/static/scss/learning-resource-drawer.scss
+++ b/static/scss/learning-resource-drawer.scss
@@ -92,6 +92,24 @@
   }
 }
 
+.elr-share {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 25px 20px 0;
+
+  .share-contents {
+    display: flex;
+    align-items: center;
+    color: $course-blue;
+    cursor: pointer;
+
+    i {
+      transform: scaleX(-1);
+      font-size: 30px;
+    }
+  }
+}
+
 .expanded-learning-resource-list {
   padding-bottom: 5px;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

closes #2435

#### What's this PR do?

this PR sets us up for allowing the user to share learning resources via a link. There are two components:

- on the learning home page we now look for URL params on startup which, if present, are used to open the learning resource drawer
- in the learning resource drawer there is now a "share" button, which opens a little popup (the same one we use for posts and comments) which has the URL for the course home page with the right URL parameters in it.

#### How should this be manually tested?

make sure that different learning resources work right! all learning resources should be supported.

#### Screenshots (if appropriate)

![Screenshot from 2020-01-06 13-56-26](https://user-images.githubusercontent.com/6207644/71841589-c8773900-308d-11ea-9ad5-794e716890d9.png)
![Screenshot from 2020-01-06 13-59-56](https://user-images.githubusercontent.com/6207644/71841624-d4fb9180-308d-11ea-93f3-f3f89d1eb133.png)



