### PR TITLE
Podcast / PodcastEpisode drawer support

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -646,6 +646,12 @@ class PodcastEpisodeSerializer(serializers.ModelSerializer):
 
     topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
     offered_by = LearningResourceOfferorField(read_only=True, allow_null=True)
+    podcast_title = serializers.SerializerMethodField()
+    object_type = serializers.CharField(read_only=True, default="episode")
+
+    def get_podcast_title(self, instance):
+        """get the podcast title"""
+        return instance.podcast.title
 
     class Meta:
         model = PodcastEpisode
@@ -663,6 +669,8 @@ class PodcastEpisodeSerializer(serializers.ModelSerializer):
             "offered_by",
             "podcast",
             "last_modified",
+            "podcast_title",
+            "object_type",
         ]
 
 
@@ -674,6 +682,7 @@ class PodcastSerializer(serializers.ModelSerializer):
     topics = CourseTopicSerializer(read_only=True, many=True, allow_null=True)
     offered_by = LearningResourceOfferorField(read_only=True, allow_null=True)
     episode_count = serializers.IntegerField(read_only=True)
+    object_type = serializers.CharField(read_only=True, default="podcast")
 
     class Meta:
         model = Podcast
@@ -690,4 +699,5 @@ class PodcastSerializer(serializers.ModelSerializer):
             "created_on",
             "updated_on",
             "episode_count",
+            "object_type",
         ]

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -254,6 +254,7 @@ def test_podcast_serializer():
         "offered_by": [offered_by.name],
         "title": podcast.title,
         "id": podcast.id,
+        "object_type": "podcast",
     }
 
 
@@ -277,4 +278,6 @@ def test_podcast_episode_serializer():
         "url": episode.url,
         "podcast": episode.podcast_id,
         "last_modified": episode.last_modified.strftime(datetime_format),
+        "object_type": "episode",
+        "podcast_title": episode.podcast.title,
     }

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -437,6 +437,7 @@ class PodcastEpisodesViewSet(viewsets.ReadOnlyModelViewSet):
             Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
             Prefetch("topics", queryset=CourseTopic.objects.all()),
         )
+        .select_related("podcast")
     )
 
 
@@ -458,4 +459,5 @@ class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
                 Prefetch("offered_by", queryset=LearningResourceOfferor.objects.all()),
                 Prefetch("topics", queryset=CourseTopic.objects.all()),
             )
+            .select_related("podcast")
         )

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -81,7 +81,13 @@ const getSimilarResourcesForObject = createSelector(
   }
 )
 
