### PR TITLE
add date to podcast episode

### DIFF
--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -2,6 +2,7 @@
 /* global SETTINGS:false */
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
+import moment from "moment"
 
 import Card from "./Card"
 import PodcastPlayButton from "./PodcastPlayButton"
@@ -19,6 +20,8 @@ type Props = {
   episode: PodcastEpisode
 }
 
+export const EPISODE_DATE_FORMAT = "MMMM D, YYYY"
+
 export default function PodcastEpisodeCard(props: Props) {
   const { episode, podcast } = props
 
@@ -34,7 +37,12 @@ export default function PodcastEpisodeCard(props: Props) {
           <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
         </div>
         <div className="podcast-name">{podcast.title}</div>
-        <PodcastPlayButton episode={episode} />
+        <div className="play-date-row">
+          <PodcastPlayButton episode={episode} />
+          <div className="date">
+            {moment(episode.last_modified).format(EPISODE_DATE_FORMAT)}
+          </div>
+        </div>
       </div>
       <div className="right-col">
         <img

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -2,13 +2,15 @@
 /* global SETTINGS:false */
 import { assert } from "chai"
 import sinon from "sinon"
+import moment from "moment"
 
 import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
 import { embedlyThumbnail } from "../lib/url"
 import IntegrationTestHelper from "../util/integration_test_helper"
 import PodcastEpisodeCard, {
   PODCAST_IMG_WIDTH,
-  PODCAST_IMG_HEIGHT
+  PODCAST_IMG_HEIGHT,
+  EPISODE_DATE_FORMAT
 } from "./PodcastEpisodeCard"
 import * as podcastHooks from "../hooks/podcasts"
 
@@ -33,6 +35,10 @@ describe("PodcastEpisodeCard", () => {
     const { wrapper } = await render()
     assert.equal(wrapper.find("Dotdotdot").props().children, episode.title)
     assert.equal(wrapper.find(".podcast-name").text(), podcast.title)
+    assert.equal(
+      wrapper.find(".date").text(),
+      moment(episode.last_modified).format(EPISODE_DATE_FORMAT)
+    )
     assert.equal(
       wrapper.find("img").prop("src"),
       embedlyThumbnail(

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -63,13 +63,33 @@
     padding-top: 10px;
   }
 
+  .play-date-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .date {
+      font-size: 14px;
+      color: $podcast-border-grey;
+    }
+  }
+
   .podcast-play-button {
     margin-top: 8px;
+  }
+
+  .left-col {
+    width: 100%;
+    margin-right: 10px;
   }
 
   .episode-cover-image {
     border: 1px solid $podcast-border-grey;
     border-radius: 5px;
+    max-width: 125px;
+    min-width: 125px;
+    max-height: 79px;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

part of #2722 

#### What's this PR do?
adds the publish date to the `PodcastEpisodeCard`

#### How should this be manually tested?

the `last_modified` date should be showing up on the episode cards, formatted like on the designs.

#### Screenshots (if appropriate)

![Screenshot from 2020-04-27 11-33-37](https://user-images.githubusercontent.com/6207644/80390811-f1a91880-887a-11ea-8ae0-5802f0b82a23.png)
