### PR TITLE
Fix error reporting when OCWSerializer is invalid

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -144,7 +144,7 @@ def digest_ocw_course(master_json, last_modified, is_published, course_prefix=""
         if not run_serializer.is_valid():
             log.error(
                 "OCW LearningResourceRun %s is not valid: %s",
-                master_json.get("key"),
+                master_json.get("uid"),
                 run_serializer.errors,
             )
             return


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2617 

#### What's this PR do?
Inserts the correct attribute value in the error message, and adds a test for that message.

#### How should this be manually tested?
N/A

