### PR TITLE
Fixed bug with missing popular resources

### DIFF
--- a/interactions/serializers.py
+++ b/interactions/serializers.py
@@ -85,14 +85,15 @@ class PopularContentListSerializer(serializers.ListSerializer):
             for item in query:
                 fetched_items[(content_type_id, item.id)] = item
 
+        item_keys = [(item["content_type_id"], item["content_id"]) for item in data]
+
         # return the items in the correct order
         # we'll use the GenericForeignKeyFieldSerializer from course_catalog
         # since those will be the only favorited items for now
         return [
-            GenericForeignKeyFieldSerializer(
-                instance=fetched_items[(item["content_type_id"], item["content_id"])]
-            ).data
-            for item in data
+            GenericForeignKeyFieldSerializer(instance=fetched_items[item_key]).data
+            for item_key in item_keys
+            if item_key in fetched_items
         ]
 
 

--- a/interactions/serializers_test.py
+++ b/interactions/serializers_test.py
@@ -56,7 +56,8 @@ def test_content_type_interactions_serializer_invalid():
     assert serializer.errors["content_type"][0].code == "does_not_exist"
 
 
-def test_popular_content_serializer():
+@pytest.mark.parametrize("is_deleted", [True, False])
+def test_popular_content_serializer(is_deleted):
     """Test PopularContentSerializer"""
     resources = [
         VideoFactory.create(),
@@ -73,6 +74,11 @@ def test_popular_content_serializer():
         }
         for resource in resources
     ]
+
+    if is_deleted:
+        for resource in resources:
+            resource.delete()
+        resources = []
 
     # NOTE: we test PopularContentSerializer instead of PopularContentListSerializer
     #       because the list serializer is never used directly, but rather many=True tells


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2606 

#### What's this PR do?
This changes the popular content serializer to filter out items that no longer exist. This can happen when the resource gets deleted, but the interaction data doesn't get deleted before that table has a `GenericForeignKey` relation which does not support cascaded deletes from the referenced record.

#### How should this be manually tested?
- In `master`, ensure you have some popular items showing up in `/learn` or that you're seeing the 500 error from that response.
- If you're not seeing that error, delete a resource that shows up in that list so that you do
- Checkout this branch and verify the error is fixed
