### PR TITLE
/podcasts keyboard accessibility

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -264,6 +264,7 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
             <div className="podcast-play-control">
               <PodcastPlayButton episode={object} />
               <a
+                tabIndex="0"
                 className="link podcast-episode-detail-link"
                 href={
                   object.episode_link

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -161,7 +161,7 @@ export default function LearningResourceDrawer(props: Props) {
               className="drawer-close"
               onKeyPress={e => {
                 if (e.key === "Enter") {
-                  closeDrawer(e)
+                  closeDrawer()
                 }
               }}
               onClick={closeDrawer}
@@ -174,7 +174,7 @@ export default function LearningResourceDrawer(props: Props) {
                 className="back"
                 onKeyPress={e => {
                   if (e.key === "Enter") {
-                    popHistory(e)
+                    popHistory()
                   }
                 }}
                 onClick={popHistory}

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -156,11 +156,29 @@ export default function LearningResourceDrawer(props: Props) {
       >
         <DrawerContent dir="ltr" ref={drawerContent}>
           <div className="drawer-nav">
-            <div className="drawer-close" onClick={closeDrawer}>
+            <div
+              tabIndex="0"
+              className="drawer-close"
+              onKeyPress={e => {
+                if (e.key === "Enter") {
+                  closeDrawer(e)
+                }
+              }}
+              onClick={closeDrawer}
+            >
               <i className="material-icons clear">clear</i>
             </div>
             {numHistoryEntries > 1 ? (
-              <div className="back" onClick={popHistory}>
+              <div
+                tabIndex="0"
+                className="back"
+                onKeyPress={e => {
+                  if (e.key === "Enter") {
+                    popHistory(e)
+                  }
+                }}
+                onClick={popHistory}
+              >
                 <i className="material-icons arrow_back">arrow_back</i>
               </div>
             ) : null}

--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -23,26 +23,28 @@ export default function PodcastCard(props: Props) {
   const openPodcastDrawer = useOpenPodcastDrawer(podcast.id)
 
   return (
-    <Card className="podcast-card borderless" onClick={openPodcastDrawer}>
-      <div className="cover-img">
-        <img
-          src={embedlyThumbnail(
-            SETTINGS.embedlyKey,
-            podcast.image_src || defaultResourceImageURL(),
-            PODCAST_IMG_HEIGHT,
-            CAROUSEL_IMG_WIDTH
-          )}
-          height={PODCAST_IMG_HEIGHT}
-          alt={`cover image for ${podcast.title}`}
-        />
-      </div>
-      <div className="podcast-info">
-        <div className="row resource-type">PODCAST</div>
-        <div className="row podcast-title">
-          <Dotdotdot clamp={3}>{podcast.title}</Dotdotdot>
+    <Card className="podcast-card borderless">
+      <button onClick={openPodcastDrawer}>
+        <div className="cover-img">
+          <img
+            src={embedlyThumbnail(
+              SETTINGS.embedlyKey,
+              podcast.image_src || defaultResourceImageURL(),
+              PODCAST_IMG_HEIGHT,
+              CAROUSEL_IMG_WIDTH
+            )}
+            height={PODCAST_IMG_HEIGHT}
+            alt={`cover image for ${podcast.title}`}
+          />
         </div>
-        <div className="row podcast-author">{podcast.offered_by}</div>
-      </div>
+        <div className="podcast-info">
+          <div className="row resource-type">PODCAST</div>
+          <div className="row podcast-title">
+            <Dotdotdot clamp={3}>{podcast.title}</Dotdotdot>
+          </div>
+          <div className="row podcast-author">{podcast.offered_by}</div>
+        </div>
+      </button>
     </Card>
   )
 }

--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -24,7 +24,17 @@ export default function PodcastCard(props: Props) {
 
   return (
     <Card className="podcast-card borderless">
-      <button onClick={openPodcastDrawer}>
+      <div
+        tabIndex="0"
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            e.stopPropagation()
+            openPodcastDrawer(e)
+          }
+        }}
+        onClick={openPodcastDrawer}
+      >
         <div className="cover-img">
           <img
             src={embedlyThumbnail(
@@ -44,7 +54,7 @@ export default function PodcastCard(props: Props) {
           </div>
           <div className="row podcast-author">{podcast.offered_by}</div>
         </div>
-      </button>
+      </div>
     </Card>
   )
 }

--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -25,6 +25,7 @@ export default function PodcastCard(props: Props) {
   return (
     <Card className="podcast-card borderless">
       <div
+        id="podcast-card-inner-container"
         tabIndex="0"
         onKeyPress={e => {
           if (e.key === "Enter") {

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -42,7 +42,7 @@ describe("PodcastCard", () => {
     const openStub = helper.sandbox.stub()
     helper.sandbox.stub(podcastHooks, "useOpenPodcastDrawer").returns(openStub)
     const { wrapper } = await render()
-    wrapper.find("Card").simulate("click")
+    wrapper.find("Card button").simulate("click")
     sinon.assert.called(openStub)
   })
 })

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -42,7 +42,7 @@ describe("PodcastCard", () => {
     const openStub = helper.sandbox.stub()
     helper.sandbox.stub(podcastHooks, "useOpenPodcastDrawer").returns(openStub)
     const { wrapper } = await render()
-    wrapper.find("Card button").simulate("click")
+    wrapper.find("#podcast-card-inner-container").simulate("click")
     sinon.assert.called(openStub)
   })
 })

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -31,34 +31,36 @@ export default function PodcastEpisodeCard(props: Props) {
   return (
     <Card
       className="podcast-episode-card low-padding"
-      onClick={openEpisodeDrawer}
       persistentShadow={persistentShadow}
+      role="button"
     >
-      <div className="left-col">
-        <div className="episode-title">
-          <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
-        </div>
-        <div className="podcast-name">{podcast.title}</div>
-        <div className="play-date-row">
-          <PodcastPlayButton episode={episode} />
-          <div className="date">
-            {moment(episode.last_modified).format(EPISODE_DATE_FORMAT)}
+      <button onClick={openEpisodeDrawer}>
+        <div className="left-col">
+          <div className="episode-title">
+            <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
+          </div>
+          <div className="podcast-name">{podcast.title}</div>
+          <div className="play-date-row">
+            <PodcastPlayButton episode={episode} />
+            <div className="date">
+              {moment(episode.last_modified).format(EPISODE_DATE_FORMAT)}
+            </div>
           </div>
         </div>
-      </div>
-      <div className="right-col">
-        <img
-          src={embedlyThumbnail(
-            SETTINGS.embedlyKey,
-            episode.image_src || defaultResourceImageURL(),
-            PODCAST_IMG_HEIGHT,
-            PODCAST_IMG_WIDTH
-          )}
-          height={PODCAST_IMG_HEIGHT}
-          alt={`cover image for ${episode.title}`}
-          className="episode-cover-image"
-        />
-      </div>
+        <div className="right-col">
+          <img
+            src={embedlyThumbnail(
+              SETTINGS.embedlyKey,
+              episode.image_src || defaultResourceImageURL(),
+              PODCAST_IMG_HEIGHT,
+              PODCAST_IMG_WIDTH
+            )}
+            height={PODCAST_IMG_HEIGHT}
+            alt={`cover image for ${episode.title}`}
+            className="episode-cover-image"
+          />
+        </div>
+      </button>
     </Card>
   )
 }

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -33,7 +33,15 @@ export default function PodcastEpisodeCard(props: Props) {
       className="podcast-episode-card low-padding"
       persistentShadow={persistentShadow}
     >
-      <button onClick={openEpisodeDrawer}>
+      <div
+        tabIndex="0"
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            openEpisodeDrawer(e)
+          }
+        }}
+        onClick={openEpisodeDrawer}
+      >
         <div className="left-col">
           <div className="episode-title">
             <Dotdotdot clamp={2}>{episode.title}</Dotdotdot>
@@ -59,7 +67,7 @@ export default function PodcastEpisodeCard(props: Props) {
             className="episode-cover-image"
           />
         </div>
-      </button>
+      </div>
     </Card>
   )
 }

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -34,6 +34,7 @@ export default function PodcastEpisodeCard(props: Props) {
       persistentShadow={persistentShadow}
     >
       <div
+        id="podcast-episode-card-inner-container"
         tabIndex="0"
         onKeyPress={e => {
           if (e.key === "Enter") {

--- a/static/js/components/PodcastEpisodeCard.js
+++ b/static/js/components/PodcastEpisodeCard.js
@@ -32,7 +32,6 @@ export default function PodcastEpisodeCard(props: Props) {
     <Card
       className="podcast-episode-card low-padding"
       persistentShadow={persistentShadow}
-      role="button"
     >
       <button onClick={openEpisodeDrawer}>
         <div className="left-col">

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -61,7 +61,7 @@ describe("PodcastEpisodeCard", () => {
     helper.sandbox.stub(podcastHooks, "useOpenEpisodeDrawer").returns(openStub)
     const { wrapper } = await render()
     wrapper
-      .find(".podcast-episode-card button")
+      .find("#podcast-episode-card-inner-container")
       .at(0)
       .simulate("click")
     sinon.assert.called(openStub)

--- a/static/js/components/PodcastEpisodeCard_test.js
+++ b/static/js/components/PodcastEpisodeCard_test.js
@@ -61,7 +61,7 @@ describe("PodcastEpisodeCard", () => {
     helper.sandbox.stub(podcastHooks, "useOpenEpisodeDrawer").returns(openStub)
     const { wrapper } = await render()
     wrapper
-      .find(".podcast-episode-card")
+      .find(".podcast-episode-card button")
       .at(0)
       .simulate("click")
     sinon.assert.called(openStub)

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -53,15 +53,22 @@ export default function PodcastPlayButton(props: Props) {
     }
   }
 
+  const playButtonClick = e => {
+    episodeAudioInitialized ? togglePlayState(e) : initializeAudioPlayer(e)
+  }
+
   const className = episodeCurrentlyPlaying ? "grey-surround" : "black-surround"
 
   return (
     <div className={`podcast-play-button ${className}`}>
-      <a
-        href="#"
-        onClick={
-          episodeAudioInitialized ? togglePlayState : initializeAudioPlayer
-        }
+      <div
+        tabIndex="0"
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            playButtonClick(e)
+          }
+        }}
+        onClick={playButtonClick}
       >
         {episodeCurrentlyPlaying ? (
           <>
@@ -74,7 +81,7 @@ export default function PodcastPlayButton(props: Props) {
             <i className="material-icons play_arrow">play_arrow</i>
           </>
         )}
-      </a>
+      </div>
     </div>
   )
 }

--- a/static/js/components/PodcastPlayButton.js
+++ b/static/js/components/PodcastPlayButton.js
@@ -56,23 +56,25 @@ export default function PodcastPlayButton(props: Props) {
   const className = episodeCurrentlyPlaying ? "grey-surround" : "black-surround"
 
   return (
-    <div
-      className={`podcast-play-button ${className}`}
-      onClick={
-        episodeAudioInitialized ? togglePlayState : initializeAudioPlayer
-      }
-    >
-      {episodeCurrentlyPlaying ? (
-        <>
-          Pause
-          <i className="material-icons pause">pause</i>
-        </>
-      ) : (
-        <>
-          Play
-          <i className="material-icons play_arrow">play_arrow</i>
-        </>
-      )}
+    <div className={`podcast-play-button ${className}`}>
+      <a
+        href="#"
+        onClick={
+          episodeAudioInitialized ? togglePlayState : initializeAudioPlayer
+        }
+      >
+        {episodeCurrentlyPlaying ? (
+          <>
+            Pause
+            <i className="material-icons pause">pause</i>
+          </>
+        ) : (
+          <>
+            Play
+            <i className="material-icons play_arrow">play_arrow</i>
+          </>
+        )}
+      </a>
     </div>
   )
 }

--- a/static/js/components/PodcastPlayButton_test.js
+++ b/static/js/components/PodcastPlayButton_test.js
@@ -9,7 +9,7 @@ import { AUDIO_PLAYER_PAUSED, AUDIO_PLAYER_PLAYING } from "../lib/constants"
 
 describe("PodcastPlayButton", () => {
   const podcastPlayButton = ".podcast-play-button"
-  const podcastPlayButtonAnchor = ".podcast-play-button a"
+  const podcastPlayButtonAnchor = ".podcast-play-button div"
   let helper, render, episode
 
   beforeEach(() => {

--- a/static/js/components/PodcastPlayButton_test.js
+++ b/static/js/components/PodcastPlayButton_test.js
@@ -8,6 +8,8 @@ import { makePodcastEpisode } from "../factories/podcasts"
 import { AUDIO_PLAYER_PAUSED, AUDIO_PLAYER_PLAYING } from "../lib/constants"
 
 describe("PodcastPlayButton", () => {
+  const podcastPlayButton = ".podcast-play-button"
+  const podcastPlayButtonAnchor = ".podcast-play-button a"
   let helper, render, episode
 
   beforeEach(() => {
@@ -22,7 +24,7 @@ describe("PodcastPlayButton", () => {
 
   it("should initialize a podcast", async () => {
     const { wrapper, store } = await render()
-    wrapper.find(".podcast-play-button").simulate("click")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
     assert.deepEqual(store.getState().audio, {
       playerState:      AUDIO_PLAYER_PLAYING,
       currentlyPlaying: {
@@ -35,39 +37,39 @@ describe("PodcastPlayButton", () => {
 
   it("should show black play button if not playing, not initialized", async () => {
     const { wrapper } = await render()
-    assert.equal(wrapper.find(".podcast-play-button").text(), "Playplay_arrow")
+    assert.equal(wrapper.find(podcastPlayButtonAnchor).text(), "Playplay_arrow")
     assert.equal(
-      wrapper.find(".podcast-play-button").prop("className"),
+      wrapper.find(podcastPlayButton).prop("className"),
       "podcast-play-button black-surround"
     )
   })
 
   it("should show grey pause button when initialized, playing", async () => {
     const { wrapper } = await render()
-    wrapper.find(".podcast-play-button").simulate("click")
-    assert.equal(wrapper.find(".podcast-play-button").text(), "Pausepause")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
+    assert.equal(wrapper.find(podcastPlayButtonAnchor).text(), "Pausepause")
     assert.equal(
-      wrapper.find(".podcast-play-button").prop("className"),
+      wrapper.find(podcastPlayButton).prop("className"),
       "podcast-play-button grey-surround"
     )
   })
 
   it("should show black play button when initialized, paused", async () => {
     const { wrapper } = await render()
-    wrapper.find(".podcast-play-button").simulate("click")
-    wrapper.find(".podcast-play-button").simulate("click")
-    assert.equal(wrapper.find(".podcast-play-button").text(), "Playplay_arrow")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
+    assert.equal(wrapper.find(podcastPlayButtonAnchor).text(), "Playplay_arrow")
     assert.equal(
-      wrapper.find(".podcast-play-button").prop("className"),
+      wrapper.find(podcastPlayButton).prop("className"),
       "podcast-play-button black-surround"
     )
   })
 
   it("should play / pause an initialized podcast", async () => {
     const { wrapper, store } = await render()
-    wrapper.find(".podcast-play-button").simulate("click")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
     assert.equal(store.getState().audio.playerState, AUDIO_PLAYER_PLAYING)
-    wrapper.find(".podcast-play-button").simulate("click")
+    wrapper.find(podcastPlayButtonAnchor).simulate("click")
     assert.equal(store.getState().audio.playerState, AUDIO_PLAYER_PAUSED)
   })
 })

--- a/static/js/hooks/audio_player.js
+++ b/static/js/hooks/audio_player.js
@@ -17,7 +17,7 @@ export function useInitAudioPlayer(audio: Object) {
       }
       Amplitude.init({
         bindings: {
-          32: "play_pause"
+          "32": "play_pause"
         },
         songs: [
           {

--- a/static/js/hooks/audio_player.js
+++ b/static/js/hooks/audio_player.js
@@ -17,7 +17,7 @@ export function useInitAudioPlayer(audio: Object) {
       }
       Amplitude.init({
         bindings: {
-          "32": "play_pause"
+          [32]: "play_pause"
         },
         songs: [
           {

--- a/static/js/hooks/audio_player.js
+++ b/static/js/hooks/audio_player.js
@@ -16,6 +16,9 @@ export function useInitAudioPlayer(audio: Object) {
         Amplitude.getAudio().pause()
       }
       Amplitude.init({
+        bindings: {
+          32: "play_pause"
+        },
         songs: [
           {
             album: audio.title,

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -29,6 +29,14 @@ export default function PodcastFrontpage() {
 
   useLearningResourcePermalink()
 
+  // prevent spacebar from scrolling the page
+  window.addEventListener("keydown", e => {
+    if (e.keyCode === 32) {
+      e.stopPropagation()
+      e.preventDefault()
+    }
+  })
+
   return (
     <div className="podcasts">
       <MetaTags>

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -31,7 +31,7 @@ export default function PodcastFrontpage() {
 
   // prevent spacebar from scrolling the page
   window.addEventListener("keydown", e => {
-    if (e.keyCode === 32) {
+    if (e.key === " ") {
       e.stopPropagation()
       e.preventDefault()
     }

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -61,7 +61,7 @@
 
 .podcast-episode-card {
   > .card-contents {
-    > button {
+    > div {
       display: flex;
       justify-content: space-between;
       background-color: white;
@@ -130,7 +130,7 @@
 
 .podcast-card {
   > .card-contents {
-    > button {
+    > div {
       background-color: white;
       margin: 0;
       padding: 0;
@@ -179,7 +179,7 @@
 }
 
 .podcast-play-button {
-  a {
+  div {
     display: inline-flex;
     font-family: $body-font;
     font-size: 14px;
@@ -194,7 +194,7 @@
   }
 
   &.grey-surround {
-    > a {
+    > div {
       color: black;
 
       i {
@@ -205,7 +205,7 @@
   }
 
   &.black-surround {
-    > a {
+    > div {
       color: white;
 
       i {

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -203,6 +203,7 @@
       }
     }
   }
+  
   &.black-surround {
     > a {
       color: white;

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -60,127 +60,163 @@
 }
 
 .podcast-episode-card {
-  @include breakpoint(materialmobile) {
-    margin-bottom: 5px;
-    border-radius: 0px;
-    min-height: 140px;
-  }
+  > .card-contents {
+    > button {
+      display: flex;
+      justify-content: space-between;
+      background-color: white;
+      color: black;
+      padding: 0;
+      margin: 0;
+      text-align: left;
+      width: 100%;
 
-  max-width: 480px;
-  cursor: pointer;
+      @include breakpoint(materialmobile) {
+        margin-bottom: 5px;
+        border-radius: 0px;
+        min-height: 140px;
+      }
 
-  .card-contents {
-    display: flex;
-    justify-content: space-between;
-  }
+      max-width: 480px;
+      cursor: pointer;
 
-  .episode-title {
-    font-size: 14px;
-    font-weight: bold;
-  }
+      .episode-title {
+        font-size: 14px;
+        font-weight: bold;
+      }
 
-  .podcast-name {
-    font-size: 14px;
-    color: $font-grey-light;
-    font-family: "Roboto";
-    padding-top: 10px;
-    @include breakpoint(materialmobile) {
-      padding-top: 15px;
-      padding-bottom: 15px;
+      .podcast-name {
+        font-size: 14px;
+        color: $font-grey-light;
+        font-family: "Roboto";
+        padding-top: 10px;
+        @include breakpoint(materialmobile) {
+          padding-top: 15px;
+          padding-bottom: 15px;
+        }
+      }
+
+      .play-date-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        .date {
+          font-size: 14px;
+          color: $podcast-border-grey;
+        }
+      }
+
+      .podcast-play-button {
+        margin-top: 8px;
+      }
+
+      .left-col {
+        width: 100%;
+        margin-right: 10px;
+      }
+
+      .episode-cover-image {
+        border: 1px solid $podcast-border-grey;
+        border-radius: 5px;
+        max-width: 125px;
+        min-width: 125px;
+        max-height: 79px;
+        overflow: hidden;
+      }
     }
-  }
-
-  .play-date-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .date {
-      font-size: 14px;
-      color: $podcast-border-grey;
-    }
-  }
-
-  .podcast-play-button {
-    margin-top: 8px;
-  }
-
-  .left-col {
-    width: 100%;
-    margin-right: 10px;
-  }
-
-  .episode-cover-image {
-    border: 1px solid $podcast-border-grey;
-    border-radius: 5px;
-    max-width: 125px;
-    min-width: 125px;
-    max-height: 79px;
-    overflow: hidden;
   }
 }
 
 .podcast-card {
-  font-family: roboto;
-  cursor: pointer;
-  @include breakpoint(materialmobile) {
-    margin-bottom: 10px;
-  }
+  > .card-contents {
+    > button {
+      background-color: white;
+      margin: 0;
+      padding: 0;
+      font-family: roboto;
+      cursor: pointer;
+      @include breakpoint(materialmobile) {
+        margin-bottom: 10px;
+      }
 
-  .cover-img {
-    img {
-      width: 100%;
-      min-height: 170px;
-      border-radius: 5px 5px 0 0;
+      .cover-img {
+        img {
+          width: 100%;
+          min-height: 170px;
+          border-radius: 5px 5px 0 0;
+        }
+      }
+
+      .podcast-info {
+        padding: 16px;
+      }
+
+      .resource-type {
+        font-size: 13px;
+        color: $font-grey-mid;
+        text-transform: uppercase;
+        font-weight: 500;
+      }
+
+      .podcast-title {
+        margin: 10px 0;
+        margin-top: 2px;
+        min-height: 62px;
+        font-size: 18px;
+        color: black;
+        font-weight: 500;
+        cursor: pointer;
+      }
+
+      .podcast-author {
+        font-size: 14px;
+        color: $font-grey-light;
+        min-height: 16px;
+      }
     }
-  }
-
-  .podcast-info {
-    padding: 16px;
-  }
-
-  .resource-type {
-    font-size: 13px;
-    color: $font-grey-mid;
-    text-transform: uppercase;
-    font-weight: 500;
-  }
-
-  .podcast-title {
-    margin: 10px 0;
-    margin-top: 2px;
-    min-height: 62px;
-    font-size: 18px;
-    color: black;
-    font-weight: 500;
-    cursor: pointer;
-  }
-
-  .podcast-author {
-    font-size: 14px;
-    color: $font-grey-light;
-    min-height: 16px;
   }
 }
 
 .podcast-play-button {
-  display: inline-flex;
-  font-size: 14px;
-  padding: 2px 10px;
-  cursor: pointer;
-  text-transform: uppercase;
+  a {
+    display: inline-flex;
+    font-family: $body-font;
+    font-size: 14px;
+    margin: 0;
+    padding: 0px 10px;
+    cursor: pointer;
+    text-transform: uppercase;
 
-  i {
-    font-size: 18px;
-    background-color: $pale-grey;
-  }
-
-  &.black-surround {
     i {
-      color: white;
-      background-color: black;
+      font-size: 18px;
     }
   }
+
+  &.grey-surround {
+    > a {
+      color: black;
+
+      i {
+        color: black;
+        background-color: $pale-grey;
+      }
+    }
+  }
+  &.black-surround {
+    > a {
+      color: white;
+
+      i {
+        color: white;
+        background-color: black;
+      }
+    }
+  }
+}
+
+.podcast-play-control {
+  display: flex;
 }
 
 .paginated-podcast-episodes {

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -203,7 +203,7 @@
       }
     }
   }
-  
+
   &.black-surround {
     > a {
       color: white;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2960

#### What's this PR do?
This adds keyboard navigation / audio playback control to the podcasts page.  

#### How should this be manually tested?
Go to `/podcasts` and use only the keyboard to:
- [ ] Tab around elements on the `PodcastFrontpage`
- [ ] Open a `PodcastEpisode` card
- [ ] Play / Pause a podcast from the button on the `PodcastEpisode` card
- [ ] Open a `Podcast` card
- [ ] Tab around elements within the drawer with a `PodcastEpisode` or `Podcast` loaded and ensure that tab focus does not exit the drawer
- [ ] Play / Pause a podcast from inside the drawer with a `PodcastEpisode` loaded
- [ ] Play / Pause a podcast from inside the drawer with a `Podcast` loaded, using the `PodcastPlayButton` on one of the `PodcastEpisode` cards
- [ ] Pause / Resume a podcast loaded into the audio player with spacebar

#### Any background context you want to provide?
Use the Enter key to "click" on elements focused in a web browser.

#### Screenshots (if appropriate)
![May-28-2020 12-23-59](https://user-images.githubusercontent.com/12089658/83167967-ca927080-a0de-11ea-9f79-8622c1fccd83.gif)
