### PR TITLE
sort type facet

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -347,7 +347,6 @@ def _transform_search_results_suggest(search_result):
     return search_result
 
 
-# pylint: disable=too-many-branches
 def transform_results(search_result, user):
     """
     Transform podcast and podcast episode, and userlist and learning path in aggergations
@@ -390,6 +389,10 @@ def transform_results(search_result, user):
                 )
             elif child_type_bucket:
                 child_type_bucket["key"] = parent_type
+
+        search_result["aggregations"]["type"]["buckets"].sort(
+            key=lambda bucket: bucket["doc_count"], reverse=True
+        )
 
     if not user.is_anonymous:
         favorites = (

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -700,8 +700,8 @@ def test_transform_results_for_aggregates(
         "aggregations": {
             "type": {
                 "buckets": [
-                    {"key": "podcast", "doc_count": 2},
                     {"key": "userlist", "doc_count": 3},
+                    {"key": "podcast", "doc_count": 2},
                 ]
             }
         },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="376" alt="Screen Shot 2020-05-18 at 4 23 37 PM" src="https://user-images.githubusercontent.com/1934992/82259072-fd8f7400-9928-11ea-9b87-eab9124dc0b8.png">
<img width="1597" alt="Screen Shot 2020-05-18 at 4 23 03 PM" src="https://user-images.githubusercontent.com/1934992/82259086-0122fb00-9929-11ea-93c3-f0be0f0dd623.png">

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2935

#### What's this PR do?
It sorts the type facet by bucket size to match other facets

#### How should this be manually tested?
Go to learn/search. The `Learning Resource` bucket should be sorted.
