### PR TITLE
Add recent podcasts API

### DIFF
--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -504,6 +504,7 @@ class PodcastEpisodeFactory(LearningResourceFactory):
     podcast = factory.SubFactory("course_catalog.factories.PodcastFactory")
     published = True
     url = factory.Faker("uri")
+    last_modified = factory.Faker("past_datetime", tzinfo=pytz.utc)
 
     class Meta:
         model = PodcastEpisode

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -689,6 +689,7 @@ class PodcastEpisodeSerializer(serializers.ModelSerializer):
             "image_src",
             "url",
             "offered_by",
+            "podcast",
         ]
 
 

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -690,6 +690,7 @@ class PodcastEpisodeSerializer(serializers.ModelSerializer):
             "url",
             "offered_by",
             "podcast",
+            "last_modified",
         ]
 
 

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -37,6 +37,7 @@ from open_discussions.factories import UserFactory
 pytestmark = pytest.mark.django_db
 
 
+datetime_format = "%Y-%m-%dT%H:%M:%SZ"
 datetime_millis_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
@@ -284,4 +285,5 @@ def test_podcast_episode_serializer():
         "topics": CourseTopicSerializer(many=True, instance=episode.topics).data,
         "url": episode.url,
         "podcast": episode.podcast_id,
+        "last_modified": episode.last_modified.strftime(datetime_format),
     }

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -283,4 +283,5 @@ def test_podcast_episode_serializer():
         "short_description": episode.short_description,
         "topics": CourseTopicSerializer(many=True, instance=episode.topics).data,
         "url": episode.url,
+        "podcast": episode.podcast_id,
     }

--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -38,6 +38,11 @@ router.register(r"podcasts", views.PodcastViewSet, basename="podcasts")
 
 
 urlpatterns = [
+    url(
+        r"^api/v0/podcasts/recent/$",
+        views.RecentPodcastEpisodesViewSet.as_view({"get": "list"}),
+        name="recent-podcast-episodes",
+    ),
     url(r"^api/v0/", include(router.urls)),
     url(r"^api/v0/ocw_webhook/$", WebhookOCWView.as_view(), name="ocw-webhook"),
     url(

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -436,6 +436,7 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     serializer_class = PodcastSerializer
+    pagination_class = DefaultPagination
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
     queryset = Podcast.objects.filter(published=True).prefetch_related(
@@ -457,6 +458,7 @@ class RecentPodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     serializer_class = PodcastEpisodeSerializer
+    pagination_class = DefaultPagination
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
     queryset = (

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -46,6 +46,7 @@ from course_catalog.serializers import (
     CourseTopicSerializer,
     UserListItemSerializer,
     PodcastSerializer,
+    PodcastEpisodeSerializer,
 )
 from course_catalog.tasks import get_ocw_courses
 from course_catalog.utils import load_course_blacklist
@@ -447,4 +448,22 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
         ),
         Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
         Prefetch("topics", queryset=CourseTopic.objects.all()),
+    )
+
+
+class RecentPodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for recent PodcastEpisodes
+    """
+
+    serializer_class = PodcastEpisodeSerializer
+    permission_classes = (ReadOnly & PodcastFeatureFlag,)
+
+    queryset = (
+        PodcastEpisode.objects.filter(published=True)
+        .order_by("-last_modified", "-id")
+        .prefetch_related(
+            Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
+            Prefetch("topics", queryset=CourseTopic.objects.all()),
+        )
     )

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -696,7 +696,11 @@ def test_podcasts(settings, client):
 
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("podcasts-list"))
-    assert resp.json() == PodcastSerializer(instance=podcasts, many=True).data
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["count"] == 2
+    assert (
+        resp.json()["results"] == PodcastSerializer(instance=podcasts, many=True).data
+    )
 
 
 def test_recent_podcast_episodes_no_feature_flag(settings, client):
@@ -718,4 +722,8 @@ def test_recent_podcast_episodes(settings, client):
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("recent-podcast-episodes"))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == PodcastEpisodeSerializer(instance=episodes, many=True).data
+    assert resp.json()["count"] == 5
+    assert (
+        resp.json()["results"]
+        == PodcastEpisodeSerializer(instance=episodes, many=True).data
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2763 

#### What's this PR do?
Adds `/api/v0/podcasts/recent/` to list recent podcast episodes

#### How should this be manually tested?
Populate some podcast episodes then go to `/api/v0/podcasts/recent/` and verify that it looks right. The `last_modified` value should start with the most recent and go backward in time.