### PR TITLE
user list -> learning list

### DIFF
--- a/static/js/components/UserListFormDialog.js
+++ b/static/js/components/UserListFormDialog.js
@@ -98,8 +98,8 @@ export default function UserListFormDialog(props: Props) {
                   value={LR_TYPE_USERLIST}
                 />
                 <label htmlFor="type-list">
-                  <span className="header">Custom List</span>
-                  Create a custom list of any of our learning resources
+                  <span className="header">Learning List</span>
+                  Create a list of any of our learning resources
                 </label>
               </div>
               <div className="option">

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -91,7 +91,7 @@ export const readableLearningResources = {
   [LR_TYPE_COURSE]:        "Course",
   [LR_TYPE_BOOTCAMP]:      "Bootcamp",
   [LR_TYPE_PROGRAM]:       "Program",
-  [LR_TYPE_USERLIST]:      "User List",
+  [LR_TYPE_USERLIST]:      "Learning List",
   [LR_TYPE_LEARNINGPATH]:  "Learning Path",
   [LR_TYPE_VIDEO]:         "Video",
   [FAVORITES_PSEUDO_LIST]: "Favorites"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -153,7 +153,7 @@ export const filterRunsByAvailability = (
 export const resourceLabel = (resource: string) => {
   switch (resource) {
   case LR_TYPE_USERLIST:
-    return "User Lists"
+    return "Learning Lists"
   case LR_TYPE_LEARNINGPATH:
     return "Learning Paths"
   default:

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -95,7 +95,7 @@ describe("Course utils", () => {
     [LR_TYPE_COURSE, "Courses"],
     [LR_TYPE_BOOTCAMP, "Bootcamps"],
     [LR_TYPE_PROGRAM, "Programs"],
-    [LR_TYPE_USERLIST, "User Lists"],
+    [LR_TYPE_USERLIST, "Learning Lists"],
     [LR_TYPE_LEARNINGPATH, "Learning Paths"]
   ].forEach(([searchType, facetText]) => {
     it(`facet text should be ${facetText} for resource type ${searchType}`, () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2546

#### What's this PR do?

changes the copy from 'User List' to 'Learning List'

#### How should this be manually tested?

make sure that the artist formerly known as 'user list' is no longer known as 'user list'

I think I got every occurence but I could have missed one.


#### Screenshots (if appropriate)

![Screenshot from 2020-01-16 14-09-44](https://user-images.githubusercontent.com/6207644/72555190-1f3cf980-386a-11ea-884f-b14cba392fe1.png)
![Screenshot from 2020-01-16 14-09-21](https://user-images.githubusercontent.com/6207644/72555192-1f3cf980-386a-11ea-9dc2-5c015b7e5718.png)
![Screenshot from 2020-01-16 14-09-08](https://user-images.githubusercontent.com/6207644/72555193-1f3cf980-386a-11ea-920e-e297bdddebe1.png)
