### PR TITLE
Snackbar update

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material/list": "^0.2.14",
     "@material/radio": "^0.30.0",
     "@material/rtl": "^0.1.7",
-    "@material/snackbar": "^0.25.0",
+    "@material/snackbar": "^0.44.0",
     "@material/toolbar": "^0.4.4",
     "@mitodl/ckeditor-custom-build": "0.0.4",
     "@mitodl/mdl-react-components": "^0.0.3",

--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -4,17 +4,12 @@ import { useSelector } from "react-redux"
 import { createSelector } from "reselect"
 import { Snackbar as RMWCSnackbar } from "@rmwc/snackbar"
 
-const getSnackbarState = createSelector(
-  state => state.ui,
-  ui => ui.snackbar
-)
+const getSnackbarState = createSelector(state => state.ui, ui => ui.snackbar)
 
 export default function Snackbar() {
   const snackbar = useSelector(getSnackbarState)
   console.log(snackbar)
   const message = snackbar ? snackbar.message : null
   const open = message ? true : false
-  return (
-    <RMWCSnackbar open={open} message={message} />
-  )
+  return <RMWCSnackbar open={open} message={message} />
 }

--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react"
+import React, { useState } from "react"
 import { useSelector } from "react-redux"
 import { createSelector } from "reselect"
 import { Snackbar as RMWCSnackbar } from "@rmwc/snackbar"
@@ -8,8 +8,19 @@ const getSnackbarState = createSelector(state => state.ui, ui => ui.snackbar)
 
 export default function Snackbar() {
   const snackbar = useSelector(getSnackbarState)
-  console.log(snackbar)
-  const message = snackbar ? snackbar.message : null
-  const open = message ? true : false
-  return <RMWCSnackbar open={open} message={message} />
+  const [id, setId] = useState(-1)
+  const [open, setOpen] = useState(false)
+  if (snackbar) {
+    if (snackbar.id !== id) {
+      setId(snackbar.id)
+      setOpen(true)
+    }
+    return (
+      <RMWCSnackbar
+        open={open}
+        onClose={() => setOpen(false)}
+        message={snackbar.message}
+      />
+    )
+  } else return <RMWCSnackbar />
 }

--- a/static/js/components/material/Snackbar.js
+++ b/static/js/components/material/Snackbar.js
@@ -1,52 +1,20 @@
 // @flow
 import React from "react"
-import R from "ramda"
+import { useSelector } from "react-redux"
+import { createSelector } from "reselect"
+import { Snackbar as RMWCSnackbar } from "@rmwc/snackbar"
 
-import { MDCSnackbar } from "@material/snackbar/dist/mdc.snackbar"
+const getSnackbarState = createSelector(
+  state => state.ui,
+  ui => ui.snackbar
+)
 
-import type { SnackbarState } from "../../reducers/ui"
-
-type Props = {
-  snackbar: ?SnackbarState
-}
-
-export default class Snackbar extends React.Component<Props> {
-  snackbar = null
-  snackbarRoot = null
-
-  componentDidMount() {
-    this.snackbar = new MDCSnackbar(this.snackbarRoot)
-  }
-
-  // see here: https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops
-  // this method will be deprecated soon, so we need to refactor away from it somehow
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (!R.equals(this.props.snackbar, nextProps.snackbar)) {
-      this.showSnackbar(nextProps.snackbar)
-    }
-  }
-
-  showSnackbar(snackbar: ?SnackbarState) {
-    if (this.snackbar && snackbar) {
-      this.snackbar.show(R.omit("id", snackbar))
-    }
-  }
-
-  render() {
-    return (
-      <div
-        className="mdc-snackbar"
-        aria-live="assertive"
-        aria-atomic="true"
-        aria-hidden="true"
-        ref={node => (this.snackbarRoot = node)}
-      >
-        <div className="mdc-snackbar__text" />
-        <div className="mdc-snackbar__action-wrapper">
-          <button type="button" className="mdc-snackbar__action-button" />
-        </div>
-      </div>
-    )
-  }
+export default function Snackbar() {
+  const snackbar = useSelector(getSnackbarState)
+  console.log(snackbar)
+  const message = snackbar ? snackbar.message : null
+  const open = message ? true : false
+  return (
+    <RMWCSnackbar open={open} message={message} />
+  )
 }

--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -19,6 +19,11 @@
     border-radius: $std-border-radius;
     margin: 5px 0;
     padding: 0;
