### PR TITLE
Ab/add new filters

### DIFF
--- a/static/js/components/CourseFilterDrawer.js
+++ b/static/js/components/CourseFilterDrawer.js
@@ -10,6 +10,8 @@ import { useDeviceCategory } from "../hooks/util"
 import { resourceLabel } from "../lib/learning_resources"
 
 export const facetDisplayMap = [
+  ["audience", null, null],
+  ["certification", "Certification", null],
   ["type", "Learning Resource", resourceLabel],
   ["topics", "Subject Area", null],
   ["offered_by", "Offered By", null]
@@ -46,11 +48,10 @@ export function FilterDisplay(props: FilterDrawerProps) {
             </span>
           </div>
         ) : null}
-        {facetDisplayMap.map(([name, title, labelFunction]) =>
+        {facetDisplayMap.map(([name, , labelFunction]) =>
           (activeFacets[name] || []).map((facet, i) => (
             <SearchFilter
               key={i}
-              title={title}
               value={facet}
               clearFacet={() => toggleFacet(name, facet, false)}
               labelFunction={labelFunction}

--- a/static/js/components/CourseFilterDrawer_test.js
+++ b/static/js/components/CourseFilterDrawer_test.js
@@ -30,9 +30,11 @@ describe("CourseFilterDrawer", () => {
     )
 
   const activeFacets = {
-    type:       ["course"],
-    topics:     ["Physics"],
-    offered_by: ["mitx"]
+    audience:      ["Open Content"],
+    certification: ["Certificate"],
+    type:          ["course"],
+    topics:        ["Physics"],
+    offered_by:    ["mitx"]
   }
 
   beforeEach(() => {
@@ -101,10 +103,9 @@ describe("CourseFilterDrawer", () => {
         activeFacets
       })
 
-      facetDisplayMap.map(([name, title, labelFn], idx) => {
+      facetDisplayMap.map(([name, , labelFn], idx) => {
         const searchFilter = wrapper.find("SearchFilter").at(idx)
 
-        assert.equal(searchFilter.prop("title"), title)
         assert.equal(searchFilter.prop("value"), activeFacets[name][0])
         assert.equal(searchFilter.prop("labelFunction"), labelFn)
         searchFilter.prop("clearFacet")()

--- a/static/js/components/SearchFacet.js
+++ b/static/js/components/SearchFacet.js
@@ -8,7 +8,7 @@ import type { FacetResult } from "../flow/searchTypes"
 type Props = {|
   results: ?FacetResult,
   name: string,
-  title: string,
+  title: ?string,
   currentlySelected: Array<string>,
   labelFunction?: Function,
   onUpdate: Function
@@ -33,13 +33,15 @@ function SearchFacet(props: Props) {
 
   return results && results.buckets && results.buckets.length === 0 ? null : (
     <div className="facets">
-      <div
-        className="filter-section-title"
-        onClick={() => setShowFacetList(!showFacetList)}
-      >
-        {title}
-        <i className={`material-icons ${titleLineIcon}`}>{titleLineIcon}</i>
-      </div>
+      {title ? (
+        <div
+          className="filter-section-title"
+          onClick={() => setShowFacetList(!showFacetList)}
+        >
+          {title}
+          <i className={`material-icons ${titleLineIcon}`}>{titleLineIcon}</i>
+        </div>
+      ) : null}
       {showFacetList ? (
         <React.Fragment>
           {results && results.buckets
@@ -74,7 +76,13 @@ function SearchFacet(props: Props) {
                     onChange={onUpdate}
                   />
                   <div className="facet-label-div">
-                    <div className="facet-key">
+                    <div
+                      className={
+                        ["audience", "certification"].includes(name)
+                          ? "facet-key facet-key-large"
+                          : "facet-key"
+                      }
+                    >
                       {labelFunction ? labelFunction(facet.key) : facet.key}
                     </div>
                     <div className="facet-count">{facet.doc_count}</div>
@@ -85,7 +93,7 @@ function SearchFacet(props: Props) {
             : null}
           {results && results.buckets.length >= FACET_COLLAPSE_THRESHOLD ? (
             <div
-              className="facet-more-less"
+              className={"facet-more-less"}
               onClick={() => setShowAllFacets(!showAllFacets)}
             >
               {showAllFacets ? "View less" : "View more"}

--- a/static/js/components/SearchFilter.js
+++ b/static/js/components/SearchFilter.js
@@ -4,19 +4,15 @@ import React from "react"
 type Props = {|
   clearFacet: Function,
   labelFunction: ?Function,
-  title: string,
   value?: string
 |}
 
-const SearchFilter = ({ title, value, clearFacet, labelFunction }: Props) => (
+const SearchFilter = ({ value, clearFacet, labelFunction }: Props) => (
   <div className="active-search-filter">
     <div className="remove-filter" onClick={clearFacet}>
       <i className="material-icons">close</i>
     </div>
-    <div>
-      {title}
-      {value ? `: ${labelFunction ? labelFunction(value) : value}` : ""}
-    </div>
+    <div>{labelFunction ? labelFunction(value) : value}</div>
   </div>
 )
 

--- a/static/js/components/SearchFilter_test.js
+++ b/static/js/components/SearchFilter_test.js
@@ -18,20 +18,17 @@ describe("SearchFilter", () => {
   })
 
   it("should render a search filter correctly", () => {
-    const title = "Availability"
     const value = "Upcoming"
     const wrapper = renderSearchFilter({
-      title,
       value,
       labelFunction: _.upperCase
     })
     const label = wrapper.text()
     assert.isTrue(label.includes(_.upperCase(value)))
-    assert.isTrue(label.includes(title))
   })
 
   it("should trigger clearFacet function on click", async () => {
-    const wrapper = renderSearchFilter({ title: "Platform", value: "ocw" })
+    const wrapper = renderSearchFilter({ value: "ocw" })
     wrapper.find(".remove-filter").simulate("click")
     sinon.assert.calledOnce(onClickStub)
   })

--- a/static/js/lib/course_search.js
+++ b/static/js/lib/course_search.js
@@ -9,6 +9,8 @@ const urlParamToArray = param => _.union(toArray(param) || [])
 type URLSearchParams = {
   text: string,
   activeFacets: {
+    audience: Array<string>,
+    certification: Array<string>,
     type: Array<string>,
     offered_by: Array<string>,
     topics: Array<string>
@@ -20,14 +22,16 @@ type Loc = {
 }
 
 export const deserializeSearchParams = (location: Loc): URLSearchParams => {
-  const { type, o, t, q } = qs.parse(location.search)
+  const { type, o, t, q, a, c } = qs.parse(location.search)
 
   return {
     text:         q,
     activeFacets: {
-      type:       urlParamToArray(type),
-      offered_by: urlParamToArray(o),
-      topics:     urlParamToArray(t)
+      audience:      urlParamToArray(a),
+      certification: urlParamToArray(c),
+      type:          urlParamToArray(type),
+      offered_by:    urlParamToArray(o),
+      topics:        urlParamToArray(t)
     }
   }
 }
@@ -37,11 +41,13 @@ export const serializeSearchParams = ({
   activeFacets
 }: Object): string => {
   // eslint-disable-next-line camelcase
-  const { type, offered_by, topics } = activeFacets
+  const { type, offered_by, topics, audience, certification } = activeFacets
 
   return qs.stringify({
     q: text || undefined,
     type,
+    a: audience,
+    c: certification,
     o: offered_by,
     t: topics
   })

--- a/static/js/lib/course_search_test.js
+++ b/static/js/lib/course_search_test.js
@@ -9,9 +9,11 @@ describe("course search library", () => {
         deserializeSearchParams({ search: "q=The Best Course" }),
         {
           activeFacets: {
-            offered_by: [],
-            topics:     [],
-            type:       []
+            audience:      [],
+            certification: [],
+            offered_by:    [],
+            topics:        [],
+            type:          []
           },
           text: "The Best Course"
         }
@@ -21,9 +23,11 @@ describe("course search library", () => {
     it("should deserialize offered by", () => {
       assert.deepEqual(deserializeSearchParams({ search: "o=MITx" }), {
         activeFacets: {
-          offered_by: ["MITx"],
-          topics:     [],
-          type:       []
+          audience:      [],
+          certification: [],
+          offered_by:    ["MITx"],
+          topics:        [],
+          type:          []
         },
         text: undefined
       })
@@ -37,8 +41,10 @@ describe("course search library", () => {
         }),
         {
           activeFacets: {
-            offered_by: [],
-            topics:     [
+            audience:      [],
+            certification: [],
+            offered_by:    [],
+            topics:        [
               "Science",
               "Physics",
               "Chemistry",
@@ -55,9 +61,40 @@ describe("course search library", () => {
     it("should deserialize type from the URL", () => {
       assert.deepEqual(deserializeSearchParams({ search: "type=course" }), {
         activeFacets: {
-          offered_by: [],
-          topics:     [],
-          type:       ["course"]
+          audience:      [],
+          certification: [],
+          offered_by:    [],
+          topics:        [],
+          type:          ["course"]
+        },
+        text: undefined
+      })
+    })
+
+    it("should deserialize audience from the URL", () => {
+      assert.deepEqual(
+        deserializeSearchParams({ search: "a=Open%20Content" }),
+        {
+          activeFacets: {
+            audience:      ["Open Content"],
+            certification: [],
+            offered_by:    [],
+            topics:        [],
+            type:          []
+          },
+          text: undefined
+        }
+      )
+    })
+
+    it("should deserialize certification from the URL", () => {
+      assert.deepEqual(deserializeSearchParams({ search: "c=Certification" }), {
+        activeFacets: {
+          audience:      [],
+          certification: ["Certification"],
+          offered_by:    [],
+          topics:        [],
+          type:          []
         },
         text: undefined
       })
@@ -66,9 +103,11 @@ describe("course search library", () => {
     it("should ignore unknown params", () => {
       assert.deepEqual(deserializeSearchParams({ search: "eeee=beeeeeep" }), {
         activeFacets: {
-          offered_by: [],
-          topics:     [],
-          type:       []
+          audience:      [],
+          certification: [],
+          offered_by:    [],
+          topics:        [],
+          type:          []
         },
         text: undefined
       })
@@ -132,6 +171,28 @@ describe("course search library", () => {
           }
         }),
         "type=course"
+      )
+    })
+
+    it("should serialize audience", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            audience: ["Open Content"]
+          }
+        }),
+        "a=Open%20Content"
+      )
+    })
+
+    it("should serialize certification", () => {
+      assert.deepEqual(
+        serializeSearchParams({
+          activeFacets: {
+            certification: ["Certificate"]
+          }
+        }),
+        "c=Certificate"
       )
     })
   })

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -149,9 +149,11 @@ export class CourseSearchPage extends React.Component<Props, State> {
     this.updateSearchState({
       text:         null,
       activeFacets: {
-        offered_by: [],
-        topics:     [],
-        type:       []
+        audience:      [],
+        certification: [],
+        offered_by:    [],
+        topics:        [],
+        type:          []
       }
     })
     this.setState({

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -131,7 +131,7 @@ describe("CourseSearchPage", () => {
     assert.equal(
       inner
         .find(SearchFacet)
-        .at(0)
+        .at(2)
         .prop("title"),
       "Learning Resource"
     )
@@ -204,9 +204,11 @@ describe("CourseSearchPage", () => {
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          offered_by: [],
-          topics:     [],
-          type:       LR_TYPE_ALL
+          audience:      [],
+          certification: [],
+          offered_by:    [],
+          topics:        [],
+          type:          LR_TYPE_ALL
         })
       )
     })
@@ -247,9 +249,11 @@ describe("CourseSearchPage", () => {
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          type:       LR_TYPE_ALL,
-          offered_by: ["OCW"],
-          topics:     ["Science", "Engineering"]
+          audience:      [],
+          certification: [],
+          type:          LR_TYPE_ALL,
+          offered_by:    ["OCW"],
+          topics:        ["Science", "Engineering"]
         })
       )
     })
@@ -279,9 +283,11 @@ describe("CourseSearchPage", () => {
       type:        ["podcast", "podcastepisode"],
       facets:      new Map(
         Object.entries({
-          type:       ["podcast", "podcastepisode"],
-          offered_by: [],
-          topics:     []
+          audience:      [],
+          certification: [],
+          type:          ["podcast", "podcastepisode"],
+          offered_by:    [],
+          topics:        []
         })
       )
     })
@@ -311,9 +317,11 @@ describe("CourseSearchPage", () => {
       type:        ["userlist", "learningpath"],
       facets:      new Map(
         Object.entries({
-          type:       ["userlist", "learningpath"],
-          offered_by: [],
-          topics:     []
+          audience:      [],
+          certification: [],
+          type:          ["userlist", "learningpath"],
+          offered_by:    [],
+          topics:        []
         })
       )
     })
@@ -453,9 +461,11 @@ describe("CourseSearchPage", () => {
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        topics:     [],
-        offered_by: [],
-        type:       ["course"]
+        audience:      [],
+        certification: [],
+        topics:        [],
+        offered_by:    [],
+        type:          ["course"]
       }
     })
   })
@@ -486,9 +496,11 @@ describe("CourseSearchPage", () => {
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        topics:     ["Physics"],
-        offered_by: [],
-        type:       []
+        audience:      [],
+        certification: [],
+        topics:        ["Physics"],
+        offered_by:    [],
+        type:          []
       }
     })
   })
@@ -511,8 +523,10 @@ describe("CourseSearchPage", () => {
           search: serializeSearchParams({
             text:         "some text",
             activeFacets: {
-              offered_by: [],
-              topics:     ["NewTopic"]
+              audience:      [],
+              certification: [],
+              offered_by:    [],
+              topics:        ["NewTopic"]
             }
           })
         }

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -158,6 +158,12 @@
         color: black;
       }
 
+      .facet-key-large {
+        font-size: 16;
+        font-weight: bold;
+        text-transform: uppercase;
+      }
+
       .facet-count {
         color: $font-grey-mid;
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="1445" alt="Screen Shot 2020-05-21 at 1 35 17 PM" src="https://user-images.githubusercontent.com/1934992/82588914-6cf3a680-9b69-11ea-87b1-8e12977c32d4.png">
<img width="1679" alt="Screen Shot 2020-05-21 at 1 22 28 PM" src="https://user-images.githubusercontent.com/1934992/82588939-7250f100-9b69-11ea-8237-84626b4173fb.png">
<img width="375" alt="Screen Shot 2020-05-21 at 1 22 43 PM" src="https://user-images.githubusercontent.com/1934992/82589041-91e81980-9b69-11ea-979d-9c3bddb0bfd1.png">

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2939

#### What's this PR do?
This pr adds facets for audience (Open Content Vs Professional Openings) and certification to the learning resource search UI
#### How should this be manually tested?
Run `docker-compose run web ./manage.py recreate_index`
Go to `http://localhost:8063/learn/search` the search should work and should look like the screenshots 

