### PR TITLE
script to generate duplicate courses yaml

### DIFF
--- a/course_catalog/etl/deduplication.py
+++ b/course_catalog/etl/deduplication.py
@@ -1,5 +1,11 @@
 """Functions to combine duplicate courses"""
-from course_catalog.constants import AvailabilityType
+import yaml
+import requests
+from django.conf import settings
+from django.db.models import Count
+
+from course_catalog.constants import AvailabilityType, PlatformType
+from course_catalog.models import Course
 
 
 def get_most_relevant_run(runs):
@@ -39,3 +45,70 @@ def get_most_relevant_run(runs):
             most_relevant_run = next((run for run in runs.reverse()))
 
     return most_relevant_run
+
+
+def generate_duplicates_yaml():
+    """Generate updated list of mitx duplicates"""
+
+    platform = PlatformType.mitx.name
+    duplicates_url = settings.DUPLICATE_COURSES_URL
+
+    if duplicates_url is not None:
+        response = requests.get(duplicates_url)
+        response.raise_for_status()
+        existing_duplicates_for_all_platforms = yaml.safe_load(response.text)
+    else:
+        existing_duplicates_for_all_platforms = {}
+
+    if platform in existing_duplicates_for_all_platforms:
+        desired_course_ids_from_existing_duplicate_file = [
+            group["course_id"]
+            for group in existing_duplicates_for_all_platforms[platform]
+        ]
+    else:
+        desired_course_ids_from_existing_duplicate_file = []
+
+    duplicate_titles = (
+        Course.objects.values_list("title", flat=True)
+        .annotate(Count("id"))
+        .filter(id__count__gt=1)
+        .filter(platform=platform)
+    )
+    duplicate_courses = (
+        Course.objects.filter(title__in=[title for title in duplicate_titles])
+        .annotate(Count("offered_by"))
+        .values("course_id", "title", "offered_by__count")
+        .order_by("title")
+    )
+    duplicate_course_groups = [
+        [course for course in duplicate_courses if course["title"] == title]
+        for title in duplicate_titles
+    ]
+
+    output_for_platform = []
+    for group in duplicate_course_groups:
+        # The sort sets the first course id in the group to, in order of priority
+        # 1) The current desired course id in the duplicate_courses.yml config file if any
+        # 2) The course with multiple offered_by values if any. Micromasters courses are offered by both micromasters and mitx
+
+        group.sort(
+            key=lambda course: [
+                course["course_id"] in desired_course_ids_from_existing_duplicate_file,
+                course["offered_by__count"],
+            ],
+            reverse=True,
+        )
+        duplicate_course_ids = [course["course_id"] for course in group]
+        course_id = group[0]["course_id"]
+        title = group[0]["title"]
+        output_for_platform.append(
+            {
+                "duplicate_course_ids": duplicate_course_ids,
+                "course_id": course_id,
+                "title": title,
+            }
+        )
+
+    output = {platform: output_for_platform}
+
+    return yaml.dump(output)

--- a/course_catalog/management/commands/print_course_duplicates_yaml.py
+++ b/course_catalog/management/commands/print_course_duplicates_yaml.py
@@ -1,0 +1,13 @@
+"""Management command for uploading master json data for OCW courses"""
+from django.core.management import BaseCommand
+
+from course_catalog.etl.deduplication import generate_duplicates_yaml
+
+
+class Command(BaseCommand):
+    """Print course duplicates yaml"""
+
+    help = "Print course duplicates yaml"
+
+    def handle(self, *args, **options):
+        self.stdout.write(generate_duplicates_yaml())


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2611

#### What's this PR do?
This pr creates a script to generate and print updated duplicate course yaml

#### How should this be manually tested?
Set DUPLICATE_COURSES_URL=https://gist.githubusercontent.com/abeglova/5dfb0717c6c54edc6e0f5e0d5287e620/raw in your .env file

Run
```
docker-compose run web ./manage.py print_course_duplicates_yaml
```

Verify that duplicate courses yaml is generated and printed in the terminal and that the `course_id` values from the DUPLICATE_COURSES_URL are preserved in the new yaml file

