### PR TITLE
Podcasts: set up navbar for /podcasts

### DIFF
--- a/static/js/components/ContentToolbar.js
+++ b/static/js/components/ContentToolbar.js
@@ -1,7 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { Link } from "react-router-dom"
+import { Link, Route } from "react-router-dom"
 import { MDCToolbar } from "@material/toolbar/dist/mdc.toolbar"
 
 import MITLogoLink from "./MITLogoLink"
@@ -9,7 +9,7 @@ import UserMenu from "./UserMenu"
 import ResponsiveWrapper from "./ResponsiveWrapper"
 
 import { TABLET, DESKTOP } from "../lib/constants"
-import { COURSE_URL, userListIndexURL } from "../lib/url"
+import { COURSE_URL, userListIndexURL, PODCAST_URL } from "../lib/url"
 import { userIsAnonymous } from "../lib/util"
 
 import type { Profile } from "../flow/discussionTypes"
@@ -20,7 +20,7 @@ type Props = {
   toggleShowUserMenu: Function
 }
 
-export default class CourseToolbar extends React.Component<Props> {
+export default class ContentToolbar extends React.Component<Props> {
   toolbarRoot: { current: null | React$ElementRef<typeof HTMLElement> }
   toolbar: Object
 
@@ -55,9 +55,16 @@ export default class CourseToolbar extends React.Component<Props> {
                   MIT Open
                 </Link>
                 <div className="bar">{" | "}</div>
-                <Link className="learning-link" to={COURSE_URL}>
-                  LEARN
-                </Link>
+                <Route path="/learn/">
+                  <Link className="section-link" to={COURSE_URL}>
+                    LEARN
+                  </Link>
+                </Route>
+                <Route path="/podcasts/">
+                  <Link className="section-link" to={PODCAST_URL}>
+                    PODCASTS
+                  </Link>
+                </Route>
               </div>
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">

--- a/static/js/components/ContentToolbar_test.js
+++ b/static/js/components/ContentToolbar_test.js
@@ -5,18 +5,18 @@ import sinon from "sinon"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 
-import CourseToolbar from "./CourseToolbar"
+import ContentToolbar from "./ContentToolbar"
 
-import { COURSE_URL, userListIndexURL } from "../lib/url"
+import { COURSE_URL, PODCAST_URL, userListIndexURL } from "../lib/url"
 import { makeProfile } from "../factories/profiles"
 import * as util from "../lib/util"
 
-describe("CourseToolbar", () => {
+describe("ContentToolbar", () => {
   let sandbox
 
   const renderToolbar = () =>
     shallow(
-      <CourseToolbar
+      <ContentToolbar
         toggleShowUserMenu={sandbox.stub()}
         showUserMenu={false}
         profile={makeProfile()}
@@ -47,6 +47,16 @@ describe("CourseToolbar", () => {
         .at(1)
         .prop("to"),
       COURSE_URL
+    )
+  })
+
+  it("should include a link to podcasts", () => {
+    assert.equal(
+      renderToolbar()
+        .find("Link")
+        .at(2)
+        .prop("to"),
+      PODCAST_URL
     )
   })
 

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -119,6 +119,8 @@ export const SITE_SEARCH_URL = "/search/"
 export const COURSE_URL = "/learn/"
 export const COURSE_SEARCH_URL = "/learn/search"
 
+export const PODCAST_URL = "/podcasts"
+
 export const toQueryString = (params: Object) =>
   R.isEmpty(params || {}) ? "" : `?${qs.stringify(params)}`
 

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -37,7 +37,7 @@ import Snackbar from "../components/material/Snackbar"
 import Banner from "../components/material/Banner"
 import Drawer from "../components/Drawer"
 import Toolbar from "../components/Toolbar"
-import CourseToolbar from "../components/CourseToolbar"
+import ContentToolbar from "../components/ContentToolbar"
 
 import { actions } from "../actions"
 import {
@@ -192,10 +192,10 @@ class App extends React.Component<Props> {
         <MetaTags>
           <title>MIT Open Learning</title>
         </MetaTags>
-        <Route path={`${match.url}learn/`}>
+        <Route path={[`${match.url}learn/`, `${match.url}podcasts/`]}>
           {({ match }) =>
             match ? (
-              <CourseToolbar
+              <ContentToolbar
                 toggleShowUserMenu={this.toggleShowUserMenu}
                 showUserMenu={showUserMenu}
                 profile={profile}

--- a/static/js/pages/App_test.js
+++ b/static/js/pages/App_test.js
@@ -141,9 +141,9 @@ describe("App", () => {
   ;[["/learn/", true], ["/", false]].forEach(([url, isLearnUrl]) => {
     it(`${shouldIf(!isLearnUrl)} include a Drawer, ${shouldIf(
       isLearnUrl
-    )} include CourseToolbar if url is ${url}`, async () => {
+    )} include ContentToolbar if url is ${url}`, async () => {
       const [wrapper] = await renderComponent(url, [])
-      assert.equal(wrapper.find("CourseToolbar").exists(), isLearnUrl)
+      assert.equal(wrapper.find("ContentToolbar").exists(), isLearnUrl)
       assert.equal(wrapper.find("Toolbar").exists(), !isLearnUrl)
       assert.equal(wrapper.find("Drawer").exists(), !isLearnUrl)
     })

--- a/static/scss/course.scss
+++ b/static/scss/course.scss
@@ -11,7 +11,7 @@
       margin-right: 8px;
     }
 
-    .learning-link {
+    .section-link {
       font-size: 24px;
       color: $nice-red;
       margin-left: 8px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2722

#### What's this PR do?

this gets the navbar set up for `/podcasts`. basically I:

- renamed the current `CourseToolbar` to `ContentToolbar`, reflecting the fact that we want to use the same styling on `/learn` and `/podcasts`
- changed the routing in `<App.js>` so that we render the `ContentToolbar` on `/learn` and `/podcasts` and the normal navbar elsewhere
- adding some `<Route>`-based logic in the navbar component (`<ContentToolbar>`) to change the branding text based on which part of the site you're in ('LEARN' vs 'PODCASTS')

#### How should this be manually tested?

the normal navbar should show up everywhere on the discussions side.

On `/learn` and its sub-routes you should see the same behavior as master.

If you visit `/podcasts` you should see the same navbar as on `/learn` but with the prominent branding text and link changed.

#### Screenshots (if appropriate)

![Screenshot from 2020-04-10 09-53-17](https://user-images.githubusercontent.com/6207644/78996002-a91afc80-7b11-11ea-8e06-418d6817c3ac.png)
![Screenshot from 2020-04-10 09-53-06](https://user-images.githubusercontent.com/6207644/78996004-a91afc80-7b11-11ea-947a-598e65cb1617.png)