### PR TITLE
use podcast image when podcast episode image is missing

### DIFF
--- a/course_catalog/etl/podcast.py
+++ b/course_catalog/etl/podcast.py
@@ -117,7 +117,7 @@ def extract():
         yield (feed, playlist_config)
 
 
-def transform_episode(rss_data, offered_by, topics):
+def transform_episode(rss_data, offered_by, topics, image):
     """
     Transform a podcast episode into our normalized data
 
@@ -125,6 +125,7 @@ def transform_episode(rss_data, offered_by, topics):
         rss_data (beautiful soup object): the extracted episode data
         offered_by (str): the offered_by value for this episode
         topics (dict of str): the topics for the podcast
+        image (str): url for podcast image
     Returns:
         dict:
             normalized podcast episode data
@@ -137,7 +138,9 @@ def transform_episode(rss_data, offered_by, topics):
         "short_description": rss_data.description.text,
         "full_description": rss_data.description.text,
         "url": rss_data.enclosure["url"],
-        "image_src": rss_data.find("image")["href"] if rss_data.find("image") else None,
+        "image_src": rss_data.find("image")["href"]
+        if rss_data.find("image")
+        else image,
         "last_modified": datetime.strptime(
             rss_data.pubDate.text, "%a, %d %b %Y  %H:%M:%S %z"
         ),
@@ -169,6 +172,11 @@ def transform(extracted_podcasts):
 
     for rss_data, config_data in extracted_podcasts:
         try:
+            image = (
+                rss_data.channel.find("itunes:image")["href"]
+                if rss_data.channel.find("itunes:image")
+                else None
+            )
             topics = (
                 [{"name": topic} for topic in config_data["topics"].split(",")]
                 if "topics" in config_data
@@ -188,7 +196,9 @@ def transform(extracted_podcasts):
                 "url": config_data["website"],
                 "topics": topics,
                 "episodes": (
-                    transform_episode(episode_rss, config_data["offered_by"], topics)
+                    transform_episode(
+                        episode_rss, config_data["offered_by"], topics, image
+                    )
                     for episode_rss in rss_data.find_all("item")
                 ),
                 "runs": [

--- a/course_catalog/etl/podcast_test.py
+++ b/course_catalog/etl/podcast_test.py
@@ -108,7 +108,7 @@ def test_transform(mocker, title, topics):
                     "short_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "full_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "url": "http://feeds.soundcloud.com/stream/episode1.mp3",
-                    "image_src": "image2.jpg",
+                    "image_src": "apicture.jpg",
                     "last_modified": datetime.datetime(
                         2020, 4, 1, 18, 20, 31, tzinfo=datetime.timezone.utc
                     ),

--- a/test_html/test_podcast.rss
+++ b/test_html/test_podcast.rss
@@ -38,7 +38,6 @@
       <itunes:subtitle>Morbi id consequat nisl. Morbi leo elit,…</itunes:subtitle>
       <description>SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor</description>
       <enclosure type="audio/mpeg" url="http://feeds.soundcloud.com/stream/episode1.mp3" length="25437522"/>
-      <itunes:image href="image2.jpg"/>
     </item>
     <item>
       <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers</guid>


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2797

#### What's this PR do?
This pr updates podcast ingestion to use the podcast image for podcast episodes that do not have their own image

#### How should this be manually tested?
set `OPEN_PODCAST_DATA_BRANCH=ab/test-ingest`
run `docker-compose run  web ./manage.py backpopulate_podcast_data`

Verify that all podcast episode objects have image_src set

