### PR TITLE
fix issue where 'footer' in nav drawer was covered by audio player

### DIFF
--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -48,10 +48,24 @@ $drawer-trans: width 500ms;
   }
 }
 
+$nav-min-height: calc(100vh - #{$toolbar-height-desktop} - #{$footer-height});
+
+.audio-player-padding-bottom {
+  .mdc-drawer__content .navigation {
+    @include breakpoint(desktop) {
+      min-height: calc(#{$nav-min-height} - #{$audio-player-height-desktop});
+    }
+
+    @include breakpoint(mobile) {
+      min-height: calc(#{$nav-min-height} - #{$audio-player-height-mobile});
+    }
+  }
+}
+
 .mdc-drawer__content .navigation {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - #{$toolbar-height-desktop} - #{$footer-height});
+  min-height: $nav-min-height;
 
   .title {
     margin-left: $text-padding-left;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #3049

#### What's this PR do?

this basically changes the `min-height` property set on the `.navigation` div in the drawer. we set this in order to force the footer to be down at the bottom of the page, but the way we were doing it doesn't account for the height of the audio player. I changed it around so that we're subtracting the audio player height from that `min-height` value when the audio player is open.

#### How should this be manually tested?

Go to `/podcasts` or the course search to start playing a podcast, then navigate to the home page by clicking the 'MIT Open' text in the top bar. You should not see the 'before' state shown in the screenshot below.

#### Screenshots (if appropriate)

before:

![Screenshot from 2020-07-14 14-41-57](https://user-images.githubusercontent.com/6207644/87463904-2efe8600-c5e0-11ea-9e41-51a12561e265.png)


after:

![Screenshot from 2020-07-14 14-41-16](https://user-images.githubusercontent.com/6207644/87463875-260db480-c5e0-11ea-98dc-0480465ae79b.png)
