### PR TITLE
Ab/focus only for keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "fetch-mock": "^6.4.4",
     "flow-bin": "^0.94.0",
     "flow-typed": "^2.4.0",
+    "focus-visible": "^5.1.0",
     "formik": "^2.0.3",
     "fuse.js": "^6.0.0",
     "history": "^4.7.2",

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -183,7 +183,16 @@ export function LearningResourceDisplay(props: Props) {
               : null}
           </div>
         </div>
-        <div className="row course-title" onClick={showResourceDrawer}>
+        <div
+          className="row course-title"
+          onClick={showResourceDrawer}
+          onKeyPress={e => {
+            if (e.key === "Enter") {
+              showResourceDrawer()
+            }
+          }}
+          tabIndex="0"
+        >
           <Dotdotdot clamp={3}>{object.title}</Dotdotdot>
         </div>
         {reordering ? null : (

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -65,6 +65,7 @@ import type { Location, Match } from "react-router"
 import type { Dispatch } from "redux"
 import type { SnackbarState, BannerState } from "../reducers/ui"
 import type { Profile } from "../flow/discussionTypes"
+import "focus-visible"
 
 export const USER_MENU_DROPDOWN = "USER_MENU_DROPDOWN"
 

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -92,6 +92,10 @@ body {
   width: 100%;
   min-height: 100vh;
 
+  *:focus:not(.focus-visible) {
+    outline: none;
+  }
+
   .mdc-layout-grid {
     padding: 0;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5842,6 +5842,11 @@ focus-trap@^5.0.0:
     tabbable "^4.0.0"
     xtend "^4.0.1"
 
+focus-visible@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.1.0.tgz#4b9d40143b865f53eafbd93ca66672b3bf9e7b6a"
+  integrity sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3009

#### What's this PR do?
Focus outlines are needed for people using the keyboard to access the app to know which element they are currently focusing on (with tab). Right now the focus object is outlined for all users of the podcasts page. This doesn't look great. This pr adds the `focus-visible` library which detects if a user is accessing the app through the keyboard to make it possible to display focus outlines only for users who need them.

#### How should this be manually tested?
Go to the /podcasts page. Check that the page is still accessible through the keyboard using the Tab and Enter keys and focus outlines are displayed when the page is viewed in this way. Check that focus outlines are not displayed when the page is accessed using a mouse.  
