### PR TITLE
add episode list to podcast drawer

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -459,6 +459,7 @@ class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
 
     serializer_class = PodcastEpisodeSerializer
     permission_classes = (ReadOnly & PodcastFeatureFlag,)
+    pagination_class = DefaultPagination
 
     def get_queryset(self):
         return (

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -748,10 +748,15 @@ def test_episodes_per_podcast(settings, client):
     settings.FEATURES[features.PODCAST_APIS] = True
     resp = client.get(reverse("episodes-in-podcast", kwargs={"pk": podcast.id}))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == PodcastEpisodeSerializer(instance=episodes, many=True).data
+    assert resp.json() == {
+        "count": 5,
+        "results": PodcastEpisodeSerializer(instance=episodes, many=True).data,
+        "next": None,
+        "previous": None,
+    }
 
     podcast.published = False
     podcast.save()
     resp = client.get(reverse("episodes-in-podcast", kwargs={"pk": podcast.id}))
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == []
+    assert resp.json() == {"count": 0, "results": [], "next": None, "previous": None}

--- a/static/js/components/Card.js
+++ b/static/js/components/Card.js
@@ -6,23 +6,34 @@ type CardProps = {|
   className?: string,
   title?: any,
   borderless?: boolean,
-  onClick?: Function
+  onClick?: Function,
+  persistentShadow?: boolean
 |}
 
-const getClassName = (className, borderless) =>
-  `card ${className || ""} ${borderless ? "borderless" : ""}`
+const getClassName = (className, borderless, persistentShadow) => {
+  const classes = [
+    "card",
+    className || "",
+    borderless ? "borderless" : "",
+    persistentShadow ? "persistent-shadow" : ""
+  ]
+
+  return classes
+    .join(" ")
     .trim()
     .replace(/\s+/g, " ")
+}
 
 const Card = ({
   children,
   className,
   title,
   borderless,
-  onClick
+  onClick,
+  persistentShadow
 }: CardProps) => (
   <div
-    className={getClassName(className, borderless)}
+    className={getClassName(className, borderless, persistentShadow)}
     onClick={onClick || null}
   >
     <div className="card-contents">

--- a/static/js/components/Card_test.js
+++ b/static/js/components/Card_test.js
@@ -31,6 +31,11 @@ describe("Card component", () => {
     assert.equal(wrapper.props().className, "card borderless")
   })
 
+  it("should add .persistent-shadow if given the prop", () => {
+    const wrapper = mountCard(<div />, { persistentShadow: true })
+    assert.equal(wrapper.props().className, "card persistent-shadow")
+  })
+
   it("should set an onClick handler, if given one", () => {
     const onClick = sinon.stub()
     const wrapper = mountCard(<div />, { onClick })

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -10,6 +10,7 @@ import TruncatedText from "./TruncatedText"
 import Embedly from "./Embedly"
 import ShareTooltip from "./ShareTooltip"
 import PodcastPlayButton from "./PodcastPlayButton"
+import PaginatedPodcastEpisodes from "./PaginatedPodcastEpisodes"
 
 import { LearningResourceRow } from "./LearningResourceCard"
 import { PaginatedUserListItems } from "./UserListItems"
@@ -126,9 +127,11 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
   const [showSimilar, setShowSimilar] = useState(false)
   const [showCourseList, setShowCourseList] = useState(false)
   const [showResourceList, setShowResourceList] = useState(false)
+  const [showPodcastList, setShowPodcastList] = useState(true)
   const similarIcon = showSimilar ? "remove" : "add"
   const coursesIcon = showCourseList ? "remove" : "add"
   const resourcesIcon = showResourceList ? "remove" : "add"
+  const podcastIcon = showPodcastList ? "remove" : "add"
 
   const updateRun = (event: Object) =>
     setShowResourceDrawer({
@@ -358,6 +361,16 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
           icon={resourcesIcon}
         >
           <PaginatedUserListItems userList={object} pageSize={10} />
+        </CollapsableSection>
+      ) : null}
+      {object.object_type === LR_TYPE_PODCAST ? (
+        <CollapsableSection
+          title="Episodes"
+          setShow={setShowPodcastList}
+          show={showPodcastList}
+          icon={podcastIcon}
+        >
+          <PaginatedPodcastEpisodes podcast={object} pageSize={10} />
         </CollapsableSection>
       ) : null}
       {!emptyOrNil(similarItems) && !hideSimilarLearningResources ? (

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -4,6 +4,7 @@ import R from "ramda"
 
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 import * as UserListItemsMod from "../components/UserListItems"
+import * as PaginatedPodcastEpisodesMod from "./PaginatedPodcastEpisodes"
 
 import {
   makeCourse,
@@ -59,6 +60,10 @@ describe("ExpandedLearningResourceDisplay", () => {
       UserListItemsMod,
       "PaginatedUserListItems",
       "PaginatedUserListItems"
+    )
+    helper.stubComponent(
+      PaginatedPodcastEpisodesMod,
+      "PaginatedPodcastEpisodes"
     )
     render = helper.configureHOCRenderer(
       ExpandedLearningResourceDisplay,
@@ -184,6 +189,12 @@ describe("ExpandedLearningResourceDisplay", () => {
     })
   })
 
+  it("should put a PaginatedPodcastEpisodes for Podcasts", async () => {
+    const object = makeLearningResource(LR_TYPE_PODCAST)
+    const { wrapper } = await render({}, { object })
+    assert.ok(wrapper.find("PaginatedPodcastEpisodes").exists())
+  })
+
   LR_TYPE_ALL.forEach(objectType => {
     it(`should render description using the TruncatedText for ${objectType}`, async () => {
       const object = makeLearningResource(objectType)
@@ -233,7 +244,8 @@ describe("ExpandedLearningResourceDisplay", () => {
       const listIdx = [
         LR_TYPE_LEARNINGPATH,
         LR_TYPE_USERLIST,
-        LR_TYPE_PROGRAM
+        LR_TYPE_PROGRAM,
+        LR_TYPE_PODCAST
       ].includes(objectType)
         ? 1
         : 0
@@ -274,7 +286,8 @@ describe("ExpandedLearningResourceDisplay", () => {
       const listIdx = [
         LR_TYPE_LEARNINGPATH,
         LR_TYPE_USERLIST,
-        LR_TYPE_PROGRAM
+        LR_TYPE_PROGRAM,
+        LR_TYPE_PODCAST
       ].includes(objectType)
         ? 1
         : 0

--- a/static/js/components/LRDrawerPaginationControls.js
+++ b/static/js/components/LRDrawerPaginationControls.js
@@ -1,0 +1,39 @@
+// @flow
+import React from "react"
+
+type Props = {
+  page: number,
+  begin: number,
+  setPage: Function,
+  count: number,
+  end: number
+}
+
+export default function LRDrawerPaginationControls(props: Props) {
+  const { page, begin, setPage, count, end } = props
+
+  return (
+    <div className="pagination-nav">
+      <button
+        onClick={() => setPage(page - 1)}
+        disabled={begin === 0}
+        className="blue-btn outlined previous"
+      >
+        <i className="material-icons keyboard_arrow_left">
+          keyboard_arrow_left
+        </i>
+        <span>Previous</span>
+      </button>
+      <button
+        onClick={() => setPage(page + 1)}
+        disabled={end > count}
+        className="blue-btn outlined next"
+      >
+        <span>Next</span>
+        <i className="material-icons keyboard_arrow_right">
+          keyboard_arrow_right
+        </i>
+      </button>
+    </div>
+  )
+}

--- a/static/js/components/PaginatedPodcastEpisodes.js
+++ b/static/js/components/PaginatedPodcastEpisodes.js
@@ -1,0 +1,83 @@
+// @flow
+import React, { useState, useMemo } from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+import { createSelector } from "reselect"
+
+import { Loading } from "../components/Loading"
+import PodcastEpisodeCard from "./PodcastEpisodeCard"
+import LRDrawerPaginationControls from "./LRDrawerPaginationControls"
+
+import {
+  podcastEpisodesRequest,
+  podcastEpisodesKey
+} from "../lib/queries/podcasts"
+
+import type { Podcast } from "../flow/podcastTypes"
+
+const SimpleLoader = <Loading className="infinite" key="loader" />
+
+type Props = {
+  podcast: Podcast,
+  pageSize: number
+}
+
+export default function PaginatedPodcastEpisodes({ podcast, pageSize }: Props) {
+  const [page, setPage] = useState(0)
+  const begin = page * pageSize
+  const end = begin + pageSize
+
+  const [{ isFinished }] = useRequest(
+    podcastEpisodesRequest(podcast.id, begin, pageSize)
+  )
+
+  const selector = useMemo(
+    () => {
+      const key = podcastEpisodesKey(podcast.id)
+
+      return createSelector(
+        state => state.entities.podcastEpisodes,
+        state => state.entities[key],
+        (podcastEpisodes, podcastSpecificState) => {
+          if (!podcastSpecificState) {
+            return {}
+          }
+
+          const { items, count } = podcastSpecificState
+
+          return {
+            episodes: items.map(item => podcastEpisodes[item]),
+            count
+          }
+        }
+      )
+    },
+    [podcast]
+  )
+
+  const { episodes, count } = useSelector(selector)
+
+  return isFinished && episodes ? (
+    <div className="paginated-podcast-episodes">
+      {episodes
+        .slice(begin, end)
+        .map(episode => (
+          <PodcastEpisodeCard
+            episode={episode}
+            podcast={podcast}
+            persistentShadow
+            key={episode.id}
+          />
+        ))}
+      <LRDrawerPaginationControls
+        page={page}
+        begin={begin}
+        setPage={setPage}
+        count={count}
+        end={end}
+      />
+    </div>
+  ) : (
+    SimpleLoader
+  )
+}

--- a/static/js/components/PaginatedPodcastEpisodes_test.js
+++ b/static/js/components/PaginatedPodcastEpisodes_test.js
@@ -1,0 +1,97 @@
+// @flow
+import R from "ramda"
+import { assert } from "chai"
+
+import PaginatedPodcastEpisodes from "./PaginatedPodcastEpisodes"
+
+import { podcastDetailEpisodesApiURL } from "../lib/url"
+import { makePodcast, makePodcastEpisode } from "../factories/podcasts"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+describe("PaginatedPodcastEpisodes", () => {
+  let podcast, episodes1, episodes2, render, helper
+
+  beforeEach(() => {
+    podcast = makePodcast()
+    episodes1 = R.times(() => makePodcastEpisode(podcast), 10)
+    episodes2 = R.times(() => makePodcastEpisode(podcast), 6)
+
+    helper = new IntegrationTestHelper()
+    helper.handleRequestStub
+      .withArgs(
+        podcastDetailEpisodesApiURL.param({ podcastId: podcast.id }).toString()
+      )
+      // page 1
+      .onFirstCall()
+      .returns({
+        status: 200,
+        body:   {
+          count:   16,
+          results: episodes1,
+          prev:    null,
+          next:    "/next"
+        }
+      })
+      // page 2
+      .onSecondCall()
+      .returns({
+        status: 200,
+        body:   {
+          count:   16,
+          results: episodes2,
+          prev:    "/prev",
+          next:    null
+        }
+      })
+      // page 1 again
+      .onThirdCall()
+      .returns({
+        status: 200,
+        body:   {
+          count:   20,
+          results: episodes1,
+          prev:    null,
+          next:    "/next"
+        }
+      })
+    render = helper.configureReduxQueryRenderer(PaginatedPodcastEpisodes, {
+      podcast,
+      pageSize: 10
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render the episodes", async () => {
+    const { wrapper } = await render()
+    const cards = wrapper.find("PodcastEpisodeCard")
+    assert.equal(cards.length, episodes1.length)
+    R.zip([...cards], episodes1).forEach(([card, episode]) => {
+      assert.deepEqual(card.props.episode, episode)
+      assert.deepEqual(card.props.podcast, podcast)
+    })
+  })
+
+  it("should let the user navigate items pages", async () => {
+    const { wrapper } = await render()
+    wrapper.find(".next").simulate("click")
+
+    let cards = wrapper.find("PodcastEpisodeCard")
+    assert.equal(cards.length, episodes2.length)
+    R.zip([...cards], episodes2).forEach(([card, episode]) => {
+      assert.deepEqual(card.props.episode, episode)
+      assert.deepEqual(card.props.podcast, podcast)
+    })
+
+    wrapper.find(".previous").simulate("click")
+
+    cards = wrapper.find("PodcastEpisodeCard")
+    assert.equal(cards.length, episodes1.length)
+    R.zip([...cards], episodes1).forEach(([card, episode]) => {
+      assert.deepEqual(card.props.episode, episode)
+      assert.deepEqual(card.props.podcast, podcast)
+    })
+  })
+})

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -17,13 +17,14 @@ export const PODCAST_IMG_WIDTH = 125
 
 type Props = {
   podcast: Podcast,
-  episode: PodcastEpisode
+  episode: PodcastEpisode,
+  persistentShadow?: boolean
 }
 
 export const EPISODE_DATE_FORMAT = "MMMM D, YYYY"
 
 export default function PodcastEpisodeCard(props: Props) {
-  const { episode, podcast } = props
+  const { episode, podcast, persistentShadow } = props
 
   const openEpisodeDrawer = useOpenEpisodeDrawer(episode.id)
 
@@ -31,6 +32,7 @@ export default function PodcastEpisodeCard(props: Props) {
     <Card
       className="podcast-episode-card low-padding"
       onClick={openEpisodeDrawer}
+      persistentShadow={persistentShadow}
     >
       <div className="left-col">
         <div className="episode-title">

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -66,4 +66,9 @@ describe("PodcastEpisodeCard", () => {
       .simulate("click")
     sinon.assert.called(openStub)
   })
+
+  it("should pass down persistentShadow to Card if passed", async () => {
+    const { wrapper } = await render({ persistentShadow: true })
+    assert.isTrue(wrapper.find("Card").prop("persistentShadow"))
+  })
 })

--- a/static/js/components/UserListItems.js
+++ b/static/js/components/UserListItems.js
@@ -11,6 +11,8 @@ import {
   LearningResourceCard,
   LearningResourceRow
 } from "../components/LearningResourceCard"
+import LRDrawerPaginationControls from "./LRDrawerPaginationControls"
+
 import { SEARCH_LIST_UI } from "../lib/search"
 import {
   userListItemsRequest,
@@ -167,28 +169,13 @@ export function PaginatedUserListItems({
           searchResultLayout={SEARCH_LIST_UI}
         />
       ))}
-      <div className="pagination-nav">
-        <button
-          onClick={() => setPage(page - 1)}
-          disabled={begin === 0}
-          className="blue-btn outlined previous"
-        >
-          <i className="material-icons keyboard_arrow_left">
-            keyboard_arrow_left
-          </i>
-          <span>Previous</span>
-        </button>
-        <button
-          onClick={() => setPage(page + 1)}
-          disabled={end > count}
-          className="blue-btn outlined next"
-        >
-          <span>Next</span>
-          <i className="material-icons keyboard_arrow_right">
-            keyboard_arrow_right
-          </i>
-        </button>
-      </div>
+      <LRDrawerPaginationControls
+        page={page}
+        begin={begin}
+        setPage={setPage}
+        count={count}
+        end={end}
+      />
     </div>
   ) : (
     loader

--- a/static/js/lib/queries/podcasts.js
+++ b/static/js/lib/queries/podcasts.js
@@ -6,7 +6,8 @@ import {
   podcastApiURL,
   recentPodcastApiURL,
   podcastDetailApiURL,
-  podcastEpisodeDetailApiURL
+  podcastEpisodeDetailApiURL,
+  podcastDetailEpisodesApiURL
 } from "../url"
 
 import { DEFAULT_POST_OPTIONS, constructIdMap } from "../redux_query"
@@ -133,3 +134,34 @@ export const favoritePodcastEpisodeMutation = (
     ...DEFAULT_POST_OPTIONS
   }
 })
+
+export const podcastEpisodesKey = (podcastId: number) =>
+  `podcast${podcastId}episodes`
+
+export const podcastEpisodesRequest = (
+  podcastId: number,
+  offset: number,
+  limit: number
+) => {
+  const key = podcastEpisodesKey(podcastId)
+
+  return {
+    url:       podcastDetailEpisodesApiURL.param({ podcastId }).toString(),
+    queryKey:  `${key}Request.page[${offset}:${offset + limit}]`,
+    body:      { offset, limit },
+    transform: ({ count, results }: Object) => ({
+      [key]: {
+        items: results.map(result => result.id),
+        count
+      },
+      podcastEpisodes: constructIdMap(results)
+    }),
+    update: {
+      podcastEpisodes: R.merge,
+      [key]:           (prev, next) => ({
+        items: prev ? [...prev.items, ...next.items] : next.items,
+        count: next.count
+      })
+    }
+  }
+}

--- a/static/js/lib/url.js
+++ b/static/js/lib/url.js
@@ -180,7 +180,7 @@ export const similarResourcesURL = "/api/v0/similar/"
 
 export const podcastApiURL = api.segment("podcasts/")
 export const recentPodcastApiURL = podcastApiURL.segment("recent/")
-export const podcastDetailApiURL = podcastApiURL.segment(":podcastId")
+export const podcastDetailApiURL = podcastApiURL.segment(":podcastId/")
 export const podcastDetailEpisodesApiURL = podcastDetailApiURL.segment(
   "episodes/"
 )

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -91,6 +91,7 @@ export default class IntegrationTestHelper {
     )
     this.getCKEditorJWTStub.returns(Promise.resolve())
 
+    // for stubbing out redux query
     const defaultResponse = {
       body:   {},
       status: 200

--- a/static/scss/card.scss
+++ b/static/scss/card.scss
@@ -29,6 +29,10 @@
     }
   }
 
+  &.persistent-shadow {
+    box-shadow: 3px 4px 12px 0 rgba(0, 0, 0, 0.36);
+  }
+
   &.low-padding {
     .card-contents {
       padding: 10px;

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -144,3 +144,7 @@
     font-size: 18px;
   }
 }
+
+.paginated-podcast-episodes {
+  padding: 10px;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2856 

#### What's this PR do?

this adds support for showing the list of episodes on a podcast, in a paginated form. it re-uses the same styling as the existing display we have for userlist items for now.

#### How should this be manually tested?

Navigate to `/podcasts`. You should be able to open a podcast in the drawer and see a list of the episodes in the podcast. for a podcast with a lot of episodes (like 'the ai podcast') you should be able to freely page forward and back through the episodes.

also you should be able to play podcast episodes from the drawer, and clicking on the title (or elsewhere) on the podcast episode card should then focus that card. you should then be able to use the 'back' button as normal to return to the podcast.

#### Screenshots (if appropriate)



![Screenshot from 2020-04-29 11-16-31](https://user-images.githubusercontent.com/6207644/80613230-fc92b300-8a0a-11ea-8be3-b66c195a53f5.png)
![Screenshot from 2020-04-29 11-15-49](https://user-images.githubusercontent.com/6207644/80613233-fd2b4980-8a0a-11ea-8b74-5b42e0002227.png)

![Screenshot from 2020-04-29 11-17-40](https://user-images.githubusercontent.com/6207644/80613277-0ddbbf80-8a0b-11ea-84ce-714077b3a5ce.png)


