### PR TITLE
fix drawer scrolling issue

### DIFF
--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useEffect } from "react"
+import React, { useRef, useCallback, useEffect } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { Drawer, DrawerContent } from "@rmwc/drawer"
 import { Theme } from "@rmwc/theme"
@@ -89,6 +89,8 @@ type Props = {
 export default function LearningResourceDrawer(props: Props) {
   const { hideSimilarLearningResources } = props
 
+  const drawerContent = useRef()
+
   useResponsive()
 
   const { objectId, objectType, runId, numHistoryEntries } = useSelector(
@@ -126,7 +128,18 @@ export default function LearningResourceDrawer(props: Props) {
     : ""
 
   const dispatch = useDispatch()
-  const clearHistory = useCallback(() => dispatch(clearLRHistory()), [dispatch])
+
+  const closeDrawer = useCallback(
+    () => {
+      dispatch(clearLRHistory())
+      const { current } = drawerContent
+      if (current) {
+        current.scroll({ top: 0 })
+      }
+    },
+    [dispatch]
+  )
+
   const pushHistory = useCallback(object => dispatch(pushLRHistory(object)), [
     dispatch
   ])
@@ -136,14 +149,14 @@ export default function LearningResourceDrawer(props: Props) {
     <Theme>
       <Drawer
         open={numHistoryEntries > 0}
-        onClose={clearHistory}
+        onClose={closeDrawer}
         dir="rtl"
         className={`align-right lr-drawer${audioPlayerPadding}`}
         modal
       >
-        <DrawerContent dir="ltr">
+        <DrawerContent dir="ltr" ref={drawerContent}>
           <div className="drawer-nav">
-            <div className="drawer-close" onClick={clearHistory}>
+            <div className="drawer-close" onClick={closeDrawer}>
               <i className="material-icons clear">clear</i>
             </div>
             {numHistoryEntries > 1 ? (

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -1,4 +1,5 @@
 import { assert } from "chai"
+import sinon from "sinon"
 
 import LearningResourceDrawer from "./LearningResourceDrawer"
 import ExpandedLearningResourceDisplay from "../components/ExpandedLearningResourceDisplay"
@@ -93,6 +94,15 @@ describe("LearningResourceDrawer", () => {
     wrapper.find(".drawer-close").simulate("click")
     // this means that the history has been cleared
     assert.deepEqual(store.getState().ui.LRDrawerHistory, [])
+  })
+
+  it("should scroll to the top on drawer close", async () => {
+    const { wrapper } = await renderWithObject(
+      course,
+      courseDetailApiURL.param({ courseId: course.id }).toString()
+    )
+    wrapper.find(".drawer-close").simulate("click")
+    sinon.assert.calledWith(helper.scrollStub, { top: 0 })
   })
 
   it("should have a back button if there is more than one object in the drawer history", async () => {

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -75,8 +75,10 @@ export default class IntegrationTestHelper {
     })
 
     this.scrollIntoViewStub = this.sandbox.stub()
+    this.scrollStub = this.sandbox.stub()
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub
+    window.HTMLDivElement.prototype.scroll = this.scrollStub
     this.browserHistory = createMemoryHistory()
     this.currentLocation = null
     this.browserHistory.listen(url => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

fixes one part of the issue in #2883

#### What's this PR do?

see the issue, this fixes the 2nd issue:

"opening the drawer, scrolling down, closing the drawer, and re-opening, on a podcast or pair of podcasts which do not trigger the first issue, can leave the drawer scrolled down because we do not scroll the drawer content to top when it closes"

#### How should this be manually tested?

A good podcast to test with is the one called 'BioGenesis'.

Check on master that if you:

- open that podcast
- scroll the drawer down a little bit
- close the drawer
- re-open it

the drawer should be at the scroll position you left it at when you closed it.

then check out this branch, and confirm that the drawer is always scrolled to the top for that podcast.

_Note that there are other podcasts for which this wont work!_ Go read the issue, but basically when podcasts have multiple pages of episodes the 'next' button seems to be grabbing focus and causing the div to scroll so it's in view - I'm not sure how to fix or why it's happening so I'm not addressing that here.