+
+    .mdc-snackbar__label {
+      width: 100%;
+      text-align: center;
+    }
   }
 }
 

--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -1,8 +1,8 @@
+@use "@material/snackbar";
+
 .mdc-snackbar {
+  background-color: transparent;
   z-index: 50;
-  background-color: $message-component-bg-color;
-  left: 50%;
-  border-radius: $std-border-radius;
 
   @include breakpoint(materialmobile) {
     left: 0;
@@ -14,14 +14,15 @@
     padding-bottom: 10px;
   }
 
-  .mdc-snackbar__label {
+  .mdc-snackbar__surface {
+    background-color: $message-component-bg-color;
+    border-radius: $std-border-radius;
     margin: 5px 0;
     padding: 0;
-    min-width: 100%;
-    width: 100%;
   }
 }
 
-.persistent-drawer-open ~ .mdc-snackbar {
-  left: calc(50% + (#{$drawer-width}/ 2));
+.persistent-drawer.open ~ .mdc-snackbar {
+  width: calc(100% - #{$drawer-width});
+  left: $drawer-width;
 }

--- a/static/scss/snackbar.scss
+++ b/static/scss/snackbar.scss
@@ -1,5 +1,5 @@
 .mdc-snackbar {
-  z-index: 10;
+  z-index: 50;
   background-color: $message-component-bg-color;
   left: 50%;
   border-radius: $std-border-radius;
@@ -8,13 +8,13 @@
     left: 0;
   }
 
-  &.mdc-snackbar--active {
+  &.mdc-snackbar--open {
     bottom: 10px;
     padding-top: 10px;
     padding-bottom: 10px;
   }
 
-  .mdc-snackbar__text {
+  .mdc-snackbar__label {
     margin: 5px 0;
     padding: 0;
     min-width: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,7 @@
 "@material/animation@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.25.0.tgz#b252ac3d0b628e79a79f0c406d7470fb56352a80"
+  integrity sha512-4RzlpMwJtMnQ3/rNf4zpG9qnoQcCkYiRs6U515MRQzv7qFl1eCZx3U3dGaUu7UVf3Hwx4RskUB/fBxGc0b61CQ==
 
 "@material/animation@^0.3.1":
   version "0.3.1"
@@ -887,6 +888,11 @@
 "@material/animation@^0.34.0":
   version "0.34.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.34.0.tgz#a99cc9dabf7d0179b4da9a0aaa1575c4d1513823"
+
+"@material/animation@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.41.0.tgz#315b45b32e1aeebee8a4cf555b8ad52076d09ddd"
+  integrity sha512-yYAwJbX3Q2AFd4dr6IYOsWLQy2HN8zWOFVl9AbUXunjzTfJCa/ecfXCriaT6qkmoNoHeTdJHRrsQJZC5GsPvzA==
 
 "@material/animation@^1.0.0":
   version "1.0.0"
@@ -917,6 +923,7 @@
 "@material/base@^0.24.0":
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.24.0.tgz#888a61e5b6580e35a66384a9f8823091b4fe7c55"
+  integrity sha512-RG1SbHl6M8a0fdrMAoMm7Fc8jkuj3HhZd0f8Dy5kfUtQk3I7PyzD+MLCrmCHgUAlKbcK2J9VxJWpd4isZr3x9w==
 
 "@material/base@^0.29.0":
   version "0.29.0"
@@ -925,6 +932,11 @@
 "@material/base@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.35.0.tgz#8640c2da385e8cc393ff56153c5a319f5a7704cb"
+
+"@material/base@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.41.0.tgz#badadce711b4c25b1eb889a5e7581e32cd07c421"
+  integrity sha512-tEyzwBRu3d1H120SfKsDVYZHcqT5lKohh/7cWKR93aAaPDkSvjpKJIjyu2yuSkjpDduVZGzVocYbOvhUKhhzXQ==
 
 "@material/base@^1.0.0":
   version "1.0.0"
@@ -948,6 +960,19 @@
     "@material/ripple" "^0.8.2"
     "@material/theme" "^0.1.7"
     "@material/typography" "^0.3.0"
+
+"@material/button@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-0.44.1.tgz#2a0bc0e6961128ace81e050770695c4aaad7f3bd"
+  integrity sha512-+eI0nI2zkxZOanPfeWzZPoQDbv2NqgUhUhPxERKoXEqkyJIne7gWRYMHqHjKPctsD2xmzgqGmGCLcrvhgFZ+FQ==
+  dependencies:
+    "@material/elevation" "^0.44.1"
+    "@material/feature-targeting" "^0.44.1"
+    "@material/ripple" "^0.44.1"
+    "@material/rtl" "^0.42.0"
+    "@material/shape" "^0.44.1"
+    "@material/theme" "^0.43.0"
+    "@material/typography" "^0.44.1"
 
 "@material/button@^3.1.0", "@material/button@^3.2.0":
   version "3.2.0"
@@ -1053,6 +1078,11 @@
     focus-trap "^5.0.0"
     tslib "^1.9.3"
 
+"@material/dom@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-0.41.0.tgz#6756865f97bad4c91ee75e69d769d7cdc25398ae"
+  integrity sha512-wOJrMwjPddYXpQFZAIaCLWI3TO/6KU1lxESTBzunni8A4FHQVWhokml5Xt85GqZwmPFeIF2s+D0wfbWyrGBuKQ==
+
 "@material/dom@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@material/dom/-/dom-1.1.0.tgz#3bd3d1a3415b4181118fecb182d93beda56a6f8c"
@@ -1115,6 +1145,15 @@
   dependencies:
     "@material/animation" "^0.34.0"
     "@material/theme" "^0.4.0"
+
+"@material/elevation@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.44.1.tgz#19efa293e195b00141711899e3c3fde6a3670454"
+  integrity sha512-Gr2x/FHysM4ty7sctLPT48pw7YItLZvhXsB4ZzXpdhuy7QshxllBW9NGlAMffzrmNu16MTl3ouGzbhArUYz4jw==
+  dependencies:
+    "@material/animation" "^0.41.0"
+    "@material/feature-targeting" "^0.44.1"
+    "@material/theme" "^0.43.0"
 
 "@material/elevation@^1.1.0":
   version "1.1.0"
@@ -1194,6 +1233,15 @@
     "@material/theme" "^3.1.0"
     "@material/typography" "^3.1.0"
     tslib "^1.9.3"
+
+"@material/icon-button@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-0.44.1.tgz#28935c16edef62c0f77fcc1195707c55331a5d0f"
+  integrity sha512-46fLWwqLjer3w1h1HvfNsVuBmNwg+rFbIrLBzUXSb9iM6YlunjBNwPZI5KTmVpt04GkzVI2h4o2ej8dOdvQWOg==
+  dependencies:
+    "@material/base" "^0.41.0"
+    "@material/ripple" "^0.44.1"
+    "@material/theme" "^0.43.0"
 
 "@material/icon-button@^3.1.0", "@material/icon-button@^3.2.0":
   version "3.2.0"
@@ -1358,6 +1406,16 @@
     "@material/base" "^0.29.0"
     "@material/theme" "^0.30.0"
 
+"@material/ripple@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.44.1.tgz#79cb2ddf1f998498d877d3e3c46b50fed6f13b01"
+  integrity sha512-prJ1p3bR+GvwAtJgtdeIixsnRVApN3bizGnX7upKoqxsqbBDHj84JxaO8EsG9bjruG/LJu8Fb6WKKdIp2oXHTA==
+  dependencies:
+    "@material/animation" "^0.41.0"
+    "@material/base" "^0.41.0"
+    "@material/feature-targeting" "^0.44.1"
+    "@material/theme" "^0.43.0"
+
 "@material/ripple@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.8.2.tgz#f1844079701121b3905fa4c47c83035dc10ed60a"
@@ -1392,6 +1450,7 @@
 "@material/rtl@^0.1.7", "@material/rtl@^0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.8.tgz#2462db15e2d4e041666485559c028382872b01fb"
+  integrity sha512-NzBobwxvhJg+dch99pVO+Z9HL1DM+esuIy5WYXgM7trfOVh8n9DkVo5vD/NKnDy6F5wCaRnJOI5T19Tev6c9Zw==
 
 "@material/rtl@^0.36.0":
   version "0.36.0"
@@ -1432,6 +1491,13 @@
   dependencies:
     "@material/ripple" "^0.30.0"
 
+"@material/shape@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-0.44.1.tgz#ff4d5d42b07c5781306677bffee43234b756ea8e"
+  integrity sha512-8mCDQmyTEhDK+HX8Tap2Lc82QlVySlXU8zDCNkWoIn1ge+UnRezSDjE4y4P1ABegN5PrkJZPartuQ1U0ttIYXw==
+  dependencies:
+    "@material/feature-targeting" "^0.44.1"
+
 "@material/shape@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@material/shape/-/shape-3.1.0.tgz#7ccac6606d0ae45b779b3e52b8921c09c2b2f429"
@@ -1453,15 +1519,21 @@
     "@material/typography" "^3.1.0"
     tslib "^1.9.3"
 
-"@material/snackbar@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-0.25.0.tgz#73169dbf51d6c3f23b7c84654a540e1b3c5a88a6"
+"@material/snackbar@^0.44.0":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-0.44.1.tgz#8548d7234230e2e56036a55a6c3e0b30d3d9b2eb"
+  integrity sha512-WfjYxBtNWK9RvnAxqjAuu/bMfpisgtM5tHHDMs2W/iiw9dIF4Z5HTKcQwSA040tSL0NxSBGAYvbDO68j+1WSEw==
   dependencies:
-    "@material/animation" "^0.25.0"
-    "@material/base" "^0.24.0"
-    "@material/rtl" "^0.1.8"
-    "@material/theme" "^0.25.0"
-    "@material/typography" "^0.3.0"
+    "@material/animation" "^0.41.0"
+    "@material/base" "^0.41.0"
+    "@material/button" "^0.44.1"
+    "@material/dom" "^0.41.0"
+    "@material/icon-button" "^0.44.1"
+    "@material/ripple" "^0.44.1"
+    "@material/rtl" "^0.42.0"
+    "@material/shape" "^0.44.1"
+    "@material/theme" "^0.43.0"
+    "@material/typography" "^0.44.1"
 
 "@material/snackbar@^3.1.0", "@material/snackbar@^3.2.0":
   version "3.2.0"
@@ -1567,10 +1639,6 @@
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.1.7.tgz#d94a7c5099feae9dc318c639802327c7ae82e872"
 
-"@material/theme@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.25.0.tgz#707b4c61ebc62e662d36164c8dd45fcf98bb1444"
-
 "@material/theme@^0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.27.0.tgz#32fd72addfec09bf22e83f66f36a7ebbdc123461"
@@ -1586,6 +1654,11 @@
 "@material/theme@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.4.0.tgz#0aef1a0279b65c15990584fb8b8eca095c734641"
+
+"@material/theme@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.43.0.tgz#6d9fa113c82e841817882172c152d60d2d203ca6"
+  integrity sha512-/zndZL6EihI18v2mYd4O8xvOBAAXmLeHyHVK28LozSAaJ9okQgD25wq5Ktk95oMTmPIC+rH66KcK6371ivNk8g==
 
 "@material/theme@^1.1.0":
   version "1.1.0"
@@ -1647,10 +1720,18 @@
 "@material/typography@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.3.0.tgz#f828c2d3215bfd66c58072709b4260c64125390a"
+  integrity sha1-+CjC0yFb/WbFgHJwm0JgxkElOQo=
 
 "@material/typography@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.35.0.tgz#23ad7eb7c9789e69c7c3fa54df8fc311cd7fc4b1"
+
+"@material/typography@^0.44.1":
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.44.1.tgz#a94f01172f9122180bc2ce0aa55658183a35590d"
+  integrity sha512-wMXHusg+Lp5Fdgoj3m0c+Lt6GCeGSh3EPRtQ1TQ2bwdBa0et2FqBaQRgXoq3tVmr0O/7unTfa0DoXlh4nVp1wA==
+  dependencies:
+    "@material/feature-targeting" "^0.44.1"
 
 "@material/typography@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2784

#### What's this PR do?
Replaces our custom Snackbar component with the RMWC wrapped equivalent, but still tied to our redux state in the same way.  Our component has also been converted to a hook.

#### How should this be manually tested?
Go to the settings page and change your notification settings.  You should get a snackbar message confirming the change.

#### Screenshots (if appropriate)
![Screen Shot 2020-05-04 at 4 49 16 PM](https://user-images.githubusercontent.com/12089658/81012291-4cb4af80-8e27-11ea-8ded-50a199aaf75a.png)
![image](https://user-images.githubusercontent.com/12089658/81012374-7077f580-8e27-11ea-84f7-d6f3fcad88f5.png)

#### What GIF best describes this PR or how it makes you feel?
![admiral ackbar](https://user-images.githubusercontent.com/12089658/80991553-364a2c00-8e06-11ea-8c1c-5de325347b1e.gif)
