### PR TITLE
Podcast episodes detail view

### DIFF
--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -35,12 +35,15 @@ router.register(r"videos", views.VideoViewSet, basename="videos")
 router.register(r"favorites", views.FavoriteItemViewSet, basename="favorites")
 router.register(r"topics", views.TopicViewSet, basename="topics")
 router.register(r"podcasts", views.PodcastViewSet, basename="podcasts")
+router.register(
+    r"podcastepisodes", views.PodcastEpisodesViewSet, basename="podcastepisodes"
+)
 
 
 urlpatterns = [
     url(
         r"^api/v0/podcasts/recent/$",
-        views.RecentPodcastEpisodesViewSet.as_view({"get": "list"}),
+        views.PodcastEpisodesViewSet.as_view({"get": "list"}),
         name="recent-podcast-episodes",
     ),
     url(r"^api/v0/", include(router.urls)),

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -449,9 +449,9 @@ class PodcastViewSet(viewsets.ReadOnlyModelViewSet):
     )
 
 
-class RecentPodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
+class PodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    Viewset for recent PodcastEpisodes
+    Viewset for PodcastEpisodes
     """
 
     serializer_class = PodcastEpisodeSerializer
@@ -459,7 +459,7 @@ class RecentPodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
 
     queryset = (
-        PodcastEpisode.objects.filter(published=True)
+        PodcastEpisode.objects.filter(published=True, podcast__published=True)
         .order_by("-last_modified", "-id")
         .prefetch_related(
             Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2809 

#### What's this PR do?
- Adds `/api/v0/podcastepisodes/` to list all podcast episodes
 - Adds `/api/v0/podcastepisodes/:number/` to get information about a podcast episode by id

#### How should this be manually tested?
Go to `/api/v0/podcastepisodes/:number/` for a podcast episode and verify that it looks fine. If the podcast episode is not published, or if the episode is published but the podcast is not, you should get a 404 error instead.