### PR TITLE
refactor course search state to be driven off of URL

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": "eslint-config-mitodl",
+  "rules": {
+      "no-prototype-builtins": [0]
+  },
   "settings": {
     "react": {
       "version": "16.4.0",

--- a/static/js/components/CourseFilterDrawer_test.js
+++ b/static/js/components/CourseFilterDrawer_test.js
@@ -1,26 +1,49 @@
 // @flow
 import React from "react"
 import { mount } from "enzyme"
-import { createSandbox } from "sinon"
+import sinon, { createSandbox } from "sinon"
 import { assert } from "chai"
 
-import CourseFilterDrawer from "./CourseFilterDrawer"
+import CourseFilterDrawer, { facetDisplayMap } from "./CourseFilterDrawer"
 
 import * as utilHooks from "../hooks/util"
 import { DESKTOP, PHONE, TABLET } from "../lib/constants"
 
 describe("CourseFilterDrawer", () => {
+  let clearAllFiltersStub,
+    toggleFacetStub,
+    mergeFacetOptionsStub,
+    onUpdateFacetsStub,
+    sandbox,
+    useDeviceCategoryStub
+
   const render = (props = {}) =>
     mount(
-      <CourseFilterDrawer {...props}>
-        <div className="child-child-child" />
-      </CourseFilterDrawer>
+      <CourseFilterDrawer
+        activeFacets={{}}
+        clearAllFilters={clearAllFiltersStub}
+        toggleFacet={toggleFacetStub}
+        mergeFacetOptions={mergeFacetOptionsStub}
+        onUpdateFacets={onUpdateFacetsStub}
+        {...props}
+      />
     )
 
-  let sandbox, useDeviceCategoryStub
+  const activeFacets = {
+    type:         ["course"],
+    topics:       ["Physics"],
+    availability: ["nextWeek"],
+    cost:         ["free"],
+    offered_by:   ["mitx"]
+  }
 
   beforeEach(() => {
     sandbox = createSandbox()
+    clearAllFiltersStub = sandbox.stub()
+    toggleFacetStub = sandbox.stub()
+    mergeFacetOptionsStub = sandbox.stub()
+    onUpdateFacetsStub = sandbox.stub()
+
     useDeviceCategoryStub = sandbox
       .stub(utilHooks, "useDeviceCategory")
       .returns(DESKTOP)
@@ -30,18 +53,13 @@ describe("CourseFilterDrawer", () => {
     sandbox.restore()
   })
 
-  it("should render the children on desktop", () => {
-    const wrapper = render()
-    assert.ok(wrapper.find(".child-child-child"))
-  })
-
   //
   ;[TABLET, PHONE].forEach(deviceCategory => {
     it(`should render an open control by default when ${deviceCategory}`, () => {
       useDeviceCategoryStub.returns(deviceCategory)
       const wrapper = render()
       assert.ok(wrapper.find(".filter-controls").exists())
-      assert.isNotOk(wrapper.find(".child-child-child").exists())
+      assert.isNotOk(wrapper.find("FilterDisplay").exists())
     })
   })
 
@@ -51,7 +69,7 @@ describe("CourseFilterDrawer", () => {
       useDeviceCategoryStub.returns(deviceCategory)
       const wrapper = render()
       wrapper.find(".filter-controls").simulate("click")
-      assert.ok(wrapper.find(".child-child-child").exists())
+      assert.ok(wrapper.find("FilterDisplay").exists())
     })
   })
 
@@ -61,9 +79,60 @@ describe("CourseFilterDrawer", () => {
       useDeviceCategoryStub.returns(deviceCategory)
       const wrapper = render()
       wrapper.find(".filter-controls").simulate("click")
-      assert.ok(wrapper.find(".child-child-child").exists())
+      assert.ok(wrapper.find("FilterDisplay").exists())
       wrapper.find(".controls i").simulate("click")
-      assert.isNotOk(wrapper.find(".child-child-child").exists())
+      assert.isNotOk(wrapper.find("FilterDisplay").exists())
+    })
+  })
+
+  describe("FilterDisplay", () => {
+    it("should show 'Clear All' if filters active", () => {
+      const wrapper = render({
+        activeFacets: {
+          topic: ["Physics"]
+        }
+      })
+      const clearBtn = wrapper.find(".clear-all-filters")
+      assert.ok(clearBtn.exists())
+      clearBtn.simulate("click")
+      sinon.assert.called(clearAllFiltersStub)
+    })
+
+    it("should create SearchFilters", () => {
+      const wrapper = render({
+        activeFacets
+      })
+
+      facetDisplayMap.map(([name, title, labelFn], idx) => {
+        const searchFilter = wrapper.find("SearchFilter").at(idx)
+
+        assert.equal(searchFilter.prop("title"), title)
+        assert.equal(searchFilter.prop("value"), activeFacets[name][0])
+        assert.equal(searchFilter.prop("labelFunction"), labelFn)
+        searchFilter.prop("clearFacet")()
+
+        sinon.assert.calledWith(
+          toggleFacetStub,
+          name,
+          activeFacets[name][0],
+          false
+        )
+      })
+    })
+
+    it("should render SearchFacets", () => {
+      const wrapper = render({
+        activeFacets
+      })
+
+      facetDisplayMap.map(([name, title, labelFn], idx) => {
+        const searchFacet = wrapper.find("SearchFacet").at(idx)
+        assert.equal(searchFacet.prop("title"), title)
+        assert.equal(searchFacet.prop("name"), name)
+        assert.equal(searchFacet.prop("onUpdate"), onUpdateFacetsStub)
+        assert.equal(searchFacet.prop("currentlySelected"), activeFacets[name])
+        assert.equal(searchFacet.prop("labelFunction"), labelFn)
+      })
     })
   })
 })

