### PR TITLE
Assign a score to child document results

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -618,7 +618,8 @@ export const buildLearnQuery = (
                     query:  text,
                     fields: ["content", "title", "short_description"]
                   }
-                }
+                },
+                score_mode: "avg"
               }
             }
             : null

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -845,7 +845,8 @@ describe("search functions", () => {
                 query:  text,
                 fields: ["content", "title", "short_description"]
               }
-            }
+            },
+            score_mode: "avg"
           }
         })
       }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2605 

#### What's this PR do?
Adds `{"score_mode": "avg"}` to the child document subquery of ES course searches.

#### How should this be manually tested?
Assuming you already have imported some OCW courses and content files:
 - search for `point of intersection` or some other phrase found in course pdf's or html pages.
 - check the `_score` values for the search results, they should not all equal `1` and they should always be returned in the same order.
 - as you scroll through the results you shouldn't see any dupes. 
