### PR TITLE
Fixed loading topics when not defined by the input data

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -41,15 +41,16 @@ User = get_user_model()
 
 def load_topics(resource, topics_data):
     """Load the topics for a resource into the database"""
-    topics = []
+    if topics_data is not None:
+        topics = []
 
-    for topic_data in topics_data:
-        topic, _ = CourseTopic.objects.get_or_create(name=topic_data["name"])
-        topics.append(topic)
+        for topic_data in topics_data:
+            topic, _ = CourseTopic.objects.get_or_create(name=topic_data["name"])
+            topics.append(topic)
 
-    resource.topics.set(topics)
-    resource.save()
-    return topics
+        resource.topics.set(topics)
+        resource.save()
+    return resource.topics.all()
 
 
 def load_prices(resource, prices_data):
@@ -117,7 +118,7 @@ def load_run(learning_resource, course_run_data):
     platform = course_run_data.get("platform")
     instructors_data = course_run_data.pop("instructors", [])
     prices_data = course_run_data.pop("prices", [])
-    topics_data = course_run_data.pop("topics", [])
+    topics_data = course_run_data.pop("topics", None)
     offered_bys_data = course_run_data.pop("offered_by", [])
     content_files = course_run_data.pop("content_files", [])
 
@@ -146,7 +147,7 @@ def load_course(course_data, blacklist, duplicates):
 
     course_id = course_data.pop("course_id")
     runs_data = course_data.pop("runs", [])
-    topics_data = course_data.pop("topics", [])
+    topics_data = course_data.pop("topics", None)
     offered_bys_data = course_data.pop("offered_by", [])
 
     if course_id in blacklist:

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -396,6 +396,14 @@ def test_load_topics(parent_factory, topics_exist):
 
     assert parent.topics.count() == len(topics)
 
+    load_topics(parent, None)
+
+    assert parent.topics.count() == len(topics)
+
+    load_topics(parent, [])
+
+    assert parent.topics.count() == 0
+
 
 @pytest.mark.parametrize("prices_exist", [True, False])
 def test_load_prices(prices_exist):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2946

#### What's this PR do?
This modifies topic loading so that if topics aren't passed in the extracted/transformed data, no changes to topics are made. This ensures micromasters courses (that have no topics in the MM catalog api) don't override the corresponding mitx course topics.

#### How should this be manually tested?

- Verify the bug in master:
  - `./manage.py backpopulate_edx_data` + `./manage.py backpopulate_micromasters_data`
  - Filter to MicroMasters courses and verify they have no subjects

- Verify the fix in this branch:
  - `./manage.py backpopulate_edx_data` + `./manage.py backpopulate_micromasters_data`
  - Filter to MicroMasters courses and verify they have now have subjects