--- a/static/js/components/CourseSearchbox.js
+++ b/static/js/components/CourseSearchbox.js
@@ -15,13 +15,13 @@ type Props = {
 
 export default function CourseSearchbox(props: Props) {
   const {
+    autoFocus,
+    children,
     onChange,
     onClear,
-    value,
     onSubmit,
     validation,
-    autoFocus,
-    children
+    value
   } = props
 
   const [text, setText] = useState("")

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -121,11 +121,11 @@ export type SortParam = {
 }
 
 export type SearchParams = {
-  type:              ?string|?Array<string>,
-  text:              ?string,
-  from:              number,
-  size:              number,
-  channelName:       ?string,
+  type?:              ?string|?Array<string>,
+  text?:              ?string,
+  from?:              number,
+  size?:              number,
+  channelName?:       ?string,
   facets?:           Map<string, Array<string>>,
   sort?:             SortParam,
 }

--- a/static/js/lib/course_search.js
+++ b/static/js/lib/course_search.js
@@ -1,0 +1,54 @@
+// @flow
+import _ from "lodash"
+import qs from "query-string"
+
+import { toArray } from "../lib/util"
+
+const urlParamToArray = param => _.union(toArray(param) || [])
+
+type URLSearchParams = {
+  text: string,
+  activeFacets: {
+    type: Array<string>,
+    offered_by: Array<string>,
+    topics: Array<string>,
+    cost: Array<string>,
+    availability: Array<string>
+  }
+}
+
+type Loc = {
+  search: string
+}
+
+export const deserializeSearchParams = (location: Loc): URLSearchParams => {
+  const { type, o, t, c, a, q } = qs.parse(location.search)
+
+  return {
+    text:         q,
+    activeFacets: {
+      type:         urlParamToArray(type),
+      offered_by:   urlParamToArray(o),
+      topics:       urlParamToArray(t),
+      cost:         urlParamToArray(c),
+      availability: urlParamToArray(a)
+    }
+  }
+}
+
+export const serializeSearchParams = ({
+  text,
+  activeFacets
+}: Object): string => {
+  // eslint-disable-next-line camelcase
+  const { type, offered_by, topics, availability, cost } = activeFacets
+
+  return qs.stringify({
+    q: text || undefined,
+    type,
+    o: offered_by,
+    t: topics,
+    a: availability,
+    c: cost
+  })
+}

--- a/static/js/lib/course_search_test.js
+++ b/static/js/lib/course_search_test.js
@@ -1,0 +1,196 @@
+import { assert } from "chai"
+
+import { deserializeSearchParams, serializeSearchParams } from "./course_search"
+
+describe("course search library", () => {
+  describe("deserializeSearchParams", () => {
+    it("should deserialize text from the URL", () => {
+      assert.deepEqual(
+        deserializeSearchParams({ search: "q=The Best Course" }),
+        {
+          activeFacets: {
+            availability: [],
+            cost:         [],
+            offered_by:   [],
+            topics:       [],
+            type:         []
+          },
+          text: "The Best Course"
+        }
+      )
+    })
+
+    it("should deserialize availability", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "a=next3Months" }), {
+        activeFacets: {
+          availability: ["next3Months"],
+          cost:         [],
+          offered_by:   [],
+          topics:       [],
+          type:         []
+        },
+        text: undefined
+      })
+    })
+
+    it("should deserialize cost", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "c=paid" }), {
+        activeFacets: {
+          availability: [],
+          cost:         ["paid"],
+          offered_by:   [],
+          topics:       [],
+          type:         []
+        },
+        text: undefined
+      })
+    })
+
+    it("should deserialize offered by", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "o=MITx" }), {
+        activeFacets: {
+          availability: [],
+          cost:         [],
+          offered_by:   ["MITx"],
+          topics:       [],
+          type:         []
+        },
+        text: undefined
+      })
+    })
+
+    it("should deserialize topics from the URL", () => {
+      assert.deepEqual(
+        deserializeSearchParams({
+          search:
+            "t=Science&t=Physics&t=Chemistry&t=Computer%20Science&t=Electronics"
+        }),
+        {
+          activeFacets: {
+            availability: [],
+            cost:         [],
+            offered_by:   [],
+            topics:       [
+              "Science",
+              "Physics",
+              "Chemistry",
+              "Computer Science",
+              "Electronics"
+            ],
+            type: []
+          },
+          text: undefined
+        }
+      )
+    })
+
+    it("should deserialize type from the URL", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "type=course" }), {
+        activeFacets: {
+          availability: [],
+          cost:         [],
+          offered_by:   [],
+          topics:       [],
+          type:         ["course"]
+        },
+        text: undefined
+      })
+    })
+
+    it("should ignore unknown params", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "eeee=beeeeeep" }), {
+        activeFacets: {
+          availability: [],
+          cost:         [],
+          offered_by:   [],
+          topics:       [],
+          type:         []
+        },
+        text: undefined
+      })
+    })
+  })
+
+  describe("serializeSearchParams", () => {
+    it("should serialize text to URL", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          text:         "my search text",
+          activeFacets: {}
+        }),
+        "q=my%20search%20text"
+      )
+    })
+
+    it("should not serialize empty text string", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          text:         "",
+          activeFacets: {}
+        }),
+        ""
+      )
+    })
+
+    it("should serialize topics", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            topics: [
+              "Science",
+              "Physics",
+              "Chemistry",
+              "Computer Science",
+              "Electronics"
+            ]
+          }
+        }),
+        "t=Science&t=Physics&t=Chemistry&t=Computer%20Science&t=Electronics"
+      )
+    })
+
+    it("should serialize cost", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            cost: ["paid"]
+          }
+        }),
+        "c=paid"
+      )
+    })
+
+    it("should serialize offered by", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            offered_by: ["MITx"]
+          }
+        }),
+        "o=MITx"
+      )
+    })
+
+    it("should serialize availability to URL", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            availability: ["next3Months"]
+          }
+        }),
+        "a=next3Months"
+      )
+    })
+
+    it("should serialize type to the URL", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            type: ["course"]
+          }
+        }),
+        "type=course"
+      )
+    })
+  })
+})

