### PR TITLE
use podcast image when podcast episode image is missing

### DIFF
--- a/course_catalog/etl/podcast_test.py
+++ b/course_catalog/etl/podcast_test.py
@@ -108,7 +108,7 @@ def test_transform(mocker, title, topics):
                     "short_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "full_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
                     "url": "http://feeds.soundcloud.com/stream/episode1.mp3",
-                    "image_src": "image2.jpg",
+                    "image_src": "apicture.jpg",
                     "last_modified": datetime.datetime(
                         2020, 4, 1, 18, 20, 31, tzinfo=datetime.timezone.utc
                     ),

--- a/test_html/test_podcast.rss
+++ b/test_html/test_podcast.rss
@@ -38,7 +38,6 @@
       <itunes:subtitle>Morbi id consequat nisl. Morbi leo elit,…</itunes:subtitle>
       <description>SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor</description>
       <enclosure type="audio/mpeg" url="http://feeds.soundcloud.com/stream/episode1.mp3" length="25437522"/>
-      <itunes:image href="image2.jpg"/>
     </item>
     <item>
       <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers</guid>


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2797

#### What's this PR do?
This pr updates podcast ingestion to use the podcast image for podcast episodes that do not have their own image

#### How should this be manually tested?
set `OPEN_PODCAST_DATA_BRANCH=ab/test-ingest`
run `docker-compose run  web ./manage.py backpopulate_podcast_data`

Verify that all podcast episode objects have image_src set

