### PR TITLE
unpublish userlists for removed playlists

### DIFF
--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -51,6 +51,7 @@ from course_catalog.models import (
     Playlist,
     VideoChannel,
     PlaylistVideo,
+    UserList,
     UserListItem,
     ContentFile,
 )
@@ -562,8 +563,22 @@ def test_load_playlist(mock_tasks):
 def test_load_playlists_unpublish():
     """Test load_playlists when a video/playlist gets unpublished"""
     channel = VideoChannelFactory.create()
-    playlist1 = PlaylistFactory.create(channel=channel, published=True)
-    playlist2 = PlaylistFactory.create(channel=channel, published=True)
+
+    userlist1 = UserListFactory.create()
+    userlist2 = UserListFactory.create()
+
+    playlist1 = PlaylistFactory.create(
+        channel=channel, published=True, has_user_list=True, user_list=userlist1
+    )
+    playlist2 = PlaylistFactory.create(
+        channel=channel, published=True, has_user_list=True, user_list=userlist2
+    )
+    playlist3 = PlaylistFactory.create(
+        channel=channel, published=True, has_user_list=True, user_list=None
+    )
+    playlist4 = PlaylistFactory.create(
+        channel=channel, published=True, has_user_list=False, user_list=None
+    )
 
     playlists_data = [
         {
@@ -577,8 +592,23 @@ def test_load_playlists_unpublish():
 
     playlist1.refresh_from_db()
     playlist2.refresh_from_db()
+    playlist3.refresh_from_db()
+    playlist4.refresh_from_db()
+
     assert playlist1.published is True
+    assert playlist1.has_user_list is True
+
     assert playlist2.published is False
+    assert playlist2.has_user_list is False
+
+    assert playlist3.published is False
+    assert playlist3.has_user_list is False
+
+    assert playlist4.published is False
+    assert playlist4.has_user_list is False
+
+    assert UserList.objects.filter(id=userlist1.id).count() == 1
+    assert UserList.objects.filter(id=userlist2.id).count() == 0
 
 
 def test_load_video_channels():

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -473,6 +473,9 @@ class PlaylistFactory(LearningResourceFactory):
 
     channel = factory.SubFactory("course_catalog.factories.VideoChannelFactory")
 
+    has_user_list = False
+    user_list = None
+
     class Meta:
         model = Playlist
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2725

#### What's this PR do?
This playlist deletes the userlist associated with the playlist when a playlist is removed from open-video-data

#### How should this be manually tested?
Set `OPEN_VIDEO_DATA_BRANCH=ab/test-playlist-delete`

Run `docker-compose  run web python manage.py backpopulate_youtube_data fetch --channel-id UCPonD0FH2WNnEXyTsYiLWMw` 

There should be a new user list called "Final Pitches" that is created

Set `OPEN_VIDEO_DATA_BRANCH=master`

Run `docker-compose  run web python manage.py backpopulate_youtube_data fetch --channel-id UCPonD0FH2WNnEXyTsYiLWMw` again

The user list named "Final Pitches" should be deleted

