### PR TITLE
fix facet filters

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -347,6 +347,7 @@ def _transform_search_results_suggest(search_result):
     return search_result
 
 
+# pylint: disable=too-many-branches
 def transform_results(search_result, user):
     """
     Transform podcast and podcast episode, and userlist and learning path in aggregations
@@ -359,6 +360,18 @@ def transform_results(search_result, user):
     Returns:
         dict: The Elasticsearch response dict with transformed aggregates and source values
     """
+
+    for aggregation_key in [
+        "type",
+        "topics",
+        "offered_by",
+        "audience",
+        "certification",
+    ]:
+        if f"agg_filter_{aggregation_key}" in search_result.get("aggregations", {}):
+            search_result["aggregations"][aggregation_key] = search_result[
+                "aggregations"
+            ][f"agg_filter_{aggregation_key}"][aggregation_key]
 
     types = search_result.get("aggregations", {}).get("type", {})
 

--- a/static/js/components/search/CourseFilterDrawer.js
+++ b/static/js/components/search/CourseFilterDrawer.js
@@ -24,7 +24,7 @@ type FilterDrawerProps = {
   activeFacets: Function,
   clearAllFilters: Function,
   toggleFacet: Function,
-  mergeFacetOptions: Function,
+  facetOptions: Function,
   onUpdateFacets: Function
 }
 
@@ -33,7 +33,7 @@ export function FilterDisplay(props: FilterDrawerProps) {
     activeFacets,
     clearAllFilters,
     toggleFacet,
-    mergeFacetOptions,
+    facetOptions,
     onUpdateFacets
   } = props
 
@@ -69,7 +69,7 @@ export function FilterDisplay(props: FilterDrawerProps) {
               key={i}
               title={title}
               name={name}
-              results={mergeFacetOptions(name)}
+              results={facetOptions(name)}
               onUpdate={onUpdateFacets}
               currentlySelected={activeFacets[name] || []}
               labelFunction={labelFunction}
@@ -79,7 +79,7 @@ export function FilterDisplay(props: FilterDrawerProps) {
               key={i}
               title={title}
               name={name}
-              results={mergeFacetOptions(name)}
+              results={facetOptions(name)}
               onUpdate={onUpdateFacets}
               currentlySelected={activeFacets[name] || []}
               labelFunction={labelFunction}

--- a/static/js/components/search/CourseFilterDrawer_test.js
+++ b/static/js/components/search/CourseFilterDrawer_test.js
@@ -12,7 +12,7 @@ import { DESKTOP, PHONE, TABLET } from "../../lib/constants"
 describe("CourseFilterDrawer", () => {
   let clearAllFiltersStub,
     toggleFacetStub,
-    mergeFacetOptionsStub,
+    facetOptionsStub,
     onUpdateFacetsStub,
     sandbox,
     useDeviceCategoryStub
@@ -23,7 +23,7 @@ describe("CourseFilterDrawer", () => {
         activeFacets={{}}
         clearAllFilters={clearAllFiltersStub}
         toggleFacet={toggleFacetStub}
-        mergeFacetOptions={mergeFacetOptionsStub}
+        facetOptions={facetOptionsStub}
         onUpdateFacets={onUpdateFacetsStub}
         {...props}
       />
@@ -41,7 +41,7 @@ describe("CourseFilterDrawer", () => {
     sandbox = createSandbox()
     clearAllFiltersStub = sandbox.stub()
     toggleFacetStub = sandbox.stub()
-    mergeFacetOptionsStub = sandbox.stub()
+    facetOptionsStub = sandbox.stub()
     onUpdateFacetsStub = sandbox.stub()
 
     useDeviceCategoryStub = sandbox

--- a/static/js/flow/searchTypes.js
+++ b/static/js/flow/searchTypes.js
@@ -104,11 +104,6 @@ export type FacetResult = {
   buckets:    Array<FacetBucket>
 }
 
-export type CurrentFacet = {
-  group: string,
-  result: FacetResult
-}
-
 export type Result = PostResult | CommentResult | ProfileResult | LearningResourceResult
 
 export type SearchInputs = {

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -217,7 +217,6 @@ describe("CourseSearchPage", () => {
     assert.isFalse(wrapper.find("InfiniteScroll").prop("hasMore"))
     assert.deepEqual(inner.state(), {
       // Because this is non-incremental the previous from value of 7 is replaced with 0
-      currentFacetGroup:  null,
       error:              null,
       from:               5,
       incremental:        true,
@@ -515,7 +514,7 @@ describe("CourseSearchPage", () => {
     sinon.assert.notCalled(helper.searchStub)
   })
 
-  it("mergeFacetOptions adds any selected facets not in results to the group", async () => {
+  it("facetOptions adds any selected facets not in results to the group", async () => {
     const { inner } = await renderPage(
       {},
       {
@@ -533,30 +532,10 @@ describe("CourseSearchPage", () => {
       }
     )
 
-    const mergedFacets = inner.instance().mergeFacetOptions("topics")
+    const mergedFacets = inner.instance().facetOptions("topics")
     assert.isTrue(
       _.findIndex(mergedFacets.buckets, { doc_count: 0, key: "NewTopic" }) > -1
     )
-  })
-
-  it("mergeFacetOptions adds any search facets not in current facet group", async () => {
-    const { inner } = await renderPage()
-    const currentFacetGroup = {
-      group:  "offered_by",
-      result: { buckets: [{ key: "OCW", doc_count: 20 }] }
-    }
-    const missingFacetGroup = _.find(
-      // $FlowFixMe: platform exists in aggregation result
-      searchResponse.aggregations.offered_by.buckets,
-      { key: "MITx" }
-    )
-    inner.setState({ currentFacetGroup })
-    const mergedFacets = inner.instance().mergeFacetOptions("offered_by")
-    assert.isTrue(
-      _.findIndex(mergedFacets.buckets, { doc_count: 20, key: "OCW" }) > -1
-    )
-    assert.isTrue(_.findIndex(mergedFacets.buckets, missingFacetGroup) > -1)
-    await wait(600)
   })
 
   // THIS IS TEMPORARY UNTIL FULL SEARCH SUPPORT IS IN PLACE!


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2975

#### What's this PR do?
This pr updates the facet filters so that the available selectors for each facet are filtered by the values in other facets but not that facet. 

#### How should this be manually tested?
Go to the learn/search page.
Select a facet option. 
Refresh the page. 
The facet options available should not change.
