### PR TITLE
combine  userlist learning path in search

### DIFF
--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -14,7 +14,6 @@ import {
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_PROGRAM,
   LR_TYPE_COURSE,
-  LR_TYPE_PODCAST_EPISODE,
   platforms
 } from "./constants"
 import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
@@ -151,14 +150,9 @@ export const filterRunsByAvailability = (
     : []
 
 export const resourceLabel = (resource: string) => {
-  switch (resource) {
-  case LR_TYPE_USERLIST:
+  if (resource === LR_TYPE_USERLIST) {
     return "Learning Lists"
-  case LR_TYPE_LEARNINGPATH:
-    return "Learning Paths"
-  case LR_TYPE_PODCAST_EPISODE:
-    return "Podcast Episodes"
-  default:
+  } else {
     return R.concat(capitalize(resource), "s")
   }
 }

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -93,8 +93,7 @@ describe("Course utils", () => {
   ;[
     [LR_TYPE_COURSE, "Courses"],
     [LR_TYPE_PROGRAM, "Programs"],
-    [LR_TYPE_USERLIST, "Learning Lists"],
-    [LR_TYPE_LEARNINGPATH, "Learning Paths"]
+    [LR_TYPE_USERLIST, "Learning Lists"]
   ].forEach(([searchType, facetText]) => {
     it(`facet text should be ${facetText} for resource type ${searchType}`, () => {
       assert.equal(resourceLabel(searchType), facetText)

--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -10,6 +10,7 @@ import {
   LR_TYPE_VIDEO,
   LR_TYPE_PODCAST,
   LR_TYPE_PODCAST_EPISODE,
+  LR_TYPE_LEARNINGPATH,
   PHONE,
   TABLET,
   DESKTOP,
@@ -161,8 +162,8 @@ export const RESOURCE_QUERY_NESTED_FIELDS = [
 ]
 
 const LIST_QUERY_FIELDS = [
-  "title.english",
-  "short_description.english",
+  "title.english^3",
+  "short_description.english^2",
   "topics"
 ]
 
@@ -249,7 +250,9 @@ const _searchFields = (type: ?string) => {
     return PODCAST_QUERY_FIELDS
   } else if (type === LR_TYPE_PODCAST_EPISODE) {
     return PODCAST_EPISODE_QUERY_FIELDS
-  } else if ([LR_TYPE_PROGRAM, LR_TYPE_USERLIST].includes(type)) {
+  } else if (
+    [LR_TYPE_PROGRAM, LR_TYPE_USERLIST, LR_TYPE_LEARNINGPATH].includes(type)
+  ) {
     return LIST_QUERY_FIELDS
   } else {
     return R.uniq([

--- a/static/js/lib/search_test.js
+++ b/static/js/lib/search_test.js
@@ -848,8 +848,11 @@ describe("search functions", () => {
           "offered_by"
         ]
       ],
-      ["program", ["title.english", "short_description.english", "topics"]],
-      ["userlist", ["title.english", "short_description.english", "topics"]],
+      ["program", ["title.english^3", "short_description.english^2", "topics"]],
+      [
+        "userlist",
+        ["title.english^3", "short_description.english^2", "topics"]
+      ],
       [
         "video",
         [

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -250,8 +250,14 @@ export class CourseSearchPage extends React.Component<Props, State> {
 
     if (emptyOrNil(activeFacets.type)) {
       activeFacets.type = LR_TYPE_ALL
-    } else if (activeFacets.type.includes(LR_TYPE_PODCAST)) {
-      activeFacets.type.push(LR_TYPE_PODCAST_EPISODE)
+    } else {
+      if (activeFacets.type.includes(LR_TYPE_PODCAST)) {
+        activeFacets.type.push(LR_TYPE_PODCAST_EPISODE)
+      }
+
+      if (activeFacets.type.includes(LR_TYPE_USERLIST)) {
+        activeFacets.type.push(LR_TYPE_LEARNINGPATH)
+      }
     }
 
     await runSearch({

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -294,6 +294,40 @@ describe("CourseSearchPage", () => {
   })
 
   //
+  it("searches for learning path when the type parameter is userlist", async () => {
+    SETTINGS.search_page_size = 5
+    await renderPage(
+      {
+        search: {
+          processing: false,
+          loaded:     false
+        }
+      },
+      {
+        location: {
+          search: "q=text&type=userlist"
+        }
+      }
+    )
+    sinon.assert.calledWith(helper.searchStub, {
+      channelName: null,
+      from:        0,
+      size:        SETTINGS.search_page_size,
+      text:        "text",
+      type:        ["userlist", "learningpath"],
+      facets:      new Map(
+        Object.entries({
+          type:         ["userlist", "learningpath"],
+          offered_by:   [],
+          topics:       [],
+          availability: [],
+          cost:         []
+        })
+      )
+    })
+  })
+
+  //
   ;[0, 5].forEach(from => {
     it(`InfiniteScroll initialLoad ${shouldIf(
       from > 0


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2020-05-11 at 1 39 09 PM" src="https://user-images.githubusercontent.com/1934992/81608769-c9eea000-93a4-11ea-91df-7d4300806ac6.png">
<img width="380" alt="Screen Shot 2020-05-11 at 1 49 41 PM" src="https://user-images.githubusercontent.com/1934992/81608777-cb1fcd00-93a4-11ea-9fc8-77fcf8783162.png">
<img width="1679" alt="Screen Shot 2020-05-11 at 1 48 49 PM" src="https://user-images.githubusercontent.com/1934992/81608779-cb1fcd00-93a4-11ea-9f53-cf9edec4d5c3.png">

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested



#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2864
https://github.com/mitodl/open-discussions/issues/2823

#### What's this PR do?
This pr updates the learning search ui to have a single category for the podcast and podcast episode types and for learning list and learning path types. Selecting "podcasts" in the search returns both podcasts and podcast episodes and selecting "learning lists" returns both learning lists and learning paths

#### How should this be manually tested?
create a few learning lists and paths if needed

The "Learning Lists" type should have whatever the combined number of learning lists and learning paths is.

Text search should return both learning lists and learning paths objects