### PR TITLE
Fix a few typos in tests

### DIFF
--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -47,7 +47,7 @@ def test_create_url_post_existing_meta(
     LinkMetaFactory.create(url=link_url, thumbnail=thumbnail)
     url = reverse("post-list", kwargs={"channel_name": channel.name})
     resp = user_client.post(url, {"title": "url title 🐨", "url": link_url})
-    assert embedly_stub.not_called()
+    embedly_stub.assert_not_called()
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.json() == {
         "title": "url title 🐨",
@@ -98,7 +98,7 @@ def test_post_create_post_new_meta(
     )
     url = reverse("post-list", kwargs={"channel_name": channel.name})
     user_client.post(url, {"title": "url title 🐨", "url": link_url})
-    assert embedly_stub.called_with(link_url)
+    embedly_stub.assert_called_with(link_url)
     assert LinkMeta.objects.filter(url=link_url).first() is not None
 
 
@@ -116,7 +116,7 @@ def test_post_create_post_no_thumbnail(
     )
     url = reverse("post-list", kwargs={"channel_name": channel.name})
     user_client.post(url, {"title": "url title 🐨", "url": link_url})
-    assert embedly_stub.called_once()
+    embedly_stub.assert_called_once_with(link_url)
     assert LinkMeta.objects.filter(url=url).first() is None
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes some incorrectly used assert calls. Due to the mock, something like `assert mock.called_once()` will always return true, since `called_once` is assumed to be a mock function too.

#### How should this be manually tested?
Tests should pass
