### PR TITLE
Restrict creation of public lists

### DIFF
--- a/app.json
+++ b/app.json
@@ -471,6 +471,10 @@
       "description": "The log level for Sentry",
       "required": false
     },
+    "STAFF_MOIRA_LISTS": {
+      "description": "moira lists of users who can create public lists",
+      "required": false
+    },
     "STATUS_TOKEN": {
       "description": "Token to access the status API."
     },

--- a/moira_lists/moira_api.py
+++ b/moira_lists/moira_api.py
@@ -171,3 +171,25 @@ def update_moira_list_users(moira_list):
         email__in=moira_user_emails(get_list_members(moira_list.name))
     )
     moira_list.users.set(users)
+
+
+def is_list_staff(user):
+    """
+    Determine if a user can author lists & paths
+
+    Args:
+        user (User): a user
+
+    Returns:
+        boolean: True or False
+    """
+    return user and (
+        user.is_superuser
+        or user.is_staff
+        or len(
+            set(user.moira_lists.values_list("name", flat=True)).intersection(
+                settings.STAFF_MOIRA_LISTS
+            )
+        )
+        > 0
+    )

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -927,6 +927,8 @@ MIT_WS_PRIVATE_KEY = get_key("MIT_WS_PRIVATE_KEY", "")
 MIT_WS_CERTIFICATE_FILE = os.path.join(STATIC_ROOT, "mit_x509.cert")
 MIT_WS_PRIVATE_KEY_FILE = os.path.join(STATIC_ROOT, "mit_x509.key")
 
+STAFF_MOIRA_LISTS = get_list_of_str("STAFF_MOIRA_LISTS", [])
+
 
 def setup_x509():
     """ write the moira x509 certification & key to files"""

--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from social_django.utils import load_strategy, load_backend
 
+from moira_lists.moira_api import is_list_staff
 from open_discussions import features
 
 from open_discussions.templatetags.render_bundle import public_path
@@ -33,6 +34,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
     user_email = None
     user_is_superuser = False
     user_id = None
+    user_list_staff = False
 
     if request.user.is_authenticated:
         user = request.user
@@ -41,6 +43,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         user_email = user.email
         user_is_superuser = user.is_superuser
         user_id = user.id
+        user_list_staff = is_list_staff(user)
 
     site = get_default_site()
 
@@ -71,6 +74,7 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "user_email": user_email,
         "user_id": user_id,
         "is_admin": user_is_superuser,
+        "is_list_staff": user_list_staff,
         "authenticated_site": {
             "title": site.title,
             "base_url": site.base_url,

--- a/open_discussions/views_test.py
+++ b/open_discussions/views_test.py
@@ -75,6 +75,7 @@ def test_webpack_url(
             "tos_url": authenticated_site.tos_url,
         },
         "is_authenticated": expect_auth,
+        "is_list_staff": False,
         "allow_saml_auth": False,
         "allow_related_posts_ui": False,
         "support_email": settings.EMAIL_SUPPORT,

--- a/static/js/components/UserListFormDialog.js
+++ b/static/js/components/UserListFormDialog.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 import { useMutation, useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
@@ -71,7 +72,8 @@ export default function UserListFormDialog(props: Props) {
           : {
             title:             "",
             short_description: "",
-            topics:            []
+            topics:            [],
+            privacy_level:     SETTINGS.is_list_staff ? null : LR_PRIVATE
           }
       }
       validate={validateCreateUserListForm}
@@ -116,31 +118,36 @@ export default function UserListFormDialog(props: Props) {
               </div>
             </div>
             {validationMessage(errors.list_type)}
-            <span className="input-name">Privacy</span>
-            <div className="privacy radio">
-              <div className="option">
-                <Field
-                  name="privacy_level"
-                  id="radio-public"
-                  type="radio"
-                  value={LR_PUBLIC}
-                />
-                <label htmlFor="radio-public">
-                  <span className="header">Public</span>
-                </label>
-              </div>
-              <div className="option">
-                <Field
-                  name="privacy_level"
-                  type="radio"
-                  id="radio-private"
-                  value={LR_PRIVATE}
-                />
-                <label htmlFor="radio-private">
-                  <span className="header">Private</span>
-                </label>
-              </div>
-            </div>
+            {SETTINGS.is_list_staff ? (
+              <>
+                <span className="input-name">Privacy</span>
+                <div className="privacy radio">
+                  <div className="option">
+                    <Field
+                      name="privacy_level"
+                      id="radio-public"
+                      type="radio"
+                      value={LR_PUBLIC}
+                    />
+                    <label htmlFor="radio-public">
+                      <span className="header">Public</span>
+                    </label>
+                  </div>
+                  <div className="option">
+                    <Field
+                      name="privacy_level"
+                      type="radio"
+                      id="radio-private"
+                      value={LR_PRIVATE}
+                    />
+                    <label htmlFor="radio-private">
+                      <span className="header">Private</span>
+                    </label>
+                  </div>
+                </div>
+              </>
+            ) : null}
+
             {validationMessage(errors.privacy_level)}
             <span className="input-name">List Title</span>
             <Field name="title" className="title" />

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -22,6 +22,7 @@ declare var SETTINGS: {
   },
   is_authenticated: boolean,
   is_admin: boolean,
+  is_list_staff: boolean,
   allow_saml_auth: boolean,
   search_page_size: number,
   search_min_length: number,

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -21,6 +21,7 @@ const _createSettings = () => ({
   allow_related_posts_ui: false,
   is_authenticated:       true,
   is_admin:               false,
+  is_list_staff:          false,
   username:               "greatusername",
   user_full_name:         "Great User",
   user_id:                0,


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #2824 

#### What's this PR do?
- Adds `STAFF_MOIRA_LISTS` .env setting (moira lists of users who can create public learning paths/lists).
- Adds a validation function to `UserListSerializer` to ensure that only users in the above moira lists (or django staff/super users) are allowed to create public learning lists.
- On the front end UserListFormDialog, hides the privacy options and sets the default to 'private' if the user is not on the moira lists.

#### How should this be manually tested?
- Set `STAFF_MOIRA_LISTS` to include at least one moira list and create a user whose MIT email is on that list (and not a staff or superuser).
- Log in as that user and verify that you can create public lists and see the privacy options on the form.
- Log in as a staff or superuser and you should still be able to create public lists.
- Log in as a user who is not on the specified moira lists, not staff, and not a superuser.  You should still be able to create learning lists/paths, but the privacy options should be hidden and the lists you create should be private.
