### PR TITLE
fix checked facet highlight

### DIFF
--- a/static/js/components/search/SearchFacetItem.js
+++ b/static/js/components/search/SearchFacetItem.js
@@ -17,7 +17,7 @@ export default function SearchFacetItem(props: Props) {
 
   return (
     <div
-      className="facet-visible"
+      className={isChecked ? "facet-visible checked" : "facet-visible"}
       onClick={() => {
         onUpdate({
           target: {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="1680" alt="Screen Shot 2020-06-01 at 12 53 15 PM" src="https://user-images.githubusercontent.com/1934992/83432454-e5c6ee00-a406-11ea-9085-317beeb63f10.png">

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2971

#### What's this PR do?
There was a small regression preventing checked facets from being highlighted in the sidebar. This fixes it

#### How should this be manually tested?
Go to /learn/search. Search facets that are checked should have key text that is larger and blue.

