### PR TITLE
trim topics white space

### DIFF
--- a/course_catalog/etl/podcast.py
+++ b/course_catalog/etl/podcast.py
@@ -177,7 +177,7 @@ def transform(extracted_podcasts):
                 else None
             )
             topics = (
-                [{"name": topic} for topic in config_data["topics"].split(",")]
+                [{"name": topic.strip()} for topic in config_data["topics"].split(",")]
                 if "topics" in config_data
                 else []
             )

--- a/course_catalog/etl/podcast_test.py
+++ b/course_catalog/etl/podcast_test.py
@@ -78,7 +78,7 @@ def test_extract(mocker):
 
 @pytest.mark.usefixtures("mock_rss_request")
 @pytest.mark.parametrize("title", [None, "Custom Title"])
-@pytest.mark.parametrize("topics", [None, "Science, Technology"])
+@pytest.mark.parametrize("topics", [None, "Science,  Technology"])
 @pytest.mark.parametrize("offered_by", [None, "Department"])
 def test_transform(mocker, title, topics, offered_by):
     """Test transform function"""
@@ -88,7 +88,9 @@ def test_transform(mocker, title, topics, offered_by):
         podcast_list
     )
 
-    expected_topics = [{"name": topic} for topic in topics.split(",")] if topics else []
+    expected_topics = (
+        [{"name": topic.strip()} for topic in topics.split(",")] if topics else []
+    )
 
     expected_title = title if title else "A Podcast"
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2999

#### What's this PR do?
Trims whitespace when importing topics

#### How should this be manually tested?
Set `OPEN_PODCAST_DATA_BRANCH=ab/test` in your .env file
Run docker-compose run web ./manage.py backpopulate_podcast_data
Verify that a topic named  '       Biology' isn't created

