### PR TITLE
add "recent episodes" UI to podcast frontpage

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -436,7 +436,6 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     serializer_class = PodcastSerializer
-    pagination_class = DefaultPagination
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
     queryset = Podcast.objects.filter(published=True).prefetch_related(

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -697,10 +697,7 @@ def test_podcasts(settings, client):
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("podcasts-list"))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()["count"] == 2
-    assert (
-        resp.json()["results"] == PodcastSerializer(instance=podcasts, many=True).data
-    )
+    assert resp.json() == PodcastSerializer(instance=podcasts, many=True).data
 
 
 def test_recent_podcast_episodes_no_feature_flag(settings, client):

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -1,0 +1,47 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import Dotdotdot from "react-dotdotdot"
+
+import Card from "./Card"
+
+import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+
+import type { Podcast, PodcastEpisode } from "../flow/podcastTypes"
+
+export const PODCAST_IMG_HEIGHT = 77
+export const PODCAST_IMG_WIDTH = 125
+
+type Props = {
+  podcast: Podcast,
+  episode: PodcastEpisode
+}
+
+export default function PodcastEpisodeCard(props: Props) {
+  const { episode, podcast } = props
+
+  return (
+    <Card className="podcast-episode-card low-padding">
+      <div className="left-col">
+        <div className="episode-title">
+          <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
+        </div>
+        <div className="podcast-name">{podcast.title}</div>
+        <div className="play-placeholder black-surround">Play</div>
+      </div>
+      <div className="right-col">
+        <img
+          src={embedlyThumbnail(
+            SETTINGS.embedlyKey,
+            episode.image_src || defaultResourceImageURL(),
+            PODCAST_IMG_HEIGHT,
+            PODCAST_IMG_WIDTH
+          )}
+          height={PODCAST_IMG_HEIGHT}
+          alt={`cover image for ${episode.title}`}
+          className="episode-cover-image"
+        />
+      </div>
+    </Card>
+  )
+}

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -1,0 +1,41 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
+import { embedlyThumbnail } from "../lib/url"
+
+import PodcastEpisodeCard, {
+  PODCAST_IMG_WIDTH,
+  PODCAST_IMG_HEIGHT
+} from "./PodcastEpisodeCard"
+
+describe("PodcastEpisodeCard", () => {
+  let podcast, episode
+  beforeEach(() => {
+    podcast = makePodcast()
+    episode = makePodcastEpisode(podcast)
+  })
+
+  const render = (props = {}) =>
+    shallow(
+      <PodcastEpisodeCard podcast={podcast} episode={episode} {...props} />
+    )
+
+  it("should render basic stuff", () => {
+    const wrapper = render()
+    assert.equal(wrapper.find("Dotdotdot").props().children, episode.title)
+    assert.equal(wrapper.find(".podcast-name").text(), podcast.title)
+    assert.equal(
+      wrapper.find("img").prop("src"),
+      embedlyThumbnail(
+        SETTINGS.embedlyKey,
+        episode.image_src,
+        PODCAST_IMG_HEIGHT,
+        PODCAST_IMG_WIDTH
+      )
+    )
+  })
+})

--- a/static/js/factories/podcasts.js
+++ b/static/js/factories/podcasts.js
@@ -1,0 +1,44 @@
+// @flow
+import casual from "casual-browserify"
+
+import { incrementer } from "../lib/util"
+
+const incr = incrementer()
+import type { Podcast, PodcastEpisode } from "../flow/podcastTypes"
+
+export const makePodcast = (): Podcast => ({
+  created_on:        casual.moment.toISOString(),
+  episodes:          [],
+  full_description:  casual.description,
+  // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
+  id:                incr.next().value,
+  image_src:         casual.url,
+  offered_by:        [],
+  podcast_id:        casual.word,
+  short_description: casual.description,
+  title:             casual.title,
+  topics:            [],
+  updated_on:        casual.moment.toISOString(),
+  url:               casual.url
+})
+
+export const makePodcastEpisode = (podcast?: Podcast): PodcastEpisode => {
+  podcast = podcast || makePodcast()
+
+  return {
+    created_on:        casual.moment.toISOString(),
+    episode_id:        casual.word,
+    full_description:  casual.description,
+    // $FlowFixMe: Flow thinks incr.next().value may be undefined
+    id:                incr.next().value,
+    image_src:         casual.url,
+    last_modified:     casual.moment.toISOString(),
+    offered_by:        [],
+    podcast:           podcast.id,
+    short_description: casual.description,
+    title:             casual.title,
+    topics:            [],
+    updated_on:        casual.moment.toISOString(),
+    url:               casual.url
+  }
+}

