### PR TITLE
Fix a few ingestion issues for OCW/MITPE

### DIFF
--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -130,6 +130,8 @@ def semester_year_to_date(semester, year, ending=False):
         month_day = "08-30" if ending else "06-01"
     elif semester.lower() == "spring":
         month_day = "05-31" if ending else "01-01"
+    elif semester.lower() == "january iap":
+        month_day = "01-31" if ending else "01-01"
     else:
         return
     return datetime.strptime("{}-{}".format(year, month_day), "%Y-%m-%d").replace(

--- a/course_catalog/utils_test.py
+++ b/course_catalog/utils_test.py
@@ -80,6 +80,8 @@ def test_get_course_url(course_id, course_json, platform, expected):
         [None, 2020, False, None],
         ["something", 2020, False, None],
         ["something", 2020, True, None],
+        ["January IAP", 2018, False, "2018-01-01"],
+        ["January IAP", 2018, True, "2018-01-31"],
     ],
 )
 def test_semester_year_to_date(semester, year, ending, expected):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?

- Adds handling for the `January IAP` semester so that courses that only have runs during that semester get updated.
- Updates MIT Professional Ed ETL to allow updating of course information even in there are no active "runs" on the catalog page (i.e. courses that either have a blank or "TBD" date)

#### How should this be manually tested?
- Run `./manage.py backpopulate_mitpe_data` and `./manage.py backpopulate_ocw_data`
- Verify the search page still works