### PR TITLE
fix isort version

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ codecov
 ddt
 django-debug-toolbar
 ipdb
-isort
+isort==4.3.21
 moto==1.3.13
 nplusone>=0.8.1
 pdbpp


### PR DESCRIPTION
#### What's this PR do?
Pins isort==4.3.21 in order to have the tests pass.

#### How should this be manually tested?
Build should not break.