### PR TITLE
fix scrollbar on post sort picker

### DIFF
--- a/static/scss/picker.scss
+++ b/static/scss/picker.scss
@@ -6,6 +6,10 @@
     align-items: center;
   }
 
+  .mdc-list {
+    overflow: hidden;
+  }
+
   .mdc-list-item {
     margin: 0 8px;
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2450

#### What's this PR do?

this just fixes an issue where on the post sort picker a scrollbar was showing up unnecessarily.

#### How should this be manually tested?

check out master, go to a channel page, see the scrollbar. then check out this branch and see it disappear! amazing!

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)

before:

![Screenshot from 2020-01-14 10-40-42](https://user-images.githubusercontent.com/6207644/72359928-312d6980-36bd-11ea-931a-9cc469319998.png)

after:

![Screenshot from 2020-01-14 11-00-19](https://user-images.githubusercontent.com/6207644/72359941-38ed0e00-36bd-11ea-9965-97618a37ab21.png)
