### PR TITLE
remove fuzzy search

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -554,9 +554,8 @@ export const buildChannelQuery = (
         should: [
           {
             multi_match: {
-              query:     text,
-              fields:    searchFields(type),
-              fuzziness: "AUTO"
+              query:  text,
+              fields: searchFields(type)
             }
           }
         ].filter(clause => clause !== null)

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -346,9 +346,8 @@ describe("search functions", () => {
         should: [
           {
             multi_match: {
-              query:     text,
-              fields:    fieldNames,
-              fuzziness: "AUTO"
+              query:  text,
+              fields: fieldNames
             }
           }
         ]


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2714

#### What's this PR do?
This PR removes the fuzzy search parameter from channel search queries. Fuzzy search produces results that are too broad. For example profiles matching "Curt" and "Murat" were returned in a search for "curated", which was de-stemmed to "curat" by elasticsearch

#### How should this be manually tested?
Create a new post titled "Outside the box"
Create a new post titled "I like foxes" 

Searching for "Fox" in http://localhost:8063/search/ should not return the second post but not the first.