### PR TITLE
fix micromasters loader bug

### DIFF
--- a/course_catalog/etl/pipelines.py
+++ b/course_catalog/etl/pipelines.py
@@ -39,14 +39,12 @@ micromasters_etl = compose(
         PlatformType.micromasters.value,
         # MicroMasters courses overlap with MITx, so configure course and run level offerors to be additive
         config=ProgramLoaderConfig(
-            courses=[
-                CourseLoaderConfig(
-                    offered_by=OfferedByLoaderConfig(additive=True),
-                    runs=LearningResourceRunLoaderConfig(
-                        offered_by=OfferedByLoaderConfig(additive=True)
-                    ),
-                )
-            ]
+            courses=CourseLoaderConfig(
+                offered_by=OfferedByLoaderConfig(additive=True),
+                runs=LearningResourceRunLoaderConfig(
+                    offered_by=OfferedByLoaderConfig(additive=True)
+                ),
+            )
         ),
     ),
     micromasters.transform,

--- a/course_catalog/etl/pipelines_test.py
+++ b/course_catalog/etl/pipelines_test.py
@@ -50,14 +50,12 @@ def test_micromasters_etl():
         PlatformType.micromasters.value,
         mock_transform.return_value,
         config=ProgramLoaderConfig(
-            courses=[
-                CourseLoaderConfig(
-                    offered_by=OfferedByLoaderConfig(additive=True),
-                    runs=LearningResourceRunLoaderConfig(
-                        offered_by=OfferedByLoaderConfig(additive=True)
-                    ),
-                )
-            ]
+            courses=CourseLoaderConfig(
+                offered_by=OfferedByLoaderConfig(additive=True),
+                runs=LearningResourceRunLoaderConfig(
+                    offered_by=OfferedByLoaderConfig(additive=True)
+                ),
+            )
         ),
     )
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3028

#### What's this PR do?
ProgramLoaderConfig is set incorrectly for micromasters causing the update job to error. This fixes the issue.

#### How should this be manually tested?
`docker-compose run web ./manage.py backpopulate_micromasters_data` should run without throwing an error