### PR TITLE
auto open the "Similar..." panel for some learning resources

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS: false */
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import R from "ramda"
 import striptags from "striptags"
 import { AllHtmlEntities } from "html-entities"
@@ -137,6 +137,19 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
     selectedRun && selectedRun.instructors
       ? selectedRun.instructors.map(instructor => getInstructorName(instructor))
       : []
+
+  useEffect(
+    () => {
+      if (
+        object &&
+        !isUserList(object.object_type) &&
+        object.object_type !== LR_TYPE_PROGRAM
+      ) {
+        setShowSimilar(true)
+      }
+    },
+    [object]
+  )
 
   return (
     <React.Fragment>

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -212,8 +212,14 @@ describe("ExpandedLearningResourceDisplay", () => {
         .find(".expanded-learning-resource-list")
         .at(listIdx)
       assert.ok(similarResourcesDiv.exists())
-      assert.equal(similarResourcesDiv.find("LearningResourceRow").length, 0)
-      similarResourcesDiv.find("i").simulate("click")
+
+      if (
+        isUserList(object.object_type) ||
+        object.object_type === LR_TYPE_PROGRAM
+      ) {
+        assert.equal(similarResourcesDiv.find("LearningResourceRow").length, 0)
+        similarResourcesDiv.find("i").simulate("click")
+      }
       assert.equal(
         wrapper
           .find(".expanded-learning-resource-list")
@@ -411,8 +417,9 @@ describe("ExpandedLearningResourceDisplay", () => {
       )
       assert.equal(
         wrapper
-          .find(".attach_money")
-          .closest(".info-row")
+          .find(".lr-metadata")
+          .find(".info-row")
+          .at(0)
           .find(".value")
           .text(),
         "$25.50"


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

https://trello.com/c/3pwqV3ev/38-open-similar-learning-resources-by-default-for-videos-courses-in-drawer

#### What's this PR do?

this PR basically makes it so that the "Similar Learning Resources" panel is always open for all learning resources except for lists and programs. We want to leave those two out because they have the course list, so it's gets a little crowded for them.

#### How should this be manually tested?

Confirm that for user lists, learning paths, and programs the "Similar..." panel is not open by default. Then confirm that it is for everything else.