--- a/static/js/flow/podcastTypes.js
+++ b/static/js/flow/podcastTypes.js
@@ -1,0 +1,31 @@
+// @flow
+export type Podcast = {
+  created_on: string,
+  episodes: Array<PodcastEpisode>,
+  full_description: string,
+  id: number,
+  image_src: string,
+  offered_by: Array<string>,
+  podcast_id: string,
+  short_description: string,
+  title: string,
+  topics: Array<string>,
+  updated_on: string,
+  url: string,
+}
+
+export type PodcastEpisode = {
+  created_on: string,
+  episode_id: string,
+  full_description: string,
+  id: number,
+  image_src: string,
+  last_modified: string,
+  offered_by: Array<string>,
+  podcast: number,
+  short_description: string,
+  title: string,
+  topics: Array<string>,
+  updated_on: string,
+  url: string
+}

--- a/static/js/lib/queries/podcasts.js
+++ b/static/js/lib/queries/podcasts.js
@@ -1,0 +1,48 @@
+// @flow
+import R from "ramda"
+import { createSelector } from "reselect"
+
+import { podcastApiURL, recentPodcastApiURL } from "../url"
+import { constructIdMap } from "../redux_query"
+
+import type { PodcastEpisode } from "../../flow/podcastTypes"
+
+export const podcastsRequest = () => ({
+  queryKey:  "podcastsRequest",
+  url:       podcastApiURL,
+  transform: (podcasts: any) => ({
+    podcasts: constructIdMap(podcasts)
+  }),
+  update: {
+    podcasts: R.merge
+  }
+})
+
+export const podcastsSelector = createSelector(
+  state => state.entities.podcasts,
+  podcasts => podcasts
+)
+
+export const recentPodcastEpisodesRequest = () => ({
+  queryKey:  "recentPodcastRequest",
+  url:       recentPodcastApiURL,
+  transform: ({ results }: any) => {
+    const recentEpisodes = results.map(episode => episode.id)
+
+    return {
+      recentEpisodes,
+      podcastEpisodes: constructIdMap(results)
+    }
+  },
+  update: {
+    recentEpisodes:  (_: any, newList: Array<PodcastEpisode>) => newList,
+    podcastEpisodes: R.merge
+  }
+})
+
+export const recentEpisodesSelector = createSelector(
+  state => state.entities.podcastEpisodes,
+  state => state.entities.recentEpisodes,
+  (episodes, recentEpisodes) =>
+    episodes && recentEpisodes ? recentEpisodes.map(id => episodes[id]) : []
+)

--- a/static/js/lib/queries/user_lists.js
+++ b/static/js/lib/queries/user_lists.js
@@ -39,9 +39,9 @@ export const myUserListsSelector = createSelector(
   userListsSelector,
   userLists =>
     userLists
-      ? Object.keys(userLists)
-        .map(key => userLists[key])
-        .filter(userList => userList.author === SETTINGS.user_id)
+      ? Object.values(userLists).filter(
+        (userList: any) => userList.author === SETTINGS.user_id
+      )
       : []
 )
 

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -174,6 +174,8 @@ export const newVideosURL = "/api/v0/videos/new/"
 export const embedlyApiURL = "/api/v0/embedly"
 export const topicApiURL = "/api/v0/topics"
 export const similarResourcesURL = "/api/v0/similar/"
+export const podcastApiURL = "/api/v0/podcasts"
+export const recentPodcastApiURL = "/api/v0/podcasts/recent"
 
 export const userListIndexURL = "/learn/lists/"
 export const userListDetailURL = (id: number) => `/learn/lists/${id}`

--- a/static/js/pages/App_test.js
+++ b/static/js/pages/App_test.js
@@ -16,6 +16,7 @@ import { makeChannelPostList } from "../factories/posts"
 import { shouldIf, shouldIfGt0, mockCourseAPIMethods } from "../lib/test_utils"
 import * as embedLib from "../lib/embed"
 import * as LearnRouterModule from "./LearnRouter"
