### PR TITLE
Filter out blank/null moira list names

### DIFF
--- a/moira_lists/moira_api.py
+++ b/moira_lists/moira_api.py
@@ -76,7 +76,9 @@ def query_moira_lists(user):
         list_infos = moira.user_list_membership(
             moira_user.username, moira_user.type, max_return_count=100_000
         )
-        list_names = [list_info["listName"] for list_info in list_infos]
+        list_names = [
+            list_info["listName"] for list_info in list_infos if list_info["listName"]
+        ]
         return list_names
     except Exception as exc:  # pylint: disable=broad-except
         if "java.lang.NullPointerException" in str(exc):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #2730 

#### What's this PR do?
Filters out blank/null moira lists names in `moira_api.query_moira_lists()`

#### How should this be manually tested?
Sign up or log in as a user who is not on any moira lists.  If on master, there will be an exception in the celery logs and a moira list with a blank name will be created (delete it from the shell).  On this branch, there shouldn't be an exception and a blank moira list should not be created.