### PR TITLE
Suggested Terms in Channel Search

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -265,7 +265,7 @@ def execute_search(*, user, query):
     search = Search(index=index)
     search.update_from_dict(query)
     search = _apply_general_query_filters(search, user)
-    return search.execute().to_dict()
+    return _transform_search_results_suggest(search.execute().to_dict())
 
 
 def execute_learn_search(*, user, query):
@@ -284,6 +284,45 @@ def execute_learn_search(*, user, query):
     search.update_from_dict(query)
     search = _apply_learning_query_filters(search, user)
     return transform_results(search.execute().to_dict(), user)
+
+
+def _transform_search_results_suggest(search_result):
+    """
+    Transform suggest results from elasticsearch
+
+    Args:
+        search_result (dict): The results from ElasticSearch
+
+    Returns:
+        dict: The Elasticsearch response dict with transformed suggestions
+    """
+
+    es_suggest = search_result.pop("suggest", {})
+    if (
+        search_result.get("hits", {}).get("total", 0)
+        <= settings.ELASTICSEARCH_MAX_SUGGEST_HITS
+    ):
+        suggestion_dict = defaultdict(int)
+        suggestions = [
+            suggestion
+            for suggestion_list in extract_values(es_suggest, "options")
+            for suggestion in suggestion_list
+            if suggestion["collate_match"] is True
+        ]
+        for suggestion in suggestions:
+            suggestion_dict[suggestion["text"]] = (
+                suggestion_dict[suggestion["text"]] + suggestion["score"]
+            )
+        search_result["suggest"] = [
+            key
+            for key, value in sorted(
+                suggestion_dict.items(), key=lambda item: item[1], reverse=True
+            )
+        ][: settings.ELASTICSEARCH_MAX_SUGGEST_RESULTS]
+    else:
+        search_result["suggest"] = []
+
+    return search_result
 
 
 def transform_results(search_result, user):
@@ -330,30 +369,8 @@ def transform_results(search_result, user):
                 hit["_source"]["lists"] = get_list_items_by_resource(
                     user, object_type, object_id
                 )
-    es_suggest = search_result.pop("suggest", {})
-    if (
-        search_result.get("hits", {}).get("total", 0)
-        <= settings.ELASTICSEARCH_MAX_SUGGEST_HITS
-    ):
-        suggestion_dict = defaultdict(int)
-        suggestions = [
-            suggestion
-            for suggestion_list in extract_values(es_suggest, "options")
-            for suggestion in suggestion_list
-            if suggestion["collate_match"] is True
-        ]
-        for suggestion in suggestions:
-            suggestion_dict[suggestion["text"]] = (
-                suggestion_dict[suggestion["text"]] + suggestion["score"]
-            )
-        search_result["suggest"] = [
-            key
-            for key, value in sorted(
-                suggestion_dict.items(), key=lambda item: item[1], reverse=True
-            )
-        ][: settings.ELASTICSEARCH_MAX_SUGGEST_RESULTS]
-    else:
-        search_result["suggest"] = []
+
+    search_result = _transform_search_results_suggest(search_result)
     return search_result
 
 

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -76,6 +76,7 @@ BASE_OBJECT_TYPE = {
         "type": "text",
         "fields": {
             "english": {"type": "text", "analyzer": "english"},
+            "trigram": {"type": "text", "analyzer": "trigram"},
             "raw": {"type": "keyword"},
         },
     },
