### PR TITLE
add episode count to podcast card

### DIFF
--- a/static/js/components/PodcastCard.js
+++ b/static/js/components/PodcastCard.js
@@ -56,6 +56,9 @@ export default function PodcastCard(props: Props) {
           <div className="row podcast-author">
             <Dotdotdot clamp={2}>{podcast.offered_by}</Dotdotdot>
           </div>
+          <div className="row podcast-episode-count">
+            {podcast.episode_count} Episodes
+          </div>
         </div>
       </div>
     </Card>

--- a/static/js/components/PodcastCard_test.js
+++ b/static/js/components/PodcastCard_test.js
@@ -41,6 +41,10 @@ describe("PodcastCard", () => {
       podcast.offered_by
     )
     assert.equal(
+      wrapper.find(".podcast-episode-count").text(),
+      `${podcast.episode_count} Episodes`
+    )
+    assert.equal(
       wrapper.find("img").prop("src"),
       embedlyThumbnail(
         SETTINGS.embedlyKey,

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -255,10 +255,14 @@
       cursor: pointer;
     }
 
-    .podcast-author {
+    .podcast-author,
+    .podcast-episode-count {
       font-size: 14px;
-      color: $font-grey-light;
       min-height: 32px;
+    }
+
+    .podcast-author {
+      color: $font-grey-light;
     }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="1177" alt="Screen Shot 2020-06-18 at 2 53 25 PM" src="https://user-images.githubusercontent.com/1934992/85064884-39149c80-b17a-11ea-87f1-4ec6ed2f1c83.png">
<img width="380" alt="Screen Shot 2020-06-18 at 2 53 10 PM" src="https://user-images.githubusercontent.com/1934992/85064888-3b76f680-b17a-11ea-95cc-5da05991d808.png">

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3001

#### What's this PR do?
Adds the episode count to podcast cards

#### How should this be manually tested?
Go to the /podcasts page. Verify that episode counts are displayed in the card and the styling looks good
