### PR TITLE
Log ProfileDoesNotExist exceptions when updating channel memberships

### DIFF
--- a/channels/membership_api.py
+++ b/channels/membership_api.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from channels.api import get_admin_api
 from channels.models import Channel
 from profiles.filters import UserFilter
+from profiles.models import Profile
 
 log = logging.getLogger()
 User = get_user_model()
@@ -31,7 +32,13 @@ def update_memberships_for_managed_channels(*, channel_ids=None, user_ids=None):
     if channel_ids:
         channels = channels.filter(id__in=channel_ids)
     for channel in channels:
-        update_memberships_for_managed_channel(channel, user_ids=user_ids)
+        try:
+            update_memberships_for_managed_channel(channel, user_ids=user_ids)
+        except Profile.DoesNotExist:
+            log.exception(
+                "Channel %s membership update failed due to missing profile",
+                channel.name,
+            )
 
 
 def update_memberships_for_managed_channel(channel, *, user_ids=None):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2694

#### What's this PR do?
Catches and logs a `ProfileDoeNotExist` exception for a channel when running `update_memberships_for_managed_channels` 

#### How should this be manually tested?
- Create a user without a profile or delete a user's existing profile
- Create a new `ChannelMembershipConfig` in django admin; add a moira list that includes the user, and select several managed channels to associate it with.
- Look for error messages about a missing profile for each selected channel in the console.