### PR TITLE
add link to podcast page to LR drawer

### DIFF
--- a/static/js/components/ExpandedLearningResourceDisplay.js
+++ b/static/js/components/ExpandedLearningResourceDisplay.js
@@ -263,23 +263,25 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
               showExpansionControls
             />
           </div>
-          {object.object_type === LR_TYPE_PODCAST_EPISODE ? (
-            <div className="podcast-play-control">
-              <PodcastPlayButton episode={object} />
+          {isPodcastObject(object) ? (
+            <div className="podcast-detail-row">
+              {object.object_type === LR_TYPE_PODCAST_EPISODE ? (
+                <PodcastPlayButton episode={object} />
+              ) : null}
               <a
                 tabIndex="0"
-                className="link podcast-episode-detail-link"
+                className="link podcast-detail-link"
                 href={
-                  object.episode_link
-                    ? object.episode_link
-                    : episodePodcast
-                      ? episodePodcast.url
-                      : "#"
+                  object.object_type === LR_TYPE_PODCAST
+                    ? object.url ?? "#"
+                    : object.episode_link ?? episodePodcast?.url ?? "#"
                 }
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                View Episode Details
+                View{" "}
+                {object.object_type === LR_TYPE_PODCAST ? "Podcast" : "Episode"}{" "}
+                Details
               </a>
             </div>
           ) : null}

--- a/static/js/components/ExpandedLearningResourceDisplay_test.js
+++ b/static/js/components/ExpandedLearningResourceDisplay_test.js
@@ -180,24 +180,34 @@ describe("ExpandedLearningResourceDisplay", () => {
     assert.deepEqual(wrapper.find(PodcastPlayButton).prop("episode"), object)
   })
 
-  it("should render a view episode details button for podcast episode", async () => {
-    const object = makeLearningResource(LR_TYPE_PODCAST_EPISODE)
-    const { wrapper } = await render({}, { object })
-    assert.ok(
-      wrapper
-        .find(".podcast-play-control .podcast-episode-detail-link")
-        .exists()
-    )
+  //
+  ;[
+    [LR_TYPE_PODCAST_EPISODE, "View Episode Details"],
+    [LR_TYPE_PODCAST, "View Podcast Details"]
+  ].forEach(([lrType, expectedText]) => {
+    it(`should render a view episode details button for ${lrType}`, async () => {
+      const object = makeLearningResource(lrType)
+      const { wrapper } = await render({}, { object })
+      const link = wrapper.find(".podcast-detail-row .podcast-detail-link")
+      assert.equal(link.text(), expectedText)
+    })
   })
 
   it("should set the href property of the view episode details button to the podcast episode's episode_link property", async () => {
     const object = makeLearningResource(LR_TYPE_PODCAST_EPISODE)
     const { wrapper } = await render({}, { object })
     assert.equal(
-      wrapper
-        .find(".podcast-play-control .podcast-episode-detail-link")
-        .prop("href"),
+      wrapper.find(".podcast-detail-row .podcast-detail-link").prop("href"),
       object.episode_link
+    )
+  })
+
+  it("should set href for podcast to the podcasts URL", async () => {
+    const object = makeLearningResource(LR_TYPE_PODCAST)
+    const { wrapper } = await render({}, { object })
+    assert.equal(
+      wrapper.find(".podcast-detail-row .podcast-detail-link").prop("href"),
+      object.url
     )
   })
 

--- a/static/scss/learning-resource-drawer.scss
+++ b/static/scss/learning-resource-drawer.scss
@@ -47,11 +47,11 @@
     font-weight: bold;
   }
 
-  .podcast-play-control {
+  .podcast-detail-row {
     margin-top: 15px;
 
-    .link {
-      margin-left: 15px;
+    .podcast-play-button {
+      margin-right: 15px;
     }
   }
 

--- a/static/scss/podcasts.scss
+++ b/static/scss/podcasts.scss
@@ -305,7 +305,7 @@
   }
 }
 
-.podcast-play-control {
+.podcast-detail-row {
   display: flex;
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #2928

#### What's this PR do?

this just adds a link to the podcast home page to the LR drawer.

#### How should this be manually tested?

Open up a podcast and ensure that you get a link to the home page!

#### Screenshots (if appropriate)

![Screenshot from 2020-07-08 09-30-50](https://user-images.githubusercontent.com/6207644/86924747-e0dc1500-c0fd-11ea-8150-b29aa4e20233.png)