+import * as PodcastFrontpageModule from "./PodcastFrontpage"
 
 describe("App", () => {
   let helper, renderComponent, channels, postList
@@ -39,6 +40,7 @@ describe("App", () => {
     mockCourseAPIMethods(helper)
     helper.sandbox.stub(embedLib, "ensureTwitterEmbedJS")
     helper.stubComponent(LearnRouterModule, "LearnRouter")
+    helper.stubComponent(PodcastFrontpageModule, "PodcastFrontpage")
   })
 
   afterEach(() => {

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -1,10 +1,56 @@
 // @flow
 import React from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+
+import PodcastEpisodeCard from "../components/PodcastEpisodeCard"
+
+import {
+  podcastsRequest,
+  podcastsSelector,
+  recentPodcastEpisodesRequest,
+  recentEpisodesSelector
+} from "../lib/queries/podcasts"
 
 export default function PodcastFrontpage() {
+  const [{ isFinished: isFinishedPodcasts }] = useRequest(podcastsRequest())
+  const [{ isFinished: isFinishedRecent }] = useRequest(
+    recentPodcastEpisodesRequest()
+  )
+
+  const loaded = isFinishedPodcasts && isFinishedRecent
+
+  const podcasts = useSelector(podcastsSelector)
+  const recentEpisodes = useSelector(recentEpisodesSelector)
+
   return (
     <div className="podcasts">
+      <div className="recent-episodes">
+        <div className="recent-header">
+          <div className="title">RECENT EPISODES</div>
+        </div>
+        {loaded ? (
+          <>
+            {recentEpisodes
+              .slice(0, 6)
+              .map((episode, idx) => (
+                <PodcastEpisodeCard
+                  episode={episode}
+                  podcast={podcasts[episode.podcast]}
+                  key={idx}
+                />
+              ))}
+          </>
+        ) : null}
+      </div>
       <h1>PODCASTS</h1>
+      {loaded
+        ? Object.values(podcasts).map((podcast: any, idx) => (
+          <div key={idx}>
+            <h3>{podcast.title}</h3>
+          </div>
+        ))
+        : null}
     </div>
   )
 }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -63,6 +63,7 @@ $white-smoky: #4f4f4f;
 $nice-red: #a32034;
 $course-blue: #126f9a;
 $teal: #3dbdbf;
+$podcast-border-grey: #9c9d9e;
 
 // font
 $body-font: "Source Sans Pro", helvetica, arial, sans-serif !important;

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -76,15 +76,24 @@ a.blue-btn {
   background-color: $course-blue;
 }
 
-.grey-surround {
+.grey-surround,
+.black-surround {
   display: flex;
   align-items: center;
   border-radius: 12.5px;
   cursor: pointer;
-  background-color: $pale-grey;
   padding: 2px;
-  color: $navy;
   font-size: 12px;
+}
+
+.grey-surround {
+  background-color: $pale-grey;
+  color: $navy;
+}
+
+.black-surround {
+  background-color: black;
+  color: white;
 }
 
 button.remove,

--- a/static/scss/card.scss
+++ b/static/scss/card.scss
@@ -28,4 +28,10 @@
       padding: 0;
     }
   }
+
+  &.low-padding {
+    .card-contents {
+      padding: 10px;
+    }
+  }
 }

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -13,4 +13,55 @@
     color: white;
     text-align: center;
   }
+
+  .recent-episodes {
+    padding-top: 60px;
+    max-width: 480px;
+    margin: auto;
+
+    .recent-header {
+      display: flex;
+      justify-content: space-between;
+      padding-bottom: 10px;
+
+      .title {
+        font-size: 20px;
+        color: white;
+      }
+    }
+  }
+
+  .podcast-episode-card {
+    max-width: 480px;
+
+    .card-contents {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .episode-title {
+      font-size: 14px;
+      font-weight: bold;
+    }
+
+    .podcast-name {
+      font-size: 14px;
+      color: $font-grey-light;
+      font-family: "Roboto";
+      padding-top: 10px;
+    }
+
+    .black-surround,
+    .grey-surround {
+      display: inline-block;
+      font-size: 14px;
+      padding: 2px 10px;
+      margin-top: 8px;
+    }
+
+    .episode-cover-image {
+      border: 1px solid $podcast-border-grey;
+      border-radius: 5px;
+    }
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2722 

#### What's this PR do?

This basically adds a placeholder display for podcasts and an initial implementation of the 'recent episodes' UI.

Currently the 'Follow' button doesn't do anything, and the podcasts and episodes can't yet be opened in the drawer (we can add once the search UI is done).

#### How should this be manually tested?

either import the podcast data (with the `backpopulate_podcast_data` management command) or create some fake podcasts. then visit `/podcast` and you should see a nice display of episodes!

for the podcasts themselves it is currently just a placeholder of displaying the title.

#### Screenshots (if appropriate)

![Screenshot from 2020-04-15 11-35-49](https://user-images.githubusercontent.com/6207644/79356684-43fa4900-7f0d-11ea-949d-ed38a8c82f12.png)

note that this mobile UI is very provisional, I will do a second follow-up PR to get this to be in line with the designs (but the screenshot shows not that much work is needed I think):

![Screenshot from 2020-04-15 11-36-17](https://user-images.githubusercontent.com/6207644/79356771-51173800-7f0d-11ea-97d9-c0d718ff7753.png)
