### PR TITLE
make config offered_by field optional

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -82,15 +82,30 @@ def load_instructors(resource, instructors_data):
     return instructors
 
 
-def load_offered_bys(resource, offered_bys_data):
-    """Loads a list of offered_by into the resource. This operation is additive-only."""
+def load_offered_bys(resource, offered_bys_data, additive_only=True):
+    """
+    Loads a list of offered_by into the resource.
+
+    Args:
+        resource (LearningResource): learning resource
+        offered_bys_data (list of dict): the offered by data for the resource
+        additive_only (bool): if True existing offered bys that are not present in offered_bys_data are not deleted
+
+    Returns:
+        offered_bys (list of LearningResourceOfferor): list of created or updated offered_bys
+    """
     offered_bys = []
 
     for offered_by_data in offered_bys_data:
         offered_by, _ = LearningResourceOfferor.objects.get_or_create(
             name=offered_by_data["name"]
         )
-        resource.offered_by.add(offered_by)
+        if additive_only:
+            resource.offered_by.add(offered_by)
+        offered_bys.append(offered_by)
+
+    if not additive_only:
+        resource.offered_by.set(offered_bys)
 
     resource.save()
     return offered_bys
@@ -613,7 +628,7 @@ def load_podcast_episode(episode_data, podcast):
     )
 
     load_topics(episode, topics_data)
-    load_offered_bys(episode, offered_bys_data)
+    load_offered_bys(episode, offered_bys_data, False)
 
     for run_data in runs_data:
         load_run(episode, run_data)
@@ -648,7 +663,7 @@ def load_podcast(podcast_data):
     )
 
     load_topics(podcast, topics_data)
-    load_offered_bys(podcast, offered_by_data)
+    load_offered_bys(podcast, offered_by_data, False)
 
     episode_ids = []
 

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -448,7 +448,10 @@ def test_load_instructors(instructor_exists):
 )
 @pytest.mark.parametrize("offeror_exists", [True, False])
 @pytest.mark.parametrize("has_other_offered_by", [True, False])
-def test_load_offered_bys(parent_factory, offeror_exists, has_other_offered_by):
+@pytest.mark.parametrize("additive_only", [True, False])
+def test_load_offered_bys(
+    parent_factory, offeror_exists, has_other_offered_by, additive_only
+):
     """Test that load_offered_bys creates and/or assigns offeror to the parent object"""
     offeror = (
         LearningResourceOfferorFactory.create(is_xpro=True)
@@ -464,9 +467,14 @@ def test_load_offered_bys(parent_factory, offeror_exists, has_other_offered_by):
 
     assert parent.offered_by.count() == (1 if has_other_offered_by else 0)
 
-    load_offered_bys(parent, [{"name": offeror.name}])
+    load_offered_bys(parent, [{"name": offeror.name}], additive_only)
 
-    assert parent.offered_by.count() == (2 if has_other_offered_by else 1)
+    if additive_only:
+        assert parent.offered_by.count() == (2 if has_other_offered_by else 1)
+    else:
+        assert parent.offered_by.count() == 1
+
+    assert offeror.name in parent.offered_by.values_list("name", flat=True)
 
 
 @pytest.mark.parametrize("video_exists", [True, False])

--- a/course_catalog/etl/podcast_test.py
+++ b/course_catalog/etl/podcast_test.py
@@ -17,14 +17,16 @@ def rss_content():
     return content
 
 
-def mock_podcast_file(podcast_title=None, topics=None, website_url="website_url"):
+def mock_podcast_file(
+    podcast_title=None, topics=None, website_url="website_url", offered_by=None
+):
     """Mock podcast github file"""
 
     content = f"""---
 rss_url: rss_url
 { "podcast_title: " + podcast_title if podcast_title else "" }
 { "topics: " + topics if topics else "" }
-offered_by: A department
+{ "offered_by: " + offered_by if offered_by else "" }
 website:  {website_url}
 """
     return Mock(decoded_content=content)
@@ -77,9 +79,10 @@ def test_extract(mocker):
 @pytest.mark.usefixtures("mock_rss_request")
 @pytest.mark.parametrize("title", [None, "Custom Title"])
 @pytest.mark.parametrize("topics", [None, "Science, Technology"])
-def test_transform(mocker, title, topics):
+@pytest.mark.parametrize("offered_by", [None, "Department"])
+def test_transform(mocker, title, topics, offered_by):
     """Test transform function"""
-    podcast_list = [mock_podcast_file(title, topics)]
+    podcast_list = [mock_podcast_file(title, topics, "website_url", offered_by)]
     mock_github_client = mocker.patch("github.Github")
     mock_github_client.return_value.get_repo.return_value.get_contents.return_value = (
         podcast_list
@@ -89,11 +92,13 @@ def test_transform(mocker, title, topics):
 
     expected_title = title if title else "A Podcast"
 
+    expected_offered_by = [{"name": offered_by}] if offered_by else []
+
     expected_results = [
         {
             "podcast_id": "d4c3dcd45dc93fbc9c3634ba0545c2e0",
             "title": expected_title,
-            "offered_by": [{"name": "A department"}],
+            "offered_by": expected_offered_by,
             "full_description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "short_description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "image_src": "apicture.jpg",
@@ -104,7 +109,7 @@ def test_transform(mocker, title, topics):
                 {
                     "episode_id": "fefc732682f83d1a8945eebcae5364b4",
                     "title": "Episode1",
-                    "offered_by": [{"name": "A department"}],
+                    "offered_by": expected_offered_by,
                     "short_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "full_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "url": "http://feeds.soundcloud.com/stream/episode1.mp3",
@@ -126,7 +131,7 @@ def test_transform(mocker, title, topics):
                 {
                     "episode_id": "e56d3047fad337ca85b577c60ff6a8da",
                     "title": "Episode2",
-                    "offered_by": [{"name": "A department"}],
+                    "offered_by": expected_offered_by,
                     "short_description": "Praesent fermentum suscipit metus nec aliquam. Proin hendrerit felis ut varius facilisis.",
                     "full_description": "Praesent fermentum suscipit metus nec aliquam. Proin hendrerit felis ut varius facilisis.",
                     "url": "http://feeds.soundcloud.com/stream/episode2.mp3",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2825

#### What's this PR do?
This pr makes the `offered_by` field in the podcast config file in open-podcast-data optional

#### How should this be manually tested?
Set OPEN_PODCAST_DATA_BRANCH=master

Run `docker-compose run web ./manage.py backpopulate_podcast_data`. It should run successfully.

Go to 
`http://localhost:8063/api/v0/podcastes/` and `http://localhost:8063/api/v0/podcastepisodes/`. Verify that the data looks good.

Create a new offered_by record for a podcast and podcast episode.
```
from course_catalog.models import *
ob, _ = LearningResourceOfferor.objects.get_or_create(name='Not in config file')
podcast  = Podcast.objects.last()
podcast_episode = PodcastEpisode.objects.last()

podcast.offered_by.add(ob)
podcast.save()

podcast_episode.offered_by.add(ob)
podcast_episode.save()
```

 Verify that running 
`docker-compose run web ./manage.py backpopulate_podcast_data` again removes the new offered by from both the podcast and the podcast episode


