### PR TITLE
fix podcast share URL

### DIFF
--- a/static/js/hooks/learning_resources.js
+++ b/static/js/hooks/learning_resources.js
@@ -1,6 +1,10 @@
 // @flow
+import { useEffect } from "react"
 import { useLocation } from "react-router-dom"
+import { useDispatch } from "react-redux"
 import qs from "query-string"
+
+import { pushLRHistory } from "../actions/ui"
 
 export function useLRDrawerParams() {
   const { search } = useLocation()
@@ -11,4 +15,20 @@ export function useLRDrawerParams() {
     objectId:   lr_id,
     objectType: type
   }
+}
+
+export function useLearningResourcePermalink() {
+  const dispatch = useDispatch()
+  const { objectId, objectType } = useLRDrawerParams()
+
+  useEffect(() => {
+    if (objectId && objectType) {
+      dispatch(
+        pushLRHistory({
+          objectId,
+          objectType
+        })
+      )
+    }
+  }, [])
 }

--- a/static/js/hooks/learning_resources_test.js
+++ b/static/js/hooks/learning_resources_test.js
@@ -1,0 +1,45 @@
+// @flow
+import { assert } from "chai"
+import qs from "query-string"
+
+import { useLearningResourcePermalink } from "./learning_resources"
+import { genericTestHarness } from "./test_util"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { LR_TYPE_PODCAST } from "../lib/constants"
+
+const PermalinkTester = genericTestHarness(useLearningResourcePermalink)
+
+describe("Learning Resources hooks", () => {
+  let helper, render
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    render = helper.configureReduxQueryRenderer(PermalinkTester)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should not dispatch if no params", async () => {
+    const { store } = await render()
+    assert.deepEqual(store.getState().ui.LRDrawerHistory, [])
+  })
+
+  it("should dispatch if params are present", async () => {
+    helper.browserHistory.push(
+      `?${qs.stringify({
+        lr_id: 1,
+        type:  LR_TYPE_PODCAST
+      })}`
+    )
+    const { store } = await render()
+    assert.deepEqual(store.getState().ui.LRDrawerHistory, [
+      {
+        objectId:   "1",
+        objectType: LR_TYPE_PODCAST,
+        runId:      undefined
+      }
+    ])
+  })
+})

--- a/static/js/hooks/test_util.js
+++ b/static/js/hooks/test_util.js
@@ -11,3 +11,11 @@ export const hookClickTestHarness = (hook: Function) => {
   }
   return TestHarness
 }
+
+export const genericTestHarness = (hook: Function) => {
+  function TestHarness() {
+    hook()
+    return <div />
+  }
+  return TestHarness
+}

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -3,6 +3,8 @@ import R from "ramda"
 import qs from "query-string"
 import UrlAssembler from "url-assembler"
 
+import { LR_TYPE_PODCAST_EPISODE, LR_TYPE_PODCAST } from "../lib/constants"
+
 import type { Post } from "../flow/discussionTypes"
 
 export const channelURL = (channelName: string) => `/c/${channelName}`
