### PR TITLE
fix facets for podcasts

### DIFF
--- a/search/serializers.py
+++ b/search/serializers.py
@@ -626,6 +626,8 @@ class ESPodcastSerializer(ESModelSerializer, LearningResourceSerializer):
 
     default_search_priority = serializers.SerializerMethodField()
 
+    runs = ESRunSerializer(read_only=True, many=True, allow_null=True)
+
     def get_default_search_priority(self, instance):
         """
         User Lists should have lower priority in the default search
@@ -645,6 +647,8 @@ class ESPodcastSerializer(ESModelSerializer, LearningResourceSerializer):
             "topics",
             "default_search_priority",
             "created",
+            "offered_by",
+            "runs",
         ]
         read_only_fields = fields
 
@@ -656,6 +660,7 @@ class ESPodcastEpisodeSerializer(ESModelSerializer, LearningResourceSerializer):
 
     series_title = serializers.SerializerMethodField()
     default_search_priority = serializers.SerializerMethodField()
+    runs = ESRunSerializer(read_only=True, many=True, allow_null=True)
 
     def get_series_title(self, instance):
         """Gets the title of the podcast to which this episode belongs"""
@@ -684,6 +689,8 @@ class ESPodcastEpisodeSerializer(ESModelSerializer, LearningResourceSerializer):
             "topics",
             "default_search_priority",
             "created",
+            "offered_by",
+            "runs",
         ]
         read_only_fields = fields
 

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -487,11 +487,12 @@ def test_es_userlist_serializer_image_src():
 
 
 @pytest.mark.django_db
-def test_es_podcast_serializer():
+@pytest.mark.parametrize("offered_by", [offered_by.value for offered_by in OfferedBy])
+def test_es_podcast_serializer(offered_by):
     """
     Test that ESPodcastSerializer correctly serializes a Podcast object
     """
-    podcast = PodcastFactory.create()
+    podcast = PodcastFactory.create(offered_by=offered_by)
     serialized = ESPodcastSerializer(podcast).data
     assert_json_equal(
         serialized,
@@ -507,16 +508,22 @@ def test_es_podcast_serializer():
             "topics": list(podcast.topics.values_list("name", flat=True)),
             "created": drf_datetime(podcast.created_on),
             "default_search_priority": 0,
+            "offered_by": list(podcast.offered_by.values_list("name", flat=True)),
+            "runs": [
+                ESRunSerializer(run).data
+                for run in podcast.runs.order_by("-best_start_date")
+            ],
         },
     )
 
 
 @pytest.mark.django_db
-def test_es_podcast_episode_serializer():
+@pytest.mark.parametrize("offered_by", [offered_by.value for offered_by in OfferedBy])
+def test_es_podcast_episode_serializer(offered_by):
     """
     Test that ESPodcastEpisodeSerializer correctly serializes a PodcastEpisode object
     """
-    podcast_episode = PodcastEpisodeFactory.create()
+    podcast_episode = PodcastEpisodeFactory.create(offered_by=offered_by)
     serialized = ESPodcastEpisodeSerializer(podcast_episode).data
     assert_json_equal(
         serialized,
@@ -536,6 +543,13 @@ def test_es_podcast_episode_serializer():
             "topics": list(podcast_episode.topics.values_list("name", flat=True)),
             "created": drf_datetime(podcast_episode.created_on),
             "default_search_priority": 0,
+            "offered_by": list(
+                podcast_episode.offered_by.values_list("name", flat=True)
+            ),
+            "runs": [
+                ESRunSerializer(run).data
+                for run in podcast_episode.runs.order_by("-best_start_date")
+            ],
         },
     )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="379" alt="Screen Shot 2020-05-13 at 4 59 32 PM" src="https://user-images.githubusercontent.com/1934992/81864924-46b38280-953b-11ea-9c03-7f03e1c68c6b.png">
<img width="1676" alt="Screen Shot 2020-05-13 at 4 58 43 PM" src="https://user-images.githubusercontent.com/1934992/81864926-474c1900-953b-11ea-820c-5f18ae7dd2a4.png">
#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2862

#### What's this PR do?
This pr updates the podcasts serializer so facet filters appear for podcasts in the learning research search

#### How should this be manually tested?
Run `docker-compose run web ./manage.py recreate-index`

Go to http://localhost:8063/learn/search?type=podcast. Verify that there are facet filters in the sidebar. 


