### PR TITLE
Use github access token for authentication

### DIFF
--- a/app.json
+++ b/app.json
@@ -109,6 +109,10 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "GITHUB_ACCESS_TOKEN": {
+      "description": "Access token for the Github API",
+      "required": false
+    },
     "INDEXING_API_USERNAME": {
       "description": "Reddit username used for indexing"
     },

--- a/course_catalog/etl/podcast.py
+++ b/course_catalog/etl/podcast.py
@@ -23,7 +23,12 @@ def github_podcast_config_files():
     Returns:
         A list of pyGithub contentFile objects
     """
-    github_client = github.Github()
+
+    if settings.GITHUB_ACCESS_TOKEN:
+        github_client = github.Github(settings.GITHUB_ACCESS_TOKEN)
+    else:
+        github_client = github.Github()
+
     repo = github_client.get_repo(CONFIG_FILE_REPO)
 
     return repo.get_contents(CONFIG_FILE_FOLDER, ref=settings.OPEN_PODCAST_DATA_BRANCH)

--- a/course_catalog/etl/youtube.py
+++ b/course_catalog/etl/youtube.py
@@ -312,7 +312,12 @@ def github_youtube_config_files():
     Returns:
         A list of pyGithub contentFile objects
     """
-    github_client = github.Github()
+
+    if settings.GITHUB_ACCESS_TOKEN:
+        github_client = github.Github(settings.GITHUB_ACCESS_TOKEN)
+    else:
+        github_client = github.Github()
+
     repo = github_client.get_repo(CONFIG_FILE_REPO)
 
     return repo.get_contents(CONFIG_FILE_FOLDER, ref=settings.OPEN_VIDEO_DATA_BRANCH)

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -842,6 +842,9 @@ EDX_API_ACCESS_TOKEN_URL = get_string("EDX_API_ACCESS_TOKEN_URL", None)
 EDX_API_CLIENT_ID = get_string("EDX_API_CLIENT_ID", None)
 EDX_API_CLIENT_SECRET = get_string("EDX_API_CLIENT_SECRET", None)
 
+# Authentication for the github api
+GITHUB_ACCESS_TOKEN = get_string("GITHUB_ACCESS_TOKEN", None)
+
 # S3 Bucket info for OCW Plone CMS exports
 OCW_CONTENT_BUCKET_NAME = get_string("OCW_CONTENT_BUCKET_NAME", None)
 OCW_CONTENT_ACCESS_KEY = get_string("OCW_CONTENT_ACCESS_KEY", None)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2801

#### What's this PR do?
Add authentication to github api requests 
#### How should this be manually tested?
Create a personal access token following these steps:
https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line

Set GITHUB_ACCESS_TOKEN in your .env file to the token you created.  Also set OPEN_PODCAST_DATA_BRANCH=ab/test-ingest Verify that 

docker-compose run web ./manage.py backpopulate_podcast_data and
docker-compose run web ./manage.py backpopulate_youtube_data

both work
