### PR TITLE
[refactor] consolidate post voting

### DIFF
--- a/static/js/components/CompactPostDisplay.js
+++ b/static/js/components/CompactPostDisplay.js
@@ -36,7 +36,6 @@ import type { Post } from "../flow/discussionTypes"
 type OwnProps = {|
   post: Post,
   showChannelLink?: boolean,
-  toggleUpvote?: Post => void,
   togglePinPost?: ?(post: Post) => Promise<*>,
   showPinUI?: boolean,
   isModerator: boolean,
@@ -77,7 +76,6 @@ export class CompactPostDisplay extends React.Component<Props> {
     const {
       dispatch,
       post,
-      toggleUpvote,
       showPinUI,
       togglePinPost,
       isModerator,
@@ -93,7 +91,7 @@ export class CompactPostDisplay extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <PostUpvoteButton post={post} toggleUpvote={toggleUpvote} />
+        <PostUpvoteButton post={post} />
         <Link
           className="comment-link grey-surround"
           to={postDetailURL(post.channel_name, post.id, post.slug)}

--- a/static/js/components/CompactPostDisplay_test.js
+++ b/static/js/components/CompactPostDisplay_test.js
@@ -12,7 +12,6 @@ import Router from "../Router"
 import DropdownMenu from "./DropdownMenu"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { wait } from "../lib/util"
 import { channelURL, postDetailURL, urlHostname, profileURL } from "../lib/url"
 import {
   PostTitleAndHostname,
@@ -39,7 +38,6 @@ describe("CompactPostDisplay", () => {
 
   const renderPostDisplay = props => {
     props = {
-      toggleUpvote:    () => {},
       menuOpen:        false,
       isModerator:     false,
       reportPost:      helper.sandbox.stub(),
@@ -241,51 +239,6 @@ describe("CompactPostDisplay", () => {
     const { to } = detailLink.props()
     assert.equal(to, postDetailURL(post.channel_name, post.id, post.slug))
     assert.ok(detailLink.find(PostTitleAndHostname).exists())
-  })
-
-  const assertButton = (wrapper, isUpvote) => {
-    if (isUpvote) {
-      assert.include(
-        wrapper.find(".post-upvote-button").props().className,
-        "upvoted"
-      )
-    } else {
-      assert.notInclude(
-        wrapper.find(".post-upvote-button").props().className,
-        "upvoted"
-      )
-    }
-  }
-
-  //
-  ;[true, false].forEach(prevUpvote => {
-    it(`should show the correct UI when the upvote
-    button is clicked when prev state was ${String(prevUpvote)}`, async () => {
-      post.upvoted = prevUpvote
-      // setting to a function so Flow doesn't complain
-      let resolveUpvote = () => null
-      const toggleUpvote = helper.sandbox.stub().returns(
-        new Promise(resolve => {
-          resolveUpvote = resolve
-        })
-      )
-      const wrapper = renderPostDisplay({
-        post,
-        toggleUpvote
-      })
-      assertButton(wrapper, prevUpvote)
-      wrapper.find(".post-upvote-button").simulate("click")
-      assert.isOk(toggleUpvote.calledOnce)
-
-      assertButton(wrapper, !prevUpvote)
-      resolveUpvote()
-      post.upvoted = !prevUpvote
-      wrapper.setProps({ post })
-      // wait for promise resolve to trigger state changes
-      await wait(10)
-      wrapper.update()
-      assertButton(wrapper, !prevUpvote)
-    })
   })
 
   describe("Dropdown menu tests", () => {

--- a/static/js/components/ExpandedPostDisplay.js
+++ b/static/js/components/ExpandedPostDisplay.js
@@ -35,7 +35,6 @@ const COVER_IMAGE_DISPLAY_HEIGHT = 300
 
 type Props = {|
   post: Post,
-  toggleUpvote: Post => void,
   approvePost: Post => void,
   removePost: Post => void,
   forms: FormsState,
@@ -107,7 +106,6 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
 
   postActionButtons = () => {
     const {
-      toggleUpvote,
       toggleFollowPost,
       post,
       beginEditing,
@@ -123,7 +121,7 @@ export default class ExpandedPostDisplay extends React.Component<Props> {
     return (
       <div className="post-actions">
         <div className="left">
-          <PostUpvoteButton post={post} toggleUpvote={toggleUpvote} />
+          <PostUpvoteButton post={post} />
           <ReportCount count={post.num_reports} />
         </div>
         <div className="right">

--- a/static/js/components/ExpandedPostDisplay_test.js
+++ b/static/js/components/ExpandedPostDisplay_test.js
@@ -15,7 +15,6 @@ import FollowButton from "./FollowButton"
 import ProfileImage from "./ProfileImage"
 import ShareTooltip from "./ShareTooltip"
 
-import { wait } from "../lib/util"
 import {
   postPermalink,
   postDetailURL,
@@ -43,7 +42,6 @@ describe("ExpandedPostDisplay", () => {
     toggleFollowPostStub
 
   const postProps = (props = {}) => ({
-    toggleUpvote: () => {},
     beginEditing: R.curry((key, post, e) => {
       beginEditingStub(key, post, e)
     }),
@@ -297,51 +295,6 @@ describe("ExpandedPostDisplay", () => {
       forms: helper.store.getState().forms
     })
     assert.lengthOf(wrapper.find(".post-actions"), 0)
-  })
-
-  const assertButton = (wrapper, isUpvote) => {
-    if (isUpvote) {
-      assert.include(
-        wrapper.find(".post-upvote-button").props().className,
-        "upvoted"
-      )
-    } else {
-      assert.notInclude(
-        wrapper.find(".post-upvote-button").props().className,
-        "upvoted"
-      )
-    }
-  }
-
-  //
-  ;[true, false].forEach(prevUpvote => {
-    it(`should show the correct UI when the upvote
-    button is clicked when prev state was ${String(prevUpvote)}`, async () => {
-      post.upvoted = prevUpvote
-      // setting to a function so Flow doesn't complain
-      let resolveUpvote = () => null
-      const toggleUpvote = helper.sandbox.stub().returns(
-        new Promise(resolve => {
-          resolveUpvote = resolve
-        })
-      )
-      const wrapper = renderPostDisplay({
-        post:         post,
-        toggleUpvote: toggleUpvote
-      })
-      assertButton(wrapper, prevUpvote)
-      wrapper.find(".post-upvote-button").simulate("click")
-      assert.isOk(toggleUpvote.calledOnce)
-
-      assertButton(wrapper, !prevUpvote)
-      resolveUpvote()
-      post.upvoted = !prevUpvote
-      wrapper.setProps({ post })
-      // wait for promise resolve to trigger state changes
-      await wait(10)
-      wrapper.update()
-      assertButton(wrapper, !prevUpvote)
-    })
   })
 
   //

--- a/static/js/components/PostList.js
+++ b/static/js/components/PostList.js
@@ -9,7 +9,6 @@ type Props = {
   posts: Array<Post>,
   showChannelLinks: boolean,
   showPinUI: boolean,
-  toggleUpvote: Post => void,
   togglePinPost?: ?(post: Post) => Promise<*>,
   isModerator: boolean,
   reportPost?: ?(post: Post) => void,
@@ -22,7 +21,6 @@ const PostList = ({
   showChannelLinks,
   showPinUI,
   isModerator,
-  toggleUpvote,
   togglePinPost,
   reportPost,
   removePost,
@@ -35,7 +33,6 @@ const PostList = ({
           post={post}
           key={index}
           showChannelLink={showChannelLinks}
-          toggleUpvote={toggleUpvote}
           showPinUI={showPinUI}
           isModerator={isModerator}
           togglePinPost={togglePinPost}

--- a/static/js/components/PostList_test.js
+++ b/static/js/components/PostList_test.js
@@ -13,9 +13,8 @@ describe("PostList", () => {
 
   beforeEach(() => {
     renderPostList = configureShallowRenderer(PostList, {
-      reportPost:   sinon.stub(),
-      toggleUpvote: sinon.stub(),
-      posts:        makeChannelPostList()
+      reportPost: sinon.stub(),
+      posts:      makeChannelPostList()
     })
   })
 

--- a/static/js/components/PostUpvoteButton.js
+++ b/static/js/components/PostUpvoteButton.js
@@ -1,57 +1,50 @@
 // @flow
-import React from "react"
+import React, { useCallback, useState } from "react"
+import { useDispatch } from "react-redux"
 
 import LoginTooltip from "./LoginTooltip"
+
 import { userIsAnonymous } from "../lib/util"
+import { actions } from "../actions"
+import { setPostData } from "../actions/post"
 
 import type { Post } from "../flow/discussionTypes"
 
 type Props = {
-  post: Post,
-  toggleUpvote?: Function
+  post: Post
 }
 
-type State = {
-  upvoting: boolean
-}
+export default function PostUpvoteButton(props: Props) {
+  const { post } = props
+  const [upvoting, setUpvoting] = useState(false)
 
-export default class PostUpvoteButton extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      upvoting: false
-    }
-  }
+  const upvoted = post.upvoted !== upvoting
+  const upvoteClass = upvoted ? "upvoted" : ""
 
-  onToggleUpvote = async () => {
-    const { toggleUpvote, post } = this.props
-    if (toggleUpvote) {
-      this.setState({
-        upvoting: true
-      })
-      await toggleUpvote(post)
-      this.setState({
-        upvoting: false
-      })
-    }
-  }
+  const dispatch = useDispatch()
 
-  render() {
-    const { post } = this.props
-    const { upvoting } = this.state
-    const upvoted = post.upvoted !== upvoting
-    const upvoteClass = upvoted ? "upvoted" : ""
+  const toggleUpvote = useCallback(
+    async e => {
+      e.preventDefault()
+      setUpvoting(true)
+      const result = await dispatch(
+        actions.postUpvotes.patch(post.id, !post.upvoted)
+      )
+      dispatch(setPostData(result))
+      setUpvoting(false)
+    },
+    [dispatch, post]
+  )
 
-    return (
-      <LoginTooltip>
-        <div
-          className={`post-upvote-button ${upvoteClass} grey-surround`}
-          onClick={upvoting || userIsAnonymous() ? null : this.onToggleUpvote}
-        >
-          <i className="material-icons arrow_upward">arrow_upward</i>
-          <span className="votes">{post.score}</span>
-        </div>
-      </LoginTooltip>
-    )
-  }
+  return (
+    <LoginTooltip>
+      <div
+        className={`post-upvote-button ${upvoteClass} grey-surround`}
+        onClick={upvoting || userIsAnonymous() ? null : toggleUpvote}
+      >
+        <i className="material-icons arrow_upward">arrow_upward</i>
+        <span className="votes">{post.score}</span>
+      </div>
+    </LoginTooltip>
+  )
 }

--- a/static/js/components/PostUpvoteButton_test.js
+++ b/static/js/components/PostUpvoteButton_test.js
@@ -1,50 +1,58 @@
 // @flow
 import { assert } from "chai"
-import sinon from "sinon"
 
 import LoginTooltip from "../components/LoginTooltip"
 import PostUpvoteButton from "./PostUpvoteButton"
 
 import { makePost } from "../factories/posts"
-import { configureShallowRenderer } from "../lib/test_utils"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("PostUpvoteButton", () => {
-  let sandbox, renderButton, upvoteStub, post
+  let render, post, helper, resolveRequest
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    upvoteStub = sandbox.stub()
     post = makePost()
-    renderButton = configureShallowRenderer(PostUpvoteButton, {
-      toggleUpvote: upvoteStub,
+    helper = new IntegrationTestHelper()
+    helper.updateUpvoteStub.resetBehavior()
+    helper.updateUpvoteStub.callsFake(
+      () =>
+        new Promise(resolve => {
+          resolveRequest = post => {
+            resolve(post)
+          }
+        })
+    )
+    render = helper.configureReduxQueryRenderer(PostUpvoteButton, {
       post
     })
   })
 
   afterEach(() => {
-    sandbox.restore()
+    helper.cleanup()
   })
 
-  it("should be wrapped with LoginTooltip", () => {
-    assert.ok(
-      renderButton()
-        .find(LoginTooltip)
-        .exists()
-    )
+  it("should be wrapped with LoginTooltip", async () => {
+    const { wrapper } = await render()
+    assert.ok(wrapper.find(LoginTooltip).exists())
   })
 
-  it("should set upvoting in this.state while upvote is in progress", async () => {
-    let resolver: Function
-    const prommo = new Promise(resolve => {
-      resolver = resolve
+  //
+  ;[true, false].forEach(value => {
+    it(`should set upvoting, and toggle when upvoted:${value.toString()}`, async () => {
+      post.upvoted = value
+      const { wrapper } = await render()
+      assert.isNotNull(wrapper.find(".post-upvote-button").prop("onClick"))
+      wrapper.find(".post-upvote-button").simulate("click")
+      assert.isNull(wrapper.find(".post-upvote-button").prop("onClick"))
+      assert.isOk(helper.updateUpvoteStub.calledWith(post.id, !value))
+      await resolveRequest(post)
+      assert.isNull(wrapper.find(".post-upvote-button").prop("onClick"))
     })
-    upvoteStub.returns(prommo)
-    const wrapper = renderButton()
-    assert.isFalse(wrapper.state().upvoting)
-    wrapper.instance().onToggleUpvote()
-    assert.isTrue(wrapper.state().upvoting)
-    // $FlowFixMe: flow thinks this isn't a function
-    await resolver()
-    assert.isFalse(wrapper.state().upvoting)
+  })
+
+  it("should show upvote count", async () => {
+    post.score = 1234
+    const { wrapper } = await render()
+    assert.equal(wrapper.find(".votes").text(), "1234")
   })
 })

--- a/static/js/components/ProfileContributionFeed.js
+++ b/static/js/components/ProfileContributionFeed.js
@@ -13,7 +13,6 @@ import CompactPostDisplay from "../components/CompactPostDisplay"
 import Comment from "../components/Comment"
 
 import { actions } from "../actions"
-import { toggleUpvote } from "../util/api_actions"
 import { POSTS_SORT_NEW } from "../lib/picker"
 import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
 import { commentPermalink } from "../lib/url"
@@ -134,7 +133,7 @@ class ProfileContributionFeed extends React.Component<Props, State> {
   }
 
   renderContributionList = () => {
-    const { dispatch, upvotedPosts, selectedTab } = this.props
+    const { upvotedPosts, selectedTab } = this.props
     const { votedComments } = this.state
 
     if (selectedTab === POSTS_OBJECT_TYPE) {
@@ -155,7 +154,6 @@ class ProfileContributionFeed extends React.Component<Props, State> {
               post={post}
               isModerator={false}
               menuOpen={false}
-              toggleUpvote={toggleUpvote(dispatch)}
               useSearchPageUI
             />
           ))}

--- a/static/js/components/ProfileContributionFeed_test.js
+++ b/static/js/components/ProfileContributionFeed_test.js
@@ -11,7 +11,6 @@ import { makeProfile } from "../factories/profiles"
 import { makeChannelPostList } from "../factories/posts"
 import { makeCommentsList } from "../factories/comments"
 import { actions } from "../actions"
-import * as apiActions from "../util/api_actions"
 import { POSTS_OBJECT_TYPE, COMMENTS_OBJECT_TYPE } from "../lib/constants"
 
 import ProfileContributionFeed from "./ProfileContributionFeed"
@@ -96,17 +95,6 @@ describe("ProfileContributionFeed", function() {
       sinon.assert.calledOnce(helper[expStubCalled])
       assert.isTrue(wrapper.find(expFeedComponent).exists())
     })
-  })
-
-  it("should handle post voting", async () => {
-    const fakeUpvoteHandler = sinon.fake()
-    helper.sandbox.stub(apiActions, "toggleUpvote").returns(fakeUpvoteHandler)
-
-    const wrapper = await renderFeed()
-
-    const firstPost = wrapper.find("CompactPostDisplay").at(0)
-    firstPost.prop("toggleUpvote")()
-    sinon.assert.calledOnce(fakeUpvoteHandler)
   })
 
   //

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -26,16 +26,14 @@ import type {
 import type { CommentInTree, Post } from "../flow/discussionTypes"
 
 type PostProps = {
-  post: Post,
-  toggleUpvote?: Function
+  post: Post
 }
-const PostSearchResult = ({ post, toggleUpvote }: PostProps) => (
+const PostSearchResult = ({ post }: PostProps) => (
   <CompactPostDisplay
     post={post}
     isModerator={false}
     menuOpen={false}
     useSearchPageUI
-    toggleUpvote={toggleUpvote}
   />
 )
 
@@ -113,7 +111,6 @@ type Props = {
   commentUpvote?: Function,
   commentDownvote?: Function,
   result: Result,
-  toggleUpvote?: Post => void,
   upvotedPost?: ?Post,
   votedComment?: ?CommentInTree,
   setShowResourceDrawer?: ({
@@ -128,7 +125,6 @@ export default class SearchResult extends React.Component<Props> {
   render() {
     const {
       result,
-      toggleUpvote,
       upvotedPost,
       votedComment,
       commentUpvote,
@@ -140,7 +136,7 @@ export default class SearchResult extends React.Component<Props> {
     if (result.object_type === "post") {
       // $FlowFixMe: This will always be a PostResult
       const post = upvotedPost || searchResultToPost(result)
-      return <PostSearchResult post={post} toggleUpvote={toggleUpvote} />
+      return <PostSearchResult post={post} />
     } else if (result.object_type === "comment") {
       // $FlowFixMe: This will always be a Comment result
       let comment = searchResultToComment(result)

--- a/static/js/hoc/withPostList.js
+++ b/static/js/hoc/withPostList.js
@@ -6,7 +6,6 @@ import InfiniteScroll from "react-infinite-scroller"
 import { Loading } from "../components/Loading"
 import PostList from "../components/PostList"
 
-import { toggleUpvote } from "../util/api_actions"
 import { actions } from "../actions"
 import { evictPostsForChannel } from "../actions/posts_for_channel"
 
@@ -24,7 +23,6 @@ type Props = {
   reportPost: (p: Post) => void,
   removePost: (p: Post) => void,
   deletePost: (p: Post) => void,
-  toggleUpvote: (post: Post) => Promise<*>,
   dispatch: Dispatch<any>,
   showChannelLinks: boolean,
   showReportPost: boolean,
@@ -77,7 +75,6 @@ const withPostList = (WrappedComponent: Class<React.Component<*, *>>) => {
 
     renderPosts = () => {
       const {
-        dispatch,
         pagination,
         posts,
         isModerator,
@@ -99,7 +96,6 @@ const withPostList = (WrappedComponent: Class<React.Component<*, *>>) => {
       let postList = (
         <PostList
           posts={posts}
-          toggleUpvote={toggleUpvote(dispatch)}
           isModerator={isModerator}
           togglePinPost={showTogglePinPost ? this.togglePinPost : null}
           reportPost={showReportPost ? reportPost : null}

--- a/static/js/hoc/withPostList_test.js
+++ b/static/js/hoc/withPostList_test.js
@@ -12,7 +12,6 @@ import {
   makePost
 } from "../factories/posts"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import * as apiActions from "../util/api_actions"
 import { actions } from "../actions"
 import { EVICT_POSTS_FOR_CHANNEL } from "../actions/posts_for_channel"
 
@@ -137,21 +136,6 @@ describe("withPostList", () => {
         const props = inner.find("PostList").props()
 
         assert.deepEqual(props.posts, postList)
-      })
-
-      it("toggles an upvote", async () => {
-        const post = makePost()
-        const innerStub = helper.sandbox.stub()
-        const stub = helper.sandbox.stub(apiActions, "toggleUpvote")
-        stub.get(() =>
-          R.curry(async (dispatch, post) => innerStub(dispatch, post))
-        )
-        const { inner } = await render()
-        const props = inner.find("PostList").props()
-        await props.toggleUpvote(post)
-
-        assert.equal(innerStub.callCount, 1)
-        assert.equal(innerStub.firstCall.args[1], post)
       })
       ;[
         ["reportPost", "showReportPost", true],

--- a/static/js/pages/PostPage.js
+++ b/static/js/pages/PostPage.js
@@ -31,7 +31,7 @@ import {
 import { actions } from "../actions"
 import { clearCommentError, replaceMoreComments } from "../actions/comment"
 import { setSnackbarMessage, showDialog, hideDialog } from "../actions/ui"
-import { toggleUpvote, toggleFollowPost } from "../util/api_actions"
+import { toggleFollowPost } from "../util/api_actions"
 import { getPostID, getCommentID, truncate } from "../lib/util"
 import {
   anyErrorExcept404,
@@ -293,7 +293,6 @@ export class PostPage extends React.Component<PostPageProps> {
             <ExpandedPostDisplay
               post={post}
               isModerator={isModerator}
-              toggleUpvote={toggleUpvote(dispatch)}
               approvePost={approvePost.bind(this)}
               removePost={removePost.bind(this)}
               forms={forms}

--- a/static/js/pages/SearchPage.js
+++ b/static/js/pages/SearchPage.js
@@ -18,7 +18,6 @@ import { actions } from "../actions"
 import { clearSearch } from "../actions/search"
 import { SEARCH_FILTER_ALL, updateSearchFilterParam } from "../lib/picker"
 import { preventDefaultAndInvoke, emptyOrNil } from "../lib/util"
-import { toggleUpvote } from "../util/api_actions"
 import { validateSearchQuery } from "../lib/validation"
 
 import type { Location, Match } from "react-router"
@@ -53,7 +52,6 @@ type Props = {
   suggest: Array<string>,
   total: number,
   clearSearch: () => void,
-  toggleUpvote: () => void,
   upvotedPosts: Map<string, Post>
 }
 
@@ -167,7 +165,6 @@ export class SearchPage extends React.Component<Props, State> {
       initialLoad,
       suggest,
       total,
-      toggleUpvote,
       upvotedPosts
     } = this.props
     const { from, votedComments } = this.state
@@ -214,7 +211,6 @@ export class SearchPage extends React.Component<Props, State> {
             <SearchResult
               key={i}
               result={result}
-              toggleUpvote={toggleUpvote}
               upvotedPost={
                 result.object_type === "post"
                   ? upvotedPosts.get(result.post_id)
@@ -346,7 +342,6 @@ const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
     dispatch(actions.search.clear())
     await dispatch(clearSearch())
   },
-  toggleUpvote: toggleUpvote(dispatch),
   dispatch
 })
 

--- a/static/js/util/api_actions.js
+++ b/static/js/util/api_actions.js
@@ -8,15 +8,6 @@ import { setSnackbarMessage } from "../actions/ui"
 import type { Post, CommentInTree } from "../flow/discussionTypes"
 import type { Dispatch } from "redux"
 
-export const toggleUpvote = R.curry(
-  async (dispatch: Dispatch<*>, post: Post) => {
-    const result = await dispatch(
-      actions.postUpvotes.patch(post.id, !post.upvoted)
-    )
-    return dispatch(setPostData(result))
-  }
-)
-
 export const approvePost = R.curry(
   async (dispatch: Dispatch<*>, post: Post) => {
     const result = await dispatch(actions.postRemoved.patch(post.id, false))

--- a/static/js/util/api_actions_test.js
+++ b/static/js/util/api_actions_test.js
@@ -6,7 +6,6 @@ import { actions } from "../actions"
 import { SET_POST_DATA } from "../actions/post"
 import { SET_SNACKBAR_MESSAGE } from "../actions/ui"
 import {
-  toggleUpvote,
   approvePost,
   removePost,
   approveComment,
@@ -30,25 +29,6 @@ describe("api_actions util", () => {
 
   afterEach(() => {
     helper.cleanup()
-  })
-
-  describe("toggleUpvote", () => {
-    beforeEach(() => {
-      helper.updateUpvoteStub.returns(Promise.resolve(makePost))
-    })
-
-    for (const value of [true, false]) {
-      it(`should set invert the upvoted value for upvoted:${value.toString()}`, async () => {
-        const { requestType, successType } = actions.postUpvotes.patch
-        const post = makePost()
-        post.upvoted = value
-        await helper.listenForActions([requestType, successType], () => {
-          toggleUpvote(helper.store.dispatch, post)
-        })
-
-        assert.isOk(helper.updateUpvoteStub.calledWith(post.id, !value))
-      })
-    }
   })
 
   describe("toggleFollowPost", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

the way we do post voting is sort of a mess right now. We have one component called a `PostUpvoteButton` which has responsibility for _rendering_ the button, but responsibility for declaring the callbacks is external to it. So anywhere we're display a post we have to pass a `toggleUpvote` function in to `ExpandedPostDisplay` and `CompactPostDisplay` so that they can then pass that down to the `PostUpvoteButton`. Because we show posts in a variety of places (home page, channel page, post page, profile contribution feed, search results...) this is wicked messy and leads to needlessly passing callbacks down the component tree.

So I refactored `PostUpvoteButton` so that it manages its own callback without external dependencies. This means that all it needs as a prop is a `Post` - simplifying it's API and removing the need to create specific functions to pass in to it.

Lets us delete a fair bit of boilerplate type code and remove several redundant tests (well, tests that were testing the same thing but necessary because we were implementing the same thing in a bunch of places).

#### How should this be manually tested?

check that you can vote everywhere on posts, both your own and someone elses. check on:

- post page
- home page
- channel page
- moderation page
- search results
- profile contribution feed

it should work everywhere. there should be a `LoginTooltip` that works too. Behavior should be identical to on master.