### PR TITLE
add podcast cards

### DIFF
--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -1,0 +1,45 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import Dotdotdot from "react-dotdotdot"
+
+import Card from "./Card"
+
+import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+import { CAROUSEL_IMG_WIDTH } from "../lib/constants"
+
+import type { Podcast } from "../flow/podcastTypes"
+
+type Props = {
+  podcast: Podcast
+}
+
+export const PODCAST_IMG_HEIGHT = 170
+
+export default function PodcastCard(props: Props) {
+  const { podcast } = props
+
+  return (
+    <Card className="podcast-card borderless">
+      <div className="cover-img">
+        <img
+          src={embedlyThumbnail(
+            SETTINGS.embedlyKey,
+            podcast.image_src || defaultResourceImageURL(),
+            PODCAST_IMG_HEIGHT,
+            CAROUSEL_IMG_WIDTH
+          )}
+          height={PODCAST_IMG_HEIGHT}
+          alt={`cover image for ${podcast.title}`}
+        />
+      </div>
+      <div className="podcast-info">
+        <div className="row resource-type">PODCAST</div>
+        <div className="row podcast-title">
+          <Dotdotdot clamp={3}>{podcast.title}</Dotdotdot>
+        </div>
+        <div className="row podcast-author">{podcast.offered_by}</div>
+      </div>
+    </Card>
+  )
+}

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -1,0 +1,36 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import PodcastCard, { PODCAST_IMG_HEIGHT } from "./PodcastCard"
+
+import { makePodcast } from "../factories/podcasts"
+import { embedlyThumbnail } from "../lib/url"
+import { CAROUSEL_IMG_WIDTH } from "../lib/constants"
+
+describe("PodcastCard", () => {
+  let podcast
+
+  beforeEach(() => {
+    podcast = makePodcast()
+  })
+
+  const render = (props = {}) =>
+    shallow(<PodcastCard podcast={podcast} {...props} />)
+
+  it("should render basic stuff", () => {
+    const wrapper = render()
+    assert.equal(wrapper.find("Dotdotdot").props().children, podcast.title)
+    assert.equal(
+      wrapper.find("img").prop("src"),
+      embedlyThumbnail(
+        SETTINGS.embedlyKey,
+        podcast.image_src,
+        PODCAST_IMG_HEIGHT,
+        CAROUSEL_IMG_WIDTH
+      )
+    )
+  })
+})

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -4,6 +4,8 @@ import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 
 import PodcastEpisodeCard from "../components/PodcastEpisodeCard"
+import PodcastCard from "../components/PodcastCard"
+import { Cell, Grid } from "../components/Grid"
 
 import {
   podcastsRequest,
@@ -43,14 +45,18 @@ export default function PodcastFrontpage() {
           </>
         ) : null}
       </div>
-      <h1>PODCASTS</h1>
-      {loaded
-        ? Object.values(podcasts).map((podcast: any, idx) => (
-          <div key={idx}>
-            <h3>{podcast.title}</h3>
-          </div>
-        ))
-        : null}
+      <div className="all-podcasts">
+        <h1>Podcasts Series</h1>
+        {loaded ? (
+          <Grid>
+            {Object.values(podcasts).map((podcast: any) => (
+              <Cell width={4} key={podcast.id}>
+                <PodcastCard podcast={podcast} />
+              </Cell>
+            ))}
+          </Grid>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -31,37 +31,85 @@
     }
   }
 
-  .podcast-episode-card {
-    max-width: 480px;
+  .all-podcasts {
+    max-width: 900px;
+    margin: auto;
 
-    .card-contents {
-      display: flex;
-      justify-content: space-between;
+    h1 {
+      text-align: left;
+      color: black;
     }
+  }
+}
 
-    .episode-title {
-      font-size: 14px;
-      font-weight: bold;
-    }
+.podcast-episode-card {
+  max-width: 480px;
 
-    .podcast-name {
-      font-size: 14px;
-      color: $font-grey-light;
-      font-family: "Roboto";
-      padding-top: 10px;
-    }
+  .card-contents {
+    display: flex;
+    justify-content: space-between;
+  }
 
-    .black-surround,
-    .grey-surround {
-      display: inline-block;
-      font-size: 14px;
-      padding: 2px 10px;
-      margin-top: 8px;
-    }
+  .episode-title {
+    font-size: 14px;
+    font-weight: bold;
+  }
 
-    .episode-cover-image {
-      border: 1px solid $podcast-border-grey;
-      border-radius: 5px;
+  .podcast-name {
+    font-size: 14px;
+    color: $font-grey-light;
+    font-family: "Roboto";
+    padding-top: 10px;
+  }
+
+  .black-surround,
+  .grey-surround {
+    display: inline-block;
+    font-size: 14px;
+    padding: 2px 10px;
+    margin-top: 8px;
+  }
+
+  .episode-cover-image {
+    border: 1px solid $podcast-border-grey;
+    border-radius: 5px;
+  }
+}
+
+.podcast-card {
+  font-family: roboto;
+
+  .cover-img {
+    img {
+      width: 100%;
+      min-height: 170px;
+      border-radius: 5px 5px 0 0;
     }
+  }
+
+  .podcast-info {
+    padding: 16px;
+  }
+
+  .resource-type {
+    font-size: 13px;
+    color: $font-grey-mid;
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+
+  .podcast-title {
+    margin: 10px 0;
+    margin-top: 2px;
+    min-height: 62px;
+    font-size: 18px;
+    color: black;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .podcast-author {
+    font-size: 14px;
+    color: $font-grey-light;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #2722 

#### What's this PR do?

this adds 'podcast cards' which show all of our podcasts on the `/podcasts` 'front page'.

currently it just fetches all of them in one big request that returns everything. Obviously this is not ideal! I think we should re-paginate the API and then add an infinite scroll here probably (see #2795).

#### How should this be manually tested?

if you've imported podcasts into your dev env you should be able to visit `/podcasts` and see a card for each podcast in a grid below the 'recent episodes' display. clicking them doesn't do anything yet :smile: 

#### Screenshots (if appropriate)

![Screenshot from 2020-04-17 11-36-27](https://user-images.githubusercontent.com/6207644/79587456-8e5fff00-80a0-11ea-9917-ff06ab3cb21e.png)
![Screenshot from 2020-04-17 11-36-19](https://user-images.githubusercontent.com/6207644/79587459-8ef89580-80a0-11ea-8987-851d933e9a3e.png)

mobile UI has not been optimized yet:

![Screenshot from 2020-04-17 11-38-38](https://user-images.githubusercontent.com/6207644/79587450-8e5fff00-80a0-11ea-837d-50a337612468.png)