### PR TITLE
Upgrade to Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM python:3.6.8
+FROM python:3.7
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
 WORKDIR /tmp
 
-# Install packages and add repo needed for postgres 9.6
+# Install packages
 COPY apt.txt /tmp/apt.txt
-RUN echo deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main > /etc/apt/sources.list.d/pgdg.list
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
-
-# Add repo needed for postgres 9.6 and install it
-RUN apt-get update && apt-get install libpq-dev postgresql-client-9.6 -y
+RUN apt-get update && apt-get install libpq-dev postgresql-client -y
 
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -6,12 +6,7 @@ from django.http import HttpResponseRedirect
 from social_django.views import _do_login as login
 from social_core.backends.email import EmailAuth
 from social_core.exceptions import InvalidEmail, AuthException
-from social_core.utils import (
-    user_is_authenticated,
-    user_is_active,
-    partial_pipeline_data,
-    sanitize_redirect,
-)
+from social_core.utils import partial_pipeline_data, sanitize_redirect
 from rest_framework import serializers
 
 from authentication.exceptions import (
@@ -86,7 +81,7 @@ class SocialAuthSerializer(serializers.Serializer):
         backend = self.context["backend"]
         user = request.user
 
-        is_authenticated = user_is_authenticated(user)
+        is_authenticated = user.is_authenticated
         user = user if is_authenticated else None
 
         kwargs = {"request": request, "flow": flow}
@@ -115,7 +110,7 @@ class SocialAuthSerializer(serializers.Serializer):
                 SocialAuthState.STATE_SUCCESS, redirect_url=redirect_url
             )
         elif user:
-            if user_is_active(user):
+            if user.is_active:
                 social_user = user.social_user
 
                 login(backend, user, social_user)

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 django-cors-headers==2.1.0
 Django==2.2.10
 base36
-beautifulsoup4==4.6.0
+beautifulsoup4==4.8.2
 betamax
 betamax_serializers
 boto==2.39.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 amqp==2.5.2               # via kombu
 backcall==0.1.0           # via ipython
 base36==0.1.1
-beautifulsoup4==4.6.0
+beautifulsoup4==4.8.2
 betamax-serializers==0.2.0
 betamax==0.8.0
 billiard==3.6.2.0         # via celery
@@ -88,7 +88,7 @@ pycparser==2.18           # via cffi
 pygithub==1.44.1
 pygments==2.5.2           # via ipython
 pyjwt==1.5.2              # via djangorestframework-jwt, pygithub, social-auth-core
-python-dateutil==2.6.0
+python-dateutil==2.8.1
 python-rapidjson==0.9.1
 python3-openid==3.1.0     # via social-auth-core
 python3-saml==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.11.5              # via cairocffi
 chardet==3.0.4            # via requests
 cssselect2==0.2.1         # via cairosvg
 decorator==4.4.1          # via ipython, traitlets
-defusedxml==0.5.0         # via cairosvg, python3-openid, python3-saml, social-auth-core
+defusedxml==0.6.0         # via cairosvg, python3-openid, python3-saml, social-auth-core
 deprecated==1.2.7         # via pygithub
 dj-database-url==0.3.0
 dj-static==0.0.6

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.8
+python-3.7.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Changes the python version used in the docker container and runtime.txt to 3.7. Other package upgrades were made to fix deprecation warnings. Since we are using Django 2.x I think `user.is_authenticated` and `user.is_staff` should always be properties so we don't need to use the helper method from python-social-auth, which was causing deprecation warnings.

#### How should this be manually tested?
Go to Travis and verify that the output shows that Python tests are running, and that they are passing.

#### Any background context you want to provide?
We should remove tox and use pytest directly, similar to how we have it set up on mitxpro. See this PR: https://github.com/mitodl/mitxpro/pull/44
