### PR TITLE
Redirect discussions.odl.mit.edu to open.mit.edu

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -51,6 +51,12 @@ http {
     }
 
     server {
+        server_name discussions.odl.mit.edu;
+        listen <%= ENV["PORT"] %>;
+        return 301 https://open.mit.edu$request_uri;
+    }
+
+    server {
         listen <%= ENV["PORT"] %> default_server;
         server_name _;
         root /app;


### PR DESCRIPTION

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

https://trello.com/c/PrRZFPAx/60-redirect-discussionsodlmitedu-to-openmitedu

#### What's this PR do?

It will redirect requests on the old discussions.odl.mit.edu domain to their corresponding paths on open.mit.edu.

Users may encounter old discussions.odl.mit.edu links to private channels. When they try to access them, the "next" login flow fails and, even though they can log in with micromasters, they don't end up on the correct page (whether a post or channel).

#### How should this be manually tested?

I think we can probably test it in CI or staging by using `curl` and setting the `Host` HTTP header to `discussions.odl.mit.edu`. Another way would be to add an entry in one's `hosts` file to fake `discussions.odl.mitl.edu`. In either case, we'd be looking for redirect response.

