### PR TITLE
Added xPro topic mapping

### DIFF
--- a/course_catalog/data/ucc-topic-mappings.csv
+++ b/course_catalog/data/ucc-topic-mappings.csv
@@ -1,0 +1,27 @@
+UCC Topic,UCC Sub Topic,OCW topic & subtopic 1,OCW topic & subtopic 2
+Business,Other,Business,
+Business,Digital Business/IT,Information Technology,
+Business,Systems Thinking,Systems Engineering,
+Business,Entrepreneurship,Entrepreneurship,
+Business,Operations,Operations Management,
+Business,Finance,Finance,
+Business,Strategy,Innovation,
+Business,Marketing & Communications,Marketing,Communications
+Business,Leadership & Organizations,Leadership,Organizational Behavior
+Business,Management,Management,
+Business,Business Analytics,Finance,Accounting
+Technology,Other,,
+Technology,Quantum Computing,Physics,Computer Science
+Technology,Systems Engineering,Systems Engineering,
+Technology,PROTOTYPE/LAB,,
+Technology,AI/Machine Learning,Computer Science,
+Technology,Data Science,Computer Science,
+Engineering,Systems Engineering,Systems Engineering,
+Engineering,Manufacturing,Mechanical Engineerinig,
+Engineering,Sustainability,Environmental Engineering,
+Innovation,no sub category,innovation,
+Industry-Based,Other,,
+Industry-Based,BioTech,Biological Engineering,
+Industry-Based,Manufacturing,Mechanical Engineerinig,
+Industry-Based,Real Estate,Real Estate,
+Industry-Based,Educators,Teaching and Education,

--- a/course_catalog/etl/xpro_test.py
+++ b/course_catalog/etl/xpro_test.py
@@ -1,6 +1,7 @@
 """Tests for MicroMasters ETL functions"""
 # pylint: disable=redefined-outer-name
 from datetime import datetime
+from itertools import chain
 import json
 import os
 import pathlib
@@ -21,6 +22,7 @@ from course_catalog.etl.xpro import (
     transform_content_files,
     documents_from_olx,
     get_text_from_element,
+    UCC_TOPIC_MAPPINGS,
 )
 from open_discussions.test_utils import any_instance_of
 
@@ -97,7 +99,15 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
             "offered_by": xpro.OFFERED_BY,
             "published": bool(program_data["current_price"]),
             "url": program_data["url"],
-            "topics": program_data.get("topics", []),
+            "topics": [
+                {"name": topic_name}
+                for topic_name in chain.from_iterable(
+                    [
+                        UCC_TOPIC_MAPPINGS.get(topic["name"], [topic["name"]])
+                        for topic in program_data.get("topics", [])
+                    ]
+                )
+            ],
             "runs": [
                 {
                     "run_id": program_data["readable_id"],
@@ -135,7 +145,15 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
                             course_data["courseruns"],
                         )
                     ),
-                    "topics": course_data.get("topics", []),
+                    "topics": [
+                        {"name": topic_name}
+                        for topic_name in chain.from_iterable(
+                            [
+                                UCC_TOPIC_MAPPINGS.get(topic["name"], [topic["name"]])
+                                for topic in course_data.get("topics", [])
+                            ]
+                        )
+                    ],
                     "runs": [
                         {
                             "run_id": course_run_data["courseware_id"],
@@ -190,7 +208,15 @@ def test_xpro_transform_courses(mock_xpro_courses_data):
                     course_data["courseruns"],
                 )
             ),
-            "topics": course_data.get("topics", []),
+            "topics": [
+                {"name": topic_name}
+                for topic_name in chain.from_iterable(
+                    [
+                        UCC_TOPIC_MAPPINGS.get(topic["name"], [topic["name"]])
+                        for topic in course_data.get("topics", [])
+                    ]
+                )
+            ],
             "runs": [
                 {
                     "run_id": course_run_data["courseware_id"],

--- a/test_json/xpro_courses.json
+++ b/test_json/xpro_courses.json
@@ -6,7 +6,8 @@
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+SysEngxB1",
     "courseruns": [],
-    "next_run_id": null
+    "next_run_id": null,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 20,
@@ -30,7 +31,8 @@
         "product_id": 13
       }
     ],
-    "next_run_id": 49
+    "next_run_id": 49,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 19,
@@ -54,7 +56,8 @@
         "product_id": 12
       }
     ],
-    "next_run_id": 48
+    "next_run_id": 48,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 21,
@@ -63,7 +66,8 @@
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+SysEngxB4",
     "courseruns": [],
-    "next_run_id": null
+    "next_run_id": null,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 30,
@@ -109,7 +113,8 @@
         "product_id": null
       }
     ],
-    "next_run_id": 73
+    "next_run_id": 73,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 31,
@@ -118,7 +123,8 @@
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+DgtlLearn2",
     "courseruns": [],
-    "next_run_id": null
+    "next_run_id": null,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   },
   {
     "id": 32,
@@ -127,6 +133,7 @@
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+DgtlLearn3",
     "courseruns": [],
-    "next_run_id": null
+    "next_run_id": null,
+    "topics": [{"name": "Business:Leadership & Organizations"}]
   }
 ]

--- a/test_json/xpro_programs.json
+++ b/test_json/xpro_programs.json
@@ -10,7 +10,7 @@
     "start_date": "2019-09-01T00:00:00Z",
     "end_date": "2019-12-01T00:00:00Z",
     "enrollment_start": "2019-08-01T00:00:00Z",
-    "topics": ["Engineering", "Planning"],
+    "topics": [{"name": "Business:Leadership & Organizations"}, {"name": "Planning"}],
     "courses": [
       {
         "id": 18,
@@ -20,7 +20,7 @@
         "readable_id": "course-v1:xPRO+SysEngxB1",
         "courseruns": [],
         "next_run_id": null,
-        "topics": ["Engineering"]
+        "topics": [{"name": "Business:Leadership & Organizations"}]
       },
       {
         "id": 20,
@@ -53,7 +53,7 @@
         "description": "<p>Course 2 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program. This course may be taken individually, without enrolling in the professional certificate program.</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB2",
-        "topics": ["Planning"],
+        "topics": [{"name": "Business:Leadership & Organizations"}],
         "courseruns": [
           {
             "title": "SEED Models in Engineering - Spring 2020",
@@ -95,7 +95,7 @@
     "start_date": "2019-09-10T00:00:00Z",
     "end_date": "2019-12-10T00:00:00Z",
     "enrollment_start": null,
-    "topics": ["Education", "Computer Science"],
+    "topics": [{"name": "Business:Leadership & Organizations"}],
     "courses": [
       {
         "id": 30,
@@ -103,7 +103,7 @@
         "description": "<p>An introductory course to Digital Learning</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+DgtlLearn1",
-        "topics": ["Education", "Computer Science"],
+        "topics": [{"name": "Business:Leadership & Organizations"}],
         "courseruns": [
           {
             "title": "SEED Digital Learning 100 - August 2020",
@@ -152,7 +152,7 @@
         "readable_id": "course-v1:xPRO+DgtlLearn2",
         "courseruns": [],
         "next_run_id": null,
-        "topics": ["Education", "Computer Science"]
+        "topics": [{"name": "Business:Leadership & Organizations"}]
       },
       {
         "id": 32,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2992 
 
#### What's this PR do?
This adds a mapping for xPro topics into OCW topics based on a csv

#### How should this be manually tested?
- Run `./manage.py backpopulate_xpro_data` on master, observe that you get new, unmapped topics for xPro courses.
- Run the same command on this branch, the new topics should go away and be mapped to existing ones instead.