-export default function LearningResourceDrawer() {
+type Props = {
+  hideSimilarLearningResources?: boolean
+}
+
+export default function LearningResourceDrawer(props: Props) {
+  const { hideSimilarLearningResources } = props
+
   useResponsive()
 
   const { objectId, objectType, runId, numHistoryEntries } = useSelector(
@@ -147,6 +153,7 @@ export default function LearningResourceDrawer() {
               setShowResourceDrawer={pushHistory}
               embedly={embedly}
               similarItems={similarResources}
+              hideSimilarLearningResources={!!hideSimilarLearningResources}
             />
           ) : null}
           <div className="footer" />

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -70,13 +70,13 @@ describe("LearningResourceDrawer", () => {
       body:   object
     })
 
-  const renderWithObject = async (object, apiUrl) => {
+  const renderWithObject = async (object, apiUrl, extraProps = {}) => {
     helper.handleRequestStub.withArgs(apiUrl).returns({
       status: 200,
       body:   object
     })
 
-    const { wrapper, store } = await render({}, [
+    const { wrapper, store } = await render(extraProps, [
       pushLRHistory({
         objectId:   object.id,
         objectType: object.object_type
@@ -88,7 +88,7 @@ describe("LearningResourceDrawer", () => {
   it("should have a button to hide the course drawer", async () => {
     const { wrapper, store } = await renderWithObject(
       course,
-      courseDetailApiURL
+      courseDetailApiURL.param({ courseId: course.id }).toString()
     )
     wrapper.find(".drawer-close").simulate("click")
     // this means that the history has been cleared
@@ -133,7 +133,10 @@ describe("LearningResourceDrawer", () => {
   })
 
   it("should log a view interaction when the drawer is shown", async () => {
-    await renderWithObject(course, courseDetailApiURL)
+    await renderWithObject(
+      course,
+      courseDetailApiURL.param({ courseId: course.id }).toString()
+    )
     assert.ok(helper.handleRequestStub.calledWith(interactionsApiURL))
   })
 
@@ -207,5 +210,17 @@ describe("LearningResourceDrawer", () => {
     assert.deepEqual(expandedDisplay.prop("object"), video)
     assert.deepEqual(expandedDisplay.prop("embedly"), embedly)
     assert.deepEqual(expandedDisplay.prop("similarItems"), similarItems)
+  })
+
+  it("should pass hideSimilarLearningResources prop to ExpandedLearningResourceDisplay", async () => {
+    const url = courseDetailApiURL.param({ courseId: course.id }).toString()
+    const { wrapper } = await renderWithObject(course, url, {
+      hideSimilarLearningResources: true
+    })
+    assert.ok(
+      wrapper
+        .find(ExpandedLearningResourceDisplay)
+        .prop("hideSimilarLearningResources")
+    )
   })
 })

--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -7,6 +7,7 @@ import Card from "./Card"
 
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
 import { CAROUSEL_IMG_WIDTH } from "../lib/constants"
+import { useOpenPodcastDrawer } from "../hooks/podcasts"
 
 import type { Podcast } from "../flow/podcastTypes"
 
@@ -19,8 +20,10 @@ export const PODCAST_IMG_HEIGHT = 170
 export default function PodcastCard(props: Props) {
   const { podcast } = props
 
+  const openPodcastDrawer = useOpenPodcastDrawer(podcast.id)
+
   return (
-    <Card className="podcast-card borderless">
+    <Card className="podcast-card borderless" onClick={openPodcastDrawer}>
       <div className="cover-img">
         <img
           src={embedlyThumbnail(

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -1,27 +1,31 @@
 // @flow
 /* global SETTINGS:false */
-import React from "react"
-import { shallow } from "enzyme"
 import { assert } from "chai"
+import sinon from "sinon"
 
 import PodcastCard, { PODCAST_IMG_HEIGHT } from "./PodcastCard"
 
 import { makePodcast } from "../factories/podcasts"
 import { embedlyThumbnail } from "../lib/url"
 import { CAROUSEL_IMG_WIDTH } from "../lib/constants"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import * as podcastHooks from "../hooks/podcasts"
 
 describe("PodcastCard", () => {
-  let podcast
+  let podcast, helper, render
 
   beforeEach(() => {
     podcast = makePodcast()
+    helper = new IntegrationTestHelper()
+    render = helper.configureReduxQueryRenderer(PodcastCard, { podcast })
   })
 
-  const render = (props = {}) =>
-    shallow(<PodcastCard podcast={podcast} {...props} />)
+  afterEach(() => {
+    helper.cleanup()
+  })
 
-  it("should render basic stuff", () => {
-    const wrapper = render()
+  it("should render basic stuff", async () => {
+    const { wrapper } = await render()
     assert.equal(wrapper.find("Dotdotdot").props().children, podcast.title)
     assert.equal(
       wrapper.find("img").prop("src"),
@@ -32,5 +36,13 @@ describe("PodcastCard", () => {
         CAROUSEL_IMG_WIDTH
       )
     )
+  })
+
+  it("should put a click handler on the card to open drawer", async () => {
+    const openStub = helper.sandbox.stub()
+    helper.sandbox.stub(podcastHooks, "useOpenPodcastDrawer").returns(openStub)
+    const { wrapper } = await render()
+    wrapper.find("Card").simulate("click")
+    sinon.assert.called(openStub)
   })
 })

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -1,16 +1,15 @@
 // @flow
 /* global SETTINGS:false */
-import React, { useCallback } from "react"
-import { useDispatch } from "react-redux"
+import React from "react"
 import Dotdotdot from "react-dotdotdot"
 
 import Card from "./Card"
+import PodcastPlayButton from "./PodcastPlayButton"
 
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
+import { useOpenEpisodeDrawer } from "../hooks/podcasts"
 
 import type { Podcast, PodcastEpisode } from "../flow/podcastTypes"
-
-import { setCurrentlyPlayingAudio } from "../actions/audio"
 
 export const PODCAST_IMG_HEIGHT = 77
 export const PODCAST_IMG_WIDTH = 125
@@ -23,30 +22,19 @@ type Props = {
 export default function PodcastEpisodeCard(props: Props) {
   const { episode, podcast } = props
 
-  const dispatch = useDispatch()
-  const playClick = useCallback(
-    () => {
-      dispatch(
-        setCurrentlyPlayingAudio({
-          title:       podcast.title,
-          description: episode.title,
-          url:         episode.url
-        })
-      )
-    },
-    [dispatch]
-  )
+  const openEpisodeDrawer = useOpenEpisodeDrawer(episode.id)
 
   return (
-    <Card className="podcast-episode-card low-padding">
+    <Card
+      className="podcast-episode-card low-padding"
+      onClick={openEpisodeDrawer}
+    >
       <div className="left-col">
         <div className="episode-title">
           <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
         </div>
         <div className="podcast-name">{podcast.title}</div>
-        <div className="play-button black-surround" onClick={playClick}>
-          Play
-        </div>
+        <PodcastPlayButton episode={episode} />
       </div>
       <div className="right-col">
         <img

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -1,18 +1,20 @@
 // @flow
 /* global SETTINGS:false */
 import { assert } from "chai"
+import sinon from "sinon"
 
 import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
 import { embedlyThumbnail } from "../lib/url"
 import IntegrationTestHelper from "../util/integration_test_helper"
-
 import PodcastEpisodeCard, {
   PODCAST_IMG_WIDTH,
   PODCAST_IMG_HEIGHT
 } from "./PodcastEpisodeCard"
+import * as podcastHooks from "../hooks/podcasts"
 
 describe("PodcastEpisodeCard", () => {
   let podcast, episode, render, helper
+
   beforeEach(() => {
     podcast = makePodcast()
     episode = makePodcastEpisode(podcast)
@@ -40,5 +42,22 @@ describe("PodcastEpisodeCard", () => {
         PODCAST_IMG_WIDTH
       )
     )
+  })
+
+  it("should have a play button", async () => {
+    const { wrapper } = await render()
+    assert.ok(wrapper.find("PodcastPlayButton").exists())
+    assert.deepEqual(wrapper.find("PodcastPlayButton").prop("episode"), episode)
+  })
+
+  it("should put a click handler on card to open drawer", async () => {
+    const openStub = helper.sandbox.stub()
+    helper.sandbox.stub(podcastHooks, "useOpenEpisodeDrawer").returns(openStub)
+    const { wrapper } = await render()
+    wrapper
+      .find(".podcast-episode-card")
+      .at(0)
+      .simulate("click")
+    sinon.assert.called(openStub)
   })
 })

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -1,0 +1,39 @@
+// @flow
+import React, { useCallback } from "react"
+
+import { useDispatch } from "react-redux"
+
+import { setCurrentlyPlayingAudio } from "../actions/audio"
+
+import type { PodcastEpisode } from "../flow/podcastTypes"
+
+type Props = {
+  episode: PodcastEpisode
+}
+
+export default function PodcastPlayButton(props: Props) {
+  const { episode } = props
+
+  const dispatch = useDispatch()
+  const playClick = useCallback(
+    e => {
+      e.stopPropagation()
+      e.preventDefault()
+      dispatch(
+        setCurrentlyPlayingAudio({
+          title:       episode.podcast_title,
+          description: episode.title,
+          url:         episode.url
+        })
+      )
+    },
+    [dispatch]
+  )
+
+  return (
+    <div className="podcast-play-button black-surround" onClick={playClick}>
+      Play
+      <i className="material-icons play_arrow">play_arrow</i>
+    </div>
+  )
+}

--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -14,9 +14,12 @@ import {
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_VIDEO,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE,
   OBJECT_TYPE_MAPPING,
   DATE_FORMAT
 } from "../lib/constants"
+import { makePodcast, makePodcastEpisode } from "./podcasts"
 
 import type {
   Course,
@@ -191,26 +194,25 @@ export const makeVideo = (): Video => ({
   lists:             []
 })
 
-export const makeLearningResource = (objectType: string): Object => {
-  switch (objectType) {
-  case LR_TYPE_COURSE:
-    return R.merge({ object_type: LR_TYPE_COURSE }, makeCourse())
-  case LR_TYPE_PROGRAM:
-    return R.merge({ object_type: LR_TYPE_PROGRAM }, makeProgram())
-  case LR_TYPE_USERLIST:
-    return R.merge(
-      { object_type: LR_TYPE_USERLIST, list_type: LR_TYPE_USERLIST },
-      makeUserList()
-    )
-  case LR_TYPE_LEARNINGPATH:
-    return R.merge(
-      { object_type: LR_TYPE_LEARNINGPATH, list_type: LR_TYPE_LEARNINGPATH },
-      makeUserList()
-    )
-  case LR_TYPE_VIDEO:
-    return R.merge({ object_type: LR_TYPE_VIDEO }, makeVideo())
-  }
+const LR_FACTORY_MAPPING = {
+  [LR_TYPE_COURSE]:   makeCourse,
+  [LR_TYPE_PROGRAM]:  makeProgram,
+  [LR_TYPE_USERLIST]: R.compose(
+    R.merge({ list_type: LR_TYPE_USERLIST }),
+    makeUserList
+  ),
+  [LR_TYPE_LEARNINGPATH]: R.compose(
+    R.merge({ list_type: LR_TYPE_LEARNINGPATH }),
+    makeUserList
+  ),
+  [LR_TYPE_VIDEO]:           makeVideo,
+  [LR_TYPE_PODCAST]:         makePodcast,
+  [LR_TYPE_PODCAST_EPISODE]: makePodcastEpisode
 }
+
+// eslint-disable-next-line camelcase
+export const makeLearningResource = (object_type: string): Object =>
+  R.merge({ object_type }, LR_FACTORY_MAPPING[object_type]())
 
 const formatFavorite = contentType => resource => ({
   content_data: resource,

--- a/static/js/factories/podcasts.js
+++ b/static/js/factories/podcasts.js
@@ -37,6 +37,7 @@ export const makePodcastEpisode = (podcast?: Podcast): PodcastEpisode => {
     podcast:           podcast.id,
     short_description: casual.description,
     title:             casual.title,
+    podcast_title:     podcast.title,
     topics:            [],
     updated_on:        casual.moment.toISOString(),
     url:               casual.url

--- a/static/js/flow/podcastTypes.js
+++ b/static/js/flow/podcastTypes.js
@@ -11,7 +11,7 @@ export type Podcast = {
   title: string,
   topics: Array<string>,
   updated_on: string,
-  url: string,
+  url: string
 }
 
 export type PodcastEpisode = {
@@ -27,5 +27,6 @@ export type PodcastEpisode = {
   title: string,
   topics: Array<string>,
   updated_on: string,
-  url: string
+  url: string,
+  podcast_title: string
 }

--- a/static/js/hooks/podcasts.js
+++ b/static/js/hooks/podcasts.js
@@ -1,0 +1,46 @@
+// @flow
+import { useCallback } from "react"
+import { useDispatch } from "react-redux"
+
+import { pushLRHistory } from "../actions/ui"
+import { LR_TYPE_PODCAST, LR_TYPE_PODCAST_EPISODE } from "../lib/constants"
+
+export function useOpenPodcastDrawer(podcastId: number) {
+  const dispatch = useDispatch()
+
+  const openPodcastDrawer = useCallback(
+    (e: Event) => {
+      e.preventDefault()
+
+      dispatch(
+        pushLRHistory({
+          objectId:   podcastId,
+          objectType: LR_TYPE_PODCAST
+        })
+      )
+    },
+    [dispatch, podcastId]
+  )
+
+  return openPodcastDrawer
+}
+
+export function useOpenEpisodeDrawer(episodeId: number) {
+  const dispatch = useDispatch()
+
+  const openEpisodeDrawer = useCallback(
+    (e: Event) => {
+      e.preventDefault()
+
+      dispatch(
+        pushLRHistory({
+          objectId:   episodeId,
+          objectType: LR_TYPE_PODCAST_EPISODE
+        })
+      )
+    },
+    [dispatch, episodeId]
+  )
+
+  return openEpisodeDrawer
+}

--- a/static/js/hooks/podcasts_test.js
+++ b/static/js/hooks/podcasts_test.js
@@ -1,0 +1,66 @@
+// @flow
+import { assert } from "chai"
+
+import { hookClickTestHarness } from "./test_util"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
+import { useOpenPodcastDrawer, useOpenEpisodeDrawer } from "./podcasts"
+import { LR_TYPE_PODCAST, LR_TYPE_PODCAST_EPISODE } from "../lib/constants"
+
+const OpenPodcastComponent = hookClickTestHarness(useOpenPodcastDrawer)
+const OpenEpisodeComponent = hookClickTestHarness(useOpenEpisodeDrawer)
+
+describe("Podcast hooks", () => {
+  let helper, render
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  describe("Podcast drawer hook", () => {
+    let podcast
+    beforeEach(() => {
+      podcast = makePodcast()
+      render = helper.configureReduxQueryRenderer(OpenPodcastComponent, {
+        hookArgs: podcast.id
+      })
+    })
+
+    it("should dispatch the action we expect to the store", async () => {
+      const { wrapper, store } = await render()
+      wrapper.find(OpenPodcastComponent).simulate("click")
+
+      assert.deepEqual(store.getState().ui.LRDrawerHistory[0], {
+        objectId:   podcast.id,
+        objectType: LR_TYPE_PODCAST,
+        runId:      undefined
+      })
+    })
+  })
+
+  describe("Episode drawer hook", () => {
+    let episode
+
+    beforeEach(() => {
+      episode = makePodcastEpisode()
+      render = helper.configureReduxQueryRenderer(OpenEpisodeComponent, {
+        hookArgs: episode.id
+      })
+    })
+
+    it("should dispatch the action we expect to the store", async () => {
+      const { wrapper, store } = await render()
+      wrapper.find(OpenEpisodeComponent).simulate("click")
+
+      assert.deepEqual(store.getState().ui.LRDrawerHistory[0], {
+        objectId:   episode.id,
+        objectType: LR_TYPE_PODCAST_EPISODE,
+        runId:      undefined
+      })
+    })
+  })
+})

--- a/static/js/hooks/test_util.js
+++ b/static/js/hooks/test_util.js
@@ -1,0 +1,13 @@
+// @flow
+import React from "react"
+
+export const hookClickTestHarness = (hook: Function) => {
+  function TestHarness(props: Object) {
+    const { hookArgs } = props
+
+    const clickHandler = hook(hookArgs)
+
+    return <div onClick={clickHandler} />
+  }
+  return TestHarness
+}

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -79,13 +79,17 @@ export const LR_TYPE_PROGRAM = "program"
 export const LR_TYPE_USERLIST = "userlist"
 export const LR_TYPE_LEARNINGPATH = "learningpath"
 export const LR_TYPE_VIDEO = "video"
+export const LR_TYPE_PODCAST = "podcast"
+export const LR_TYPE_PODCAST_EPISODE = "episode"
 export const FAVORITES_PSEUDO_LIST = "favorites"
 export const LR_TYPE_ALL = [
   LR_TYPE_COURSE,
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
 ]
 
 export const OBJECT_TYPE_MAPPING = {

--- a/static/js/lib/queries/learning_resources.js
+++ b/static/js/lib/queries/learning_resources.js
@@ -11,20 +11,25 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
   LR_TYPE_VIDEO,
-  LR_TYPE_LEARNINGPATH
+  LR_TYPE_LEARNINGPATH,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
 } from "../constants"
 import { courseRequest } from "./courses"
 import { programRequest } from "./programs"
 import { videoRequest } from "./videos"
 import { userListRequest } from "./user_lists"
+import { podcastRequest, podcastEpisodeRequest } from "./podcasts"
 
 // object_type => $KEY for `entities.$KEY` mapping
 export const OBJECT_TYPE_ENTITY_ROUTING = {
-  [LR_TYPE_USERLIST]:     "userLists",
-  [LR_TYPE_LEARNINGPATH]: "userLists",
-  [LR_TYPE_COURSE]:       "courses",
-  [LR_TYPE_PROGRAM]:      "programs",
-  [LR_TYPE_VIDEO]:        "videos"
+  [LR_TYPE_USERLIST]:        "userLists",
+  [LR_TYPE_LEARNINGPATH]:    "userLists",
+  [LR_TYPE_COURSE]:          "courses",
+  [LR_TYPE_PROGRAM]:         "programs",
+  [LR_TYPE_VIDEO]:           "videos",
+  [LR_TYPE_PODCAST]:         "podcasts",
+  [LR_TYPE_PODCAST_EPISODE]: "podcastEpisodes"
 }
 
 export const normalizeResourcesByObjectType = R.compose(
@@ -34,10 +39,12 @@ export const normalizeResourcesByObjectType = R.compose(
 )
 
 export const updateLearningResources = {
-  courses:   R.merge,
-  programs:  R.merge,
-  userLists: R.merge,
-  videos:    R.merge
+  courses:         R.merge,
+  programs:        R.merge,
+  userLists:       R.merge,
+  videos:          R.merge,
+  podcasts:        R.merge,
+  podcastEpisodes: R.merge
 }
 
 export const mapResourcesToResourceRefs = R.map(
@@ -74,11 +81,15 @@ export const favoritesRequest = () => ({
     const { next, results } = responseJson
 
     return {
-      courses:   constructIdMap(filterFavorites(results, LR_TYPE_COURSE)),
-      programs:  constructIdMap(filterFavorites(results, LR_TYPE_PROGRAM)),
-      userLists: constructIdMap(filterFavorites(results, LR_TYPE_USERLIST)),
-      videos:    constructIdMap(filterFavorites(results, LR_TYPE_VIDEO)),
-      next:      next
+      courses:         constructIdMap(filterFavorites(results, LR_TYPE_COURSE)),
+      programs:        constructIdMap(filterFavorites(results, LR_TYPE_PROGRAM)),
+      userLists:       constructIdMap(filterFavorites(results, LR_TYPE_USERLIST)),
+      videos:          constructIdMap(filterFavorites(results, LR_TYPE_VIDEO)),
+      podcasts:        constructIdMap(filterFavorites(results, LR_TYPE_PODCAST)),
+      podcastEpisodes: constructIdMap(
+        filterFavorites(results, LR_TYPE_PODCAST_EPISODE)
+      ),
+      next: next
     }
   },
   update: {
@@ -151,6 +162,10 @@ export const getResourceRequest = (objectId: ?number, objectType: ?string) => {
     return programRequest(objectId)
   case LR_TYPE_VIDEO:
     return videoRequest(objectId)
+  case LR_TYPE_PODCAST:
+    return podcastRequest(objectId)
+  case LR_TYPE_PODCAST_EPISODE:
+    return podcastEpisodeRequest(objectId)
   default:
     return userListRequest(objectId)
   }
@@ -161,7 +176,9 @@ export const learningResourceSelector = createSelector(
   state => state.entities.programs,
   state => state.entities.userLists,
   state => state.entities.videos,
-  (courses, programs, userLists, videos) =>
+  state => state.entities.podcasts,
+  state => state.entities.podcastEpisodes,
+  (courses, programs, userLists, videos, podcasts, podcastEpisodes) =>
     memoize(
       (objectId, objectType) => {
         switch (objectType) {
@@ -171,6 +188,10 @@ export const learningResourceSelector = createSelector(
           return programs ? programs[objectId] : null
         case LR_TYPE_VIDEO:
           return videos ? videos[objectId] : null
+        case LR_TYPE_PODCAST:
+          return podcasts ? podcasts[objectId] : null
+        case LR_TYPE_PODCAST_EPISODE:
+          return podcastEpisodes ? podcastEpisodes[objectId] : null
         default:
           return userLists ? userLists[objectId] : null
         }

--- a/static/js/lib/queries/podcasts.js
+++ b/static/js/lib/queries/podcasts.js
@@ -2,7 +2,12 @@
 import R from "ramda"
 import { createSelector } from "reselect"
 
-import { podcastApiURL, recentPodcastApiURL } from "../url"
+import {
+  podcastApiURL,
+  recentPodcastApiURL,
+  podcastDetailApiURL,
+  podcastEpisodeDetailApiURL
+} from "../url"
 import { constructIdMap } from "../redux_query"
 
 import type { PodcastEpisode } from "../../flow/podcastTypes"
@@ -12,6 +17,17 @@ export const podcastsRequest = () => ({
   url:       podcastApiURL.toString(),
   transform: (podcasts: any) => ({
     podcasts: constructIdMap(podcasts)
+  }),
+  update: {
+    podcasts: R.merge
+  }
+})
+
+export const podcastRequest = (podcastId: number) => ({
+  queryKey:  "podcastsRequest",
+  url:       podcastDetailApiURL.param({ podcastId }).toString(),
+  transform: (podcast: any) => ({
+    podcasts: constructIdMap([podcast])
   }),
   update: {
     podcasts: R.merge
@@ -36,6 +52,17 @@ export const recentPodcastEpisodesRequest = () => ({
   },
   update: {
     recentEpisodes:  (_: any, newList: Array<PodcastEpisode>) => newList,
+    podcastEpisodes: R.merge
+  }
+})
+
+export const podcastEpisodeRequest = (episodeId: number) => ({
+  queryKey:  "podcastEpisode",
+  url:       podcastEpisodeDetailApiURL.param({ episodeId }).toString(),
+  transform: (episode: any) => ({
+    podcastEpisodes: constructIdMap([episode])
+  }),
+  update: {
     podcastEpisodes: R.merge
   }
 })

--- a/static/js/lib/queries/user_list_items_test.js
+++ b/static/js/lib/queries/user_list_items_test.js
@@ -16,7 +16,12 @@ import {
   makeUserList
 } from "../../factories/learning_resources"
 import { userListItemsApiURL, userListItemsDetailApiURL } from "../url"
-import { LR_TYPE_ALL, OBJECT_TYPE_MAPPING } from "../constants"
+import {
+  LR_TYPE_ALL,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE,
+  OBJECT_TYPE_MAPPING
+} from "../constants"
 // import { constructIdMap } from "../redux_query"
 
 describe("UserList Items API", () => {
@@ -74,7 +79,12 @@ describe("UserList Items API", () => {
   })
 
   describe("createUserListItemMutation", () => {
-    LR_TYPE_ALL.forEach(objectType => {
+    // TEMPORARY! when we add full support for podcasts and podcast episodes
+    // in user lists we can change this
+    LR_TYPE_ALL.filter(
+      objectType =>
+        objectType !== LR_TYPE_PODCAST && objectType !== LR_TYPE_PODCAST_EPISODE
+    ).forEach(objectType => {
       let item, resource, request, entityKey, contentType
 
       beforeEach(() => {
@@ -223,7 +233,12 @@ describe("UserList Items API", () => {
       assert.equal(request.options.method, "DELETE")
     })
 
-    LR_TYPE_ALL.forEach(contentType => {
+    // TEMPORARY! when we add full support for podcasts and podcast episodes
+    // in user lists we can change this
+    LR_TYPE_ALL.filter(
+      objectType =>
+        objectType !== LR_TYPE_PODCAST && objectType !== LR_TYPE_PODCAST_EPISODE
+    ).forEach(contentType => {
       it(`optimistically updates the state for contentType=${contentType}`, () => {
         const userList = makeUserList()
         const item = makeUserListItem(contentType)

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -178,7 +178,15 @@ export const similarResourcesURL = "/api/v0/similar/"
 
 export const podcastApiURL = api.segment("podcasts/")
 export const recentPodcastApiURL = podcastApiURL.segment("recent/")
-export const podcastDetailURL = podcastApiURL.segment(":podcastId")
+export const podcastDetailApiURL = podcastApiURL.segment(":podcastId")
+export const podcastDetailEpisodesApiURL = podcastDetailApiURL.segment(
+  "episodes/"
+)
+
+export const podcastEpisodeApiURL = api.segment("podcastepisodes/")
+export const podcastEpisodeDetailApiURL = podcastEpisodeApiURL.segment(
+  ":episodeId"
+)
 
 export const userListIndexURL = "/learn/lists/"
 export const userListDetailURL = (id: number) => `/learn/lists/${id}`

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -39,6 +39,7 @@ import Drawer from "../components/Drawer"
 import Toolbar from "../components/Toolbar"
 import ContentToolbar from "../components/ContentToolbar"
 import AudioPlayer from "../components/AudioPlayer"
+import LearningResourceDrawer from "../components/LearningResourceDrawer"
 
 import { actions } from "../actions"
 import {
@@ -332,6 +333,7 @@ class App extends React.Component<Props> {
             <Route path={`${match.url}podcasts`}>
               <PodcastFrontpage />
               <AudioPlayer />
+              <LearningResourceDrawer hideSimilarLearningResources />
             </Route>
           ) : null}
         </div>

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -30,7 +30,9 @@ import {
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
 } from "../lib/constants"
 import {
   emptyOrNil,
@@ -316,7 +318,14 @@ export class CourseSearchPage extends React.Component<Props, State> {
   getFavoriteOrListedObject = (result: LearningResourceResult) => {
     // Get the latest data from state if any to reflect recent changes in favorites/lists
     const { entities } = this.props
-    const { courses, programs, userLists, videos } = entities
+    const {
+      courses,
+      programs,
+      userLists,
+      videos,
+      podcasts,
+      episodes
+    } = entities
     switch (result.object_type) {
     case LR_TYPE_COURSE:
       return courses ? courses[result.id] || null : null
@@ -326,6 +335,10 @@ export class CourseSearchPage extends React.Component<Props, State> {
       return userLists ? userLists[result.id] || null : null
     case LR_TYPE_VIDEO:
       return videos ? videos[result.id] || null : null
+    case LR_TYPE_PODCAST:
+      return podcasts ? podcasts[result.id] || null : null
+    case LR_TYPE_PODCAST_EPISODE:
+      return episodes ? episodes[result.id] || null : null
     case LR_TYPE_LEARNINGPATH:
       return userLists ? userLists[result.id] || null : null
     }

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -22,7 +22,9 @@ import {
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_PROGRAM,
   LR_TYPE_USERLIST,
-  LR_TYPE_VIDEO
+  LR_TYPE_VIDEO,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
 } from "../lib/constants"
 import { SEARCH_LIST_UI } from "../lib/search"
 import { wait } from "../lib/util"
@@ -538,7 +540,10 @@ describe("CourseSearchPage", () => {
     await wait(600)
   })
 
-  LR_TYPE_ALL.forEach(resourceType => {
+  // THIS IS TEMPORARY UNTIL FULL SEARCH SUPPORT IS IN PLACE!
+  LR_TYPE_ALL.filter(
+    type => type !== LR_TYPE_PODCAST && type !== LR_TYPE_PODCAST_EPISODE
+  ).forEach(resourceType => {
     it(`overrideObject ${resourceType} is null if not in entities`, async () => {
       const resource = makeLearningResourceResult(resourceType)
       searchResponse.hits.hits[0] = resource

--- a/static/scss/learning-resource-drawer.scss
+++ b/static/scss/learning-resource-drawer.scss
@@ -46,6 +46,10 @@
     font-weight: bold;
   }
 
+  .podcast-play-control {
+    margin-top: 15px;
+  }
+
   .topics {
     margin: 25px 0;
 
@@ -53,6 +57,17 @@
       display: flex;
       flex-flow: wrap;
     }
+  }
+
+  .podcast-subtitle {
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  .podcast-main-title {
+    font-size: 24px;
+    color: $course-blue;
+    font-weight: bold;
   }
 
   .title {

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -44,6 +44,7 @@
 
 .podcast-episode-card {
   max-width: 480px;
+  cursor: pointer;
 
   .card-contents {
     display: flex;
@@ -62,11 +63,7 @@
     padding-top: 10px;
   }
 
-  .black-surround,
-  .grey-surround {
-    display: inline-block;
-    font-size: 14px;
-    padding: 2px 10px;
+  .podcast-play-button {
     margin-top: 8px;
   }
 
@@ -78,6 +75,7 @@
 
 .podcast-card {
   font-family: roboto;
+  cursor: pointer;
 
   .cover-img {
     img {
@@ -111,5 +109,18 @@
   .podcast-author {
     font-size: 14px;
     color: $font-grey-light;
+  }
+}
+
+.podcast-play-button {
+  display: inline-flex;
+  font-size: 14px;
+  padding: 2px 10px;
+  cursor: pointer;
+  text-transform: uppercase;
+
+  i {
+    color: white;
+    font-size: 18px;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

part of #2722 

#### What's this PR do?

adds basic support for podcasts and podcast episodes to our learning resource drawer.

#### How should this be manually tested?

you should be able to open any podcast or podcast episode in the drawer, the display should be adequate. you should be able to start playing an episode from the drawer.

#### Screenshots (if appropriate)

![Screenshot from 2020-04-27 11-17-38](https://user-images.githubusercontent.com/6207644/80389168-be658a00-8878-11ea-9ea4-6967dcab69c1.png)
![Screenshot from 2020-04-27 11-17-29](https://user-images.githubusercontent.com/6207644/80389170-be658a00-8878-11ea-8351-f9244aa89184.png)
![Screenshot from 2020-04-27 11-16-49](https://user-images.githubusercontent.com/6207644/80389172-befe2080-8878-11ea-9655-0cc125fec47b.png)
![Screenshot from 2020-04-27 11-16-38](https://user-images.githubusercontent.com/6207644/80389175-befe2080-8878-11ea-8bd6-24dfc09df4e6.png)


#### What GIF best describes this PR or how it makes you feel?
(Optional)
