### PR TITLE
do not select run with missing dates as best run

### DIFF
--- a/static/js/lib/constants.js
+++ b/static/js/lib/constants.js
@@ -119,8 +119,6 @@ export const readableLearningResources = {
 }
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
-export const DEFAULT_START_DT = "1970-01-01T00:00:00Z"
-export const DEFAULT_END_DT = "2500-01-01T23:59:59Z"
 export const DISPLAY_DATE_FORMAT = "MMMM D, YYYY"
 
 export const PHONE = "PHONE"

--- a/static/js/lib/learning_resources.js
+++ b/static/js/lib/learning_resources.js
@@ -8,8 +8,6 @@ import {
   COURSE_CURRENT,
   COURSE_PRIOR,
   DATE_FORMAT,
-  DEFAULT_END_DT,
-  DEFAULT_START_DT,
   LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_PROGRAM,
@@ -38,18 +36,20 @@ export const availabilityLabel = (availability: ?string) => {
   }
 }
 
-export const runStartDate = (objectRun: LearningResourceRun): moment$Moment =>
-  moment(objectRun.best_start_date || DEFAULT_START_DT, DATE_FORMAT)
+const runStartDate = (objectRun: LearningResourceRun): moment$Moment =>
+  moment(objectRun.best_start_date, DATE_FORMAT)
 
-export const runEndDate = (objectRun: LearningResourceRun): moment$Moment =>
-  moment(objectRun.best_end_date || DEFAULT_END_DT, DATE_FORMAT)
+const runEndDate = (objectRun: LearningResourceRun): moment$Moment =>
+  moment(objectRun.best_end_date, DATE_FORMAT)
 
-export const compareRuns = (
+const compareRuns = (
   firstRun: LearningResourceRun,
   secondRun: LearningResourceRun
 ) => runStartDate(firstRun).diff(runStartDate(secondRun), "hours")
 
 export const bestRun = (runs: Array<LearningResourceRun>) => {
+  runs = runs.filter(run => run.best_start_date && run.best_end_date)
+
   // Runs that are running right now
   const currentRuns = runs.filter(
     run => runStartDate(run).isSameOrBefore() && runEndDate(run).isAfter()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2984

#### What's this PR do?
There is currently a bug in the code that preferentially selects runs with no start or end date as the best run (due to how we set default dates). This fixes it.

#### How should this be manually tested?
If there is currently a course with "Invalid date" in your local app, this should fix it. Otherwise create one by picking a course with a certificate then running

```
from course_catalog.models import *
from search import task_helpers

run = course.runs.last()
run.best_start_date = None
run.best_end_date = None
run.save()
task_helpers.upsert_course(course.id)
```

The course should have "Invalid date" in the card in the master branch but not this branch