### PR TITLE
add created_on to elasticsearch

### DIFF
--- a/search/serializers.py
+++ b/search/serializers.py
@@ -391,6 +391,7 @@ class ESCourseSerializer(ESModelSerializer, LearningResourceSerializer):
             "published",
             "offered_by",
             "runs",
+            "created_on",
         ]
 
         read_only_fields = fields
@@ -419,6 +420,7 @@ class ESBootcampSerializer(ESCourseSerializer):
             "published",
             "offered_by",
             "runs",
+            "created_on",
         ]
 
         read_only_fields = fields
@@ -443,6 +445,7 @@ class ESProgramSerializer(ESModelSerializer, LearningResourceSerializer):
             "topics",
             "runs",
             "offered_by",
+            "created_on",
         ]
 
         read_only_fields = fields
@@ -506,6 +509,7 @@ class ESVideoSerializer(ESModelSerializer, LearningResourceSerializer):
             "published",
             "runs",
             "offered_by",
+            "created_on",
         ]
 
         read_only_fields = fields

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -307,6 +307,7 @@ def test_es_course_serializer(offered_by):
             ],
             "published": True,
             "offered_by": list(course.offered_by.values_list("name", flat=True)),
+            "created_on": course.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         },
     )
 
@@ -333,6 +334,7 @@ def test_es_program_serializer(offered_by):
                 for program_run in program.runs.order_by("-best_start_date")
             ],
             "offered_by": list(program.offered_by.values_list("name", flat=True)),
+            "created_on": program.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         },
     )
 


### PR DESCRIPTION
#### What's this PR do?
This adds created_on to the elasticsearch index so that there is no downtime when
https://github.com/mitodl/open-discussions/pull/2541
is merged.

#### How should this be manually tested?
Recreate your elasticsearch index. Make sure it does not break