### PR TITLE
Add episodes per podcast view

### DIFF
--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -46,6 +46,11 @@ urlpatterns = [
         views.PodcastEpisodesViewSet.as_view({"get": "list"}),
         name="recent-podcast-episodes",
     ),
+    url(
+        r"^api/v0/podcasts/(?P<pk>[^/.]+)/episodes/$",
+        views.EpisodesInPodcast.as_view({"get": "list"}),
+        name="episodes-in-podcast",
+    ),
     url(r"^api/v0/", include(router.urls)),
     url(r"^api/v0/ocw_webhook/$", WebhookOCWView.as_view(), name="ocw-webhook"),
     url(

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -478,7 +478,9 @@ class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return (
-            PodcastEpisode.objects.filter(published=True, podcast=self.kwargs["pk"])
+            PodcastEpisode.objects.filter(
+                published=True, podcast__published=True, podcast=self.kwargs["pk"]
+            )
             .order_by("-last_modified", "-id")
             .prefetch_related(
                 Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -466,3 +466,22 @@ class PodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
             Prefetch("topics", queryset=CourseTopic.objects.all()),
         )
     )
+
+
+class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for listing PodcastEpisodes for a given Podcast primary key
+    """
+
+    serializer_class = PodcastEpisodeSerializer
+    permission_classes = (ReadOnly & PodcastFeatureFlag,)
+
+    def get_queryset(self):
+        return (
+            PodcastEpisode.objects.filter(published=True, podcast=self.kwargs["pk"])
+            .order_by("-last_modified", "-id")
+            .prefetch_related(
+                Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
+                Prefetch("topics", queryset=CourseTopic.objects.all()),
+            )
+        )

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -774,8 +774,15 @@ def test_episodes_per_podcast(settings, client):
     )
     # Make sure these aren't included
     PodcastEpisodeFactory.create_batch(5)
+    PodcastEpisodeFactory.create(podcast=podcast, published=False)
 
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("episodes-in-podcast", kwargs={"pk": podcast.id}))
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == PodcastEpisodeSerializer(instance=episodes, many=True).data
+
+    podcast.published = False
+    podcast.save()
+    resp = client.get(reverse("episodes-in-podcast", kwargs={"pk": podcast.id}))
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == []


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2813

#### What's this PR do?
Adds `/api/v0/podcasts/:number/episodes/` to list all serialized episodes for a given podcast id

#### How should this be manually tested?
Go to the endpoint and verify that the episodes match what you expect to see. Unpublished episodes should not be included in the list.
