### PR TITLE
Podcast drawer "view episode details" link

### DIFF
--- a/course_catalog/migrations/0072_podcastepisode_episode_link.py
+++ b/course_catalog/migrations/0072_podcastepisode_episode_link.py
@@ -5,12 +5,14 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [("course_catalog", "0071_update_podcast_episode_default_name")]
+    dependencies = [
+        ('course_catalog', '0071_update_podcast_episode_default_name'),
+    ]
 
     operations = [
         migrations.AddField(
-            model_name="podcastepisode",
-            name="episode_link",
+            model_name='podcastepisode',
+            name='episode_link',
             field=models.URLField(max_length=2048, null=True),
-        )
+        ),
     ]

--- a/course_catalog/migrations/0072_podcastepisode_episode_link.py
+++ b/course_catalog/migrations/0072_podcastepisode_episode_link.py
@@ -5,14 +5,12 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('course_catalog', '0071_update_podcast_episode_default_name'),
-    ]
+    dependencies = [("course_catalog", "0071_update_podcast_episode_default_name")]
 
     operations = [
         migrations.AddField(
-            model_name='podcastepisode',
-            name='episode_link',
+            model_name="podcastepisode",
+            name="episode_link",
             field=models.URLField(max_length=2048, null=True),
-        ),
+        )
     ]

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -1,6 +1,8 @@
 // @flow
 /* global SETTINGS: false */
 import React, { useState, useEffect } from "react"
+import { createSelector } from "reselect"
+import { useSelector } from "react-redux"
 import R from "ramda"
 import striptags from "striptags"
 import { AllHtmlEntities } from "html-entities"
@@ -34,6 +36,7 @@ import {
   hasCourseList,
   isUserList
 } from "../lib/learning_resources"
+import { podcastsSelector } from "../lib/queries/podcasts"
 import {
   defaultResourceImageURL,
   embedlyThumbnail,
@@ -172,6 +175,18 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
     (isUserList(object.object_type) && object.privacy_level === LR_PRIVATE) ||
     isPodcastObject(object)
 
+  const episodePodcastSelector =
+    object.object_type === LR_TYPE_PODCAST_EPISODE
+      ? createSelector(
+        podcastsSelector,
+        podcasts => (podcasts ? podcasts[object.podcast] : null)
+      )
+      : null
+  const episodePodcast =
+    object.object_type === LR_TYPE_PODCAST_EPISODE
+      ? useSelector(episodePodcastSelector)
+      : null
+
   return (
     <React.Fragment>
       <div className="expanded-lr-summary">
@@ -254,6 +269,20 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
           {object.object_type === LR_TYPE_PODCAST_EPISODE ? (
             <div className="podcast-play-control">
               <PodcastPlayButton episode={object} />
+              <a
+                className="link"
+                href={
+                  object.episode_link
+                    ? object.episode_link
+                    : episodePodcast
+                      ? episodePodcast.url
+                      : "#"
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View Episode Details
+              </a>
             </div>
           ) : null}
           {!emptyOrNil(object.topics) ? (

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -270,7 +270,7 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
             <div className="podcast-play-control">
               <PodcastPlayButton episode={object} />
               <a
-                className="link"
+                className="link podcast-episode-detail-link"
                 href={
                   object.episode_link
                     ? object.episode_link

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -180,6 +180,27 @@ describe("ExpandedLearningResourceDisplay", () => {
     assert.deepEqual(wrapper.find(PodcastPlayButton).prop("episode"), object)
   })
 
+  it("should render a view episode details button for podcast episode", async () => {
+    const object = makeLearningResource(LR_TYPE_PODCAST_EPISODE)
+    const { wrapper } = await render({}, { object })
+    assert.ok(
+      wrapper
+        .find(".podcast-play-control .podcast-episode-detail-link")
+        .exists()
+    )
+  })
+
+  it("should set the href property of the view episode details button to the podcast episode's episode_link property", async () => {
+    const object = makeLearningResource(LR_TYPE_PODCAST_EPISODE)
+    const { wrapper } = await render({}, { object })
+    assert.equal(
+      wrapper
+        .find(".podcast-play-control .podcast-episode-detail-link")
+        .prop("href"),
+      object.episode_link
+    )
+  })
+
   //
   ;[LR_TYPE_PODCAST, LR_TYPE_PODCAST_EPISODE].forEach(objectType => {
     it(`should not display metadata section for ${objectType}`, async () => {

--- a/static/js/factories/podcasts.js
+++ b/static/js/factories/podcasts.js
@@ -44,6 +44,7 @@ export const makePodcastEpisode = (podcast?: Podcast): PodcastEpisode => {
     topics:            [],
     updated_on:        casual.moment.toISOString(),
     url:               casual.url,
+    episode_link:      casual.url,
     is_favorite:       casual.boolean,
     object_type:       LR_TYPE_PODCAST_EPISODE
   }

--- a/static/scss/learning-resource-drawer.scss
+++ b/static/scss/learning-resource-drawer.scss
@@ -49,6 +49,10 @@
 
   .podcast-play-control {
     margin-top: 15px;
+
+    .link {
+      margin-left: 15px;
+    }
   }
 
   .topics {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2927

#### What's this PR do?
This adds a "View Episode Details" link next to the `PodcastPlayButton` in the `ExpandedLearningResourceDrawer`.  If the `PodcastEpisode` has an `episode_link` property set, this is used as the `href` property, otherwise the parent `Podcast`'s `url` property is used.

#### How should this be manually tested?
Go to the podcasts page and view any podcast.  The "View Episode Details" link should render, and if you click it it should take you to either of the destinations detailed above.

An example of a `PodcastEpisode` without an `episode_link`:
MIT Catalysts - Sudeb Dalai

#### Screenshots (if appropriate)
![Screen Shot 2020-05-20 at 4 10 39 PM](https://user-images.githubusercontent.com/12089658/82492672-91da1200-9ab4-11ea-9639-e26acd77b5b9.png)
![Screen Shot 2020-05-20 at 4 10 56 PM](https://user-images.githubusercontent.com/12089658/82492687-969ec600-9ab4-11ea-9eae-56840f647c45.png)
