### PR TITLE
raw_json should be write-only on LearningResourceRunSerializer

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -289,6 +289,7 @@ class LearningResourceRunSerializer(BaseCourseSerializer):
     class Meta:
         model = LearningResourceRun
         fields = "__all__"
+        extra_kwargs = {"raw_json": {"write_only": True}}
 
 
 class LearningResourceRunMixin(serializers.Serializer):

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -64,6 +64,7 @@ def test_serialize_courserun_related_models():
         instructors=CourseInstructorFactory.create_batch(2),
     )
     serializer = LearningResourceRunSerializer(courserun)
+    assert "raw_json" not in serializer.data
     assert len(serializer.data["prices"]) == 2
     for attr in ("mode", "price"):
         assert attr in serializer.data["prices"][0].keys()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Makes `raw_json` write-only in `LearningResourceRunSerializer`

#### How should this be manually tested?
Go to `http://od.odl.local:8063/api/v0/popular-content/` - the JSON should not include `raw_json` in the runs.