@@ -193,7 +195,12 @@ export const userListDetailURL = (id: number) => `/learn/lists/${id}`
 
 export const learningResourcePermalink = (object: Object) =>
   absolutizeURL(
-    `${COURSE_URL}${toQueryString({
+    `${
+      object.object_type === LR_TYPE_PODCAST ||
+      object.object_type === LR_TYPE_PODCAST_EPISODE
+        ? PODCAST_URL
+        : COURSE_URL
+    }${toQueryString({
       lr_id: object.id,
       type:  object.object_type
     })}`

--- a/static/js/lib/url_test.js
+++ b/static/js/lib/url_test.js
@@ -32,7 +32,11 @@ import {
 } from "./url"
 import { makePost } from "../factories/posts"
 import { makeLearningResource } from "../factories/learning_resources"
-import { LR_TYPE_ALL } from "../lib/constants"
+import {
+  LR_TYPE_ALL,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
+} from "../lib/constants"
 
 describe("url helper functions", () => {
   describe("channelURL", () => {
@@ -305,11 +309,14 @@ describe("url helper functions", () => {
     LR_TYPE_ALL.forEach(objectType => {
       it(`learningResourcePermalink should return a good link for ${objectType}`, () => {
         const object = makeLearningResource(objectType)
+        const isPodcastObject =
+          object.object_type === LR_TYPE_PODCAST ||
+          object.object_type === LR_TYPE_PODCAST_EPISODE
         assert.equal(
           learningResourcePermalink(object),
-          `${window.location.origin}/learn/?lr_id=${object.id}&type=${
-            object.object_type
-          }`
+          `${window.location.origin}/${
+            isPodcastObject ? "podcasts" : "learn/"
+          }?lr_id=${object.id}&type=${object.object_type}`
         )
       })
     })

--- a/static/js/pages/CourseIndexPage.js
+++ b/static/js/pages/CourseIndexPage.js
@@ -1,7 +1,7 @@
 // @flow
-import React, { useEffect } from "react"
+import React from "react"
 import { useRequest } from "redux-query-react"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
 import { Link } from "react-router-dom"
 
 import CourseCarousel from "../components/CourseCarousel"
@@ -36,8 +36,7 @@ import {
 } from "../lib/queries/learning_resources"
 import { toQueryString, COURSE_SEARCH_URL, COURSE_BANNER_URL } from "../lib/url"
 import { PHONE, TABLET, DESKTOP } from "../lib/constants"
-import { useLRDrawerParams } from "../hooks/learning_resources"
-import { pushLRHistory } from "../actions/ui"
+import { useLearningResourcePermalink } from "../hooks/learning_resources"
 
 import type { LearningResourceSummary } from "../flow/discussionTypes"
 
@@ -86,19 +85,7 @@ export default function CourseIndexPage({ history }: Props) {
   const favorites = useSelector(favoritesListSelector)
   const popularResources = useSelector(popularContentSelector)
 
-  const dispatch = useDispatch()
-  const { objectId, objectType } = useLRDrawerParams()
-
-  useEffect(() => {
-    if (objectId && objectType) {
-      dispatch(
-        pushLRHistory({
-          objectId,
-          objectType
-        })
-      )
-    }
-  }, [])
+  useLearningResourcePermalink()
 
   return (
     <BannerPageWrapper>

--- a/static/js/pages/CourseIndexPage_test.js
+++ b/static/js/pages/CourseIndexPage_test.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from "chai"
 import R from "ramda"
+import sinon from "sinon"
 
 import CourseIndexPage from "./CourseIndexPage"
 import {
@@ -28,7 +29,6 @@ import {
   makePopularContentResponse
 } from "../factories/learning_resources"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { LR_TYPE_COURSE } from "../lib/constants"
 import * as lrHooks from "../hooks/learning_resources"
 
 describe("CourseIndexPage", () => {
@@ -41,7 +41,7 @@ describe("CourseIndexPage", () => {
     courseLists,
     favorites,
     popularContent,
-    paramsStub
+    hookStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -103,10 +103,7 @@ describe("CourseIndexPage", () => {
       .returns(queryListResponse([]))
     render = helper.configureReduxQueryRenderer(CourseIndexPage)
 
-    paramsStub = helper.sandbox.stub(lrHooks, "useLRDrawerParams").returns({
-      objectId:   null,
-      objectType: null
-    })
+    hookStub = helper.sandbox.stub(lrHooks, "useLearningResourcePermalink")
   })
 
   afterEach(() => {
@@ -218,17 +215,8 @@ describe("CourseIndexPage", () => {
     })
   })
 
-  it("should open the drawer if sharing URL params present", async () => {
-    paramsStub.returns({
-      objectId:   1,
-      objectType: LR_TYPE_COURSE
-    })
-    const { store } = await render()
-    const [entry] = store.getState().ui.LRDrawerHistory
-    assert.deepEqual(entry, {
-      objectId:   1,
-      objectType: LR_TYPE_COURSE,
-      runId:      undefined
-    })
+  it("should call hook for drawer sharing", async () => {
+    await render()
+    sinon.assert.called(hookStub)
   })
 })

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -14,6 +14,7 @@ import {
   recentPodcastEpisodesRequest,
   recentEpisodesSelector
 } from "../lib/queries/podcasts"
+import { useLearningResourcePermalink } from "../hooks/learning_resources"
 
 export default function PodcastFrontpage() {
   const [{ isFinished: isFinishedPodcasts }] = useRequest(podcastsRequest())
@@ -23,6 +24,8 @@ export default function PodcastFrontpage() {
 
   const podcasts = useSelector(podcastsSelector)
   const recentEpisodes = useSelector(recentEpisodesSelector)
+
+  useLearningResourcePermalink()
 
   return (
     <div className="podcasts">

--- a/static/js/pages/PodcastFrontpage_test.js
+++ b/static/js/pages/PodcastFrontpage_test.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from "chai"
 import R from "ramda"
+import sinon from "sinon"
 
 import PodcastFrontpage from "./PodcastFrontpage"
 
@@ -14,9 +15,10 @@ import {
 } from "../lib/test_utils"
 import { podcastApiURL, recentPodcastApiURL } from "../lib/url"
 import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
+import * as lrHooks from "../hooks/learning_resources"
 
 describe("PodcastFrontpage tests", () => {
-  let helper, render, podcasts, episodes
+  let helper, render, podcasts, episodes, hookStub
 
   beforeEach(() => {
     podcasts = R.times(makePodcast, 10)
@@ -30,6 +32,7 @@ describe("PodcastFrontpage tests", () => {
       .withArgs(recentPodcastApiURL.toString())
       .returns(queryListResponse(episodes))
     render = helper.configureReduxQueryRenderer(PodcastFrontpage)
+    hookStub = helper.sandbox.stub(lrHooks, "useLearningResourcePermalink")
   })
 
   afterEach(() => {
@@ -95,5 +98,10 @@ describe("PodcastFrontpage tests", () => {
         })
       }
     )
+  })
+
+  it("should call hook for drawer sharing", async () => {
+    await render()
+    sinon.assert.called(hookStub)
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2856

#### What's this PR do?

this makes it so that podcasts and podcast episodes will share "over" the podcast frontpage (`/podcasts`) instead of the learn page (`/learn`). non-podcast things should behave as before.

#### How should this be manually tested?

confirm that sharing of other learning resources works as normal. then confirm that podcast share links point to the `/podcast` page instead of `/learn.

#### Screenshots (if appropriate)

![Screenshot from 2020-04-28 10-01-59](https://user-images.githubusercontent.com/6207644/80496513-4ca04580-8937-11ea-8d39-191d0828c048.png)
