### PR TITLE
Audio player Z index fix

### DIFF
--- a/static/scss/audio-player.scss
+++ b/static/scss/audio-player.scss
@@ -12,6 +12,7 @@
   left: 0;
   bottom: 0;
   width: 100vw;
+  z-index: 45;
 
   @include breakpoint(desktop) {
     height: $audio-player-height-desktop;


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2866

#### What's this PR do?
Sets the z-index on the outer container of the audio player to be above everything else.

#### How should this be manually tested?
Go to /podcasts on mobile (or in the mobile simulator) and click one of the recent episode cards.  Click play within the card, and the audio player should now show up on top.

#### Screenshots (if appropriate)
![Screen Shot 2020-04-28 at 6 21 13 PM](https://user-images.githubusercontent.com/12089658/80543531-0ff73d00-897d-11ea-947f-a433969a1a0f.png)

![Screen Shot 2020-04-28 at 6 20 12 PM](https://user-images.githubusercontent.com/12089658/80543509-ff46c700-897c-11ea-828a-d931f5241379.png)