### PR TITLE
fix another podcast card height issue

### DIFF
--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -53,7 +53,9 @@ export default function PodcastCard(props: Props) {
           <div className="row podcast-title">
             <Dotdotdot clamp={3}>{podcast.title}</Dotdotdot>
           </div>
-          <div className="row podcast-author">{podcast.offered_by}</div>
+          <div className="row podcast-author">
+            <Dotdotdot clamp={2}>{podcast.offered_by}</Dotdotdot>
+          </div>
         </div>
       </div>
     </Card>

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -26,7 +26,20 @@ describe("PodcastCard", () => {
 
   it("should render basic stuff", async () => {
     const { wrapper } = await render()
-    assert.equal(wrapper.find("Dotdotdot").props().children, podcast.title)
+    assert.equal(
+      wrapper
+        .find("Dotdotdot")
+        .at(0)
+        .props().children,
+      podcast.title
+    )
+    assert.equal(
+      wrapper
+        .find("Dotdotdot")
+        .at(1)
+        .props().children,
+      podcast.offered_by
+    )
     assert.equal(
       wrapper.find("img").prop("src"),
       embedlyThumbnail(

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -174,6 +174,7 @@
         color: $font-grey-light;
         font-family: "Roboto";
         padding-top: 10px;
+
         @include breakpoint(materialmobile) {
           padding-top: 15px;
           padding-bottom: 15px;
@@ -213,51 +214,51 @@
 }
 
 .podcast-card {
-  > .card-contents {
-    > div {
-      background-color: white;
-      margin: 0;
-      padding: 0;
-      font-family: roboto;
+  #podcast-card-inner-container {
+    background-color: white;
+    margin: 0;
+    padding: 0;
+    font-family: roboto;
+    cursor: pointer;
+    border-radius: 5px;
+
+    @include breakpoint(materialmobile) {
+      margin-bottom: 10px;
+    }
+
+    .cover-img {
+      img {
+        width: 100%;
+        min-height: 170px;
+        border-radius: 5px 5px 0 0;
+      }
+    }
+
+    .podcast-info {
+      padding: 16px;
+    }
+
+    .resource-type {
+      font-size: 13px;
+      color: $font-grey-mid;
+      text-transform: uppercase;
+      font-weight: 500;
+    }
+
+    .podcast-title {
+      margin: 10px 0;
+      margin-top: 2px;
+      min-height: 62px;
+      font-size: 18px;
+      color: black;
+      font-weight: 500;
       cursor: pointer;
-      @include breakpoint(materialmobile) {
-        margin-bottom: 10px;
-      }
+    }
 
-      .cover-img {
-        img {
-          width: 100%;
-          min-height: 170px;
-          border-radius: 5px 5px 0 0;
-        }
-      }
-
-      .podcast-info {
-        padding: 16px;
-      }
-
-      .resource-type {
-        font-size: 13px;
-        color: $font-grey-mid;
-        text-transform: uppercase;
-        font-weight: 500;
-      }
-
-      .podcast-title {
-        margin: 10px 0;
-        margin-top: 2px;
-        min-height: 62px;
-        font-size: 18px;
-        color: black;
-        font-weight: 500;
-        cursor: pointer;
-      }
-
-      .podcast-author {
-        font-size: 14px;
-        color: $font-grey-light;
-        min-height: 16px;
-      }
+    .podcast-author {
+      font-size: 14px;
+      color: $font-grey-light;
+      min-height: 32px;
     }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #2966 

#### What's this PR do?

sets a min-height on the podcast author div and clamps it to two lines of text.

I also noticed that the border-radius was accidentally removed from the podcast cards, so I added that back.

#### How should this be manually tested?

make sure that the issue isn't causing any podcast cards to be of different height.


#### Screenshots (if appropriate)

![Screenshot from 2020-06-01 10-52-13](https://user-images.githubusercontent.com/6207644/83421351-f3c04300-a3f5-11ea-9c1d-bcfe6e44ae6a.png)

