### PR TITLE
Audio player Safari / Apple Webkit fix

### DIFF
--- a/static/js/actions/audio.js
+++ b/static/js/actions/audio.js
@@ -1,6 +1,11 @@
 // @flow
 import { createAction } from "redux-actions"
 
+export const SET_AUDIO_PLAYER_STATE = "SET_AUDIO_PLAYER_STATE"
+export const setAudioPlayerState = createAction<string, *>(
+  SET_AUDIO_PLAYER_STATE
+)
+
 export const SET_CURRENTLY_PLAYING_AUDIO = "SET_CURRENTLY_PLAYING_AUDIO"
 export const setCurrentlyPlayingAudio = createAction<string, *>(
   SET_CURRENTLY_PLAYING_AUDIO

--- a/static/js/components/AudioPlayer.js
+++ b/static/js/components/AudioPlayer.js
@@ -4,55 +4,30 @@ import React, { useEffect, useRef, useCallback, useState } from "react"
 import { useSelector } from "react-redux"
 import Amplitude from "amplitudejs"
 
-import { currentlyPlayingAudioSelector } from "../lib/redux_selectors"
+import { INITIAL_AUDIO_STATE } from "../reducers/audio"
+import {
+  audioPlayerStateSelector,
+  currentlyPlayingAudioSelector
+} from "../lib/redux_selectors"
 
 export default function AudioPlayer() {
   const seekBar = useRef()
   const playPauseButton = useRef()
+  const audioPlayerState = useSelector(audioPlayerStateSelector)
   const currentlyPlayingAudio = useSelector(currentlyPlayingAudioSelector)
   const [audioLoaded, setAudioLoaded] = useState(false)
   const [audioPlaying, setAudioPlaying] = useState(false)
 
-  const amplitudeInitialized = useCallback(() => {
-    const audio = Amplitude.getAudio()
-    audio.addEventListener("play", playbackStarted)
-    audio.addEventListener("pause", playbackPaused)
-  })
-
-  const playbackStarted = useCallback(() => {
-    setAudioPlaying(true)
-  })
-
-  const playbackPaused = useCallback(() => {
-    setAudioPlaying(false)
-  })
-
   useEffect(
     () => {
-      if (Amplitude.getPlayerState() === "playing") {
-        Amplitude.pause()
+      if (
+        !_.isEqual(currentlyPlayingAudio, INITIAL_AUDIO_STATE.currentlyPlaying)
+      ) {
+        setAudioLoaded(true)
       }
-      if (_.values(currentlyPlayingAudio).every(_.isEmpty)) {
-        setAudioLoaded(false)
-        return
-      }
-      Amplitude.init({
-        songs: [
-          {
-            album: currentlyPlayingAudio.title,
-            name:  currentlyPlayingAudio.description,
-            url:   currentlyPlayingAudio.url
-          }
-        ],
-        callbacks: {
-          initialized: amplitudeInitialized
-        }
-      })
-      Amplitude.play()
-      setAudioLoaded(true)
-      setAudioPlaying(true)
+      setAudioPlaying(audioPlayerState === "playing")
     },
-    [currentlyPlayingAudio]
+    [audioPlayerState, currentlyPlayingAudio]
   )
 
   const backTenClick = useCallback(() => {

--- a/static/js/components/AudioPlayer_test.js
+++ b/static/js/components/AudioPlayer_test.js
@@ -1,8 +1,7 @@
 import { assert } from "chai"
-import Amplitude from "amplitudejs"
 
 import AudioPlayer from "./AudioPlayer"
-import { setCurrentlyPlayingAudio } from "../actions/audio"
+import { setAudioPlayerState, setCurrentlyPlayingAudio } from "../actions/audio"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("AudioPlayer", () => {
@@ -24,11 +23,21 @@ describe("AudioPlayer", () => {
     helper.cleanup()
   })
 
-  it("should render the component", async () => {
+  it("should be hidden if we try and render it without setting audio", async () => {
+    const { wrapper } = await render({}, [])
+    assert.isTrue(
+      wrapper.find(".audio-player-container-outer").hasClass("hidden")
+    )
+  })
+
+  it("should render the component and be visible if audio is passed in", async () => {
     const { wrapper } = await render({}, [
       setCurrentlyPlayingAudio(exampleAudio)
     ])
-    assert.equal(wrapper.find(".audio-player-container-outer").length, 1)
+    assert.equal(wrapper.find(`.audio-player-container-outer`).length, 1)
+    assert.isFalse(
+      wrapper.find(".audio-player-container-outer").hasClass("hidden")
+    )
   })
 
   it("should render all the necessary controls and fields", async () => {
@@ -46,10 +55,25 @@ describe("AudioPlayer", () => {
     assert.equal(wrapper.find(`.amplitude-playback-speed`).length, 1)
   })
 
-  it("should properly set the episode info in amplitudejs", async () => {
-    await render({}, [setCurrentlyPlayingAudio(exampleAudio)])
-    assert.equal(Amplitude.getConfig().songs[0].album, exampleAudio.title)
-    assert.equal(Amplitude.getConfig().songs[0].name, exampleAudio.description)
-    assert.equal(Amplitude.getConfig().songs[0].url, exampleAudio.url)
+  it("should render a pause icon when the player state is playing", async () => {
+    const { wrapper } = await render({}, [
+      setCurrentlyPlayingAudio(exampleAudio),
+      setAudioPlayerState("playing")
+    ])
+    assert.equal(
+      wrapper.find(`.amplitude-play-pause span`).text(),
+      "pause_circle_outline"
+    )
+  })
+
+  it("should render a play icon when the player state is paused", async () => {
+    const { wrapper } = await render({}, [
+      setCurrentlyPlayingAudio(exampleAudio),
+      setAudioPlayerState("paused")
+    ])
+    assert.equal(
+      wrapper.find(`.amplitude-play-pause span`).text(),
+      "play_circle_outline"
+    )
   })
 })

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS:false */
-import React, { useCallback } from "react"
+import React from "react"
 import Dotdotdot from "react-dotdotdot"
 
 import Card from "./Card"

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS:false */
-import React from "react"
+import React, { useCallback } from "react"
 import Dotdotdot from "react-dotdotdot"
 
 import Card from "./Card"

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -16,7 +16,7 @@ export default function PodcastPlayButton(props: Props) {
 
   const dispatch = useDispatch()
   const initAudioPlayer = useInitAudioPlayer({
-    title:       episode.podcast.title,
+    title:       episode.podcast_title,
     description: episode.title,
     url:         episode.url
   })

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -3,7 +3,7 @@ import React, { useCallback } from "react"
 
 import { useDispatch } from "react-redux"
 
-import { setCurrentlyPlayingAudio } from "../actions/audio"
+import { useInitAudioPlayer } from "../hooks/audio_player"
 
 import type { PodcastEpisode } from "../flow/podcastTypes"
 
@@ -15,17 +15,16 @@ export default function PodcastPlayButton(props: Props) {
   const { episode } = props
 
   const dispatch = useDispatch()
+  const initAudioPlayer = useInitAudioPlayer({
+    title:       episode.podcast.title,
+    description: episode.title,
+    url:         episode.url
+  })
   const playClick = useCallback(
     e => {
       e.stopPropagation()
       e.preventDefault()
-      dispatch(
-        setCurrentlyPlayingAudio({
-          title:       episode.podcast_title,
-          description: episode.title,
-          url:         episode.url
-        })
-      )
+      initAudioPlayer()
     },
     [dispatch]
   )

--- a/static/js/hooks/audio_player.js
+++ b/static/js/hooks/audio_player.js
@@ -1,0 +1,40 @@
+// @flow
+import { useCallback } from "react"
+import { useDispatch } from "react-redux"
+import Amplitude from "amplitudejs"
+
+import { setAudioPlayerState, setCurrentlyPlayingAudio } from "../actions/audio"
+
+export function useInitAudioPlayer(audio: Object) {
+  const dispatch = useDispatch()
+
+  const initAudioPlayer = useCallback(
+    () => {
+      dispatch(setCurrentlyPlayingAudio(audio))
+      if (Amplitude.getAudio()) {
+        Amplitude.getAudio().pause()
+      }
+      Amplitude.init({
+        songs: [
+          {
+            album: audio.title,
+            name:  audio.description,
+            url:   audio.url
+          }
+        ]
+      })
+      const audioElement = Amplitude.getAudio()
+      audioElement.pause()
+      audioElement.addEventListener("play", () => {
+        dispatch(setAudioPlayerState("playing"))
+      })
+      audioElement.addEventListener("pause", () => {
+        dispatch(setAudioPlayerState("paused"))
+      })
+      audioElement.play()
+    },
+    [dispatch, audio]
+  )
+
+  return initAudioPlayer
+}

--- a/static/js/hooks/audio_player_test.js
+++ b/static/js/hooks/audio_player_test.js
@@ -1,0 +1,52 @@
+// @flow
+import React from "react"
+import { assert } from "chai"
+import Amplitude from "amplitudejs"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { getCurrentlyPlayingAudio } from "../lib/redux_selectors"
+import { useInitAudioPlayer } from "./audio_player"
+
+describe("audio player hooks", () => {
+  let helper
+  const exampleAudio = {
+    title:       "Test Title",
+    description: "Test Description",
+    url:
+      "https://chtbl.com/track/F9DD6B/cdn.simplecast.com/audio/2c64ac/2c64ace6-baf4-4e86-b527-445e611e6a31/aa0ca88f-3c4c-4d33-9897-36e45c43e012/film-is-for-everyone-with-prof-david-thorburn_tc.mp3"
+  }
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  describe("useInitAudioPlayer", () => {
+    let render
+    const TestComponent = () => {
+      const initAudioPlayer = useInitAudioPlayer(exampleAudio)
+
+      return <div id="testDiv" onClick={initAudioPlayer} />
+    }
+
+    beforeEach(() => {
+      render = helper.configureReduxQueryRenderer(TestComponent)
+    })
+
+    it("starts playing upon click", async () => {
+      const { wrapper } = await render()
+      wrapper.find("#testDiv").simulate("click")
+      assert.isTrue(Amplitude.getAudio()._playStub.calledOnce)
+    })
+
+    it("sets the example audio as the currently playing audio", async () => {
+      const { wrapper, store } = await render()
+      wrapper.find("#testDiv").simulate("click")
+      const currentlyPlayingAudio = getCurrentlyPlayingAudio(store.getState())
+      assert.deepEqual(exampleAudio, currentlyPlayingAudio)
+    })
+  })
+})

--- a/static/js/lib/redux_selectors.js
+++ b/static/js/lib/redux_selectors.js
@@ -14,6 +14,14 @@ export const getSubscribedChannels = (state: Object): Array<Channel> =>
 export const getOwnProfile = (state: Object): ?Profile =>
   SETTINGS.username ? state.profiles.data.get(SETTINGS.username) : null
 
+export const getAudioPlayerState = (state: Object): any =>
+  state.audio.playerState
+
+export const audioPlayerStateSelector = createSelector(
+  state => state.audio,
+  audio => audio.playerState
+)
+
 export const getCurrentlyPlayingAudio = (state: Object): any =>
   state.audio.currentlyPlaying
 

--- a/static/js/reducers/audio.js
+++ b/static/js/reducers/audio.js
@@ -1,5 +1,8 @@
 // @flow
-import { SET_CURRENTLY_PLAYING_AUDIO } from "../actions/audio"
+import {
+  SET_AUDIO_PLAYER_STATE,
+  SET_CURRENTLY_PLAYING_AUDIO
+} from "../actions/audio"
 import type { Action } from "../flow/reduxTypes"
 
 export type Audio = {
@@ -11,6 +14,7 @@ export type AudioState = {
   currentlyPlaying: Audio
 }
 export const INITIAL_AUDIO_STATE: AudioState = {
+  playerState:      "paused",
   currentlyPlaying: {
     title:       "",
     description: "",
@@ -23,6 +27,8 @@ export const audio = (
   action: Action<any, null>
 ): AudioState => {
   switch (action.type) {
+  case SET_AUDIO_PLAYER_STATE:
+    return { ...state, playerState: action.payload }
   case SET_CURRENTLY_PLAYING_AUDIO:
     return { ...state, currentlyPlaying: action.payload }
   }

--- a/static/js/reducers/audio_test.js
+++ b/static/js/reducers/audio_test.js
@@ -47,7 +47,7 @@ describe("audio reducer", () => {
   })
 
   it("should let you set the audio player state", () => {
-    dispatchThen(setAudioPlayerState("playing", [SET_AUDIO_PLAYER_STATE]))
+    dispatchThen(setAudioPlayerState("playing"), [SET_AUDIO_PLAYER_STATE])
     const audioPlayerState = getAudioPlayerState(store.getState())
     assert.equal("playing", audioPlayerState)
   })

--- a/static/js/reducers/audio_test.js
+++ b/static/js/reducers/audio_test.js
@@ -2,9 +2,14 @@
 import { assert } from "chai"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { getCurrentlyPlayingAudio } from "../lib/redux_selectors"
+import {
+  getAudioPlayerState,
+  getCurrentlyPlayingAudio
+} from "../lib/redux_selectors"
 import { INITIAL_AUDIO_STATE } from "./audio"
 import {
+  SET_AUDIO_PLAYER_STATE,
+  setAudioPlayerState,
   SET_CURRENTLY_PLAYING_AUDIO,
   setCurrentlyPlayingAudio
 } from "../actions/audio"
@@ -39,5 +44,11 @@ describe("audio reducer", () => {
     ])
     const currentlyPlaying = getCurrentlyPlayingAudio(store.getState())
     assert.deepEqual(exampleAudio, currentlyPlaying)
+  })
+
+  it("should let you set the audio player state", () => {
+    dispatchThen(setAudioPlayerState("playing", [SET_AUDIO_PLAYER_STATE]))
+    const audioPlayerState = getAudioPlayerState(store.getState())
+    assert.equal("playing", audioPlayerState)
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2842

#### What's this PR do?
Apple Webkit based browsers (Safari & literally all browsers on iOS) disallow programmatically starting playback of audio or video without user interaction.  This PR takes the amplitudejs init code out of the AudioPlayer component itself and moves it to own own hook.  This way, this callback can be executed directly from a click handler to initialize the player and start playing the audio directly.

#### How should this be manually tested?
Aside from tests passing, you should be able to visit `/podcasts` in Safari and click "Play" on a podcast.  The player should load and audio should automatically start playing.

#### Screenshots
![Screen Shot 2020-04-24 at 6 10 57 PM](https://user-images.githubusercontent.com/12089658/80260930-06a56200-8657-11ea-8804-fe289770f24e.png)

#### What GIF best describes this PR or how it makes you feel?
Not a GIF, but I thought this was relevant:
![image](https://user-images.githubusercontent.com/12089658/80260842-ce058880-8656-11ea-9b92-6447e189528a.png)
