### PR TITLE
fix favorite / not favorite display for 'similar items' in LR drawer

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -675,6 +675,12 @@ class FavoriteItemSerializer(serializers.ModelSerializer):
     content_data = GenericForeignKeyFieldSerializer(source="item")
     content_type = serializers.CharField(source="content_type.name")
 
+    def to_representation(self, instance):
+        """put `is_favorite` in to the content data"""
+        data = super().to_representation(instance)
+        data["content_data"]["is_favorite"] = True
+        return data
+
     class Meta:
         model = FavoriteItem
         fields = "__all__"

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -17,6 +17,7 @@ from course_catalog.factories import (
     PodcastFactory,
     PodcastEpisodeFactory,
     LearningResourceOfferorFactory,
+    VideoFactory,
 )
 from course_catalog.models import FavoriteItem, UserListItem
 from course_catalog.serializers import (
@@ -29,6 +30,7 @@ from course_catalog.serializers import (
     CourseTopicSerializer,
     PodcastSerializer,
     PodcastEpisodeSerializer,
+    VideoSerializer,
 )
 from open_discussions.factories import UserFactory
 
@@ -216,19 +218,52 @@ def test_favorites_serializer():
     course = CourseFactory.create()
     user_list = UserListFactory.create(author=user)
     program = ProgramFactory.create()
+    video = VideoFactory.create()
+    podcast = PodcastFactory.create()
+    podcast_episode = PodcastEpisodeFactory.create()
     course_topic = CourseTopicFactory.create()
 
     favorite_item = FavoriteItem(user=user, item=course)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data") == CourseSerializer(course).data
+    assert serializer.data.get("content_data") == {
+        **CourseSerializer(course).data,
+        "is_favorite": True,
+    }
 
     favorite_item = FavoriteItem(user=user, item=user_list)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data") == UserListSerializer(user_list).data
+    assert serializer.data.get("content_data") == {
+        **UserListSerializer(user_list).data,
+        "is_favorite": True,
+    }
 
     favorite_item = FavoriteItem(user=user, item=program)
     serializer = FavoriteItemSerializer(favorite_item)
-    assert serializer.data.get("content_data") == ProgramSerializer(program).data
+    assert serializer.data.get("content_data") == {
+        **ProgramSerializer(program).data,
+        "is_favorite": True,
+    }
+
+    favorite_item = FavoriteItem(user=user, item=video)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data") == {
+        **VideoSerializer(video).data,
+        "is_favorite": True,
+    }
+
+    favorite_item = FavoriteItem(user=user, item=podcast)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data") == {
+        **PodcastSerializer(podcast).data,
+        "is_favorite": True,
+    }
+
+    favorite_item = FavoriteItem(user=user, item=podcast_episode)
+    serializer = FavoriteItemSerializer(favorite_item)
+    assert serializer.data.get("content_data") == {
+        **PodcastEpisodeSerializer(podcast_episode).data,
+        "is_favorite": True,
+    }
 
     favorite_item = FavoriteItem(user=user, item=course_topic)
     serializer = FavoriteItemSerializer(favorite_item)

--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -43,7 +43,8 @@ import {
   learningResourcePermalink
 } from "../lib/url"
 import { capitalize, emptyOrNil, languageName } from "../lib/util"
-import { SEARCH_LIST_UI, searchResultToLearningResource } from "../lib/search"
+import { SEARCH_LIST_UI } from "../lib/search"
+import { useSearchResultToFavoriteLR } from "../hooks/learning_resources"
 
 import type { LearningResourceResult } from "../flow/searchTypes"
 
@@ -180,6 +181,8 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
     podcasts => (podcasts ? podcasts[object.podcast] : null)
   )
   const episodePodcast = useSelector(episodePodcastSelector)
+
+  const searchResultToFavoriteLR = useSearchResultToFavoriteLR()
 
   return (
     <React.Fragment>
@@ -406,9 +409,7 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
           setShow={setShowSimilar}
           show={showSimilar}
           icon={similarIcon}
-          objects={similarItems.map(item =>
-            searchResultToLearningResource(item)
-          )}
+          objects={similarItems.map(searchResultToFavoriteLR)}
         />
       ) : null}
     </React.Fragment>

--- a/static/js/hooks/learning_resources.js
+++ b/static/js/hooks/learning_resources.js
@@ -1,10 +1,15 @@
 // @flow
-import { useEffect } from "react"
+import { useEffect, useCallback } from "react"
 import { useLocation } from "react-router-dom"
 import { useDispatch } from "react-redux"
 import qs from "query-string"
+import { useSelector } from "react-redux"
 
+import { searchResultToLearningResource } from "../lib/search"
+import { learningResourceSelector } from "../lib/queries/learning_resources"
 import { pushLRHistory } from "../actions/ui"