--- a/static/js/pages/admin/EditChannelAppearancePage_test.js
+++ b/static/js/pages/admin/EditChannelAppearancePage_test.js
@@ -231,7 +231,7 @@ describe("EditChannelAppearancePage", () => {
         sinon.assert.calledOnce(helper.updateChannelStub)
         const channelUpdateArg = helper.updateChannelStub.firstCall.args[0]
         assert.equal(
-          channelUpdateArg.hasOwnProperty("title"), // eslint-disable-line no-prototype-builtins
+          channelUpdateArg.hasOwnProperty("title"),
           expectIncludeTitle
         )
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2333

#### What's this PR do?

this PR basically refactors how we store the search state for the course search page so that the params in the URL are the sole source of truth for the filters and so on.

right now in master these things are sort of stored in two places - in the URL bar and in the component state for the `CourseSearchPage` component. We have some sort of weird logic for syncing them, and for getting param values from the url bar on startup.

This makes it so that a few things (like incremental vs full-refresh searching) are driven off of values kept in component state while filters and all that stuff are driven purely off of the URL bar. I think this makes it simpler - hopefully you agree!

#### How should this be manually tested?

There should be no regressions in user experience or behavior on the course search page. things should work!

And definitely read through all the code to make sure it makes sense. It's a fairly involved refactor - I think I dotted all the 'i's and crossed the 't's but I easily could have missed a few :smiley: