### PR TITLE
add tooltips to learning resource card

### DIFF
--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -7,6 +7,7 @@ import { useDispatch } from "react-redux"
 
 import Card from "./Card"
 import LoginTooltip from "./LoginTooltip"
+import LearningResourceIcon from "./LearningResourceIcon"
 
 import { setDialogData } from "../actions/ui"
 import { bestRun } from "../lib/learning_resources"
@@ -16,8 +17,7 @@ import {
   CAROUSEL_IMG_HEIGHT,
   LR_TYPE_VIDEO,
   DISPLAY_DATE_FORMAT,
-  readableLearningResources,
-  iconMap
+  readableLearningResources
 } from "../lib/constants"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
 import { toQueryString, COURSE_SEARCH_URL } from "../lib/url"
@@ -149,10 +149,12 @@ export function LearningResourceDisplay(props: Props) {
     hasCertificate && bestAvailableRun
       ? moment(bestAvailableRun.best_start_date).format(DISPLAY_DATE_FORMAT)
       : null
-  const icons =
+
+  const iconKeys =
     object.audience && object.certification
-      ? object.audience.concat(object.certification).map(key => iconMap[key])
+      ? object.audience.concat(object.certification)
       : []
+
   const inLists = object ? object.lists : []
 
   const bookmarkIconName =
@@ -174,8 +176,10 @@ export function LearningResourceDisplay(props: Props) {
             {readableLearningResources[object.object_type]}
           </div>
           <div className="audience-certificates">
-            {icons.length > 0
-              ? icons.map((icon, i) => <img src={icon} key={i} />)
+            {iconKeys.length > 0
+              ? iconKeys.map((key, i) => (
+                <LearningResourceIcon iconKey={key} key={i} />
+              ))
               : null}
           </div>
         </div>

--- a/static/js/components/LearningResourceCard_test.js
+++ b/static/js/components/LearningResourceCard_test.js
@@ -24,8 +24,7 @@ import {
   OPEN_CONTENT,
   PROFESSIONAL,
   CERTIFICATE,
-  DISPLAY_DATE_FORMAT,
-  iconMap
+  DISPLAY_DATE_FORMAT
 } from "../lib/constants"
 import {
   COURSE_SEARCH_URL,
@@ -35,6 +34,12 @@ import {
 } from "../lib/url"
 import { DIALOG_ADD_TO_LIST } from "../actions/ui"
 import { queryListResponse } from "../lib/test_utils"
+
+const iconMap = {
+  [OPEN_CONTENT]: "/static/images/open_content_icon.png",
+  [PROFESSIONAL]: "/static/images/professional_icon.png",
+  [CERTIFICATE]:  "/static/images/certificate_icon.png"
+}
 
 describe("LearningResourceCard", () => {
   let course, userList, helper, render, renderRow

--- a/static/js/components/LearningResourceIcon.js
+++ b/static/js/components/LearningResourceIcon.js
@@ -1,0 +1,37 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { OPEN_CONTENT, PROFESSIONAL, CERTIFICATE } from "../lib/constants"
+
+const OPEN_CONTENT_ICON = "/static/images/open_content_icon.png"
+const PROFESSIONAL_ICON = "/static/images/professional_icon.png"
+const CERTIFICATE_ICON = "/static/images/certificate_icon.png"
+
+const iconMap = {
+  [OPEN_CONTENT]: OPEN_CONTENT_ICON,
+  [PROFESSIONAL]: PROFESSIONAL_ICON,
+  [CERTIFICATE]:  CERTIFICATE_ICON
+}
+
+const tooltipTextMap = {
+  [OPEN_CONTENT]: "For those looking to learn now",
+  [PROFESSIONAL]: "For those looking to invest in professional development",
+  [CERTIFICATE]:  "Recieve a certificate upon completion"
+}
+
+type Props = {|
+  iconKey: string
+|}
+
+const LearningResourceIcon = (props: Props) => {
+  const { iconKey } = props
+
+  return (
+    <span className="learning-resource-icon" key={iconKey}>
+      <span className="icon-tooltip-text">{tooltipTextMap[iconKey]}</span>
+      <img src={iconMap[iconKey]} />
+    </span>
+  )
+}
+
+export default LearningResourceIcon

--- a/static/js/components/search/SearchFacetItem.js
+++ b/static/js/components/search/SearchFacetItem.js
@@ -1,12 +1,7 @@
 // @flow
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
-import {
-  iconMap,
-  OPEN_CONTENT,
-  PROFESSIONAL,
-  CERTIFICATE
-} from "../../lib/constants"
+import LearningResourceIcon from "../LearningResourceIcon"
 
 type Props = {
   facet: Object,
@@ -17,12 +12,6 @@ type Props = {
 }
 
 const featuredFacetNames = ["audience", "certification"]
-
-const tooltipTextMap = {
-  [OPEN_CONTENT]: "For those looking to learn now",
-  [PROFESSIONAL]: "For those looking to invest in professional development",
-  [CERTIFICATE]:  "Recieve a certificate upon completion"
-}
 
 export default function SearchFacetItem(props: Props) {
   const { facet, isChecked, onUpdate, labelFunction, name } = props
@@ -60,11 +49,8 @@ export default function SearchFacetItem(props: Props) {
           <Dotdotdot clamp={1}>{labelText}</Dotdotdot>
         </div>
         {featuredFacetNames.includes(name) ? (
-          <div className="facet-icon">
-            <span className="icon-tooltip-text">
-              {tooltipTextMap[facet.key]}
-            </span>
-            <img src={iconMap[facet.key]} />
+          <div>
+            <LearningResourceIcon iconKey={facet.key} />
           </div>
         ) : (
           <div className="facet-count">{facet.doc_count}</div>

--- a/static/js/components/search/SearchFacet_test.js
+++ b/static/js/components/search/SearchFacet_test.js
@@ -139,7 +139,7 @@ describe("SearchFacet", () => {
   it("should show item counts for facets that are not featured", () => {
     const wrapper = renderSearchFacet()
     assert.ok(wrapper.find(".facet-count").exists())
-    assert.isNotOk(wrapper.find(".facet-icon").exists())
+    assert.isNotOk(wrapper.find(".learning-resource-icon").exists())
   })
 
   it("should show icons instead of item counts for featured facets", () => {
@@ -148,7 +148,7 @@ describe("SearchFacet", () => {
     results.buckets = [{ key: CERTIFICATE, doc_count: 32 }]
     const wrapper = renderSearchFacet()
     assert.isNotOk(wrapper.find(".facet-count").exists())
-    assert.ok(wrapper.find(".facet-icon").exists())
+    assert.ok(wrapper.find(".learning-resource-icon").exists())
     assert.ok(wrapper.find(".icon-tooltip-text").exists())
   })
 })

--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -15,10 +15,6 @@ export const OPEN_CONTENT = "Open Content"
 export const PROFESSIONAL = "Professional Offerings"
 export const CERTIFICATE = "Certificates"
 
-export const OPEN_CONTENT_ICON = "/static/images/open_content_icon.png"
-export const PROFESSIONAL_ICON = "/static/images/professional_icon.png"
-export const CERTIFICATE_ICON = "/static/images/certificate_icon.png"
-
 const ocwPlatform = "ocw"
 const edxPlatform = "mitx"
 const bootcampsPlatform = "bootcamps"
@@ -53,12 +49,6 @@ export const platformLogos = {
   [seePlatform]:          "/static/images/sloan-logo.png",
   [mitpePlatform]:        "/static/images/mitpe-logo.png",
   [csailPlatform]:        "/static/images/csail-logo.png"
-}
-
-export const iconMap = {
-  [OPEN_CONTENT]: OPEN_CONTENT_ICON,
-  [PROFESSIONAL]: PROFESSIONAL_ICON,
-  [CERTIFICATE]:  CERTIFICATE_ICON
 }
 
 export const offeredBys = {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -78,6 +78,7 @@
 @import "podcasts";
 @import "audio-player";
 @import "filterable-facet";
+@import "learning-resource-icon";
 
 body {
   font-family: $body-font;

--- a/static/scss/learning-resource-card.scss
+++ b/static/scss/learning-resource-card.scss
@@ -16,6 +16,10 @@
     }
   }
 
+  .learning-resource-icon .icon-tooltip-text {
+    margin-left: -35px;
+  }
+
   .drag-handle {
     display: flex;
     flex-direction: column;

--- a/static/scss/learning-resource-icon.scss
+++ b/static/scss/learning-resource-icon.scss
@@ -1,0 +1,29 @@
+.learning-resource-icon {
+  img {
+    height: 20px;
+  }
+
+  .icon-tooltip-text {
+    visibility: hidden;
+    width: 120px;
+    background-color: $font-grey-mid;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+    font-size: 12px;
+
+    position: absolute;
+    z-index: 1;
+    margin-left: -50px;
+    margin-top: 25px;
+  }
+
+  @include breakpoint(desktop) {
+    &:hover {
+      .icon-tooltip-text {
+        visibility: visible;
+      }
+    }
+  }
+}

--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -170,36 +170,6 @@
         padding: 5px;
       }
 
-      .facet-icon {
-        img {
-          height: 20px;
-        }
-
-        .icon-tooltip-text {
-          visibility: hidden;
-          width: 120px;
-          background-color: $font-grey-mid;
-          color: #fff;
-          text-align: center;
-          border-radius: 6px;
-          padding: 5px 0;
-          font-size: 12px;
-
-          position: absolute;
-          z-index: 1;
-          margin-left: -50px;
-          margin-top: 25px;
-        }
-
-        @include breakpoint(desktop) {
-          &:hover {
-            .icon-tooltip-text {
-              visibility: visible;
-            }
-          }
-        }
-      }
-
       .facet-count {
         color: $font-grey-mid;
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/2979

#### What's this PR do?
This adds tooltip descriptions to the open content, professional content and certificate icons on learning resource cards

#### How should this be manually tested?
Go to /learn/search. Verify that there is a tooltip when you hover over the icons on the card 

<img width="1285" alt="Screen Shot 2020-06-04 at 12 19 15 PM" src="https://user-images.githubusercontent.com/1934992/83784574-8105d080-a65e-11ea-86b2-993e4355bd77.png">
