### PR TITLE
fix podcast etl

### DIFF
--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -1015,6 +1015,9 @@ def test_load_podcast(mock_upsert_tasks, podcast_exists, is_published):
     if podcast_exists:
         existing_podcast_episode.refresh_from_db()
         assert existing_podcast_episode.published is False
+        mock_upsert_tasks.delete_podcast_episode.assert_called_with(
+            existing_podcast_episode
+        )
 
     if podcast_exists and not is_published:
         mock_upsert_tasks.delete_podcast.assert_called_with(result)

--- a/course_catalog/etl/podcast.py
+++ b/course_catalog/etl/podcast.py
@@ -127,7 +127,7 @@ def transform_episode(rss_data, offered_by, topics, parent_image):
         dict:
             normalized podcast episode data
     """
-    episode_id = generate_unique_id(rss_data.enclosure["url"])
+    episode_id = generate_unique_id(rss_data.guid.text)
     return {
         "episode_id": episode_id,
         "title": rss_data.title.text,

--- a/course_catalog/etl/podcast_test.py
+++ b/course_catalog/etl/podcast_test.py
@@ -109,7 +109,7 @@ def test_transform(mocker, title, topics, offered_by):
             "topics": expected_topics,
             "episodes": [
                 {
-                    "episode_id": "fefc732682f83d1a8945eebcae5364b4",
+                    "episode_id": "0a19bfc1f30334389fc039e716d35306",
                     "title": "Episode1",
                     "offered_by": expected_offered_by,
                     "short_description": "SMorbi id consequat nisl. Morbi leo elit, vulputate nec aliquam molestie, ullamcorper sit amet tortor",
@@ -125,7 +125,7 @@ def test_transform(mocker, title, topics, offered_by):
                     "topics": expected_topics,
                 },
                 {
-                    "episode_id": "e56d3047fad337ca85b577c60ff6a8da",
+                    "episode_id": "85855fa506bf36999f8978302f3413ec",
                     "title": "Episode2",
                     "offered_by": expected_offered_by,
                     "short_description": "Praesent fermentum suscipit metus nec aliquam. Proin hendrerit felis ut varius facilisis.",

--- a/test_html/test_podcast.rss
+++ b/test_html/test_podcast.rss
@@ -27,7 +27,7 @@
     </image>
     <itunes:category text="Science"/>
     <item>
-      <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers</guid>
+      <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers1</guid>
       <title>Episode1</title>
       <pubDate>Wed, 01 Apr 2020 18:20:31 +0000</pubDate>
       <link>https://soundcloud.com/podcast/episode1</link>
@@ -40,7 +40,7 @@
       <enclosure type="audio/mpeg" url="http://feeds.soundcloud.com/stream/episode1.mp3" length="25437522"/>
     </item>
     <item>
-      <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers</guid>
+      <guid isPermaLink="false">tag:soundcloud,2010:tracks/numbers2</guid>
       <title>Episode2</title>
       <pubDate>Wed, 01 Apr 2020 18:20:31 +0000</pubDate>
       <link>https://soundcloud.com/podcast/episode2</link>


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3019

#### What's this PR do?
There is a bug in the loader so elasticsearch is not updated when an episode is marked as no longer published.  Also, we generate episode ids based on the url, which can change instead of the guid which is not supposed to change. This fixes both those issues.

#### How should this be manually tested?
Run `docker-compose run web ./manage.py backpopulate_podcast_data`. Verify that there are not duplicate episodes in /learn/search
