### PR TITLE
remove cost and availability facets

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -350,7 +350,7 @@ def _transform_search_results_suggest(search_result):
 # pylint: disable=too-many-branches
 def transform_results(search_result, user):
     """
-    Transform the reverse nested availability aggregate counts into a format matching the other facets.
+    Transform podcast and podcast episode, and userlist and learning path in aggergations
     Add 'is_favorite' and 'lists' fields to the '_source' attributes for learning resources.
 
     Args:
@@ -358,24 +358,8 @@ def transform_results(search_result, user):
         user (User): the user who performed the search
 
     Returns:
-        dict: The Elasticsearch response dict with transformed availability aggregates and source values
+        dict: The Elasticsearch response dict with transformed aggregates and source values
     """
-    availability_runs = (
-        search_result.get("aggregations", {}).get("availability", {}).pop("runs", {})
-    )
-    if availability_runs:
-        search_result["aggregations"]["availability"]["buckets"] = [
-            {"key": bucket["key"], "doc_count": bucket["courses"]["doc_count"]}
-            for bucket in availability_runs.pop("buckets", [])
-            if bucket["courses"]["doc_count"] > 0
-        ]
-    prices = search_result.get("aggregations", {}).get("cost", {}).pop("prices", {})
-    if prices:
-        search_result["aggregations"]["cost"]["buckets"] = [
-            {"key": bucket["key"], "doc_count": bucket["courses"]["doc_count"]}
-            for bucket in prices.pop("buckets", [])
-            if bucket["courses"]["doc_count"] > 0
-        ]
 
     types = search_result.get("aggregations", {}).get("type", {})
 

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -533,8 +533,7 @@ def test_transform_results(
     user, is_anonymous, suggest_min_hits, max_suggestions, settings
 ):  # pylint: disable=too-many-locals
     """
-    transform_results should transform reverse nested availability results if present, and move
-    scripted fields into the source result
+    transform_results should move scripted fields into the source result
     """
     settings.ELASTICSEARCH_MAX_SUGGEST_HITS = suggest_min_hits
     settings.ELASTICSEARCH_MAX_SUGGEST_RESULTS = max_suggestions
@@ -638,38 +637,7 @@ def test_transform_results(
         "hits": {"hits": raw_hits, "total": 3},
         "suggest": RAW_SUGGESTIONS,
         "aggregations": {
-            "availability": {
-                "runs": {
-                    "buckets": [
-                        {
-                            "key": "availableNow",
-                            "doc_count": 1000,
-                            "courses": {"doc_count": 800},
-                        },
-                        {"key": "next30", "doc_count": 0, "courses": {"doc_count": 0}},
-                        {"key": "next60", "doc_count": 10, "courses": {"doc_count": 7}},
-                    ]
-                }
-            },
-            "cost": {
-                "prices": {
-                    "buckets": [
-                        {
-                            "key": "free",
-                            "to": 0.01,
-                            "doc_count": 3290,
-                            "courses": {"doc_count": 1937},
-                        },
-                        {
-                            "key": "paid",
-                            "from": 0.01,
-                            "doc_count": 545,
-                            "courses": {"doc_count": 267},
-                        },
-                    ]
-                }
-            },
-            "topics": {"buckets": [{"key": "Engineering", "doc_count": 30}]},
+            "topics": {"buckets": [{"key": "Engineering", "doc_count": 30}]}
         },
     }
 
@@ -678,23 +646,10 @@ def test_transform_results(
         "hits": {"hits": raw_hits if is_anonymous else expected_hits, "total": 3},
         "suggest": expected_suggest,
         "aggregations": {
-            "availability": {
-                "buckets": [
-                    {"key": "availableNow", "doc_count": 800},
-                    {"key": "next60", "doc_count": 7},
-                ]
-            },
-            "cost": {
-                "buckets": [
-                    {"key": "free", "doc_count": 1937},
-                    {"key": "paid", "doc_count": 267},
-                ]
-            },
-            "topics": {"buckets": [{"key": "Engineering", "doc_count": 30}]},
+            "topics": {"buckets": [{"key": "Engineering", "doc_count": 30}]}
         },
     }
