### PR TITLE
Updated /learn to have per-carousel loaders

### DIFF
--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -39,9 +39,31 @@ import { PHONE, TABLET, DESKTOP } from "../lib/constants"
 import { useLRDrawerParams } from "../hooks/learning_resources"
 import { pushLRHistory } from "../actions/ui"
 
+import type { LearningResourceSummary } from "../flow/discussionTypes"
+
 type Props = {|
   history: Object
 |}
+
+type CarouselSectionProps = {
+  title: string,
+  isFinished: boolean,
+  items: Array<LearningResourceSummary>
+}
+
+const CarouselSection = ({
+  title,
+  isFinished,
+  items
+}: CarouselSectionProps) => {
+  if (!isFinished) {
+    return <CarouselLoading />
+  }
+
+  return items.length !== 0 ? (
+    <CourseCarousel title={title} courses={items} />
+  ) : null
+}
 
 export default function CourseIndexPage({ history }: Props) {
   const [{ isFinished: isFinishedFeatured }] = useRequest(
@@ -63,14 +85,6 @@ export default function CourseIndexPage({ history }: Props) {
   const newVideos = useSelector(newVideosSelector)
   const favorites = useSelector(favoritesListSelector)
   const popularResources = useSelector(popularContentSelector)
-
-  const loaded =
-    isFinishedFeatured &&
-    isFinishedUpcoming &&
-    isFinishedNew &&
-    isFinishedFavorites &&
-    isFinishedVideos &&
-    isFinishedPopular
 
   const dispatch = useDispatch()
   const { objectId, objectType } = useLRDrawerParams()
@@ -118,40 +132,38 @@ export default function CourseIndexPage({ history }: Props) {
         </div>
       </ResponsiveWrapper>
       <Grid className="main-content one-column">
-        {loaded ? (
-          <Cell width={12}>
-            {favorites.length !== 0 ? (
-              <CourseCarousel title="Your Favorites" courses={favorites} />
-            ) : null}
-            {featuredCourses.length !== 0 ? (
-              <CourseCarousel
-                title="Featured Courses"
-                courses={featuredCourses}
-              />
-            ) : null}
-            <CourseCarousel title="New Courses" courses={newCourses} />
-            {popularResources.length !== 0 ? (
-              <CourseCarousel
-                title="Popular Learning Resources"
-                courses={popularResources}
-              />
-            ) : null}
-            <CourseCarousel
-              title="Upcoming Courses"
-              courses={upcomingCourses}
-            />
-            {newVideos.length !== 0 ? (
-              <CourseCarousel title="New Videos" courses={newVideos} />
-            ) : null}
-          </Cell>
-        ) : (
-          <Cell width={12}>
-            <CarouselLoading />
-            <CarouselLoading />
-            <CarouselLoading />
-            <CarouselLoading />
-          </Cell>
-        )}
+        <Cell width={12}>
+          <CarouselSection
+            title="Your Favorites"
+            isFinished={isFinishedFavorites}
+            items={favorites}
+          />
+          <CarouselSection
+            title="Featured Courses"
+            isFinished={isFinishedFeatured}
+            items={featuredCourses}
+          />
+          <CarouselSection
+            title="New Courses"
+            isFinished={isFinishedNew}
+            items={newCourses}
+          />
+          <CarouselSection
+            title="Popular Learning Resources"
+            isFinished={isFinishedPopular}
+            items={popularResources}
+          />
+          <CarouselSection
+            title="Upcoming Courses"
+            isFinished={isFinishedUpcoming}
+            items={upcomingCourses}
+          />
+          <CarouselSection
+            title="New Videos"
+            isFinished={isFinishedVideos}
+            items={newVideos}
+          />
+        </Cell>
       </Grid>
     </BannerPageWrapper>
   )

--- a/static/js/pages/CourseIndexPage_test.js
+++ b/static/js/pages/CourseIndexPage_test.js
@@ -203,10 +203,19 @@ describe("CourseIndexPage", () => {
     assert.equal(search, "?q=search%20term")
   })
 
-  it("should have a loading state", async () => {
-    helper.handleRequestStub.withArgs(favoritesURL).returns({})
-    const { wrapper } = await render()
-    assert.equal(wrapper.find("CarouselLoading").length, 4)
+  //
+  ;[
+    newVideosURL,
+    newCoursesURL,
+    popularContentUrl,
+    featuredCoursesURL,
+    favoritesURL
+  ].forEach(url => {
+    it(`should have a loading state for ${url}`, async () => {
+      helper.handleRequestStub.withArgs(favoritesURL).returns({})
+      const { wrapper } = await render()
+      assert.equal(wrapper.find("CarouselLoading").length, 1)
+    })
   })
 
   it("should open the drawer if sharing URL params present", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2690 

#### What's this PR do?
This switches the loading ui from a single set of loaders to a per-carousel loader layout.

#### How should this be manually tested?
Go to /learn, each loader should complete independently of each other rather than waiting for all requests to complete.