### PR TITLE
Fix audio player width

### DIFF
--- a/static/scss/audio-player.scss
+++ b/static/scss/audio-player.scss
@@ -26,8 +26,8 @@
     align-items: center;
     flex: 1;
     padding: $audio-player-padding-vertical $audio-player-padding-horizontal;
-    height: calc(100% - $audio-player-padding-vertical);
-    width: calc(100% - $audio-player-padding-horizontal);
+    height: calc(100% - #{$audio-player-padding-vertical * 2});
+    width: calc(100% - #{$audio-player-padding-horizontal * 2});
 
     @include breakpoint(mobile) {
       flex-direction: column;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2841

#### What's this PR do?
Fixes issues with the width of the inner container for the audio player

#### How should this be manually tested?
Run the player and make sure the content is not overflowing outside the container.  It's easiest to see on mobile, see the screenshots below.

#### Screenshots (if appropriate)
The issue:
![image](https://user-images.githubusercontent.com/12089658/80233488-8ebe4400-8624-11ea-831e-c0cd5e05e763.png)
How it should look:
![Screen Shot 2020-04-24 at 12 10 44 PM](https://user-images.githubusercontent.com/12089658/80233581-aeee0300-8624-11ea-996a-2700b4fc57dc.png)


#### What GIF best describes this PR or how it makes you feel?
![toobig](https://user-images.githubusercontent.com/12089658/80233678-e52b8280-8624-11ea-9723-e3c8cd92f455.gif)
