### PR TITLE
fix popular resourses learning path

### DIFF
--- a/static/js/factories/learning_resources.js
+++ b/static/js/factories/learning_resources.js
@@ -214,6 +214,14 @@ const LR_FACTORY_MAPPING = {
 export const makeLearningResource = (object_type: string): Object =>
   R.merge({ object_type }, LR_FACTORY_MAPPING[object_type]())
 
+export const makeLearningPath = R.compose(
+  R.merge({
+    list_type:   LR_TYPE_LEARNINGPATH,
+    object_type: LR_TYPE_LEARNINGPATH
+  }),
+  makeUserList
+)
+
 const formatFavorite = contentType => resource => ({
   content_data: resource,
   content_type: contentType

--- a/static/js/lib/queries/interactions.js
+++ b/static/js/lib/queries/interactions.js
@@ -7,7 +7,8 @@ import {
   LR_TYPE_USERLIST,
   LR_TYPE_VIDEO,
   LR_TYPE_PODCAST,
-  LR_TYPE_PODCAST_EPISODE
+  LR_TYPE_PODCAST_EPISODE,
+  LR_TYPE_LEARNINGPATH
 } from "../constants"
 import { interactionsApiURL, popularContentUrl } from "../url"
 import { constructIdMap, DEFAULT_POST_OPTIONS } from "../redux_query"
@@ -65,7 +66,10 @@ export const popularContentRequest = () => ({
           filterObjectType(body.results, LR_TYPE_PROGRAM)
         ),
         userLists: constructIdMap(
-          filterObjectType(body.results, LR_TYPE_USERLIST)
+          filterObjectType(body.results, [
+            LR_TYPE_USERLIST,
+            LR_TYPE_LEARNINGPATH
+          ])
         ),
         podcasts: constructIdMap(
           filterObjectType(body.results, LR_TYPE_PODCAST)

--- a/static/js/lib/queries/interactions_test.js
+++ b/static/js/lib/queries/interactions_test.js
@@ -13,7 +13,8 @@ import {
   makeVideo,
   makeCourse,
   makeUserList,
-  makeProgram
+  makeProgram,
+  makeLearningPath
 } from "../../factories/learning_resources"
 import { makePodcast, makePodcastEpisode } from "../../factories/podcasts"
 
@@ -66,9 +67,18 @@ describe("Interactions API", () => {
     const video = makeVideo()
     const program = makeProgram()
     const userList = makeUserList()
+    const learningPath = makeLearningPath()
     const podcast = makePodcast()
     const podcastEpisode = makePodcastEpisode(podcast)
-    const results = [course, video, program, userList, podcast, podcastEpisode]
+    const results = [
+      course,
+      video,
+      program,
+      userList,
+      learningPath,
+      podcast,
+      podcastEpisode
+    ]
     const request = popularContentRequest()
     assert.equal(request.url, popularContentUrl)
     assert.deepEqual(request.transform({ results }), {
@@ -82,7 +92,8 @@ describe("Interactions API", () => {
         [video.id]: video
       },
       userLists: {
-        [userList.id]: userList
+        [userList.id]:     userList,
+        [learningPath.id]: learningPath
       },
       podcasts: {
         [podcast.id]: podcast

--- a/static/js/lib/queries/learning_resources.js
+++ b/static/js/lib/queries/learning_resources.js
@@ -59,8 +59,14 @@ export const mapResourcesToResourceRefs = R.map(
 
 export const filterObjectType = (
   results: Array<Object>,
-  objectType: string
-): Array<Object> => results.filter(result => result.object_type === objectType)
+  objectType: string | Array<string>
+): Array<Object> => {
+  if (Array.isArray(objectType)) {
+    return results.filter(result => objectType.includes(result.object_type))
+  } else {
+    return results.filter(result => result.object_type === objectType)
+  }
+}
 
 export const filterFavorites = (
   results: Array<Object>,

--- a/static/js/lib/queries/learning_resources_test.js
+++ b/static/js/lib/queries/learning_resources_test.js
@@ -57,10 +57,24 @@ describe("learning resource queries", () => {
     )
   })
 
-  it("filterObjectType returns only objects of the specified object_type", () => {
+  it("filterObjectType returns only objects of the specified object_type when object_type is a string", () => {
     assert.deepEqual(
       filterObjectType([{ object_type: "abc" }, { object_type: "def" }], "abc"),
       [{ object_type: "abc" }]
+    )
+  })
+
+  it("filterObjectType returns only objects of the specified object_type when object_type is and array", () => {
+    assert.deepEqual(
+      filterObjectType(
+        [
+          { object_type: "abc" },
+          { object_type: "def" },
+          { object_type: "ghi" }
+        ],
+        ["abc", "ghi"]
+      ),
+      [{ object_type: "abc" }, { object_type: "ghi" }]
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2915

#### What's this PR do?
When a learning path is a popular resource it breaks the /learn page. This fixes the issue. 

#### How should this be manually tested?
Pick a learning path and click on it in http://localhost:8063/learn/search enough times so it becomes a popular resource for you locally. Verify that http://localhost:8063/learn/ loads and displays the learning path under popular resources

