### PR TITLE
prevent course title from being cut off

### DIFF
--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -170,7 +170,7 @@ export function LearningResourceDisplay(props: Props) {
           {readableLearningResources[object.object_type]}
         </div>
         <div className="row course-title" onClick={showResourceDrawer}>
-          <Dotdotdot clamp={2}>{object.title}</Dotdotdot>
+          <Dotdotdot clamp={3}>{object.title}</Dotdotdot>
         </div>
         {reordering ? null : (
           <>

--- a/static/scss/course-carousel.scss
+++ b/static/scss/course-carousel.scss
@@ -6,7 +6,7 @@
   }
 
   .slider-list {
-    max-height: 365px;
+    max-height: 385px;
   }
 
   .title {

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -33,7 +33,7 @@
   &.borderless {
     .lr-info {
       padding: 16px;
-      height: 160px;
+      min-height: 160px;
     }
 
     .cover-image img {
@@ -44,7 +44,7 @@
   &.list-view {
     &:not(.reordering) {
       .lr-info {
-        height: 130px;
+        min-height: 130px;
       }
     }
 
@@ -169,7 +169,7 @@
     &.course-title {
       margin: 10px 0;
       margin-top: 2px;
-      min-height: 40px;
+      min-height: 62px;
       font-size: 18px;
       color: black;
       font-weight: 500;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

**List View**
<img width="826" alt="Screen Shot 2020-01-17 at 1 03 01 PM" src="https://user-images.githubusercontent.com/1934992/72635169-2f1c1280-392a-11ea-9f2c-bb86e734e594.png">

**Grid View:**
<img width="1079" alt="Screen Shot 2020-01-17 at 1 03 48 PM" src="https://user-images.githubusercontent.com/1934992/72635185-3b07d480-392a-11ea-8ee0-31801af3c04d.png">
<img width="828" alt="Screen Shot 2020-01-17 at 1 16 52 PM" src="https://user-images.githubusercontent.com/1934992/72635821-b918ab00-392b-11ea-8083-b6542b4a038b.png">


  - [x] Mobile width screenshots
**List View**
<img width="370" alt="Screen Shot 2020-01-17 at 1 03 16 PM" src="https://user-images.githubusercontent.com/1934992/72635171-2fb4a900-392a-11ea-8fa3-716dca646cf2.png">

**Grid View**
<img width="361" alt="Screen Shot 2020-01-17 at 1 04 23 PM" src="https://user-images.githubusercontent.com/1934992/72635191-40fdb580-392a-11ea-9262-93239b887ab6.png">
<img width="364" alt="Screen Shot 2020-01-17 at 1 05 10 PM" src="https://user-images.githubusercontent.com/1934992/72635192-40fdb580-392a-11ea-8561-fac77645c007.png">

  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2539

#### What's this PR do?
For the list view:
The course card should expand so that the course title can take up as many lines as needed

For the grid view:
The course card should have space for three lines for the title (instead of two as was the case previously). This accommodates almost all the titles with a full page window. After three lines the course title is cut off.

#### How should this be manually tested?
Go to the list and grid views for search results and make sure that the course title looks good