-    results["aggregations"]["availability"].pop("runs", None)
-    results["aggregations"]["cost"].pop("prices", None)
+
     assert (
         transform_results(results, search_user)["aggregations"]
         == results["aggregations"]

--- a/static/js/components/CourseFilterDrawer.js
+++ b/static/js/components/CourseFilterDrawer.js
@@ -7,17 +7,11 @@ import SearchFilter from "../components/SearchFilter"
 
 import { DESKTOP } from "../lib/constants"
 import { useDeviceCategory } from "../hooks/util"
-import {
-  availabilityFacetLabel,
-  resourceLabel
-} from "../lib/learning_resources"
-import { capitalize } from "../lib/util"
+import { resourceLabel } from "../lib/learning_resources"
 
 export const facetDisplayMap = [
   ["type", "Learning Resource", resourceLabel],
   ["topics", "Subject Area", null],
-  ["availability", "Availability", availabilityFacetLabel],
-  ["cost", "Cost", capitalize],
   ["offered_by", "Offered By", null]
 ]
 

--- a/static/js/components/CourseFilterDrawer_test.js
+++ b/static/js/components/CourseFilterDrawer_test.js
@@ -30,11 +30,9 @@ describe("CourseFilterDrawer", () => {
     )
 
   const activeFacets = {
-    type:         ["course"],
-    topics:       ["Physics"],
-    availability: ["nextWeek"],
-    cost:         ["free"],
-    offered_by:   ["mitx"]
+    type:       ["course"],
+    topics:     ["Physics"],
+    offered_by: ["mitx"]
   }
 
   beforeEach(() => {

--- a/static/js/lib/course_search.js
+++ b/static/js/lib/course_search.js
@@ -11,9 +11,7 @@ type URLSearchParams = {
   activeFacets: {
     type: Array<string>,
     offered_by: Array<string>,
-    topics: Array<string>,
-    cost: Array<string>,
-    availability: Array<string>
+    topics: Array<string>
   }
 }
 
@@ -22,16 +20,14 @@ type Loc = {
 }
 
 export const deserializeSearchParams = (location: Loc): URLSearchParams => {
-  const { type, o, t, c, a, q } = qs.parse(location.search)
+  const { type, o, t, q } = qs.parse(location.search)
 
   return {
     text:         q,
     activeFacets: {
-      type:         urlParamToArray(type),
-      offered_by:   urlParamToArray(o),
-      topics:       urlParamToArray(t),
-      cost:         urlParamToArray(c),
-      availability: urlParamToArray(a)
+      type:       urlParamToArray(type),
+      offered_by: urlParamToArray(o),
+      topics:     urlParamToArray(t)
     }
   }
 }
@@ -41,14 +37,12 @@ export const serializeSearchParams = ({
   activeFacets
 }: Object): string => {
   // eslint-disable-next-line camelcase
-  const { type, offered_by, topics, availability, cost } = activeFacets
+  const { type, offered_by, topics } = activeFacets
 
   return qs.stringify({
     q: text || undefined,
     type,
     o: offered_by,
-    t: topics,
-    a: availability,
-    c: cost
+    t: topics
   })
 }

--- a/static/js/lib/course_search_test.js
+++ b/static/js/lib/course_search_test.js
@@ -9,51 +9,21 @@ describe("course search library", () => {
         deserializeSearchParams({ search: "q=The Best Course" }),
         {
           activeFacets: {
-            availability: [],
-            cost:         [],
-            offered_by:   [],
-            topics:       [],
-            type:         []
+            offered_by: [],
+            topics:     [],
+            type:       []
           },
           text: "The Best Course"
         }
       )
     })
 
-    it("should deserialize availability", () => {
-      assert.deepEqual(deserializeSearchParams({ search: "a=next3Months" }), {
-        activeFacets: {
-          availability: ["next3Months"],
-          cost:         [],
-          offered_by:   [],
-          topics:       [],
-          type:         []
-        },
-        text: undefined
-      })
-    })
-
-    it("should deserialize cost", () => {
-      assert.deepEqual(deserializeSearchParams({ search: "c=paid" }), {
-        activeFacets: {
-          availability: [],
-          cost:         ["paid"],
-          offered_by:   [],
-          topics:       [],
-          type:         []
-        },
-        text: undefined
-      })
-    })
-
     it("should deserialize offered by", () => {
       assert.deepEqual(deserializeSearchParams({ search: "o=MITx" }), {
         activeFacets: {
-          availability: [],
-          cost:         [],
-          offered_by:   ["MITx"],
-          topics:       [],
-          type:         []
+          offered_by: ["MITx"],
+          topics:     [],
+          type:       []
         },
         text: undefined
       })
@@ -67,10 +37,8 @@ describe("course search library", () => {
         }),
         {
           activeFacets: {
-            availability: [],
-            cost:         [],
-            offered_by:   [],
-            topics:       [
+            offered_by: [],
+            topics:     [
               "Science",
               "Physics",
               "Chemistry",
@@ -87,11 +55,9 @@ describe("course search library", () => {
     it("should deserialize type from the URL", () => {
       assert.deepEqual(deserializeSearchParams({ search: "type=course" }), {
         activeFacets: {
-          availability: [],
-          cost:         [],
-          offered_by:   [],
-          topics:       [],
-          type:         ["course"]
+          offered_by: [],
+          topics:     [],
+          type:       ["course"]
         },
         text: undefined
       })
@@ -100,11 +66,9 @@ describe("course search library", () => {
     it("should ignore unknown params", () => {
       assert.deepEqual(deserializeSearchParams({ search: "eeee=beeeeeep" }), {
         activeFacets: {
-          availability: [],
-          cost:         [],
-          offered_by:   [],
-          topics:       [],
-          type:         []
+          offered_by: [],
+          topics:     [],
+          type:       []
         },
         text: undefined
       })
@@ -149,17 +113,6 @@ describe("course search library", () => {
       )
     })
 
-    it("should serialize cost", () => {
-      assert.deepEqual(
-        serializeSearchParams({
-          activeFacets: {
-            cost: ["paid"]
-          }
-        }),
-        "c=paid"
-      )
-    })
-
     it("should serialize offered by", () => {
       assert.deepEqual(
         serializeSearchParams({
@@ -168,17 +121,6 @@ describe("course search library", () => {
           }
         }),
         "o=MITx"
-      )
-    })
-
-    it("should serialize availability to URL", () => {
-      assert.deepEqual(
-        serializeSearchParams({
-          activeFacets: {
-            availability: ["next3Months"]
-          }
-        }),
-        "a=next3Months"
       )
     })
 

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -16,7 +16,7 @@ import {
   LR_TYPE_COURSE,
   platforms
 } from "./constants"
-import { AVAILABILITY_MAPPING, AVAILABLE_NOW } from "./search"
+
 import { capitalize, emptyOrNil, formatPrice } from "./util"
 
 import type {
@@ -25,9 +25,33 @@ import type {
   CoursePrice
 } from "../flow/discussionTypes"
 
-export const availabilityFacetLabel = (availability: ?string) => {
-  const facetKey = availability ? AVAILABILITY_MAPPING[availability] : null
-  return facetKey ? facetKey.label : availability
+export const AVAILABLE_NOW = "availableNow"
+
+export const AVAILABILITY_MAPPING = {
+  [AVAILABLE_NOW]: {
+    label:  "Available Now",
+    filter: { to: "now" }
+  },
+  ["nextWeek"]: {
+    label:  "Within next week",
+    filter: { from: "now", to: "now+7d" }
+  },
+  ["nextMonth"]: {
+    label:  "Within next month",
+    filter: { from: "now", to: "now+1M" }
+  },
+  ["next3Months"]: {
+    label:  "Within next 3 months",
+    filter: { from: "now", to: "now+3M" }
+  },
+  ["next6Months"]: {
+    label:  "Within next 6 months",
+    filter: { from: "now", to: "now+6M" }
+  },
+  ["nextYear"]: {
+    label:  "Within next year",
+    filter: { from: "now", to: "now+12M" }
+  }
 }
 
 export const availabilityLabel = (availability: ?string) => {

--- a/static/js/lib/learning_resources_test.js
+++ b/static/js/lib/learning_resources_test.js
@@ -17,13 +17,11 @@ import {
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_VIDEO
 } from "./constants"
-import { AVAILABILITY_MAPPING } from "./search"
 import {
   availabilityLabel,
   minPrice,
   maxPrice,
   resourceLabel,
-  availabilityFacetLabel,
   availabilityFilterToMoment,
   inDateRanges,
   bestRunLabel,
@@ -34,7 +32,8 @@ import {
   getInstructorName,
   privacyIcon,
   isCoursewareResource,
-  formatDurationClockTime
+  formatDurationClockTime,
+  AVAILABILITY_MAPPING
 } from "./learning_resources"
 import { makeCourse, makeRun } from "../factories/learning_resources"
 import moment from "moment"
@@ -97,24 +96,6 @@ describe("Course utils", () => {
   ].forEach(([searchType, facetText]) => {
     it(`facet text should be ${facetText} for resource type ${searchType}`, () => {
       assert.equal(resourceLabel(searchType), facetText)
-    })
-  })
-
-  //
-  ;[
-    ["availableNow", AVAILABILITY_MAPPING["availableNow"].label],
-    ["nextWeek", AVAILABILITY_MAPPING["nextWeek"].label],
-    ["nextMonth", AVAILABILITY_MAPPING["nextMonth"].label],
-    ["next3Months", AVAILABILITY_MAPPING["next3Months"].label],
-    ["next6Months", AVAILABILITY_MAPPING["next6Months"].label],
-    ["nextYear", AVAILABILITY_MAPPING["nextYear"].label],
-    ["something", "something"],
-    [null, null]
-  ].forEach(([searchType, label]) => {
-    it(`facet label should be ${String(label)} for search type ${String(
-      searchType
-    )}`, () => {
-      assert.equal(availabilityFacetLabel(searchType), label)
     })
   })
 })

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -149,11 +149,9 @@ export class CourseSearchPage extends React.Component<Props, State> {
     this.updateSearchState({
       text:         null,
       activeFacets: {
-        offered_by:   [],
-        availability: [],
-        topics:       [],
-        cost:         [],
-        type:         []
+        offered_by: [],
+        topics:     [],
+        type:       []
       }
     })
     this.setState({
@@ -369,9 +367,8 @@ export class CourseSearchPage extends React.Component<Props, State> {
   }
 
   renderResults = () => {
-    const { location, results, processing, loaded, total } = this.props
+    const { results, processing, loaded, total } = this.props
     const { from, incremental, searchResultLayout } = this.state
-    const { activeFacets } = deserializeSearchParams(location)
 
     if ((processing || !loaded) && !incremental) {
       return <CourseSearchLoading layout={searchResultLayout} />
@@ -400,7 +397,6 @@ export class CourseSearchPage extends React.Component<Props, State> {
                   this.getFavoriteOrListedObject(result)
                 }
                 toggleFacet={this.toggleFacet}
-                availabilities={activeFacets["availability"]}
                 searchResultLayout={searchResultLayout}
               />
             </Cell>

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -204,11 +204,9 @@ describe("CourseSearchPage", () => {
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          offered_by:   [],
-          topics:       [],
-          availability: [],
-          cost:         [],
-          type:         LR_TYPE_ALL
+          offered_by: [],
+          topics:     [],
+          type:       LR_TYPE_ALL
         })
       )
     })
@@ -237,7 +235,7 @@ describe("CourseSearchPage", () => {
       },
       {
         location: {
-          search: "q=text&o=OCW&t=Science&t=Engineering&a=availableNow&c=free"
+          search: "q=text&o=OCW&t=Science&t=Engineering"
         }
       }
     )
@@ -249,11 +247,9 @@ describe("CourseSearchPage", () => {
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          type:         LR_TYPE_ALL,
-          offered_by:   ["OCW"],
-          topics:       ["Science", "Engineering"],
-          availability: ["availableNow"],
-          cost:         ["free"]
+          type:       LR_TYPE_ALL,
+          offered_by: ["OCW"],
+          topics:     ["Science", "Engineering"]
         })
       )
     })
@@ -283,11 +279,9 @@ describe("CourseSearchPage", () => {
       type:        ["podcast", "podcastepisode"],
       facets:      new Map(
         Object.entries({
-          type:         ["podcast", "podcastepisode"],
-          offered_by:   [],
-          topics:       [],
-          availability: [],
-          cost:         []
+          type:       ["podcast", "podcastepisode"],
+          offered_by: [],
+          topics:     []
         })
       )
     })
@@ -317,11 +311,9 @@ describe("CourseSearchPage", () => {
       type:        ["userlist", "learningpath"],
       facets:      new Map(
         Object.entries({
-          type:         ["userlist", "learningpath"],
-          offered_by:   [],
-          topics:       [],
-          availability: [],
-          cost:         []
+          type:       ["userlist", "learningpath"],
+          offered_by: [],
+          topics:     []
         })
       )
     })
@@ -421,11 +413,9 @@ describe("CourseSearchPage", () => {
   it("displays filters and clicking 'Clear all filters' removes all active facets", async () => {
     const text = "testtext wowowow"
     const activeFacets = {
-      offered_by:   ["OCW"],
-      topics:       ["Science", "Law"],
-      availability: ["Current"],
-      cost:         ["paid"],
-      type:         LR_TYPE_ALL
+      offered_by: ["OCW"],
+      topics:     ["Science", "Law"],
+      type:       LR_TYPE_ALL
     }
     const search = serializeSearchParams({ text, activeFacets })
     const { wrapper } = await renderPage(
@@ -463,11 +453,9 @@ describe("CourseSearchPage", () => {
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        topics:       [],
-        offered_by:   [],
-        availability: [],
-        cost:         [],
-        type:         ["course"]
+        topics:     [],
+        offered_by: [],
+        type:       ["course"]
       }
     })
   })
@@ -498,11 +486,9 @@ describe("CourseSearchPage", () => {
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        topics:       ["Physics"],
-        offered_by:   [],
-        availability: [],
-        cost:         [],
-        type:         []
+        topics:     ["Physics"],
+        offered_by: [],
+        type:       []
       }
     })
   })
@@ -517,54 +503,6 @@ describe("CourseSearchPage", () => {
     sinon.assert.notCalled(helper.searchStub)
   })
 
-  //
-  ;[false, true].forEach(isChecked => {
-    it(`${shouldIf(
-      isChecked
-    )} include an availability facet in search after checkbox change`, async () => {
-      const { inner } = await renderPage(
-        {},
-        {
-          location: {
-            search: serializeSearchParams({
-              text:         "some text",
-              activeFacets: {
-                offered_by:   [],
-                topics:       [],
-                cost:         [],
-                availability: isChecked ? [] : ["nextWeek"]
-              }
-            })
-          }
-        }
-      )
-      helper.searchStub.reset()
-      await inner.instance().onUpdateFacets({
-        target: {
-          checked: isChecked,
-          name:    "availability",
-          value:   "nextWeek"
-        }
-      })
-      // this ensures that the debounced calls go through without having to wait
-      inner.instance().debouncedRunSearch.flush()
-      await wait(10)
-      const search = replaceStub.args[0][0].search
-
-      assert.deepEqual(deserializeSearchParams({ search }), {
-        text:         "some text",
-        activeFacets: {
-          topics:       [],
-          offered_by:   [],
-          availability: isChecked ? ["nextWeek"] : [],
-          cost:         [],
-          type:         []
-        }
-      })
-      sinon.assert.called(helper.searchStub)
-    })
-  })
-
   it("mergeFacetOptions adds any selected facets not in results to the group", async () => {
     const { inner } = await renderPage(
       {},
@@ -573,10 +511,8 @@ describe("CourseSearchPage", () => {
           search: serializeSearchParams({
             text:         "some text",
             activeFacets: {
-              offered_by:   [],
-              topics:       ["NewTopic"],
-              cost:         [],
-              availability: []
+              offered_by: [],
+              topics:     ["NewTopic"]
             }
           })
         }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2918

#### What's this PR do?
This removes cost and availability facet filters from the search page.
#### How should this be manually tested?
Go to http://localhost:8063/learn/search. There should be no cost or availability filters. Text search and the remaining filters should continue to work as expected.  Cost and availability should still be displayed the same way as it was previously in learning resource cards. This will be updated in a future pr.

<img width="377" alt="Screen Shot 2020-05-13 at 11 43 09 AM" src="https://user-images.githubusercontent.com/1934992/81835042-c62b5c80-950f-11ea-8c0e-72fb5d4a2494.png">
<img width="1678" alt="Screen Shot 2020-05-13 at 11 42 31 AM" src="https://user-images.githubusercontent.com/1934992/81835045-c6c3f300-950f-11ea-8384-43d0ffd86881.png">
