### PR TITLE
fix card height for the learning path reorder UI

### DIFF
--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -42,6 +42,12 @@
   }
 
   &.list-view {
+    &:not(.reordering) {
+      .lr-info {
+        height: 130px;
+      }
+    }
+
     .card-contents {
       display: flex;
 
@@ -63,10 +69,6 @@
         .video-play-icon {
           height: 75px;
         }
-      }
-
-      .lr-info {
-        height: 130px;
       }
     }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2543

#### What's this PR do?

this fixes the height for the "list view" learning resource cards when reordering. I think this was an unintentional effect of https://github.com/mitodl/open-discussions/pull/2532

#### How should this be manually tested?

go to the edit page for a learning path. reorder it, and confirm that the cards get shorter when you're in the reordering mode.

#### Screenshots (if appropriate)

before:

![Screenshot from 2020-01-16 09-42-33](https://user-images.githubusercontent.com/6207644/72535767-17b82900-3847-11ea-89cf-2551756c5f38.png)

after:

![Screenshot from 2020-01-16 10-01-14](https://user-images.githubusercontent.com/6207644/72535785-21da2780-3847-11ea-8a35-6b8305643ed9.png)

![Screenshot from 2020-01-16 10-01-30](https://user-images.githubusercontent.com/6207644/72535806-2bfc2600-3847-11ea-8e2d-0f2c00071685.png)
