### PR TITLE
Added podcast indexing upon ingestion

### DIFF
--- a/course_catalog/etl/pipelines.py
+++ b/course_catalog/etl/pipelines.py
@@ -74,5 +74,4 @@ youtube_etl = compose(loaders.load_video_channels, youtube.transform, youtube.ex
 # pipeline for generating topic data for videos based on course topics
 video_topics_etl = compose(loaders.load_videos, video.extract_videos_topics)
 
-
 podcast_etl = compose(loaders.load_podcasts, podcast.transform, podcast.extract)

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -24,6 +24,8 @@ from search.api import (
     gen_user_list_id,
     gen_video_id,
     gen_content_file_id,
+    gen_podcast_id,
+    gen_podcast_episode_id,
 )
 from search.constants import (
     PROFILE_TYPE,
@@ -32,6 +34,8 @@ from search.constants import (
     PROGRAM_TYPE,
     USER_LIST_TYPE,
     VIDEO_TYPE,
+    PODCAST_TYPE,
+    PODCAST_EPISODE_TYPE,
 )
 from search.serializers import ESPostSerializer, ESCommentSerializer
 from search import tasks
@@ -508,3 +512,49 @@ def delete_video(video_obj):
         video_obj (course_catalog.models.Video): A Video object
     """
     delete_document.delay(gen_video_id(video_obj), VIDEO_TYPE)
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def upsert_podcast(podcast_id):
+    """
+    Run a task to create or update a podcast Elasticsearch document
+
+    Args:
+        podcast_id (int): the database primary key of the Podcast to update in ES
+    """
+    tasks.upsert_podcast.delay(podcast_id)
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def delete_podcast(podcast_obj):
+    """
+    Runs a task to delete an ES Podcast document
+
+    Args:
+        podcast_obj (course_catalog.models.Podcast): A Podcast object
+    """
+    delete_document.delay(gen_podcast_id(podcast_obj), PODCAST_TYPE)
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def upsert_podcast_episode(podcast_episode_id):
+    """
+    Run a task to create or update a podcast episode Elasticsearch document
+
+    Args:
+        podcast_episode_id (int): the database primary key of the PodcastEpisode to update in ES
+    """
+    tasks.upsert_podcast_episode.delay(podcast_episode_id)
+
+
+@if_feature_enabled(INDEX_UPDATES)
+def delete_podcast_episode(podcast_episode_obj):
+    """
+    Runs a task to delete an ES PodcastEpisode document
+
+    Args:
+        podcast_episode_obj (course_catalog.models.PodcastEpisode): A PodcastEpisode object
+    """
+    delete_document.delay(
+        gen_podcast_episode_id(podcast_episode_obj), PODCAST_EPISODE_TYPE
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2791 

#### What's this PR do?
Indexes podcasts and podcast episodes upon ingestion

#### How should this be manually tested?
One way to test this would be to follow the logic of the test cases, e.g.: 

```python
podcast = PodcastFactory.build()
podcast_data = model_to_dict(podcast)
load_podcast(podcast_data)
```

After that example, you should see a new podcast in the ES index
