### PR TITLE
hide 'my lists' when on `/podcasts`

### DIFF
--- a/static/js/components/ContentToolbar.js
+++ b/static/js/components/ContentToolbar.js
@@ -69,7 +69,7 @@ export default class ContentToolbar extends React.Component<Props> {
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
               <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
-                {userIsAnonymous() ? (
+                {userIsAnonymous() || !SETTINGS.course_ui_enabled ? (
                   <div />
                 ) : (
                   <Link className="user-list-link" to={userListIndexURL}>

--- a/static/js/components/ContentToolbar_test.js
+++ b/static/js/components/ContentToolbar_test.js
@@ -60,10 +60,19 @@ describe("ContentToolbar", () => {
     )
   })
 
-  it("should include a link to the my lists page", () => {
-    const link = renderToolbar().find(".user-list-link")
-    assert.equal(link.prop("children")[1], "My Lists")
-    assert.equal(link.prop("to"), userListIndexURL)
+  //
+  ;[true, false].forEach(courseUIEnabled => {
+    it("should include a link to the my lists page", () => {
+      SETTINGS.course_ui_enabled = courseUIEnabled
+
+      const link = renderToolbar().find(".user-list-link")
+      if (courseUIEnabled) {
+        assert.equal(link.prop("children")[1], "My Lists")
+        assert.equal(link.prop("to"), userListIndexURL)
+      } else {
+        assert.isNotOk(link.exists())
+      }
+    })
   })
 
   it("should hide the my lists link when you're anonymous", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2793

#### What's this PR do?

fixes a little issue where the 'my lists' link is still shown on `/podcasts` even if the `COURSE_UI` feature is disabled.

#### How should this be manually tested?

disable `COURSE_UI` and enable `PODCAST_FRONTPAGE` and then visit `/podcasts`. You shouldn't see the 'my lists' link up in the top bar.

if you have `COURSE_UI` enabled it should be there.

#### screens

![Screenshot from 2020-04-17 15-16-10](https://user-images.githubusercontent.com/6207644/79605696-62537680-80be-11ea-9fb5-28f6bee16eda.png)
