### PR TITLE
add link in drawer from podcast episode to all episodes

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -248,8 +248,20 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
             />
           </div>
           {object.object_type === LR_TYPE_PODCAST_EPISODE ? (
-            <div className="podcast-play-control">
+            <div className="podcast-episode-row">
               <PodcastPlayButton episode={object} />
+              <div
+                className="view-all-episodes"
+                onClick={() => {
+                  setShowResourceDrawer({
+                    objectId:   object.podcast,
+                    objectType: LR_TYPE_PODCAST,
+                    runId:      undefined
+                  })
+                }}
+              >
+                View All Episodes
+              </div>
             </div>
           ) : null}
           {!emptyOrNil(object.topics) ? (

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -1,6 +1,7 @@
 // @flow
 import { assert } from "chai"
 import R from "ramda"
+import sinon from "sinon"
 
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
 import * as UserListItemsMod from "../components/UserListItems"
@@ -193,6 +194,18 @@ describe("ExpandedLearningResourceDisplay", () => {
     const object = makeLearningResource(LR_TYPE_PODCAST)
     const { wrapper } = await render({}, { object })
     assert.ok(wrapper.find("PaginatedPodcastEpisodes").exists())
+  })
+
+  it("should have a link to open all episodes for PodcastEpisodes", async () => {
+    const object = makeLearningResource(LR_TYPE_PODCAST_EPISODE)
+    const { wrapper } = await render({}, { object })
+
+    wrapper.find(".view-all-episodes").simulate("click")
+    sinon.assert.calledWith(setShowResourceDrawerStub, {
+      objectId:   object.podcast,
+      objectType: LR_TYPE_PODCAST,
+      runId:      undefined
+    })
   })
 
   LR_TYPE_ALL.forEach(objectType => {

--- a/static/scss/learning-resource-drawer.scss
+++ b/static/scss/learning-resource-drawer.scss
@@ -47,8 +47,16 @@
     font-weight: bold;
   }
 
-  .podcast-play-control {
+  .podcast-episode-row {
     margin-top: 15px;
+
+    display: flex;
+    justify-content: space-between;
+
+    .view-all-episodes {
+      color: $course-blue;
+      cursor: pointer;
+    }
   }
 
   .topics {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #2881

#### What's this PR do?

^^ see the PR title :smile: 

#### How should this be manually tested?

if you open a podcast episode in the drawer you should see a link to 'View All Episodes' which should open the podcast itself in the drawer.

#### Screenshots (if appropriate)

![Screenshot from 2020-05-01 11-05-41](https://user-images.githubusercontent.com/6207644/80815476-b882e800-8b9b-11ea-88d1-5af9454192e5.png)
![Screenshot from 2020-05-01 11-05-34](https://user-images.githubusercontent.com/6207644/80815477-b91b7e80-8b9b-11ea-82f8-5c1f737bce7f.png)
