### PR TITLE
Make frontend URL parsing more resilient

### DIFF
--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -122,8 +122,20 @@ export const COURSE_SEARCH_URL = "/learn/search"
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`
 
-export const urlHostname = (url: ?string) =>
-  url ? new URL(url).hostname.replace(/^www\.(.*\.\w)/i, "$1") : ""
+export const urlHostname = (url: ?string) => {
+  if (!url) {
+    return ""
+  }
+
+  if (!url.startsWith("https:") && !url.startsWith("http:")) {
+    url = `https://${url}`
+  }
+  try {
+    return new URL(url).hostname.replace(/^www\.(.*\.\w)/i, "$1")
+  } catch (_) {
+    return ""
+  }
+}
 
 export const getNextParam = (search: string) => qs.parse(search).next || "/"
 

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -211,7 +211,8 @@ describe("url helper functions", () => {
           "nytimes.com"
         ],
         ["http://www.org/Security", "www.org"],
-        ["http://www.www.org/Security", "www.org"]
+        ["http://www.www.org/Security", "www.org"],
+        ["www.mit.edu", "mit.edu"]
       ].forEach(([url, expectation]) => {
         assert.equal(urlHostname(url), expectation)
       })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2727

#### What's this PR do?
Changes URL hostname function to tolerate URLs which don't start with a https

#### How should this be manually tested?
Find a post. In the database change `post.url` to remove the `http` part at the beginning, leaving only `www.mit.edu` for example. Run `search.indexing_api.index_posts([post.id])`. Find a search phrase for the post. On master you should see the screen become blank with a console error when searching for that phrase, but on this PR it  should work fine.