@@ -85,13 +86,15 @@ BASE_OBJECT_TYPE = {
 
 PROFILE_OBJECT_TYPE = {
     **BASE_OBJECT_TYPE,
-    "author_bio": ENGLISH_TEXT_FIELD,
+    "author_bio": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
     "author_channel_membership": {"type": "keyword"},
     "author_channel_join_data": {
         "type": "nested",
         "properties": {"name": {"type": "keyword"}, "joined": {"type": "date"}},
     },
     "author_avatar_medium": {"type": "keyword"},
+    "suggest_field1": {"type": "alias", "path": "author_name.trigram"},
+    "suggest_field2": {"type": "alias", "path": "author_bio.trigram"},
 }
 
 CONTENT_OBJECT_TYPE = {
@@ -99,14 +102,16 @@ CONTENT_OBJECT_TYPE = {
     "channel_name": {"type": "keyword"},
     "channel_title": ENGLISH_TEXT_FIELD,
     "channel_type": {"type": "keyword"},
-    "text": ENGLISH_TEXT_FIELD,
+    "text": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
     "score": {"type": "long"},
     "post_id": {"type": "keyword"},
-    "post_title": ENGLISH_TEXT_FIELD,
+    "post_title": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
     "post_slug": {"type": "keyword"},
     "created": {"type": "date"},
     "deleted": {"type": "boolean"},
     "removed": {"type": "boolean"},
+    "suggest_field1": {"type": "alias", "path": "post_title.trigram"},
+    "suggest_field2": {"type": "alias", "path": "text.trigram"},
 }
 
 

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -352,6 +352,55 @@ describe("search functions", () => {
           }
         ]
       }
+
+      const suggestQuery = {
+        suggest_field1: {
+          phrase: {
+            collate: {
+              params: {
+                field_name: "suggest_field1"
+              },
+              prune: true,
+              query: {
+                source: {
+                  match_phrase: {
+                    "{{field_name}}": "{{suggestion}}"
+                  }
+                }
+              }
+            },
+            confidence: 0.0001,
+            field:      "suggest_field1",
+            gram_size:  1,
+            max_errors: 3,
+            size:       5
+          }
+        },
+        suggest_field2: {
+          phrase: {
+            collate: {
+              params: {
+                field_name: "suggest_field2"
+              },
+              prune: true,
+              query: {
+                source: {
+                  match_phrase: {
+                    "{{field_name}}": "{{suggestion}}"
+                  }
+                }
+              }
+            },
+            confidence: 0.0001,
+            field:      "suggest_field2",
+            gram_size:  1,
+            max_errors: 3,
+            size:       5
+          }
+        },
+        text: "some text here"
+      }
+
       assert.deepEqual(buildSearchQuery({ type, text }), {
         query: {
           bool: {
@@ -377,7 +426,8 @@ describe("search functions", () => {
               }
             ]
           }
-        }
+        },
+        suggest: suggestQuery
       })
       sinon.assert.calledWith(stub, type)
     })
@@ -638,8 +688,8 @@ describe("search functions", () => {
               }
             },
             suggest: {
-              text:              text,
-              short_description: {
+              text:                        text,
+              "short_description.trigram": {
                 phrase: {
                   confidence: 0.0001,
                   field:      "short_description.trigram",
@@ -661,7 +711,7 @@ describe("search functions", () => {
                   }
                 }
               },
-              title: {
+              "title.trigram": {
                 phrase: {
                   confidence: 0.0001,
                   field:      "title.trigram",

--- a/static/js/pages/SearchPage_test.js
+++ b/static/js/pages/SearchPage_test.js
@@ -49,6 +49,7 @@ describe("SearchPage", () => {
         loaded: true,
         data:   {
           results:     searchResponse.hits.hits,
+          suggest:     ["test"],
           total:       searchResponse.hits.total,
           incremental: false
         }
@@ -104,6 +105,15 @@ describe("SearchPage", () => {
         result.post_id === upvotedPost.id ? upvotedPost : null
       )
     })
+  })
+
+  it("renders suggestion and changes search text if clicked", async () => {
+    const { inner } = await renderPage()
+    const suggestDiv = inner.find(".suggestion")
+    assert.isOk(suggestDiv.text().includes("Did you mean"))
+    assert.isOk(suggestDiv.text().includes("test"))
+    suggestDiv.find("a").simulate("click")
+    assert.equal(inner.state()["text"], "test")
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
<img width="1673" alt="Screen Shot 2020-04-03 at 3 41 58 PM" src="https://user-images.githubusercontent.com/1934992/78398853-cefc4a80-75c1-11ea-9d17-0a8b7f604800.png">
<img width="366" alt="Screen Shot 2020-04-03 at 3 42 23 PM" src="https://user-images.githubusercontent.com/1934992/78398859-d02d7780-75c1-11ea-8e64-6657913e0fd5.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2721

#### What's this PR do?
This PR updates the code to display suggestions in the channel search when there are no hits for a search term, similar to the ones in the learning resource search

#### How should this be manually tested?
Create 5-6 comments and posts with the word "robot" 
Go to http://localhost:8063/search/ and search for "robo". Verify that "robot"  is returned as a suggestion and clicking the link searches for "robot" .

Also verify that the channel search still works for terms for which there are hits and that the learning resource search still works as expected as well 
