### PR TITLE
add footer to podcast page

### DIFF
--- a/static/js/components/PodcastFooter.js
+++ b/static/js/components/PodcastFooter.js
@@ -1,0 +1,56 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { Link } from "react-router-dom"
+import moment from "moment"
+
+import { PODCAST_URL } from "../lib/url"
+
+export default function PodcastFooter() {
+  return (
+    <div className="podcast-footer">
+      <div className="cells">
+        <div className="cell logo-legal">
+          <a
+            href="https://www.mit.edu/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              src="/static/images/mit-logo-darkgrey.svg"
+              alt="MIT logo"
+              width="36"
+              height="16"
+            />
+          </a>
+          <div className="legal">
+            Massachusetts Institute of Technology
+            <br />© 2016-{moment().format("Y")} - All rights reserved
+          </div>
+        </div>
+        <div className="cell links">
+          <a
+            href={`mailto:${SETTINGS.support_email}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Contact us
+          </a>
+          <div className="bar">{" | "}</div>
+          <Link to="/content_policy">Community Guidelines</Link>
+          <div className="bar">{" | "}</div>
+          <a href={SETTINGS.authenticated_site.tos_url}>Terms & Conditions</a>
+        </div>
+        <div className="cell title">
+          <Link className="home-link" to="/">
+            MIT Open
+          </Link>
+          <div className="bar">{" | "}</div>
+          <Link className="section-link" to={PODCAST_URL}>
+            PODCASTS
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/static/js/pages/PodcastFrontpage.js
+++ b/static/js/pages/PodcastFrontpage.js
@@ -8,6 +8,7 @@ import PodcastEpisodeCard from "../components/PodcastEpisodeCard"
 import PodcastCard from "../components/PodcastCard"
 import { Cell, Grid } from "../components/Grid"
 import { PodcastLoading, PodcastEpisodeLoading } from "../components/Loading"
+import PodcastFooter from "../components/PodcastFooter"
 
 import { formatTitle } from "../lib/title"
 import {
@@ -76,6 +77,7 @@ export default function PodcastFrontpage() {
           <PodcastLoading />
         )}
       </div>
+      <PodcastFooter />
     </div>
   )
 }

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -18,6 +18,7 @@
     padding-top: 60px;
     max-width: 480px;
     margin: auto;
+
     @include breakpoint(materialmobile) {
       padding-top: 50px;
     }
@@ -30,6 +31,7 @@
       .title {
         font-size: 20px;
         color: white;
+
         @include breakpoint(materialmobile) {
           margin-left: 15px;
           padding-bottom: 25px;
@@ -41,6 +43,7 @@
   .all-podcasts {
     max-width: 900px;
     margin: auto;
+
     @include breakpoint(materialmobile) {
       padding-left: 20px;
       padding-right: 20px;
@@ -51,9 +54,90 @@
       color: black;
       text-transform: uppercase;
       font-size: 20px;
+
       @include breakpoint(materialmobile) {
         padding-top: 15px;
         padding-bottom: 15px;
+      }
+    }
+  }
+
+  .podcast-footer {
+    width: 100%;
+    border-top: 10px solid $course-blue;
+
+    .cells {
+      display: flex;
+      justify-content: space-between;
+      max-width: 900px;
+      margin: auto;
+      align-items: center;
+
+      @include breakpoint(mobile) {
+        flex-direction: column;
+      }
+
+      padding: 0 10px;
+
+      @include breakpoint(desktopwide) {
+        padding: 0 60px;
+      }
+    }
+
+    .cell {
+      display: flex;
+      align-items: center;
+      padding: 6px 0;
+
+      @include breakpoint(desktop) {
+        padding: 33px 0;
+      }
+    }
+
+    .cell.logo-legal {
+      a {
+        margin-right: 28px;
+      }
+
+      .legal {
+        font-size: 12px;
+      }
+    }
+
+    .cell.links {
+      a,
+      .bar {
+        color: black;
+        font-size: 12px;
+      }
+
+      .bar {
+        padding: 0 3px;
+      }
+    }
+
+    .cell.title {
+      display: flex;
+      align-items: center;
+      font-weight: bold;
+
+      .bar {
+        margin-bottom: 3px;
+      }
+
+      .home-link {
+        margin-right: 8px;
+        color: black;
+      }
+
+      .section-link {
+        font-size: 24px;
+        color: $nice-red;
+        margin-left: 8px;
+
+        @include breakpoint(mobile) {
+          font-size: 18px;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #2907 

#### What's this PR do?

this adds a footer to `/podcasts`, following the designs, which has both mobile and desktop styling.

#### How should this be manually tested?

I think the main thing is to play around with the device width and make sure it works well at all widths.

#### Screenshots (if appropriate)

![Screenshot from 2020-05-28 15-41-51](https://user-images.githubusercontent.com/6207644/83185925-c293fa00-a0f9-11ea-947f-f4418da99d9d.png)
![Screenshot from 2020-05-28 15-41-38](https://user-images.githubusercontent.com/6207644/83185927-c32c9080-a0f9-11ea-861a-2c98b5e4387a.png)
![Screenshot from 2020-05-28 15-41-27](https://user-images.githubusercontent.com/6207644/83185928-c32c9080-a0f9-11ea-992b-ba8c3f6fabba.png)
![Screenshot from 2020-05-28 15-41-20](https://user-images.githubusercontent.com/6207644/83185929-c32c9080-a0f9-11ea-8b34-54d682e15496.png)

