### PR TITLE
pause / play podcast from the PodcastPlayButton

### DIFF
--- a/static/js/babelhook.js
+++ b/static/js/babelhook.js
@@ -53,12 +53,14 @@ global.Audio = class Audio {
     this._pauseStub()
   }
 
-  addEventListener() {
+  addEventListener(name, fn) {
     this._addEventListenerStub()
+    window.addEventListener(name, fn)
   }
 
-  removeEventListener() {
+  removeEventListener(name, fn) {
     this._removeEventListenerStub()
+    window.removeEventListener(name, fn)
   }
 }
 

--- a/static/js/components/AudioPlayer.js
+++ b/static/js/components/AudioPlayer.js
@@ -1,6 +1,6 @@
 // @flow
 import _ from "lodash"
-import React, { useEffect, useRef, useCallback, useState } from "react"
+import React, { useRef, useCallback } from "react"
 import { useSelector } from "react-redux"
 import Amplitude from "amplitudejs"
 
@@ -9,25 +9,18 @@ import {
   audioPlayerStateSelector,
   currentlyPlayingAudioSelector
 } from "../lib/redux_selectors"
+import { AUDIO_PLAYER_PLAYING } from "../lib/constants"
 
 export default function AudioPlayer() {
   const seekBar = useRef()
   const playPauseButton = useRef()
+
   const audioPlayerState = useSelector(audioPlayerStateSelector)
   const currentlyPlayingAudio = useSelector(currentlyPlayingAudioSelector)
-  const [audioLoaded, setAudioLoaded] = useState(false)
-  const [audioPlaying, setAudioPlaying] = useState(false)
 
-  useEffect(
-    () => {
-      if (
-        !_.isEqual(currentlyPlayingAudio, INITIAL_AUDIO_STATE.currentlyPlaying)
-      ) {
-        setAudioLoaded(true)
-      }
-      setAudioPlaying(audioPlayerState === "playing")
-    },
-    [audioPlayerState, currentlyPlayingAudio]
+  const audioLoaded = !_.isEqual(
+    currentlyPlayingAudio,
+    INITIAL_AUDIO_STATE.currentlyPlaying
   )
 
   const backTenClick = useCallback(() => {
@@ -79,7 +72,7 @@ export default function AudioPlayer() {
                 ref={playPauseButton}
               >
                 <span className="material-icons">
-                  {audioPlaying
+                  {audioPlayerState === AUDIO_PLAYER_PLAYING
                     ? "pause_circle_outline"
                     : "play_circle_outline"}
                 </span>

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -1,9 +1,14 @@
 // @flow
 import React, { useCallback } from "react"
-
-import { useDispatch } from "react-redux"
+import { useSelector } from "react-redux"
+import Amplitude from "amplitudejs"
 
 import { useInitAudioPlayer } from "../hooks/audio_player"
+import {
+  audioPlayerStateSelector,
+  currentlyPlayingAudioSelector
+} from "../lib/redux_selectors"
+import { AUDIO_PLAYER_PLAYING } from "../lib/constants"
 
 import type { PodcastEpisode } from "../flow/podcastTypes"
 
@@ -14,25 +19,60 @@ type Props = {
 export default function PodcastPlayButton(props: Props) {
   const { episode } = props
 
-  const dispatch = useDispatch()
+  const audioPlayerState = useSelector(audioPlayerStateSelector)
+  const currentlyPlayingAudio = useSelector(currentlyPlayingAudioSelector)
+
+  const episodeAudioInitialized = currentlyPlayingAudio.url === episode.url
+  const episodeCurrentlyPlaying =
+    episodeAudioInitialized && audioPlayerState === AUDIO_PLAYER_PLAYING
+
   const initAudioPlayer = useInitAudioPlayer({
     title:       episode.podcast_title,
     description: episode.title,
     url:         episode.url
   })
-  const playClick = useCallback(
+
+  const initializeAudioPlayer = useCallback(
     e => {
       e.stopPropagation()
       e.preventDefault()
       initAudioPlayer()
     },
-    [dispatch]
+    [initAudioPlayer]
   )
 
+  const togglePlayState = e => {
+    e.stopPropagation()
+    e.preventDefault()
+
+    const audioElement = Amplitude.getAudio()
+    if (audioPlayerState === AUDIO_PLAYER_PLAYING) {
+      audioElement.pause()
+    } else {
+      audioElement.play()
+    }
+  }
+
+  const className = episodeCurrentlyPlaying ? "grey-surround" : "black-surround"
+
   return (
-    <div className="podcast-play-button black-surround" onClick={playClick}>
-      Play
-      <i className="material-icons play_arrow">play_arrow</i>
+    <div
+      className={`podcast-play-button ${className}`}
+      onClick={
+        episodeAudioInitialized ? togglePlayState : initializeAudioPlayer
+      }
+    >
+      {episodeCurrentlyPlaying ? (
+        <>
+          Pause
+          <i className="material-icons pause">pause</i>
+        </>
+      ) : (
+        <>
+          Play
+          <i className="material-icons play_arrow">play_arrow</i>
+        </>
+      )}
     </div>
   )
 }

--- a/static/js/components/PodcastPlayButton_test.js
+++ b/static/js/components/PodcastPlayButton_test.js
@@ -1,0 +1,73 @@
+// @flow
+import { assert } from "chai"
+
+import PodcastPlayButton from "./PodcastPlayButton"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makePodcastEpisode } from "../factories/podcasts"
+import { AUDIO_PLAYER_PAUSED, AUDIO_PLAYER_PLAYING } from "../lib/constants"
+
+describe("PodcastPlayButton", () => {
+  let helper, render, episode
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    episode = makePodcastEpisode()
+    render = helper.configureReduxQueryRenderer(PodcastPlayButton, { episode })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should initialize a podcast", async () => {
+    const { wrapper, store } = await render()
+    wrapper.find(".podcast-play-button").simulate("click")
+    assert.deepEqual(store.getState().audio, {
+      playerState:      AUDIO_PLAYER_PLAYING,
+      currentlyPlaying: {
+        title:       episode.podcast_title,
+        description: episode.title,
+        url:         episode.url
+      }
+    })
+  })
+
+  it("should show black play button if not playing, not initialized", async () => {
+    const { wrapper } = await render()
+    assert.equal(wrapper.find(".podcast-play-button").text(), "Playplay_arrow")
+    assert.equal(
+      wrapper.find(".podcast-play-button").prop("className"),
+      "podcast-play-button black-surround"
+    )
+  })
+
+  it("should show grey pause button when initialized, playing", async () => {
+    const { wrapper } = await render()
+    wrapper.find(".podcast-play-button").simulate("click")
+    assert.equal(wrapper.find(".podcast-play-button").text(), "Pausepause")
+    assert.equal(
+      wrapper.find(".podcast-play-button").prop("className"),
+      "podcast-play-button grey-surround"
+    )
+  })
+
+  it("should show black play button when initialized, paused", async () => {
+    const { wrapper } = await render()
+    wrapper.find(".podcast-play-button").simulate("click")
+    wrapper.find(".podcast-play-button").simulate("click")
+    assert.equal(wrapper.find(".podcast-play-button").text(), "Playplay_arrow")
+    assert.equal(
+      wrapper.find(".podcast-play-button").prop("className"),
+      "podcast-play-button black-surround"
+    )
+  })
+
+  it("should play / pause an initialized podcast", async () => {
+    const { wrapper, store } = await render()
+    wrapper.find(".podcast-play-button").simulate("click")
+    assert.equal(store.getState().audio.playerState, AUDIO_PLAYER_PLAYING)
+    wrapper.find(".podcast-play-button").simulate("click")
+    assert.equal(store.getState().audio.playerState, AUDIO_PLAYER_PAUSED)
+  })
+})

--- a/static/js/hooks/audio_player.js
+++ b/static/js/hooks/audio_player.js
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux"
 import Amplitude from "amplitudejs"
 
 import { setAudioPlayerState, setCurrentlyPlayingAudio } from "../actions/audio"
+import { AUDIO_PLAYER_PAUSED, AUDIO_PLAYER_PLAYING } from "../lib/constants"
 
 export function useInitAudioPlayer(audio: Object) {
   const dispatch = useDispatch()
@@ -26,10 +27,10 @@ export function useInitAudioPlayer(audio: Object) {
       const audioElement = Amplitude.getAudio()
       audioElement.pause()
       audioElement.addEventListener("play", () => {
-        dispatch(setAudioPlayerState("playing"))
+        dispatch(setAudioPlayerState(AUDIO_PLAYER_PLAYING))
       })
       audioElement.addEventListener("pause", () => {
-        dispatch(setAudioPlayerState("paused"))
+        dispatch(setAudioPlayerState(AUDIO_PLAYER_PAUSED))
       })
       audioElement.play()
     },

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -126,3 +126,6 @@ export const TABLET_WIDTH = 839
 
 export const LR_PUBLIC = "public"
 export const LR_PRIVATE = "private"
+
+export const AUDIO_PLAYER_PAUSED = "paused"
+export const AUDIO_PLAYER_PLAYING = "playing"

--- a/static/js/lib/redux_selectors.js
+++ b/static/js/lib/redux_selectors.js
@@ -4,9 +4,10 @@ import { safeBulkGet } from "../lib/maps"
 import { createSelector } from "reselect"
 import _ from "lodash"
 
+import { INITIAL_AUDIO_STATE } from "../reducers/audio"
+
 import type { Channel } from "../flow/discussionTypes"
 import type { Profile } from "../flow/discussionTypes"
-import { INITIAL_AUDIO_STATE } from "../reducers/audio"
 
 export const getSubscribedChannels = (state: Object): Array<Channel> =>
   state.subscribedChannels.loaded

--- a/static/js/reducers/audio.js
+++ b/static/js/reducers/audio.js
@@ -3,6 +3,8 @@ import {
   SET_AUDIO_PLAYER_STATE,
   SET_CURRENTLY_PLAYING_AUDIO
 } from "../actions/audio"
+import { AUDIO_PLAYER_PAUSED } from "../lib/constants"
+
 import type { Action } from "../flow/reduxTypes"
 
 export type Audio = {
@@ -14,7 +16,7 @@ export type AudioState = {
   currentlyPlaying: Audio
 }
 export const INITIAL_AUDIO_STATE: AudioState = {
-  playerState:      "paused",
+  playerState:      AUDIO_PLAYER_PAUSED,
   currentlyPlaying: {
     title:       "",
     description: "",

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -140,8 +140,15 @@
   text-transform: uppercase;
 
   i {
-    color: white;
     font-size: 18px;
+    background-color: $pale-grey;
+  }
+
+  &.black-surround {
+    i {
+      color: white;
+      background-color: black;
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2878

#### What's this PR do?

this makes it so that after you've started playing a podcast the 'play' button (in the episode card or the drawer) will change to a 'pause' button.

I also added some overall tests to the `PodcastPlayButton` to make sure it does what we want.

#### How should this be manually tested?

Make sure it works as advertised.

Podcast playing state should be synchronized between the player, the drawer, and the card. You should be able to play/pause anywhere and the update should be reflected everywhere right away

#### Screenshots (if appropriate)

![Screenshot from 2020-04-30 11-55-00](https://user-images.githubusercontent.com/6207644/80731975-a0e32b00-8ad9-11ea-83ac-c788c4eca4c1.png)

![Screenshot from 2020-04-30 11-54-53](https://user-images.githubusercontent.com/6207644/80732058-c7a16180-8ad9-11ea-8cdb-cce707e88cf6.png)
