### PR TITLE
Fix the xPRO offered by value

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -16,7 +16,7 @@ class OfferedBy(Enum):
     ocw = "OCW"
     micromasters = "MicroMasters"
     bootcamps = "Bootcamps"
-    xpro = "xPro"
+    xpro = "xPRO"
     oll = "Open Learning Library"
     see = "Sloan Executive Education"
     mitpe = "Professional Education"
@@ -121,7 +121,7 @@ mitpe_edx_mapping = {
     "Imaging": ["Computer Science", "Electrical Engineering"],
     "Innovation": ["Innovation"],
     "Leadership & Communication": ["Leadership", "Communication"],
-    "Radar": ["Electronics", "Signal Processing"],
+    "Radar": ["Electrical Engineering"],
     "Real Estate": ["Real Estate"],
     "Systems Engineering": ["Systems Engineering"],
 }

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -52,7 +52,7 @@ export const offeredBys = {
   micromasters: "MicroMasters",
   bootcamps:    "Bootcamps",
   mitx:         "MITx",
-  xpro:         "xPro",
+  xpro:         "xPRO",
   see:          "Sloan",
   mitpe:        "Professional",
   csail:        "CSAIL"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #2955

#### What's this PR do?
- Renames usages of "xPro" to "xPRO"
- Remaps MIT PE `Radar` subject to `Electrical Engineering`

#### How should this be manually tested?
- Run in a shell:
```python
from course_catalog.models import LearningResourceOfferor
LearningResourceOfferor.objects.filter(name="xPro").delete()
```
- `./manage.py backpopulate_mitpe_data` and `./manage.py backpopulate_xpro_data`
- You should now see a single `xPRO` option in the Offered By facet
- You may or may not see a PE course titled "Build a Small Radar System", if you don't, that's expected/ok, if you do, it should only have the "Electrical Engineering" subject.
