### PR TITLE
ensure course cards have the same height

### DIFF
--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -67,7 +67,7 @@ const offeredBySearchLink = offeredBy => (
 )
 
 const Subtitle = ({ label, content }) => (
-  <div className="row subtitle">
+  <div className="subtitle">
     <div className="lr-subtitle">
       <span className="grey">{label}</span>
       {content}
@@ -173,20 +173,22 @@ export function LearningResourceDisplay(props: Props) {
         </div>
         {reordering ? null : (
           <>
-            {object.offered_by.length ? (
-              <Subtitle
-                content={offeredBySearchLink(object.offered_by.join(", "))}
-                label="Offered by - "
-              />
-            ) : null}
-            {object.topics.length > 0 ? (
-              <Subtitle
-                content={formatTopics(object.topics)}
-                label={`${
-                  object.topics.length === 1 ? "Subject" : "Subjects"
-                } - `}
-              />
-            ) : null}
+            <div className="row subtitles">
+              {object.offered_by.length ? (
+                <Subtitle
+                  content={offeredBySearchLink(object.offered_by.join(", "))}
+                  label="Offered by - "
+                />
+              ) : null}
+              {object.topics.length > 0 ? (
+                <Subtitle
+                  content={formatTopics(object.topics)}
+                  label={`${
+                    object.topics.length === 1 ? "Subject" : "Subjects"
+                  } - `}
+                />
+              ) : null}
+            </div>
             <div className="row availability-price-favorite">
               {cost ? (
                 <div className="price grey-surround">

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -33,6 +33,7 @@
   &.borderless {
     .lr-info {
       padding: 16px;
+      height: 160px;
     }
 
     .cover-image img {
@@ -62,6 +63,10 @@
         .video-play-icon {
           height: 75px;
         }
+      }
+
+      .lr-info {
+        height: 130px;
       }
     }
 
@@ -118,6 +123,37 @@
   .row {
     display: flex;
 
+    &.subtitles {
+      min-height: 45px;
+      flex-direction: column;
+
+      .subtitle {
+        margin-bottom: 5px;
+
+        .lr-subtitle {
+          font-size: 14px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          width: 100%;
+
+          a {
+            color: black;
+            margin-right: 10px;
+
+            &:hover {
+              color: black;
+              text-decoration: underline;
+            }
+          }
+
+          .grey {
+            color: $font-grey-light;
+          }
+        }
+      }
+    }
+
     &.resource-type {
       font-size: 13px;
       color: $font-grey-mid;
@@ -133,32 +169,6 @@
       color: black;
       font-weight: 500;
       cursor: pointer;
-    }
-
-    &.subtitle {
-      margin-bottom: 5px;
-
-      .lr-subtitle {
-        font-size: 14px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 100%;
-
-        a {
-          color: black;
-          margin-right: 10px;
-
-          &:hover {
-            color: black;
-            text-decoration: underline;
-          }
-        }
-
-        .grey {
-          color: $font-grey-light;
-        }
-      }
     }
 
     &.availability-price-favorite {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2496

#### What's this PR do?
Currently, when there is no course topic for a learning resource the course card is shorter in the grid view. This pr fixes that issue

#### How should this be manually tested?
Verify that the search page looks good in both grid view and list view. Verify that when the offered by and/or subject is missing for a learning resource, the course card is the same height as other course cards.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
