### PR TITLE
Audio player padding adjustments

### DIFF
--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -41,6 +41,7 @@ type DrawerPropsFromState = {
   showDrawerDesktop: boolean,
   showDrawerMobile: boolean,
   showDrawerHover: boolean,
+  audioPlayerLoaded: boolean,
   subscribedChannels: Array<Channel>,
   channels: Map<string, Channel>
 }

--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -20,7 +20,10 @@ import {
   setShowDrawerHover,
   setShowDrawerDesktop
 } from "../actions/ui"
-import { getSubscribedChannels } from "../lib/redux_selectors"
+import {
+  getSubscribedChannels,
+  isAudioPlayerLoaded
+} from "../lib/redux_selectors"
 import {
   getViewportWidth,
   isMobileWidth,
@@ -123,6 +126,7 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
       showDrawerDesktop,
       showDrawerHover,
       showDrawerMobile,
+      audioPlayerLoaded,
       subscribedChannels,
       location: { pathname }
     } = this.props
@@ -143,9 +147,12 @@ export class ResponsiveDrawer extends React.Component<DrawerProps> {
     }
 
     const expanded = isMobile ? true : showDrawerDesktop || showDrawerHover
+    const audioPlayerPadding = audioPlayerLoaded
+      ? " audio-player-padding-bottom"
+      : ""
 
     return (
-      <div className={this.wrappingClass}>
+      <div className={`${this.wrappingClass}${audioPlayerPadding}`}>
         <Theme>
           <Drawer
             modal={isMobile}
@@ -189,6 +196,7 @@ export const mapStateToProps = (state: Object): DrawerPropsFromState => ({
   showDrawerDesktop:  state.ui.showDrawerDesktop,
   showDrawerHover:    state.ui.showDrawerHover,
   showDrawerMobile:   state.ui.showDrawerMobile,
+  audioPlayerLoaded:  isAudioPlayerLoaded(state),
   channels:           state.channels.data
 })
 

--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -22,7 +22,7 @@ import {
 } from "../actions/ui"
 import {
   getSubscribedChannels,
-  isAudioPlayerLoaded
+  isAudioPlayerLoadedSelector
 } from "../lib/redux_selectors"
 import {
   getViewportWidth,
@@ -197,7 +197,7 @@ export const mapStateToProps = (state: Object): DrawerPropsFromState => ({
   showDrawerDesktop:  state.ui.showDrawerDesktop,
   showDrawerHover:    state.ui.showDrawerHover,
   showDrawerMobile:   state.ui.showDrawerMobile,
-  audioPlayerLoaded:  isAudioPlayerLoaded(state),
+  audioPlayerLoaded:  isAudioPlayerLoadedSelector(state),
   channels:           state.channels.data
 })
 

--- a/static/js/components/Drawer_test.js
+++ b/static/js/components/Drawer_test.js
@@ -241,7 +241,10 @@ describe("Drawer", () => {
         selectors,
         "getSubscribedChannels"
       )
-      isAudioPlayerLoadedStub = sandbox.stub(selectors, "isAudioPlayerLoaded")
+      isAudioPlayerLoadedStub = sandbox.stub(
+        selectors,
+        "isAudioPlayerLoadedSelector"
+      )
     })
 
     it("should grab state.ui.showDrawer props", () => {
@@ -255,7 +258,7 @@ describe("Drawer", () => {
       assert.equal(showDrawerHover, state.ui.showDrawerHover)
     })
 
-    it("should call isAudioPlayerLoaded", () => {
+    it("should call isAudioPlayerLoadedSelector", () => {
       mapStateToProps(state)
       assert.ok(isAudioPlayerLoadedStub.calledWith(state))
     })

--- a/static/js/components/Drawer_test.js
+++ b/static/js/components/Drawer_test.js
@@ -19,6 +19,7 @@ import { channelURL, newPostURL } from "../lib/url"
 import { makeChannelList } from "../factories/channels"
 import { makeLocation } from "../factories/util"
 import { shouldIf } from "../lib/test_utils"
+import { INITIAL_AUDIO_STATE } from "../reducers/audio"
 
 describe("Drawer", () => {
   let sandbox, dispatchStub, channels, isMobileWidthStub, getViewportWidthStub
@@ -45,6 +46,7 @@ describe("Drawer", () => {
         showDrawerDesktop={false}
         showDrawerMobile={false}
         showDrawerHover={false}
+        audioPlayerLoaded={false}
         {...props}
       />
     )
@@ -221,7 +223,7 @@ describe("Drawer", () => {
   })
 
   describe("mapStateToProps", () => {
-    let state, getSubscribedChannelsStub
+    let state, getSubscribedChannelsStub, isAudioPlayerLoadedStub
 
     beforeEach(() => {
       state = {
@@ -230,12 +232,16 @@ describe("Drawer", () => {
           showDrawerMobile:  true,
           showDrawerDesktop: true,
           showDrawerHover:   true
+        },
+        audio: {
+          currentlyPlaying: INITIAL_AUDIO_STATE
         }
       }
       getSubscribedChannelsStub = sandbox.stub(
         selectors,
         "getSubscribedChannels"
       )
+      isAudioPlayerLoadedStub = sandbox.stub(selectors, "isAudioPlayerLoaded")
     })
 
     it("should grab state.ui.showDrawer props", () => {
@@ -247,6 +253,11 @@ describe("Drawer", () => {
       assert.equal(showDrawerMobile, state.ui.showDrawerMobile)
       assert.equal(showDrawerDesktop, state.ui.showDrawerDesktop)
       assert.equal(showDrawerHover, state.ui.showDrawerHover)
+    })
+
+    it("should call isAudioPlayerLoaded", () => {
+      mapStateToProps(state)
+      assert.ok(isAudioPlayerLoadedStub.calledWith(state))
     })
 
     it("should call getSubscribedChannels", () => {

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -19,6 +19,7 @@ import {
   getSimilarResources
 } from "../lib/queries/learning_resources"
 import { interactionMutation } from "../lib/queries/interactions"
+import { isAudioPlayerLoadedSelector } from "../lib/redux_selectors"
 
 const getLRHistory = createSelector(
   state => state.ui,
@@ -119,6 +120,11 @@ export default function LearningResourceDrawer(props: Props) {
   useRequest(object ? similarResourcesRequest(object) : null)
   const similarResources = useSelector(getSimilarResourcesForObject)
 
+  const audioPlayerLoaded = useSelector(isAudioPlayerLoadedSelector)
+  const audioPlayerPadding = audioPlayerLoaded
+    ? " audio-player-padding-bottom"
+    : ""
+
   const dispatch = useDispatch()
   const clearHistory = useCallback(() => dispatch(clearLRHistory()), [dispatch])
   const pushHistory = useCallback(object => dispatch(pushLRHistory(object)), [
@@ -132,7 +138,7 @@ export default function LearningResourceDrawer(props: Props) {
         open={numHistoryEntries > 0}
         onClose={clearHistory}
         dir="rtl"
-        className="align-right lr-drawer"
+        className={`align-right lr-drawer${audioPlayerPadding}`}
         modal
       >
         <DrawerContent dir="ltr">

--- a/static/js/hooks/audio_player_test.js
+++ b/static/js/hooks/audio_player_test.js
@@ -4,7 +4,7 @@ import { assert } from "chai"
 import Amplitude from "amplitudejs"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { getCurrentlyPlayingAudio } from "../lib/redux_selectors"
+import { currentlyPlayingAudioSelector } from "../lib/redux_selectors"
 import { useInitAudioPlayer } from "./audio_player"
 
 describe("audio player hooks", () => {
@@ -45,7 +45,9 @@ describe("audio player hooks", () => {
     it("sets the example audio as the currently playing audio", async () => {
       const { wrapper, store } = await render()
       wrapper.find("#testDiv").simulate("click")
-      const currentlyPlayingAudio = getCurrentlyPlayingAudio(store.getState())
+      const currentlyPlayingAudio = currentlyPlayingAudioSelector(
+        store.getState()
+      )
       assert.deepEqual(exampleAudio, currentlyPlayingAudio)
     })
   })

--- a/static/js/lib/redux_selectors.js
+++ b/static/js/lib/redux_selectors.js
@@ -16,24 +16,15 @@ export const getSubscribedChannels = (state: Object): Array<Channel> =>
 export const getOwnProfile = (state: Object): ?Profile =>
   SETTINGS.username ? state.profiles.data.get(SETTINGS.username) : null
 
-export const getAudioPlayerState = (state: Object): any =>
-  state.audio.playerState
-
 export const audioPlayerStateSelector = createSelector(
   state => state.audio,
   audio => audio.playerState
 )
 
-export const getCurrentlyPlayingAudio = (state: Object): any =>
-  state.audio.currentlyPlaying
-
 export const currentlyPlayingAudioSelector = createSelector(
   state => state.audio,
   audio => audio.currentlyPlaying
 )
-
-export const isAudioPlayerLoaded = (state: Object): any =>
-  !_.isEqual(state.audio.currentlyPlaying, INITIAL_AUDIO_STATE.currentlyPlaying)
 
 export const isAudioPlayerLoadedSelector = createSelector(
   state => state.audio,

--- a/static/js/lib/redux_selectors.js
+++ b/static/js/lib/redux_selectors.js
@@ -2,9 +2,11 @@
 /* global SETTINGS:false */
 import { safeBulkGet } from "../lib/maps"
 import { createSelector } from "reselect"
+import _ from "lodash"
 
 import type { Channel } from "../flow/discussionTypes"
 import type { Profile } from "../flow/discussionTypes"
+import { INITIAL_AUDIO_STATE } from "../reducers/audio"
 
 export const getSubscribedChannels = (state: Object): Array<Channel> =>
   state.subscribedChannels.loaded
@@ -28,4 +30,13 @@ export const getCurrentlyPlayingAudio = (state: Object): any =>
 export const currentlyPlayingAudioSelector = createSelector(
   state => state.audio,
   audio => audio.currentlyPlaying
+)
+
+export const isAudioPlayerLoaded = (state: Object): any =>
+  !_.isEqual(state.audio.currentlyPlaying, INITIAL_AUDIO_STATE.currentlyPlaying)
+
+export const isAudioPlayerLoadedSelector = createSelector(
+  state => state.audio,
+  audio =>
+    !_.isEqual(audio.currentlyPlaying, INITIAL_AUDIO_STATE.currentlyPlaying)
 )

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -54,7 +54,7 @@ import { setChannelData } from "../actions/channel"
 import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
 import { isAnonAccessiblePath, needsAuthedSite } from "../lib/auth"
 import { isMobileWidth, preventDefaultAndInvoke } from "../lib/util"
-import { getOwnProfile } from "../lib/redux_selectors"
+import { getOwnProfile, isAudioPlayerLoaded } from "../lib/redux_selectors"
 import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
 import { channelIndexRoute } from "../lib/routing"
 
@@ -182,12 +182,17 @@ class App extends React.Component<Props> {
       snackbar,
       banner,
       showUserMenu,
+      audioPlayerLoaded,
       profile
     } = this.props
 
     if (needsAuthedSite() && !isAnonAccessiblePath(pathname)) {
       return <Redirect to={AUTH_REQUIRED_URL} />
     }
+
+    const audioPlayerPadding = audioPlayerLoaded
+      ? " audio-player-padding-bottom"
+      : ""
 
     return (
       <div className="app">
@@ -220,7 +225,7 @@ class App extends React.Component<Props> {
           banner={banner}
           hide={preventDefaultAndInvoke(this.hideBanner)}
         />
-        <div className="content">
+        <div className={`content${audioPlayerPadding}`}>
           <Route exact path={match.url} component={HomePage} />
           <Route
             path={channelIndexRoute(match.url)}
@@ -355,7 +360,8 @@ const mapStateToProps = state => {
     snackbar,
     banner,
     showUserMenu,
-    profile: getOwnProfile(state)
+    audioPlayerLoaded: isAudioPlayerLoaded(state),
+    profile:           getOwnProfile(state)
   }
 }
 

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -54,7 +54,10 @@ import { setChannelData } from "../actions/channel"
 import { AUTH_REQUIRED_URL, SETTINGS_URL } from "../lib/url"
 import { isAnonAccessiblePath, needsAuthedSite } from "../lib/auth"
 import { isMobileWidth, preventDefaultAndInvoke } from "../lib/util"
-import { getOwnProfile, isAudioPlayerLoaded } from "../lib/redux_selectors"
+import {
+  getOwnProfile,
+  isAudioPlayerLoadedSelector
+} from "../lib/redux_selectors"
 import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
 import { channelIndexRoute } from "../lib/routing"
 
@@ -361,7 +364,7 @@ const mapStateToProps = state => {
     snackbar,
     banner,
     showUserMenu,
-    audioPlayerLoaded: isAudioPlayerLoaded(state),
+    audioPlayerLoaded: isAudioPlayerLoadedSelector(state),
     profile:           getOwnProfile(state)
   }
 }

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -71,6 +71,7 @@ type StateProps = {|
   snackbar: SnackbarState,
   banner: BannerState,
   showUserMenu: boolean,
+  audioPlayerLoaded: boolean,
   profile: ?Profile
 |}
 

--- a/static/js/reducers/audio_test.js
+++ b/static/js/reducers/audio_test.js
@@ -3,8 +3,8 @@ import { assert } from "chai"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import {
-  getAudioPlayerState,
-  getCurrentlyPlayingAudio
+  audioPlayerStateSelector,
+  currentlyPlayingAudioSelector
 } from "../lib/redux_selectors"
 import { INITIAL_AUDIO_STATE } from "./audio"
 import {
@@ -42,13 +42,13 @@ describe("audio reducer", () => {
     dispatchThen(setCurrentlyPlayingAudio(exampleAudio), [
       SET_CURRENTLY_PLAYING_AUDIO
     ])
-    const currentlyPlaying = getCurrentlyPlayingAudio(store.getState())
+    const currentlyPlaying = currentlyPlayingAudioSelector(store.getState())
     assert.deepEqual(exampleAudio, currentlyPlaying)
   })
 
   it("should let you set the audio player state", () => {
     dispatchThen(setAudioPlayerState("playing"), [SET_AUDIO_PLAYER_STATE])
-    const audioPlayerState = getAudioPlayerState(store.getState())
+    const audioPlayerState = audioPlayerStateSelector(store.getState())
     assert.equal("playing", audioPlayerState)
   })
 })

--- a/static/scss/audio-player.scss
+++ b/static/scss/audio-player.scss
@@ -254,3 +254,12 @@
     }
   }
 }
+
+.audio-player-padding-bottom {
+  @include breakpoint(desktop) {
+    padding-bottom: $audio-player-height-desktop;
+  }
+  @include breakpoint(mobile) {
+    padding-bottom: $audio-player-height-mobile;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None at the moment

#### What's this PR do?
Adds redux selectors to check if the audio player is currently loaded, then implements them on the classes that have outermost container UI elements; `App.js`, `Drawer.js` and `LearningResourceDrawer.js`.  When the audio player is active, a class is added to the outermost elements that adds bottom padding based on the value of the audio player height sass variables.  This would all be much simpler if CSS4 was released, because we could just use the `:has` selector to only apply a rule to an outer element that contains a `:not(.hidden)` `.audio-player-container-outer`.  This is the best way to do it right now, from what I can tell.

#### How should this be manually tested?
Go to /podcasts and click play on one of the episodes.  When the audio player loads, you should be able to scroll to the bottom of the page and the end of the content should line up with the top of the audio player.  You should be able to do the same in the drawer.