### PR TITLE
combine podcast and podcast episode

### DIFF
--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -250,6 +250,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
     if (emptyOrNil(activeFacets.type)) {
       activeFacets.type = LR_TYPE_ALL
+    } else if (activeFacets.type.includes(LR_TYPE_PODCAST)) {
+      activeFacets.type.push(LR_TYPE_PODCAST_EPISODE)
     }
 
     await runSearch({

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -225,6 +225,7 @@ describe("CourseSearchPage", () => {
     })
   })
 
+  //
   it("searches with parameters", async () => {
     SETTINGS.search_page_size = 5
     await renderPage(
@@ -253,6 +254,40 @@ describe("CourseSearchPage", () => {
           topics:       ["Science", "Engineering"],
           availability: ["availableNow"],
           cost:         ["free"]
+        })
+      )
+    })
+  })
+
+  //
+  it("searches for podcast episodes when the type parameter is podcast", async () => {
+    SETTINGS.search_page_size = 5
+    await renderPage(
+      {
+        search: {
+          processing: false,
+          loaded:     false
+        }
+      },
+      {
+        location: {
+          search: "q=text&type=podcast"
+        }
+      }
+    )
+    sinon.assert.calledWith(helper.searchStub, {
+      channelName: null,
+      from:        0,
+      size:        SETTINGS.search_page_size,
+      text:        "text",
+      type:        ["podcast", "podcastepisode"],
+      facets:      new Map(
+        Object.entries({
+          type:         ["podcast", "podcastepisode"],
+          offered_by:   [],
+          topics:       [],
+          availability: [],
+          cost:         []
         })
       )
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="1680" alt="Screen Shot 2020-05-07 at 10 44 33 AM" src="https://user-images.githubusercontent.com/1934992/81309415-e8753400-9050-11ea-88b2-6ab41c753c24.png">
<img width="1674" alt="Screen Shot 2020-05-07 at 10 45 49 AM" src="https://user-images.githubusercontent.com/1934992/81309423-eb702480-9050-11ea-80d2-4cc402353b42.png">
<img width="379" alt="Screen Shot 2020-05-07 at 10 46 54 AM" src="https://user-images.githubusercontent.com/1934992/81309432-edd27e80-9050-11ea-8e88-4dca7dc84bac.png">


#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2864

#### What's this PR do?
This pr updates the learning search ui to have a single category for the podcast and podcast episode types. Selecting "podcasts" in the search returns both podcasts and podcast episodes.

#### How should this be manually tested?
run `docker-compose run web ./manage.py backpopulate_podcast_data` if needed. 
Go to the learning search. The "Podcast" type should have 963 entries, which is the combined number of podcasts and podcast episodes. Filtering for "Podcast" should return both types of podcast resources

