### PR TITLE
Additional index updates for default search

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -110,6 +110,9 @@ LEARNING_RESOURCE_TYPE = {
     "image_src": {"type": "keyword"},
     "topics": {"type": "keyword"},
     "offered_by": {"type": "keyword"},
+    "created": {"type": "date"},
+    "default_search_priority": {"type": "integer"},
+    "minimum_price": {"type": "scaled_float", "scaling_factor": 100},
     "runs": {
         "type": "nested",
         "properties": {
@@ -130,12 +133,16 @@ LEARNING_RESOURCE_TYPE = {
             "instructors": {"type": "text"},
             "prices": {
                 "type": "nested",
-                "properties": {"mode": {"type": "text"}, "price": {"type": "float"}},
+                "properties": {
+                    "mode": {"type": "text"},
+                    "price": {"type": "scaled_float", "scaling_factor": 100},
+                },
             },
             "image_src": {"type": "keyword"},
             "published": {"type": "boolean"},
             "availability": {"type": "keyword"},
             "offered_by": {"type": "keyword"},
+            "created": {"type": "date"},
         },
     },
 }
@@ -169,6 +176,9 @@ USER_LIST_OBJECT_TYPE = {
     "author": {"type": "keyword"},
     "privacy_level": {"type": "keyword"},
     "list_type": {"type": "keyword"},
+    "created": {"type": "date"},
+    "default_search_priority": {"type": "integer"},
+    "minimum_price": {"type": "scaled_float", "scaling_factor": 100},
 }
 
 VIDEO_OBJECT_TYPE = {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/open-discussions/issues/2494

#### What's this PR do?
I am breaking up the PR for the sorting order in the default search page into two PRs so there is no downtime when it is released. This PR adds `minimum_price` and `default_search_priority` to the elasticsearch index. https://github.com/mitodl/open-discussions/pull/2571
updates the search query.

#### How should this be manually tested?
Recreate your elasticsearch index. The script should not break and the course search UI should still look and work the same as before after it runs