### PR TITLE
always upload the course image, but not the rest of the course content

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -452,7 +452,7 @@ def sync_ocw_course(
     if course_json["course_id"] in blacklist:
         is_published = False
 
-    if upload_to_s3 and is_published:
+    if is_published:
         try:
             parser.setup_s3_uploading(
                 settings.OCW_LEARNING_COURSE_BUCKET_NAME,
@@ -462,9 +462,8 @@ def sync_ocw_course(
                 # actual element and [-1] is an empty string
                 course_prefix.split("/")[-2],
             )
-            if settings.OCW_UPLOAD_IMAGE_ONLY:
-                parser.upload_course_image()
-            else:
+            parser.upload_course_image()
+            if upload_to_s3:
                 parser.upload_all_media_to_s3(upload_master_json=True)
         except:  # pylint: disable=bare-except
             log.exception(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2980

#### What's this PR do?
Sets the `course_catalog` API to always upload the course image to S3 to ensure it exists and be able to properly get the URL.

#### How should this be manually tested?
Run OCW import, ensure course images exist.

#### What GIF best describes this PR or how it makes you feel?
![giphy (1)](https://user-images.githubusercontent.com/12089658/83788951-02ac2d00-a664-11ea-962e-eb16adfd5619.gif)
