### PR TITLE
Various fixes for ETL loading bugs

### DIFF
--- a/course_catalog/etl/constants.py
+++ b/course_catalog/etl/constants.py
@@ -1,7 +1,61 @@
 """Constants for course catalog ETL processes"""
+from collections import namedtuple
+
 from django.conf import settings
 
 # A custom UA so that operators of OpenEdx will know who is pinging their service
 COMMON_HEADERS = {
     "User-Agent": f"CourseCatalogBot/{settings.VERSION} ({settings.SITE_BASE_URL})"
 }
+
+
+OfferedByLoaderConfig = namedtuple(
+    "OfferedByLoaderConfig", ["additive"], defaults=[False]
+)
+LearningResourceRunLoaderConfig = namedtuple(
+    "RunLoaderConfig", ["offered_by"], defaults=[OfferedByLoaderConfig()]
+)
+
+CourseLoaderConfig = namedtuple(
+    "CourseLoaderConfig",
+    ["prune", "offered_by", "runs"],
+    defaults=[True, OfferedByLoaderConfig(), LearningResourceRunLoaderConfig()],
+)
+
+ProgramLoaderConfig = namedtuple(
+    "ProgramLoaderConfig",
+    ["courses", "offered_by", "runs"],
+    defaults=[
+        CourseLoaderConfig(),
+        OfferedByLoaderConfig(),
+        LearningResourceRunLoaderConfig(),
+    ],
+)
+
+PodcastEpisodeLoaderConfig = namedtuple(
+    "PodcastEpisodeLoaderConfig",
+    ["offered_by", "runs"],
+    defaults=[OfferedByLoaderConfig(), LearningResourceRunLoaderConfig()],
+)
+
+PodcastLoaderConfig = namedtuple(
+    "PodcastLoaderConfig",
+    ["episodes", "offered_by", "runs"],
+    defaults=[
+        PodcastEpisodeLoaderConfig(),
+        OfferedByLoaderConfig(),
+        LearningResourceRunLoaderConfig(),
+    ],
+)
+
+VideoLoaderConfig = namedtuple(
+    "VideoLoaderConfig",
+    ["offered_by", "runs"],
+    defaults=[OfferedByLoaderConfig(), LearningResourceRunLoaderConfig()],
+)
+
+PlaylistLoaderConfig = namedtuple(
+    "PlaylistLoaderConfig",
+    ["offered_by", "videos"],
+    defaults=[OfferedByLoaderConfig(), VideoLoaderConfig()],
+)

--- a/course_catalog/etl/csail.py
+++ b/course_catalog/etl/csail.py
@@ -12,11 +12,7 @@ from bs4 import BeautifulSoup as bs
 from django.conf import settings
 
 from course_catalog.constants import OfferedBy, PlatformType
-from course_catalog.etl.utils import (
-    log_exceptions,
-    generate_unique_id,
-    strip_extra_whitespace,
-)
+from course_catalog.etl.utils import generate_unique_id, strip_extra_whitespace
 
 OFFERED_BY = [{"name": OfferedBy.csail.value}]
 PLATFORM = PlatformType.csail.value
@@ -170,12 +166,12 @@ def _parse_full_description(details):
     return strip_extra_whitespace(" ".join([p for p in p_texts]))
 
 
-@log_exceptions("Error extracting CSAIL catalog", exc_return_value=[])
 def extract():
     """Loads the CSAIL catalog data via BeautifulSoup"""
     if not settings.CSAIL_BASE_URL:
         log.error("CSAIL base URL not set, skipping ETL")
         return []
