### PR TITLE
Chunk up OCW import task and use rapidjson to speed up processing

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -408,9 +408,13 @@ def sync_ocw_course(
         is_published = False
 
     log.info("Digesting %s...", course_prefix)
-    course, run = digest_ocw_course(
-        course_json, last_modified, is_published, course_prefix
-    )
+    try:
+        course, run = digest_ocw_course(
+            course_json, last_modified, is_published, course_prefix
+        )
+    except TypeError:
+        log.info("Course and run not returned, skipping")
+        return None
 
     if upload_to_s3 and is_published:
         try:
@@ -450,6 +454,8 @@ def sync_ocw_courses(*, course_prefixes, blacklist, force_overwrite, upload_to_s
     Sync OCW courses to the database
 
     Args:
+        course_prefixes (list of str): The course prefixes to process
+        blacklist (list of str): list of course ids to skip
         force_overwrite (bool): A boolean value to force the incoming course data to overwrite existing data
         upload_to_s3 (bool): If True, upload course media to S3
 

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -436,7 +436,7 @@ def sync_ocw_course(
             run.delete()
             raise
     course.published = (
-        Course.objects.get(id=course.id).runs.filter(published=True).count() > 0
+        Course.objects.get(id=course.id).runs.filter(published=True).exists()
     )
     course.save()
     if course.published:

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -435,7 +435,7 @@ def sync_ocw_course(
             )
             run.delete()
             raise
-    course.published = (
+    course.published = is_published or (
         Course.objects.get(id=course.id).runs.filter(published=True).exists()
     )
     course.save()

--- a/course_catalog/etl/ocw.py
+++ b/course_catalog/etl/ocw.py
@@ -1,8 +1,8 @@
 """OCW course catalog ETL"""
-import json
 import logging
 
 import boto3
+import rapidjson
 from django.conf import settings
 
 log = logging.getLogger()
@@ -52,5 +52,5 @@ def upload_mitx_course_manifest(courses):
     manifest = {"results": courses, "count": len(courses)}
 
     ocw_bucket = _get_ocw_learning_course_bucket()
-    ocw_bucket.put_object(Key="edx_courses.json", Body=json.dumps(manifest))
+    ocw_bucket.put_object(Key="edx_courses.json", Body=rapidjson.dumps(manifest))
     return True

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -79,7 +79,7 @@ def get_ocw_data(
                 upload_to_s3=upload_to_s3,
             )
             for prefixes in chunks(
-                ocw_courses, chunk_size=settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE
+                ocw_courses, chunk_size=settings.OCW_ITERATOR_CHUNK_SIZE
             )
         ]
     )

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -2,16 +2,24 @@
 course_catalog tasks
 """
 import logging
-import json
+
+import celery
+import rapidjson
 import requests
 import boto3
 from django.conf import settings
 
-from open_discussions.celery import app
+from course_catalog.utils import load_course_blacklist
 from course_catalog.constants import PlatformType
 from course_catalog.models import Course
-from course_catalog.api import sync_ocw_data, parse_bootcamp_json_data
+from course_catalog.api import (
+    parse_bootcamp_json_data,
+    generate_course_prefix_list,
+    sync_ocw_courses,
+)
 from course_catalog.etl import pipelines, youtube
+from open_discussions.celery import app
+from open_discussions.utils import chunks
 
 log = logging.getLogger(__name__)
 
@@ -23,8 +31,19 @@ def get_mitx_data():
 
 
 @app.task
+def get_ocw_courses(*, course_prefixes, blacklist, force_overwrite, upload_to_s3):
+    """Task to sync a batch of OCW courses"""
+    sync_ocw_courses(
+        course_prefixes=course_prefixes,
+        blacklist=blacklist,
+        force_overwrite=force_overwrite,
+        upload_to_s3=upload_to_s3,
+    )
+
+
+@app.task(bind=True)
 def get_ocw_data(
-    force_overwrite=False, upload_to_s3=True
+    self, force_overwrite=False, upload_to_s3=True
 ):  # pylint:disable=too-many-locals,too-many-branches
     """
     Task to sync OCW course data with database
@@ -39,7 +58,32 @@ def get_ocw_data(
     ):
         log.warning("Required settings missing for get_ocw_data")
         return
-    sync_ocw_data(force_overwrite=force_overwrite, upload_to_s3=upload_to_s3)
+
+    # get all the courses prefixes we care about
+    raw_data_bucket = boto3.resource(
+        "s3",
+        aws_access_key_id=settings.OCW_CONTENT_ACCESS_KEY,
+        aws_secret_access_key=settings.OCW_CONTENT_SECRET_ACCESS_KEY,
+    ).Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
+    ocw_courses = generate_course_prefix_list(raw_data_bucket)
+
+    # get a list of blacklisted course ids
+    blacklist = load_course_blacklist()
+
+    ocw_tasks = celery.group(
+        [
+            get_ocw_courses.si(
+                course_prefixes=prefixes,
+                blacklist=blacklist,
+                force_overwrite=force_overwrite,
+                upload_to_s3=upload_to_s3,
+            )
+            for prefixes in chunks(
+                ocw_courses, chunk_size=settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE
+            )
+        ]
+    )
+    raise self.replace(ocw_tasks)
 
 
 @app.task
@@ -64,7 +108,7 @@ def upload_ocw_master_json():
 
         s3_bucket.put_object(
             Key=s3_folder + f"/{course.course_id}_master.json",
-            Body=json.dumps(course.raw_json),
+            Body=rapidjson.dumps(course.raw_json),
             ACL="private",
         )
 

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -217,6 +217,21 @@ def test_get_ocw_overwrite(
     assert mock_digest.call_count == (1 if overwrite else 0)
 
 
+@mock_s3
+def test_get_ocw_typeerror(mocker, settings):
+    """Test that a course is skipped if digest_ocw_course returns None"""
+    setup_s3(settings)
+    mock_info_logger = mocker.patch("course_catalog.api.log.info")
+    mocker.patch("course_catalog.api.digest_ocw_course", return_value=None)
+    get_ocw_courses.delay(
+        course_prefixes=[TEST_PREFIX],
+        blacklist=[],
+        force_overwrite=True,
+        upload_to_s3=True,
+    )
+    mock_info_logger.assert_any_call("Course and run not returned, skipping")
+
+
 def test_get_ocw_data_no_settings(settings):
     """
     No data should be imported if OCW settings are missing

--- a/requirements.in
+++ b/requirements.in
@@ -41,6 +41,7 @@ psycopg2==2.8.3
 praw==4.5.1
 pyyaml==5.1.2
 python-dateutil
+python-rapidjson==0.9.1
 python3-saml==1.4.1
 pygithub==1.44.1
 pytube==9.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,6 +86,7 @@ pygithub==1.44.1
 pygments==2.2.0           # via ipython
 pyjwt==1.5.2              # via djangorestframework-jwt, pygithub, social-auth-core
 python-dateutil==2.6.0
+python-rapidjson==0.9.1
 python3-openid==3.1.0     # via social-auth-core
 python3-saml==1.4.1
 pytube==9.5.2


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2568

#### What's this PR do?
- Uses rapidjson to read/write JSON
- Checks if the course needs updating before parsing all the course JSON files.
- Chunks up the import task into multiple parallel celery tasks
- Sets course published status based on whatever runs currently exist.

#### How should this be manually tested?
If you haven't already imported all the OCW data and want to get this over with without waiting for 90K files to upload to S3 (this still takes a long time), run this:
- `manage.py backpopulate_ocw_data --skip-s3`

If you already have most/all of the OCW data, you can just run:
- `manage.py backpopulate_ocw_data`


#### Any background context you want to provide?
Running the import from scratch (no OCW courses present) is still going to take many hours to process all courses and upload their files.

If all courses are already imported, running time to check for changes is:
This branch: 515 seconds
Master:  ??? - I killed it after a few hours

#### What GIF best describes this PR or how it makes you feel?
![sloth](https://user-images.githubusercontent.com/187676/73464236-93889a00-434c-11ea-943a-3a208aaef728.gif)

