### PR TITLE
even out the height of podcast cards

### DIFF
--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -159,6 +159,7 @@
   .podcast-author {
     font-size: 14px;
     color: $font-grey-light;
+    min-height: 16px;
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2883

#### What's this PR do?

this just sets a `min-height` on the div that we use to show `offered_by` on the podcast cards to ensure that the podcast card heights are the same, regardless of whether the `offered_by` field is filled in or not.

#### How should this be manually tested?

all my podcasts locally have `offered_by` filled-in, so what I did is just edit the HTML directly in the dev tools to confirm the issue (i.e. delete the text inside of `div.row.podcast-author`) , and then check out this branch to confirm it fixes it.

#### Screenshots (if appropriate)

![Screenshot from 2020-05-12 13-22-46](https://user-images.githubusercontent.com/6207644/81725676-31175d80-9454-11ea-8850-242a71eaafdf.png)
