### PR TITLE
Add episode_count field to episodes REST API

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -701,6 +701,7 @@ class PodcastSerializer(serializers.ModelSerializer):
 
     topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
     offered_by = LearningResourceOfferorField(read_only=True, allow_null=True)
+    episode_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Podcast
@@ -716,4 +717,5 @@ class PodcastSerializer(serializers.ModelSerializer):
             "offered_by",
             "created_on",
             "updated_on",
+            "episode_count",
         ]

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -438,9 +438,14 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PodcastSerializer
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
-    queryset = Podcast.objects.filter(published=True).prefetch_related(
-        Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
-        Prefetch("topics", queryset=CourseTopic.objects.all()),
+    queryset = (
+        Podcast.objects.filter(published=True, episodes__published=True)
+        .prefetch_related(
+            Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
+            Prefetch("topics", queryset=CourseTopic.objects.all()),
+        )
+        .annotate(episode_count=Count("episodes"))
+        .order_by("id")
     )
 
 

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -697,7 +697,10 @@ def test_podcasts(settings, client):
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("podcasts-list"))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == PodcastSerializer(instance=podcasts, many=True).data
+    assert resp.json() == [
+        {"episode_count": 2, **podcast}
+        for podcast in PodcastSerializer(instance=podcasts, many=True).data
+    ]
 
 
 def test_recent_podcast_episodes_no_feature_flag(settings, client):

--- a/static/js/factories/podcasts.js
+++ b/static/js/factories/podcasts.js
@@ -8,6 +8,7 @@ import type { Podcast, PodcastEpisode } from "../flow/podcastTypes"
 
 export const makePodcast = (): Podcast => ({
   created_on:        casual.moment.toISOString(),
+  episode_count:     casual.integer(2, 37),
   full_description:  casual.description,
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   id:                incr.next().value,

--- a/static/js/flow/podcastTypes.js
+++ b/static/js/flow/podcastTypes.js
@@ -1,6 +1,7 @@
 // @flow
 export type Podcast = {
   created_on: string,
+  episode_count: number,
   full_description: string,
   id: number,
   image_src: string,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2806 

#### What's this PR do?
Adds `episode_count` to podcasts API, which is the count of all published episodes for that podcast

#### How should this be manually tested?
Go to `/api/v0/podcasts` and verify that the numbers make sense. You should be able to mark an episode `published=False` in the database and see the count for that podcast decrease by 1.

