### PR TITLE
improve elasticsearch scoring between indexes

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -31,6 +31,7 @@ from search.constants import (
 
 RELATED_POST_RELEVANT_FIELDS = ["plain_text", "post_title", "author_id", "channel_name"]
 SIMILAR_RESOURCE_RELEVANT_FIELDS = ["title", "short_description"]
+SEARCH_TYPE = "dfs_query_then_fetch"
 
 
 def gen_post_id(reddit_obj_id):
@@ -266,6 +267,7 @@ def execute_learn_search(*, user, query):
     """
     index = get_default_alias_name(ALIAS_ALL_INDICES)
     search = Search(index=index)
+    search = search.params(search_type=SEARCH_TYPE)
     search.update_from_dict(query)
     search = _apply_learning_query_filters(search, user)
     return transform_results(search.execute().to_dict(), user)

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -241,6 +241,7 @@ def test_execute_learn_search(user, elasticsearch):
         },
         doc_type=[],
         index=[get_default_alias_name(ALIAS_ALL_INDICES)],
+        search_type="dfs_query_then_fetch",
     )
 
 
@@ -368,6 +369,7 @@ def test_execute_learn_search_anonymous(elasticsearch):
         },
         doc_type=[],
         index=[get_default_alias_name(ALIAS_ALL_INDICES)],
+        search_type="dfs_query_then_fetch",
     )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2545

#### What's this PR do?
Currently bootcamps don't show up in the search because elasticsearch normalizes document scores individually for each index by default and the results for bootcamps are off because there are not a lot of items in the index.

This PR sets a setting for elasticsearch to normalize document scores accross indexes.
Elasticsearch documentation: https://www.elastic.co/blog/understanding-query-then-fetch-vs-dfs-query-then-fetch

#### How should this be manually tested?
Search for "MIT Sports Entrepreneurship Bootcamp" without quotes. Ensure that the Sports Entrepreneurship Bootcamp is the first result. Also this and other searches should not be slower than usual.