### PR TITLE
limit to one recent episode per podcast

### DIFF
--- a/course_catalog/urls.py
+++ b/course_catalog/urls.py
@@ -42,7 +42,7 @@ router.register(
 urlpatterns = [
     url(
         r"^api/v0/podcasts/recent/$",
-        views.PodcastEpisodesViewSet.as_view({"get": "list"}),
+        views.RecentPodcastEpisodesViewSet.as_view({"get": "list"}),
         name="recent-podcast-episodes",
     ),
     url(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3004

#### What's this PR do?
This limits the podcast episodes in the recent list on the /podcasts page to one episode per podcast

#### How should this be manually tested?
Check if you have multiple episodes from the same podcast in the recent episodes list on the /podcasts page when you run the app with the master branch.  If not, update the `last_modified` date on a podcast episode so that you do have multiple episodes from the same podcast in the list. 

Run the code in this branch. You should no longer have more than one episode per podcast in that list.