### PR TITLE
Improve ES performance by not validating connection for read operations

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,7 +75,8 @@
       "description": "Basic auth settings for connecting to Elasticsearch"
     },
     "ELASTICSEARCH_INDEX": {
-      "description": "Index to use on Elasticsearch"
+      "description": "Index to use on Elasticsearch",
+      "required": true
     },
     "ELASTICSEARCH_INDEXING_CHUNK_SIZE": {
       "description": "Chunk size to use for Elasticsearch indexing tasks",

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from fixtures.aws import *
 from fixtures.betamax import *
 from fixtures.common import *
+from fixtures.elasticsearch import *
 from fixtures.reddit import *
 from fixtures.users import *
 from open_discussions.exceptions import DoNotUseRequestException

--- a/fixtures/elasticsearch.py
+++ b/fixtures/elasticsearch.py
@@ -1,0 +1,17 @@
+"""Elasticsearch fixtures"""
+from types import SimpleNamespace
+
+import pytest
+
+from search.connection import configure_connections
+
+
+@pytest.fixture(autouse=True)
+def elasticsearch(mocker, settings):
+    """Fixture for mocking elasticsearch"""
+    settings.ELASTICSEARCH_URL = "test.elastic"
+    mock_get_connection = mocker.patch(
+        "elasticsearch_dsl.connections.Connections.get_connection", autospec=True
+    )
+    configure_connections()
+    yield SimpleNamespace(conn=mock_get_connection.return_value)

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -625,6 +625,8 @@ CACHES = {
 # Elasticsearch
 ELASTICSEARCH_DEFAULT_PAGE_SIZE = get_int("ELASTICSEARCH_DEFAULT_PAGE_SIZE", 6)
 ELASTICSEARCH_URL = get_string("ELASTICSEARCH_URL", None)
+if not ELASTICSEARCH_URL:
+    raise ImproperlyConfigured("Missing ELASTICSEARCH_URL")
 if get_string("HEROKU_PARENT_APP_NAME", None) is not None:
     ELASTICSEARCH_INDEX = get_string("HEROKU_APP_NAME", None)
 else:

--- a/open_discussions/settings_test.py
+++ b/open_discussions/settings_test.py
@@ -15,6 +15,7 @@ import semantic_version
 
 
 REQUIRED_SETTINGS = {
+    "ELASTICSEARCH_URL": "http://localhost:9300/",
     "ELASTICSEARCH_INDEX": "some_index",
     "MAILGUN_SENDER_DOMAIN": "mailgun.fake.domain",
     "MAILGUN_KEY": "fake_mailgun_key",

--- a/search/__init__.py
+++ b/search/__init__.py
@@ -1,0 +1,2 @@
+"""Search"""
+default_app_config = "search.apps.SearchAppConfig"

--- a/search/api.py
+++ b/search/api.py
@@ -19,7 +19,7 @@ from course_catalog.constants import PrivacyLevel
 from course_catalog.models import FavoriteItem
 from course_catalog.utils import get_list_items_by_resource
 from open_discussions.utils import extract_values
-from search.connection import get_conn, get_default_alias_name
+from search.connection import get_default_alias_name
 from search.constants import (
     ALIAS_ALL_INDICES,
     GLOBAL_DOC_TYPE,
@@ -247,7 +247,7 @@ def execute_search(*, user, query):
         dict: The Elasticsearch response dict
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
-    search = Search(index=index, using=get_conn())
+    search = Search(index=index)
     search.update_from_dict(query)
     search = _apply_general_query_filters(search, user)
     return search.execute().to_dict()
@@ -265,7 +265,7 @@ def execute_learn_search(*, user, query):
         dict: The Elasticsearch response dict
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
-    search = Search(index=index, using=get_conn())
+    search = Search(index=index)
     search.update_from_dict(query)
     search = _apply_learning_query_filters(search, user)
     return transform_results(search.execute().to_dict(), user)
@@ -354,7 +354,7 @@ def find_related_documents(*, user, post_id):
         dict: The Elasticsearch response dict
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
-    search = Search(index=index, using=get_conn())
+    search = Search(index=index)
     search = _apply_general_query_filters(search, user)
     search = search.query(
         MoreLikeThis(
@@ -382,7 +382,7 @@ def find_similar_resources(*, user, value_doc):
         dict: The Elasticsearch response dict
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
-    search = Search(index=index, using=get_conn())
+    search = Search(index=index)
     search = _apply_general_query_filters(search, user)
     search = search.filter(Q("terms", object_type=LEARNING_RESOURCE_TYPES))
     search = search.query(
@@ -424,7 +424,7 @@ def get_similar_topics(value_doc, num_topics, min_term_freq, min_doc_freq):
             list of topic values
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
-    search = Search(index=index, using=get_conn())
+    search = Search(index=index)
     search = search.filter(Q("terms", object_type=[COURSE_TYPE]))
     search = search.query(
         MoreLikeThis(

--- a/search/apps.py
+++ b/search/apps.py
@@ -1,0 +1,14 @@
+"""Search app config"""
+from django.apps import AppConfig
+
+
+class SearchAppConfig(AppConfig):
+    """Search app config"""
+
+    name = "search"
+
+    def ready(self):
+        """Application is ready"""
+        from search import connection
+
+        connection.configure_connections()

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -218,7 +218,7 @@ def clear_and_create_index(*, index_name=None, skip_mapping=False, object_type=N
         raise ValueError(
             "A valid object type must be specified when clearing and creating an index"
         )
-    conn = get_conn(verify=False)
+    conn = get_conn()
     if conn.indices.exists(index_name):
         conn.indices.delete(index_name)
     index_create_data = {
@@ -265,7 +265,7 @@ def create_document(doc_id, data):
         doc_id (str): The ES document id
         data (dict): Full ES document data
     """
-    conn = get_conn(verify=True)
+    conn = get_conn()
     for alias in get_active_aliases(conn, [data["object_type"]]):
         conn.create(index=alias, doc_type=GLOBAL_DOC_TYPE, body=data, id=doc_id)
 
@@ -278,7 +278,7 @@ def delete_document(doc_id, object_type):
         doc_id (str): The ES document id
         object_type (str): The object type
     """
-    conn = get_conn(verify=True)
+    conn = get_conn()
     for alias in get_active_aliases(conn, [object_type]):
         try:
             conn.delete(index=alias, doc_type=GLOBAL_DOC_TYPE, id=doc_id)
@@ -306,7 +306,7 @@ def update_field_values_by_query(query, field_dict, object_types=None):
         params.update({new_param: field_value})
     if not object_types:
         object_types = VALID_OBJECT_TYPES
-    conn = get_conn(verify=True)
+    conn = get_conn()
     for alias in get_active_aliases(conn, object_types):
         es_response = conn.update_by_query(  # pylint: disable=unexpected-keyword-arg
             index=alias,
@@ -343,7 +343,7 @@ def _update_document_by_id(doc_id, body, object_type, *, retry_on_conflict=0):
         object_type (str): The object type to update (post, comment, etc)
         retry_on_conflict (int): Number of times to retry if there's a conflict (default=0)
     """
-    conn = get_conn(verify=True)
+    conn = get_conn()
     for alias in get_active_aliases(conn, [object_type]):
         try:
             conn.update(
@@ -545,7 +545,7 @@ def create_backing_index(object_type):
     Returns:
         str: The new backing index
     """
-    conn = get_conn(verify=False)
+    conn = get_conn()
 
     # Create new backing index for reindex
     new_backing_index = make_backing_index_name(object_type)
@@ -573,7 +573,7 @@ def switch_indices(backing_index, object_type):
         backing_index (str): The backing index of the reindex alias
         object_type (str): The object type for the index (post, comment, etc)
     """
-    conn = get_conn(verify=False)
+    conn = get_conn()
     actions = []
     old_backing_indexes = []
     default_alias = get_default_alias_name(object_type)

--- a/search/indexing_api_test.py
+++ b/search/indexing_api_test.py
@@ -63,7 +63,7 @@ def test_create_document(mocked_es, mocker, object_type):
     )
     create_document(doc_id, data)
     mock_get_aliases.assert_called_once_with(mocked_es.conn, [object_type])
-    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.get_conn.assert_called_once_with()
     mocked_es.conn.create.assert_any_call(
         index=object_type, doc_type=GLOBAL_DOC_TYPE, body=data, id=doc_id
     )
@@ -87,7 +87,7 @@ def test_update_field_values_by_query(
     }
     update_field_values_by_query(query, {field_name: field_value})
 
-    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.get_conn.assert_called_once_with()
     for alias in mocked_es.active_aliases:
         mocked_es.conn.update_by_query.assert_any_call(
             index=alias,
@@ -118,7 +118,7 @@ def test_update_document_with_partial(mocked_es, mocker, object_type):
     doc_id, data = ("doc_id", {"key1": "value1"})
     update_document_with_partial(doc_id, data, object_type)
     mock_get_aliases.assert_called_once_with(mocked_es.conn, [object_type])
-    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.get_conn.assert_called_once_with()
     mocked_es.conn.update.assert_called_once_with(
         index=object_type,
         doc_type=GLOBAL_DOC_TYPE,
@@ -166,7 +166,7 @@ def test_increment_document_integer_field(mocked_es):
     """
     doc_id, field_name, incr_amount = ("doc_id", "some_field_name", 1)
     increment_document_integer_field(doc_id, field_name, incr_amount, POST_TYPE)
-    mocked_es.get_conn.assert_called_once_with(verify=True)
+    mocked_es.get_conn.assert_called_once_with()
 
     for alias in mocked_es.active_aliases:
         mocked_es.conn.update.assert_any_call(
@@ -294,7 +294,7 @@ def test_create_backing_index(mocked_es, mocker, temp_alias_exists):
     assert create_backing_index(POST_TYPE) == backing_index
 
     get_conn_mock = mocked_es.get_conn
-    get_conn_mock.assert_called_once_with(verify=False)
+    get_conn_mock.assert_called_once_with()
     make_backing_index_mock.assert_called_once_with(POST_TYPE)
     clear_and_create_mock.assert_called_once_with(
         index_name=backing_index, object_type=POST_TYPE

--- a/tox.ini
+++ b/tox.ini
@@ -39,5 +39,6 @@ setenv =
     OPEN_DISCUSSIONS_BASE_URL=http://localhost:8063/
     MAILGUN_SENDER_DOMAIN=other.fake.site
     MAILGUN_KEY=fake_mailgun_key
+    ELASTICSEARCH_URL=http://localhost:9300/
     ELASTICSEARCH_INDEX=testindex
     INDEXING_API_USERNAME=mitodl


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2534 

#### What's this PR do?
This improves performance by removing extraneous requests to validate a connection. We end up making requests to validate that all of the indexes exist, but actually only assert that at least one exists, which isn't a particularly useful property because it doesn't really guarantee us anything.

I also noticed that `elasticsearch_dsl.connections` internally caches the connections which is the exact same thing `get_conn` is doing. So I moved configuration code into a `configure_connections` which is now called from the `ready()` function of the app. I modified `get_conn` to return the default connection and removed `get_conn` calls where the default behavior would've been to use the default connection anyway. That means only code dealing with the indicies APIs uses `get_conn` now.

#### How should this be manually tested?

- Go to the various search pages and verify they all still work
- You may or may not notice a performance gain locally between this branch and master 
- Verify reindexing works