+
+import type { LearningResourceResult } from "../flow/searchTypes"
 
 export function useLRDrawerParams() {
   const { search } = useLocation()
@@ -31,4 +36,18 @@ export function useLearningResourcePermalink() {
       )
     }
   }, [])
+}
+
+export function useSearchResultToFavoriteLR() {
+  const selector = useSelector(learningResourceSelector)
+
+  const getFavoriteOrListedObject = useCallback(
+    (searchResult: LearningResourceResult) => {
+      const object = searchResultToLearningResource(searchResult)
+      const storedObject = selector(object.id, object.object_type)
+      return storedObject || object
+    },
+    [selector]
+  )
+  return getFavoriteOrListedObject
 }

--- a/static/js/lib/queries/learning_resources_test.js
+++ b/static/js/lib/queries/learning_resources_test.js
@@ -13,15 +13,20 @@ import {
 import {
   makeCourse,
   makeProgram,
-  makeLearningResource
+  makeLearningResource,
+  makeUserList,
+  makeVideo
 } from "../../factories/learning_resources"
+import { makePodcast, makePodcastEpisode } from "../../factories/podcasts"
 import {
   LR_TYPE_COURSE,
   LR_TYPE_ALL,
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_USERLIST,
   LR_TYPE_VIDEO,
-  LR_TYPE_PROGRAM
+  LR_TYPE_PROGRAM,
+  LR_TYPE_PODCAST,
+  LR_TYPE_PODCAST_EPISODE
 } from "../constants"
 import { similarResourcesURL } from "../url"
 
@@ -29,7 +34,25 @@ describe("learning resource queries", () => {
   let favorites
 
   beforeEach(() => {
-    favorites = [...R.times(makeCourse, 5), ...R.times(makeProgram, 5)]
+    favorites = R.flatten(
+      [
+        [makeCourse, LR_TYPE_COURSE],
+        [makeProgram, LR_TYPE_PROGRAM],
+        [makeUserList, LR_TYPE_USERLIST],
+        [makeVideo, LR_TYPE_VIDEO],
+        [makePodcast, LR_TYPE_PODCAST],
+        [makePodcastEpisode, LR_TYPE_PODCAST_EPISODE]
+      ].map(([factory, LRType]) => [
+        {
+          content_data: factory(),
+          content_type: LRType
+        },
+        {
+          content_data: factory(),
+          content_type: LRType
+        }
+      ])
+    )
   })
 
   it("mapResourcesToResourceRefs should map learning resources to a ref object", () => {
@@ -78,12 +101,11 @@ describe("learning resource queries", () => {
     )
   })
 
-  //
-  ;[LR_TYPE_COURSE, LR_TYPE_PROGRAM].forEach(resourceType => {
-    it("filterFavorites should separate by content type", () => {
+  LR_TYPE_ALL.forEach(resourceType => {
+    it(`filterFavorites should separate out ${resourceType}`, () => {
       const filtered = filterFavorites(favorites, resourceType)
       filtered.forEach(object => {
-        assert.equal(resourceType, object.content_type)
+        assert.equal(resourceType, object.object_type)
       })
     })
   })

--- a/static/js/pages/LearnRouter.js
+++ b/static/js/pages/LearnRouter.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react"
 import { Route, Switch } from "react-router-dom"
+import { useRequest } from "redux-query-react"
 
 import CourseSearchPage from "./CourseSearchPage"
 import CourseIndexPage from "./CourseIndexPage"
@@ -11,6 +12,8 @@ import FavoritesDetailPage from "./FavoritesDetailPage"
 import LearningResourceDrawer from "../components/LearningResourceDrawer"
 import AddToListDialog from "../components/AddToListDialog"
 
+import { favoritesRequest } from "../lib/queries/learning_resources"
+
 import type { Match } from "react-router"
 
 type Props = {
@@ -19,6 +22,8 @@ type Props = {
 
 export default function LearnRouter(props: Props) {
   const { match } = props
+
+  useRequest(favoritesRequest())
 
   return (
     <>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #2871

#### What's this PR do?

this PR fixes the issue with items in the 'similar items' panel in the LR drawer not showing up as favorited / added to a list when they have been.

I found an issue that was unexpected: although the individual APIs for all of our learning resources have an `is_favorite` boolean field on them, for some reason in the favorites API this field is not present on the objects in the response. So to fix it I made a change to the favorite item serializer to insert the field manually.

#### How should this be manually tested?

go to the course search and open up an item in the drawer. favorite one of the items in the 'similar items' panel. if you reload the page and open the drawer for that same item you should see the 'favorite' icon filled-in for the item you favorited (or added to a user list).

Another way to test is to look at <http://localhost:8063/api/v0/favorites/> and ensure that you see the `is_favorite` field in the responses.

#### Screenshots (if appropriate)
![Screenshot from 2020-06-04 12-35-43](https://user-images.githubusercontent.com/6207644/83785857-ea3a1380-a65f-11ea-9dfc-5c429b0c33cc.png)

