### PR TITLE
Remove nested episodes from podcasts API to improve performance

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -699,7 +699,6 @@ class PodcastSerializer(serializers.ModelSerializer):
     Serializer for Podcasts
     """
 
-    episodes = PodcastEpisodeSerializer(many=True)
     topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
     offered_by = LearningResourceOfferorField(read_only=True, allow_null=True)
 
@@ -717,5 +716,4 @@ class PodcastSerializer(serializers.ModelSerializer):
             "offered_by",
             "created_on",
             "updated_on",
-            "episodes",
         ]

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -246,14 +246,12 @@ def test_favorites_serializer():
 def test_podcast_serializer():
     """PodcastSerializer should generate relevant JSON for a given Podcast"""
     podcast = PodcastFactory.create()
-    episodes = PodcastEpisodeFactory.create_batch(2, podcast=podcast)
     offered_by = LearningResourceOfferorFactory.create()
     podcast.offered_by.add(offered_by)
 
     assert PodcastSerializer(instance=podcast).data == {
         "created_on": podcast.created_on.strftime(datetime_millis_format),
         "updated_on": podcast.updated_on.strftime(datetime_millis_format),
-        "episodes": PodcastEpisodeSerializer(many=True, instance=episodes).data,
         "full_description": podcast.full_description,
         "topics": CourseTopicSerializer(many=True, instance=podcast.topics).data,
         "url": podcast.url,

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -439,13 +439,6 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
     queryset = Podcast.objects.filter(published=True).prefetch_related(
-        Prefetch(
-            "episodes",
-            queryset=PodcastEpisode.objects.filter(published=True).prefetch_related(
-                Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
-                Prefetch("topics", queryset=CourseTopic.objects.all()),
-            ),
-        ),
         Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
         Prefetch("topics", queryset=CourseTopic.objects.all()),
     )

--- a/static/js/factories/podcasts.js
+++ b/static/js/factories/podcasts.js
@@ -8,7 +8,6 @@ import type { Podcast, PodcastEpisode } from "../flow/podcastTypes"
 
 export const makePodcast = (): Podcast => ({
   created_on:        casual.moment.toISOString(),
-  episodes:          [],
   full_description:  casual.description,
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   id:                incr.next().value,

--- a/static/js/flow/podcastTypes.js
+++ b/static/js/flow/podcastTypes.js
@@ -1,7 +1,6 @@
 // @flow
 export type Podcast = {
   created_on: string,
-  episodes: Array<PodcastEpisode>,
   full_description: string,
   id: number,
   image_src: string,


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes slow performance in podcasts API due to a large amount of data being provided. The nested episodes are the largest piece of the REST API and they're not needed so they are removed from the results.

#### How should this be manually tested?
Populate some podcast data. Then go to `/api/v0/podcasts/` and make sure it feels reasonably snappy.
