### PR TITLE
hide 'share' button on podcasts, podcast episodes in drawer

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -168,6 +168,10 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
     [object]
   )
 
+  const shouldHideShareMenu =
+    (isUserList(object.object_type) && object.privacy_level === LR_PRIVATE) ||
+    isPodcastObject(object)
+
   return (
     <React.Fragment>
       <div className="expanded-lr-summary">
@@ -329,21 +333,20 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
           ) : null}
         </div>
       </div>
-      {isUserList(object.object_type) &&
-      object.privacy_level === LR_PRIVATE ? null : (
-          <div className="elr-share">
-            <ShareTooltip
-              url={learningResourcePermalink(object)}
-              objectType={readableLearningResources[object.object_type]}
-              placement="topLeft"
-            >
-              <div className="share-contents">
-                <i className="material-icons reply">reply</i>
+      {shouldHideShareMenu ? null : (
+        <div className="elr-share">
+          <ShareTooltip
+            url={learningResourcePermalink(object)}
+            objectType={readableLearningResources[object.object_type]}
+            placement="topLeft"
+          >
+            <div className="share-contents">
+              <i className="material-icons reply">reply</i>
               Share
-              </div>
-            </ShareTooltip>
-          </div>
-        )}
+            </div>
+          </ShareTooltip>
+        </div>
+      )}
       {hasCourseList(object.object_type) && !emptyOrNil(object.items) ? (
         <ListItemsSection
           title="Learning Resources in this Program"

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -305,11 +305,19 @@ describe("ExpandedLearningResourceDisplay", () => {
         object.privacy_level = LR_PUBLIC
       }
       const { wrapper } = await render({}, { object })
-      const { objectType: _objectType, url } = wrapper
-        .find("ShareTooltip")
-        .props()
-      assert.equal(_objectType, readableLearningResources[object.object_type])
-      assert.equal(url, learningResourcePermalink(object))
+
+      if (
+        objectType === LR_TYPE_PODCAST ||
+        objectType === LR_TYPE_PODCAST_EPISODE
+      ) {
+        assert.isNotOk(wrapper.find("ShareTooltip").exists())
+      } else {
+        const { objectType: _objectType, url } = wrapper
+          .find("ShareTooltip")
+          .props()
+        assert.equal(_objectType, readableLearningResources[object.object_type])
+        assert.equal(url, learningResourcePermalink(object))
+      }
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

no ticket, @abdulkdawson asked me to make this change

#### What's this PR do?

hide 'share' button on podcasts, podcast episodes in drawer


#### How should this be manually tested?

when a podcast or episode is open in the drawer the share button should not be there, otherwise, it should be there for courses and whatnot.

#### Screenshots (if appropriate)

![Screenshot from 2020-05-04 14-28-11](https://user-images.githubusercontent.com/6207644/81000047-ab702e00-8e13-11ea-8902-d8d190700d77.png)
![Screenshot from 2020-05-04 14-28-06](https://user-images.githubusercontent.com/6207644/81000049-ac08c480-8e13-11ea-9f3e-9a14920ed980.png)

