### PR TITLE
Sort default search results

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -505,6 +505,14 @@ export const buildSuggestQuery = (text: string) => {
   return suggest
 }
 
+export const buildDefaultSort = () => {
+  return [
+    { minimum_price: { order: "asc" } },
+    { default_search_priority: { order: "desc" } },
+    { created: { order: "desc" } }
+  ]
+}
+
 export const buildOrQuery = (
   builder: any,
   searchType: string,
@@ -612,6 +620,8 @@ export const buildLearnQuery = (
     if (!emptyOrNil(text)) {
       // $FlowFixMe: if we get this far, text is not null
       builder = builder.rawOption("suggest", buildSuggestQuery(text))
+    } else if (facetClauses.length === 0 && R.equals(types, LR_TYPE_ALL)) {
+      builder = builder.rawOption("sort", buildDefaultSort())
     }
   }
   return builder.build()

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -22,10 +22,12 @@ import {
   searchResultToLearningResource,
   searchResultToPost,
   searchResultToProfile,
-  buildLearnQuery
+  buildLearnQuery,
+  buildDefaultSort
 } from "./search"
 import * as searchFuncs from "./search"
 import {
+  LR_TYPE_ALL,
   LR_TYPE_BOOTCAMP,
   LR_TYPE_COURSE,
   LR_TYPE_VIDEO,
@@ -685,6 +687,11 @@ describe("search functions", () => {
           sinon.assert.calledWith(stub, type)
         })
       })
+    })
+
+    it(`sorts the search results when there are no filters or text`, () => {
+      const query = buildLearnQuery(bodybuilder(), null, LR_TYPE_ALL, null)
+      assert.deepEqual(query.sort, buildDefaultSort())
     })
 
     //


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes https://github.com/mitodl/open-discussions/issues/2494

#### What's this PR do?
Sorts results in the search page by price, then resource type, then date added when there is not text search set. 

Courses and programs should come before videos and user lists in the search when they have the same cost

#### How should this be manually tested?
Recreate your elasticsearch index
Verify that search results with no text are sorted by price, then resource type , then created on
Verify that search results with text filters are not changed
