### PR TITLE
add suggestions to channel search

### DIFF
--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -352,6 +352,55 @@ describe("search functions", () => {
           }
         ]
       }
+
+      const suggestQuery = {
+        suggest_field1: {
+          phrase: {
+            collate: {
+              params: {
+                field_name: "suggest_field1"
+              },
+              prune: true,
+              query: {
+                source: {
+                  match_phrase: {
+                    "{{field_name}}": "{{suggestion}}"
+                  }
+                }
+              }
+            },
+            confidence: 0.0001,
+            field:      "suggest_field1",
+            gram_size:  1,
+            max_errors: 3,
+            size:       5
+          }
+        },
+        suggest_field2: {
+          phrase: {
+            collate: {
+              params: {
+                field_name: "suggest_field2"
+              },
+              prune: true,
+              query: {
+                source: {
+                  match_phrase: {
+                    "{{field_name}}": "{{suggestion}}"
+                  }
+                }
+              }
+            },
+            confidence: 0.0001,
+            field:      "suggest_field2",
+            gram_size:  1,
+            max_errors: 3,
+            size:       5
+          }
+        },
+        text: "some text here"
+      }
+
       assert.deepEqual(buildSearchQuery({ type, text }), {
         query: {
           bool: {
@@ -377,7 +426,8 @@ describe("search functions", () => {
               }
             ]
           }
-        }
+        },
+        suggest: suggestQuery
       })
       sinon.assert.calledWith(stub, type)
     })
@@ -638,8 +688,8 @@ describe("search functions", () => {
               }
             },
             suggest: {
-              text:              text,
-              short_description: {
+              text:                        text,
+              "short_description.trigram": {
                 phrase: {
                   confidence: 0.0001,
                   field:      "short_description.trigram",
@@ -661,7 +711,7 @@ describe("search functions", () => {
                   }
                 }
               },
-              title: {
+              "title.trigram": {
                 phrase: {
                   confidence: 0.0001,
                   field:      "title.trigram",

--- a/static/js/pages/SearchPage_test.js
+++ b/static/js/pages/SearchPage_test.js
@@ -49,6 +49,7 @@ describe("SearchPage", () => {
         loaded: true,
         data:   {
           results:     searchResponse.hits.hits,
+          suggest:     ["test"],
           total:       searchResponse.hits.total,
           incremental: false
         }
@@ -104,6 +105,15 @@ describe("SearchPage", () => {
         result.post_id === upvotedPost.id ? upvotedPost : null
       )
     })
+  })
+
+  it("renders suggestion and changes search text if clicked", async () => {
+    const { inner } = await renderPage()
+    const suggestDiv = inner.find(".suggestion")
+    assert.isOk(suggestDiv.text().includes("Did you mean"))
+    assert.isOk(suggestDiv.text().includes("test"))
+    suggestDiv.find("a").simulate("click")
+    assert.equal(inner.state()["text"], "test")
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
<img width="1673" alt="Screen Shot 2020-04-03 at 3 41 58 PM" src="https://user-images.githubusercontent.com/1934992/78398853-cefc4a80-75c1-11ea-9d17-0a8b7f604800.png">
<img width="366" alt="Screen Shot 2020-04-03 at 3 42 23 PM" src="https://user-images.githubusercontent.com/1934992/78398859-d02d7780-75c1-11ea-8e64-6657913e0fd5.png">

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2721

This pr contains the front end changes from https://github.com/mitodl/open-discussions/pull/2740, which was reverted to avoid downtime after the deploy.

It should not be merged until https://github.com/mitodl/open-discussions/pull/2751 is deployed and the index is updated

#### What's this PR do?
This PR updates the code to display suggestions in the channel search when there are no hits for a search term, similar to the ones in the learning resource search

#### How should this be manually tested?
Create 5-6 comments and posts with the word "robot" 
Go to http://localhost:8063/search/ and search for "robo". Verify that "robot"  is returned as a suggestion and clicking the link searches for "robot" .

Also verify that the channel search still works for terms for which there are hits and that the learning resource search still works as expected as well