### PR TITLE
change URL params for LR sharing to be more readable

### DIFF
--- a/static/js/hooks/learning_resources.js
+++ b/static/js/hooks/learning_resources.js
@@ -4,10 +4,11 @@ import qs from "query-string"
 
 export function useLRDrawerParams() {
   const { search } = useLocation()
-  const { drawerObjectID, drawerObjectType } = qs.parse(search)
+  // eslint-disable-next-line camelcase
+  const { lr_id, type } = qs.parse(search)
 
   return {
-    objectId:   drawerObjectID,
-    objectType: drawerObjectType
+    objectId:   lr_id,
+    objectType: type
   }
 }

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -165,7 +165,7 @@ export const userListDetailURL = (id: number) => `/learn/lists/${id}`
 export const learningResourcePermalink = (object: Object) =>
   absolutizeURL(
     `${COURSE_URL}${toQueryString({
-      drawerObjectID:   object.id,
-      drawerObjectType: object.object_type
+      lr_id: object.id,
+      type:  object.object_type
     })}`
   )

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -306,9 +306,9 @@ describe("url helper functions", () => {
         const object = makeLearningResource(objectType)
         assert.equal(
           learningResourcePermalink(object),
-          `${window.location.origin}/learn/?drawerObjectID=${
-            object.id
-          }&drawerObjectType=${object.object_type}`
+          `${window.location.origin}/learn/?lr_id=${object.id}&type=${
+            object.object_type
+          }`
         )
       })
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

https://trello.com/c/tnkosY3B/36-user-friendly-sharing-urls

#### What's this PR do?

just changes the name of some URL params.

#### How should this be manually tested?

test out the sharing feature and make sure it works as before. The params should now be `lr_id` and `type` instead of `drawerObjectID` and `drawerObjectType`


#### Screenshots (if appropriate)

![Screenshot from 2020-01-21 11-25-44](https://user-images.githubusercontent.com/6207644/72822854-ca6dfa00-3c40-11ea-8285-726370112e62.png)
