### PR TITLE
sort default results in search page

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -505,6 +505,19 @@ export const buildSuggestQuery = (text: string) => {
   return suggest
 }
 
+export const buildDefaultSort = () => {
+  return [
+    {
+      "runs.prices.price": {
+        missing: 0,
+        order:   "asc",
+        nested:  { path: "runs.prices" }
+      }
+    },
+    { created_on: { order: "desc" } }
+  ]
+}
+
 export const buildOrQuery = (
   builder: any,
   searchType: string,
@@ -612,6 +625,8 @@ export const buildLearnQuery = (
     if (!emptyOrNil(text)) {
       // $FlowFixMe: if we get this far, text is not null
       builder = builder.rawOption("suggest", buildSuggestQuery(text))
+    } else {
+      builder.rawOption("sort", buildDefaultSort())
     }
   }
   return builder.build()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2494

#### What's this PR do?
Sorts results in the search page by price and date added when there is not text search set.

#### How should this be manually tested?
Recreate your elasticsearch index, since created_on data is added for learning resources in this PR
 
Verify that search results with no text are sorted by price then created on
Verify that search results with text filters are not changed