+
     courses = []
     soup = bs(
         _unverified_cert_request(
@@ -209,7 +205,6 @@ def extract():
     return courses
 
 
-@log_exceptions("Error transforming CSAIL catalog", exc_return_value=[])
 def transform(courses):
     """Transform the CSAIL course data"""
     return [

--- a/course_catalog/etl/micromasters.py
+++ b/course_catalog/etl/micromasters.py
@@ -6,12 +6,10 @@ import requests
 
 from course_catalog.constants import OfferedBy, PlatformType
 from course_catalog.etl.constants import COMMON_HEADERS
-from course_catalog.etl.utils import log_exceptions
 
 OFFERED_BY = [{"name": OfferedBy.micromasters.value}]
 
 
-@log_exceptions("Error extracting MicroMasters catalog", exc_return_value=[])
 def extract():
     """Loads the MicroMasters catalog data"""
     if settings.MICROMASTERS_CATALOG_API_URL:
@@ -21,7 +19,6 @@ def extract():
     return []
 
 
-@log_exceptions("Error extracting MicroMasters catalog", exc_return_value=[])
 def transform(programs):
     """Transform the micromasters catalog data"""
     # normalize the micromasters data into the course_catalog/models.py data structures

--- a/course_catalog/etl/mitpe.py
+++ b/course_catalog/etl/mitpe.py
@@ -11,7 +11,6 @@ from django.conf import settings
 
 from course_catalog.constants import OfferedBy, PlatformType, mitpe_edx_mapping
 from course_catalog.etl.utils import (
-    log_exceptions,
     generate_unique_id,
     strip_extra_whitespace,
     parse_dates,
@@ -147,9 +146,6 @@ def _has_existing_published_run(course_id):
     return bool(course) and course.runs.filter(published=True).exists()
 
 
-@log_exceptions(
-    "Error extracting MIT Professional Education catalog", exc_return_value=[]
-)
 def extract():
     """Loads the MIT Professional Education catalog data via BeautifulSoup"""
     if not settings.MITPE_BASE_URL:
@@ -226,9 +222,6 @@ def transform_course(course):
     }
 
 
-@log_exceptions(
-    "Error transforming MIT Professional Education catalog", exc_return_value=[]
-)
 def transform(courses):
     """Transform the MIT Professional Education course data"""
     return [transform_course(course) for course in courses]

--- a/course_catalog/etl/ocw.py
+++ b/course_catalog/etl/ocw.py
@@ -287,8 +287,12 @@ def upload_mitx_course_manifest(courses):
 
     log.info("Uploading edX courses data to S3")
 
-    manifest = {"results": courses, "count": len(courses)}
+    try:
+        manifest = {"results": courses, "count": len(courses)}
 
-    ocw_bucket = get_ocw_learning_course_bucket()
-    ocw_bucket.put_object(Key="edx_courses.json", Body=rapidjson.dumps(manifest))
-    return True
+        ocw_bucket = get_ocw_learning_course_bucket()
+        ocw_bucket.put_object(Key="edx_courses.json", Body=rapidjson.dumps(manifest))
+        return True
+    except:  # pylint: disable=bare-except
+        log.exception("Error uploading OCW manifest")
+        return False

--- a/course_catalog/etl/pipelines_test.py
+++ b/course_catalog/etl/pipelines_test.py
@@ -1,93 +1,116 @@
 """Tests for ETL pipelines"""
 from contextlib import contextmanager
 from importlib import reload
+from unittest.mock import patch
 
+from course_catalog.constants import PlatformType
 from course_catalog.etl import pipelines
+from course_catalog.etl.constants import (
+    ProgramLoaderConfig,
+    CourseLoaderConfig,
+    LearningResourceRunLoaderConfig,
+    OfferedByLoaderConfig,
+)
 
 
 @contextmanager
-def reload_mocked_pipeline(*mocks):
+def reload_mocked_pipeline(*patchers):
     """Create a context that is rolled back after executing the pipeline"""
-    reload(pipelines)
-
-    yield
-
-    for mock in mocks:
-        mock.stop()
+    mocks = [patcher.start() for patcher in patchers]
 
     reload(pipelines)
 
+    yield mocks
 
-def test_micromasters_etl(mocker):
+    for patcher in patchers:
+        patcher.stop()
+
+    reload(pipelines)
+
+
+def test_micromasters_etl():
     """Verify that micromasters etl pipeline executes correctly"""
     values = [1, 2, 3]
-    mock_extract = mocker.patch("course_catalog.etl.micromasters.extract")
-    mock_transform = mocker.patch(
-        "course_catalog.etl.micromasters.transform", return_value=values
-    )
-    mock_load_programs = mocker.Mock()
-    mocker.patch(
-        "course_catalog.etl.loaders.load_programs", return_value=mock_load_programs
-    )
 
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_programs):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.micromasters.extract", autospec=True),
+        patch(
+            "course_catalog.etl.micromasters.transform",
+            return_value=values,
+            autospec=True,
+        ),
+        patch("course_catalog.etl.loaders.load_programs", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_programs = patches
         result = pipelines.micromasters_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_programs.assert_called_once_with(mock_transform.return_value)
+    mock_load_programs.assert_called_once_with(
+        PlatformType.micromasters.value,
+        mock_transform.return_value,
+        config=ProgramLoaderConfig(
+            courses=[
+                CourseLoaderConfig(
+                    offered_by=OfferedByLoaderConfig(additive=True),
+                    runs=LearningResourceRunLoaderConfig(
+                        offered_by=OfferedByLoaderConfig(additive=True)
+                    ),
+                )
+            ]
+        ),
+    )
 
     assert result == mock_load_programs.return_value
 
 
-def test_xpro_programs_etl(mocker):
+def test_xpro_programs_etl():
     """Verify that xpro programs etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.xpro.extract_programs")
-    mock_transform = mocker.patch("course_catalog.etl.xpro.transform_programs")
-    mock_load_programs = mocker.Mock()
-
-    mocker.patch(
-        "course_catalog.etl.loaders.load_programs", return_value=mock_load_programs
-    )
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_programs):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.xpro.extract_programs", autospec=True),
+        patch("course_catalog.etl.xpro.transform_programs", autospec=True),
+        patch("course_catalog.etl.loaders.load_programs", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_programs = patches
         result = pipelines.xpro_programs_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_programs.assert_called_once_with(mock_transform.return_value)
+    mock_load_programs.assert_called_once_with(
+        PlatformType.xpro.value, mock_transform.return_value
+    )
 
     assert result == mock_load_programs.return_value
 
 
-def test_xpro_courses_etl(mocker):
+def test_xpro_courses_etl():
     """Verify that xpro courses etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.xpro.extract_courses")
-    mock_transform = mocker.patch("course_catalog.etl.xpro.transform_courses")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_courses):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.xpro.extract_courses", autospec=True),
+        patch("course_catalog.etl.xpro.transform_courses", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses = patches
         result = pipelines.xpro_courses_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.xpro.value, mock_transform.return_value
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_mitx_etl(mocker):
+def test_mitx_etl():
     """Verify that mitx etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.mitx.extract")
-    mock_transform = mocker.patch("course_catalog.etl.mitx.transform")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-    mock_upload_manifest = mocker.patch(
-        "course_catalog.etl.ocw.upload_mitx_course_manifest"
-    )
-
     with reload_mocked_pipeline(
-        mock_extract, mock_transform, mock_load_courses, mock_upload_manifest
-    ):
+        patch("course_catalog.etl.mitx.extract", autospec=True),
+        patch("course_catalog.etl.mitx.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+        patch("course_catalog.etl.ocw.upload_mitx_course_manifest", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses, mock_upload_manifest = patches
         result = pipelines.mitx_etl()
 
     mock_extract.assert_called_once_with()
@@ -97,84 +120,110 @@ def test_mitx_etl(mocker):
     mock_upload_manifest.assert_called_once_with(mock_extract.return_value)
 
     # load_courses should be called *only* with the return value of transform
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.mitx.value,
+        mock_transform.return_value,
+        config=CourseLoaderConfig(
+            offered_by=OfferedByLoaderConfig(additive=True),
+            runs=LearningResourceRunLoaderConfig(
+                offered_by=OfferedByLoaderConfig(additive=True)
+            ),
+        ),
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_oll_etl(mocker):
+def test_oll_etl():
     """Verify that OLL etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.oll.extract")
-    mock_transform = mocker.patch("course_catalog.etl.oll.transform")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_courses):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.oll.extract", autospec=True),
+        patch("course_catalog.etl.oll.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses = patches
         result = pipelines.oll_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.oll.value, mock_transform.return_value
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_see_etl(mocker):
+def test_see_etl():
     """Verify that SEE etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.see.extract")
-    mock_transform = mocker.patch("course_catalog.etl.see.transform")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_courses):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.see.extract", autospec=True),
+        patch("course_catalog.etl.see.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses = patches
         result = pipelines.see_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.see.value,
+        mock_transform.return_value,
+        config=CourseLoaderConfig(prune=False),
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_mitpe_etl(mocker):
+def test_mitpe_etl():
     """Verify that MITPE etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.mitpe.extract")
-    mock_transform = mocker.patch("course_catalog.etl.mitpe.transform")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_courses):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.mitpe.extract", autospec=True),
+        patch("course_catalog.etl.mitpe.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses = patches
         result = pipelines.mitpe_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.mitpe.value,
+        mock_transform.return_value,
+        config=CourseLoaderConfig(prune=False),
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_csail_etl(mocker):
+def test_csail_etl():
     """Verify that CSAIL etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.csail.extract")
-    mock_transform = mocker.patch("course_catalog.etl.csail.transform")
-    mock_load_courses = mocker.patch("course_catalog.etl.loaders.load_courses")
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_courses):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.csail.extract", autospec=True),
+        patch("course_catalog.etl.csail.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_courses", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_courses = patches
         result = pipelines.csail_etl()
 
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
-    mock_load_courses.assert_called_once_with(mock_transform.return_value)
+    mock_load_courses.assert_called_once_with(
+        PlatformType.csail.value,
+        mock_transform.return_value,
+        config=CourseLoaderConfig(prune=False),
+    )
 
     assert result == mock_load_courses.return_value
 
 
-def test_youtube_etl(mocker):
+def test_youtube_etl():
     """Verify that youtube etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.youtube.extract")
-    mock_transform = mocker.patch("course_catalog.etl.youtube.transform")
-    mock_load_video_channels = mocker.patch(
-        "course_catalog.etl.loaders.load_video_channels"
-    )
-
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_video_channels):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.youtube.extract", autospec=True),
+        patch("course_catalog.etl.youtube.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_video_channels", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_video_channels = patches
         result = pipelines.youtube_etl()
 
     mock_extract.assert_called_once_with()
@@ -184,13 +233,15 @@ def test_youtube_etl(mocker):
     assert result == mock_load_video_channels.return_value
 
 
-def test_podcast_etl(mocker):
+def test_podcast_etl():
     """Verify that podcast etl pipeline executes correctly"""
-    mock_extract = mocker.patch("course_catalog.etl.podcast.extract")
-    mock_transform = mocker.patch("course_catalog.etl.podcast.transform")
-    mock_load_podcasts = mocker.patch("course_catalog.etl.loaders.load_podcasts")
 
-    with reload_mocked_pipeline(mock_extract, mock_transform, mock_load_podcasts):
+    with reload_mocked_pipeline(
+        patch("course_catalog.etl.podcast.extract", autospec=True),
+        patch("course_catalog.etl.podcast.transform", autospec=True),
+        patch("course_catalog.etl.loaders.load_podcasts", autospec=True),
+    ) as patches:
+        mock_extract, mock_transform, mock_load_podcasts = patches
         result = pipelines.podcast_etl()
 
     mock_extract.assert_called_once_with()

--- a/course_catalog/etl/see.py
+++ b/course_catalog/etl/see.py
@@ -11,7 +11,6 @@ from django.conf import settings
 
 from course_catalog.constants import OfferedBy, PlatformType, see_edx_mapping
 from course_catalog.etl.utils import (
-    log_exceptions,
     generate_unique_id,
     strip_extra_whitespace,
     parse_dates,
@@ -147,9 +146,6 @@ def _parse_full_description(details):
     )
 
 
-@log_exceptions(
-    "Error extracting Sloan Executive Education catalog", exc_return_value=[]
-)
 def extract():
     """Loads the MIT Executive Education catalog data via BeautifulSoup"""
     if not settings.SEE_BASE_URL:
@@ -182,9 +178,6 @@ def extract():
     return courses
 
 
-@log_exceptions(
-    "Error transforming Sloan Executive Education catalog", exc_return_value=[]
-)
 def transform(courses):
     """Transform the Sloan Executive Education course data"""
     return [

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -11,7 +11,6 @@ import rapidjson
 import pytz
 from django.conf import settings
 from tika import parser as tika_parser
-from toolz import excepts
 
 log = logging.getLogger()
 
@@ -40,17 +39,20 @@ def log_exceptions(msg, *, exc_return_value=None):
         """
 
         @wraps(func)
-        def _log_exceptions_wrapper(_):
+        def _log_exceptions_wrapper(*args, **kwargs):
             """
             Log the exception and return the exc_return_value
 
             Returns:
                 Any: the exc_return_value
             """
-            log.exception(msg)
-            return exc_return_value
+            try:
+                return func(*args, **kwargs)
+            except:  # pylint: disable=bare-except
+                log.exception(msg)
+                return exc_return_value
 
-        return excepts(Exception, func, _log_exceptions_wrapper)
+        return _log_exceptions_wrapper
 
     return _log_exceptions
 

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -21,7 +21,7 @@ from course_catalog.constants import (
     PlatformType,
     VALID_TEXT_FILE_TYPES,
 )
-from course_catalog.etl.utils import extract_text_metadata, log_exceptions
+from course_catalog.etl.utils import extract_text_metadata
 from course_catalog.models import get_max_length
 
 
@@ -65,7 +65,6 @@ def _parse_datetime(value):
     )
 
 
-@log_exceptions("Error extracting xPro catalog", exc_return_value=[])
 def extract_programs():
     """Loads the xPro catalog data"""
     if settings.XPRO_CATALOG_API_URL:
@@ -141,7 +140,6 @@ def _transform_course(course):
     }
 
 
-@log_exceptions("Error transforming xPro courses", exc_return_value=[])
 def transform_courses(courses):
     """
     Transforms a list of courses into our normalized data structure
@@ -152,11 +150,9 @@ def transform_courses(courses):
     Returns:
         list of dict: normalized courses data
     """
-    # NOTE: don't use this in `transform_programs`, because this is wrapped in `log_exceptions`
     return [_transform_course(course) for course in courses]
 
 
-@log_exceptions("Error transforming xPro programs", exc_return_value=[])
 def transform_programs(programs):
     """Transform the xPro catalog data"""
     # normalize the xPro data into the course_catalog/models.py data structures

--- a/course_catalog/etl/youtube.py
+++ b/course_catalog/etl/youtube.py
@@ -18,7 +18,6 @@ from course_catalog.etl.exceptions import (
     ExtractPlaylistException,
     ExtractPlaylistItemException,
 )
-from course_catalog.etl.utils import log_exceptions
 from course_catalog.models import Video
 from open_discussions.utils import now_in_utc
 from search.task_helpers import upsert_video
@@ -391,7 +390,6 @@ def get_youtube_channel_configs(*, channel_ids=None):
     return channel_configs
 
 
-@log_exceptions("Error extracting youtube data", exc_return_value=[])
 def extract(*, channel_ids=None):
     """
     Function which returns video data for all videos in our watched playlists
@@ -476,7 +474,6 @@ def transform_playlist(
     }
 
 
-@log_exceptions("Error transforming youtube data", exc_return_value=[])
 def transform(extracted_channels):
     """
     Transforms raw video data into normalized data structure


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2961 - was causing video topics to not load completely
Part of #2955 

#### What's this PR do?
- Removes `course_catalog.etl.utils.log_exceptions` - this was a minor ergonomic improvement to writing code but a huge ergonomic detriment to testing it
- Fixes the course deduplication code to query on `platform` since otherwise it may select a course from a different platform. In practice we saw this happen between OCW + MITx courses
- Fixes a race condition (#2961) in writing out topic data. I solved this by adding transactions and taking locks on the parent resource.

#### How should this be manually tested?

- Verify you're seeing a course that doesn't appear in the API response. Message me for some examples.
- Run `./manage.py backpopulate_xpro_data` and ./manage.py backpopulate_edx_data`, they should succeed and you should see the course get unpublished.
- Adds a concept of loader configurations, to allow per-platform configuration of loaders, specifically:
  - Some integrations need to be able to treat `offered_by` as an appendable relation
  - Some integrations don't remove courses (SEE, CSAIL, MITPE) because we are parsing html pages which are sometimes updated in such ways that we can't parse a current course, but we don't want to delist existing courses