### PR TITLE
change reorder text

### DIFF
--- a/static/js/pages/UserListDetailPage.js
+++ b/static/js/pages/UserListDetailPage.js
@@ -68,9 +68,7 @@ export default function UserListDetailPage(props: Props) {
                       onClick={() => setIsSorting(!sorting)}
                     >
                       {sorting
-                        ? `Stop sorting ${
-                          readableLearningResources[userList.object_type]
-                        }`
+                        ? "Save"
                         : `Reorder ${
                           readableLearningResources[userList.object_type]
                         }`}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

<img width="929" alt="Screen Shot 2020-06-01 at 2 04 36 PM" src="https://user-images.githubusercontent.com/1934992/83439559-65f25100-a411-11ea-97ea-2d21961025bc.png">
<img width="378" alt="Screen Shot 2020-06-01 at 2 12 03 PM" src="https://user-images.githubusercontent.com/1934992/83439876-f0d34b80-a411-11ea-96c5-90a5526098f9.png">

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/2973

#### What's this PR do?
This changes the button text for completing a learning list reorder to "Save" from "Stop sorting Learning Path" 

#### How should this be manually tested?
Go to /learn/lists/
Select a learning path
Click "Reorder Learning Path"
The button to stop reordering should say "Save"