### PR TITLE
allow user to dismiss search text

### DIFF
--- a/static/js/components/CourseSearchbox.js
+++ b/static/js/components/CourseSearchbox.js
@@ -5,6 +5,7 @@ import { validationMessage } from "../lib/validation"
 
 type Props = {
   onChange?: Function,
+  onClear?: Function,
   value?: string,
   onSubmit: Function,
   validation?: ?string,
@@ -13,7 +14,15 @@ type Props = {
 }
 
 export default function CourseSearchbox(props: Props) {
-  const { onChange, value, onSubmit, validation, autoFocus, children } = props
+  const {
+    onChange,
+    onClear,
+    value,
+    onSubmit,
+    validation,
+    autoFocus,
+    children
+  } = props
 
   const [text, setText] = useState("")
 
@@ -44,6 +53,11 @@ export default function CourseSearchbox(props: Props) {
         >
           search
         </i>
+        {value ? (
+          <i className="material-icons clear-icon" onClick={onClear}>
+            clear
+          </i>
+        ) : null}
         {children}
       </div>
       {validationMessage(validation)}

--- a/static/scss/course-searchbox.scss
+++ b/static/scss/course-searchbox.scss
@@ -27,14 +27,22 @@
     i.material-icons {
       position: absolute;
       top: 12px;
-      right: 10px;
       font-size: 33px;
       cursor: pointer;
     }
 
+    i.search-icon {
+      left: 10px;
+      width: 50px;
+    }
+
+    i.clear-icon {
+      right: 10px;
+    }
+
     input.search-input {
       height: 100%;
-      padding-left: 20px;
+      padding-left: 50px;
       font-size: 20px;
       border-radius: 7px;
       border: none;


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
<img width="856" alt="Screen Shot 2020-01-09 at 11 33 59 AM" src="https://user-images.githubusercontent.com/1934992/72086926-bc7db800-32d5-11ea-8522-fd07bf4a6b0a.png">
<img width="325" alt="Screen Shot 2020-01-09 at 11 41 43 AM" src="https://user-images.githubusercontent.com/1934992/72086927-bd164e80-32d5-11ea-87c2-2b74ca29078b.png">
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2498

#### What's this PR do?
This PR adds an icon to dismiss search text from the search box on the learning resource search page when the search box is not empty. This clears the search results

#### How should this be manually tested?
Go to the learning resource search page. Verify that an X icon appears when there is text in the search box and clicking the icon clears both the search text and the search filter


