### PR TITLE
Prevent focus of buttons in the audio player

### DIFF
--- a/static/scss/audio-player.scss
+++ b/static/scss/audio-player.scss
@@ -9,6 +9,7 @@
   align-items: center;
   box-shadow: 0px -4px 15px rgba(50, 50, 50, 0.3);
   font-family: Helvetica, sans-serif;
+  user-select: none;
   left: 0;
   bottom: 0;
   width: 100vw;


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2844

#### What's this PR do?
Prevents highlighting of buttons (and all text) within the audio player with the `user-select: none` CSS rule.  The buttons were not actually receiving focus when clicking them repeatedly, they were being highlighted because the material icons we are using technically count as text that can be highlighted.  The CSS rule prevents this from happening.

#### How should this be manually tested?
Open the audio player and rapidly click any of the buttons.  Click and drag across the player.  Nothing should be highlighted.
