### PR TITLE
dedupe mitx courses

### DIFF
--- a/app.json
+++ b/app.json
@@ -47,6 +47,10 @@
       "description": "URL of a text file containing blacklisted course ids",
       "required": false
     },
+    "DUPLICATE_COURSES_URL": {
+      "description": "URL of a text file containing course ids that are duplicates of each other",
+      "required": false
+    },
     "BOOTCAMPS_URL": {
       "description": "URL to retrieve bootcamps data",
       "required": false

--- a/course_catalog/etl/deduplication.py
+++ b/course_catalog/etl/deduplication.py
@@ -1,0 +1,41 @@
+"""Functions to combine duplicate courses"""
+from course_catalog.constants import AvailabilityType
+
+
+def get_most_relevant_run(runs):
+    """
+    Helper function to determine the most relevant course run.
+
+    Args:
+        runs (QuerySet): a set of LearningResourseRun objects
+    Returns:
+        A LearningResourseRun object
+    """
+
+    # if there is a current run in the set pick it
+    most_relevant_run = next(
+        (run for run in runs if run.availability == AvailabilityType.current.value),
+        None,
+    )
+
+    if not most_relevant_run:
+        # if there a future runs in the set, pick the one with earliest start date
+        runs = runs.order_by("best_start_date")
+        most_relevant_run = next(
+            (
+                run
+                for run in runs
+                if run.availability
+                in [
+                    AvailabilityType.upcoming.value,
+                    AvailabilityType.starting_soon.value,
+                ]
+            ),
+            None,
+        )
+
+        if not most_relevant_run:
+            # get latest past run by start date
+            most_relevant_run = next((run for run in runs.reverse()))
+
+    return most_relevant_run

--- a/course_catalog/etl/deduplication_test.py
+++ b/course_catalog/etl/deduplication_test.py
@@ -1,0 +1,59 @@
+"""Tests for the deduplication ETL functions"""
+from datetime import datetime
+import pytest
+import pytz
+from course_catalog.etl.deduplication import get_most_relevant_run
+from course_catalog.constants import AvailabilityType
+from course_catalog.factories import LearningResourceRunFactory
+from course_catalog.models import LearningResourceRun
+
+
+@pytest.mark.django_db
+def test_get_most_relevant_run():
+    """Verify that most_relevant_run returns the correct run"""
+
+    most_relevant_run = LearningResourceRunFactory.create(
+        availability=AvailabilityType.archived.value,
+        best_start_date=datetime(2019, 10, 1, tzinfo=pytz.utc),
+        run_id="1",
+    )
+    LearningResourceRunFactory.create(
+        availability=AvailabilityType.archived.value,
+        best_start_date=datetime(2018, 10, 1, tzinfo=pytz.utc),
+        run_id="2",
+    )
+
+    assert (
+        get_most_relevant_run(LearningResourceRun.objects.filter(run_id__in=["1", "2"]))
+        == most_relevant_run
+    )
+
+    most_relevant_run = LearningResourceRunFactory.create(
+        availability=AvailabilityType.upcoming.value,
+        best_start_date=datetime(2017, 10, 1, tzinfo=pytz.utc),
+        run_id="3",
+    )
+
+    LearningResourceRunFactory.create(
+        availability=AvailabilityType.upcoming.value,
+        best_start_date=datetime(2020, 10, 1, tzinfo=pytz.utc),
+        run_id="4",
+    )
+
+    assert (
+        get_most_relevant_run(
+            LearningResourceRun.objects.filter(run_id__in=["1", "2", "3", "4"])
+        )
+        == most_relevant_run
+    )
+
+    most_relevant_run = LearningResourceRunFactory.create(
+        availability=AvailabilityType.current.value, run_id="5"
+    )
+
+    assert (
+        get_most_relevant_run(
+            LearningResourceRun.objects.filter(run_id__in=["1", "2", "3", "4", "5"])
+        )
+        == most_relevant_run
+    )

--- a/course_catalog/etl/pipelines.py
+++ b/course_catalog/etl/pipelines.py
@@ -1,5 +1,5 @@
 """ETL pipelines"""
-from toolz import compose, first, juxt
+from toolz import compose, first, juxt, curry
 
 from course_catalog.etl import (
     micromasters,
@@ -12,6 +12,7 @@ from course_catalog.etl import (
     youtube,
 )
 from course_catalog.etl.utils import log_exceptions
+from course_catalog.constants import PlatformType
 
 # A few notes on how this module works:
 #
@@ -22,13 +23,16 @@ from course_catalog.etl.utils import log_exceptions
 # - Each step is wrapped with log_exceptions and propogates and empty value forward (usually [])
 #   - This keeps exceptions from being raised all the way up and provides contextual data for the failure
 # - Additional specifics are commented on as needed
+load_programs = curry(loaders.load_programs)
 
 micromasters_etl = compose(
-    loaders.load_programs, micromasters.transform, micromasters.extract
+    load_programs(PlatformType.mitx.value), micromasters.transform, micromasters.extract
 )
 
 xpro_programs_etl = compose(
-    loaders.load_programs, xpro.transform_programs, xpro.extract_programs
+    load_programs(PlatformType.xpro.value),
+    xpro.transform_programs,
+    xpro.extract_programs,
 )
 xpro_courses_etl = compose(
     loaders.load_courses, xpro.transform_courses, xpro.extract_courses

--- a/course_catalog/etl/pipelines_test.py
+++ b/course_catalog/etl/pipelines_test.py
@@ -25,7 +25,10 @@ def test_micromasters_etl(mocker):
     mock_transform = mocker.patch(
         "course_catalog.etl.micromasters.transform", return_value=values
     )
-    mock_load_programs = mocker.patch("course_catalog.etl.loaders.load_programs")
+    mock_load_programs = mocker.Mock()
+    mocker.patch(
+        "course_catalog.etl.loaders.load_programs", return_value=mock_load_programs
+    )
 
     with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_programs):
         result = pipelines.micromasters_etl()
@@ -41,7 +44,11 @@ def test_xpro_programs_etl(mocker):
     """Verify that xpro programs etl pipeline executes correctly"""
     mock_extract = mocker.patch("course_catalog.etl.xpro.extract_programs")
     mock_transform = mocker.patch("course_catalog.etl.xpro.transform_programs")
-    mock_load_programs = mocker.patch("course_catalog.etl.loaders.load_programs")
+    mock_load_programs = mocker.Mock()
+
+    mocker.patch(
+        "course_catalog.etl.loaders.load_programs", return_value=mock_load_programs
+    )
 
     with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_programs):
         result = pipelines.xpro_programs_etl()

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -113,6 +113,7 @@ def setup_s3(settings):
 def test_get_mitx_data_valid(mocker):
     """Verify that the get_mitx_data invokes the MITx ETL pipeline"""
     mock_pipelines = mocker.patch("course_catalog.tasks.pipelines")
+
     get_mitx_data.delay()
     mock_pipelines.mitx_etl.assert_called_once_with()
 
@@ -393,6 +394,7 @@ def test_process_bootcamps(mock_get_bootcamps):
 def test_get_micromasters_data(mocker):
     """Verify that the get_micromasters_data invokes the MicroMasters ETL pipeline"""
     mock_pipelines = mocker.patch("course_catalog.tasks.pipelines")
+
     get_micromasters_data.delay()
     mock_pipelines.micromasters_etl.assert_called_once_with()
 

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 import pytz
 import requests
+import yaml
 from django.conf import settings
 
 from course_catalog.constants import ocw_edx_mapping, semester_mapping, PlatformType
@@ -175,4 +176,22 @@ def load_course_blacklist():
         response = requests.get(blacklist_url)
         response.raise_for_status()
         return [str(line, "utf-8") for line in response.iter_lines()]
+    return []
+
+
+def load_course_duplicates(platform):
+    """
+    Get a list of blacklisted course ids for a platform
+    Args:
+        platform (string): the platform for which course duplicates are needed
+    Returns:
+        list of lists of courses which are duplicates of each other
+    """
+    duplicates_url = settings.DUPLICATE_COURSES_URL
+    if duplicates_url is not None:
+        response = requests.get(duplicates_url)
+        response.raise_for_status()
+        duplicates_for_all_platforms = yaml.safe_load(response.text)
+        if platform in duplicates_for_all_platforms:
+            return duplicates_for_all_platforms[platform]
     return []

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -829,6 +829,8 @@ BLACKLISTED_COURSES_URL = get_string(
     "https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/courses.txt",
 )
 
+DUPLICATE_COURSES_URL = get_string("DUPLICATE_COURSES_URL", None)
+
 # Base URL for bootcamps data
 BOOTCAMPS_URL = get_string(
     "BOOTCAMPS_URL",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2219

#### What's this PR do?
This pr merges course runs from duplicate courses. The course with the most relevant run is displayed. The most relevant run is
1) A current run, if available
2) If there is no current run, the upcoming run that starts the soonest
3) If there is no current or upcoming  run, the archived run that started the most recently

#### How should this be manually tested?
Set 
DUPLICATE_COURSES_URL=https://gist.githubusercontent.com/abeglova/5dfb0717c6c54edc6e0f5e0d5287e620/raw/bc77456780bd66ee98bcf4fa1653e6ef03bcdccc/gistfile1.yml
in your .env file

run 
```
from course_catalog.tasks import *
get_mitx_data()
```
There should be only one MITx course with the following title and the search page should link to a run with the following start date:
"Discrete-Time Signal Processing" - Aug 20, 2016
"Foundations of Development Policy" - Feb 4, 2020
"Global Warming Science" - Feb 19, 2020 - also there should be no course with the title "Outdated - Global Warming Science"
"A Global History of Architecture"  - Dec 19, 2019
"The Challenges of Global Poverty"  -  Feb 4, 2020
"Just Money: Banking as if Society Mattered" - Nov 26, 2019