### PR TITLE
fix a few issues with comment voting

### DIFF
--- a/static/js/pages/PostPage.js
+++ b/static/js/pages/PostPage.js
@@ -35,7 +35,7 @@ import { toggleFollowPost } from "../util/api_actions"
 import { getPostID, getCommentID, truncate } from "../lib/util"
 import {
   anyErrorExcept404,
-  anyErrorExcept404or410,
+  anyErrorExcept404or410or500,
   any404Error,
   anyNotAuthorizedErrorType
 } from "../util/rest"
@@ -384,7 +384,7 @@ const mapStateToProps = (state, ownProps) => {
     isModerator: channel?.user_is_moderator ?? false, // eslint-disable-line camelcase
     errored:
       anyErrorExcept404([posts, channels]) ||
-      anyErrorExcept404or410([comments]),
+      anyErrorExcept404or410or500([comments]),
     subscribedChannels:         getSubscribedChannels(state),
     commentInFlight:            comments.processing,
     postDeleteDialogVisible:    ui.dialogs.has(DELETE_POST_DIALOG),

--- a/static/js/reducers/comments.js
+++ b/static/js/reducers/comments.js
@@ -22,6 +22,8 @@ import type {
   ReplaceMoreCommentsPayload
 } from "../flow/discussionTypes"
 
+export const ORPHAN_COMMENTS_KEY = "orphans"
+
 /**
  * Remove the more_comments instance at the level of the parentId
  */
@@ -209,7 +211,7 @@ type DeleteCommentPayload = {
   postId: string
 }
 
-type CommentData = Map<string, Array<GenericComment>>
+type CommentData = Map<string, Object>
 
 export const commentsEndpoint = {
   name:    "comments",
@@ -285,6 +287,15 @@ export const commentsEndpoint = {
     const oldTree = data.get(postId)
     if (oldTree) {
       update.set(postId, updateCommentTree(oldTree, response))
+    } else {
+      // comments may be upvoted on the profile contributed feed, but
+      // there will not be a comment tree to insert them into. so instead
+      // we put them in a different object where they can be accessed by id
+      const orphanComments = data.get(ORPHAN_COMMENTS_KEY) ?? {}
+      update.set(ORPHAN_COMMENTS_KEY, {
+        ...orphanComments,
+        [response.id]: response
+      })
     }
     return update
   },

--- a/static/js/util/rest.js
+++ b/static/js/util/rest.js
@@ -37,6 +37,7 @@ const anySpecificError = code =>
 export const any404Error = anySpecificError(404)
 export const anyErrorExcept404 = anyErrorExcept([404])
 export const anyErrorExcept404or410 = anyErrorExcept([404, 410])
+export const anyErrorExcept404or410or500 = anyErrorExcept([404, 410, 500])
 
 // 401/403 status codes are unreliable for detecting authentication errors.
 // Our auth endpoints return an error type in the response, and these values


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #221 (from 2017!)
partially addresses #748

#### What's this PR do?

this PR fixes a few issues with comment voting. namely:

- now instead of failing and blowing up the UI (see #748) when a comment vote fails 
- I also fixed the optimistic update behavior for the comment vote to immediately reflect what the score on the comment will be *after* the user's vote is applied.

#### How should this be manually tested?

if you have a comment on your local reddit that is older than 6 months you can use that to test this, else you can apply the following patch:

```patch
diff --git a/channels/views/comments.py b/channels/views/comments.py
index be8e5af0..d1fbfe43 100644
--- a/channels/views/comments.py
+++ b/channels/views/comments.py
@@ -209,6 +209,7 @@ class CommentDetailView(APIView):
 
     def patch(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Update a comment"""
+        return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         with translate_praw_exceptions(request.user):
             comment = self.get_object()
             subscriptions = lookup_subscriptions_for_comments(
```

then try upvoting and downvoting comments to try out the new user experience.

also play around with upvoting and downvoting various comments *without* the 500 error to make sure the optimistic score update works as it should.

also try upvoting and downvoting comments on the profile page, that should work as expected.

#### Screenshots (if appropriate)

this is what used to happen when a comment vote failed:

![Screenshot from 2020-07-16 12-32-49](https://user-images.githubusercontent.com/6207644/87697743-7e6bc000-c760-11ea-92b3-166e1588a55f.png)

this is what happens now:

![Screenshot from 2020-07-16 12-33-47](https://user-images.githubusercontent.com/6207644/87697813-9c392500-c760-11ea-8869-4cd887394eef.png)

so the user at least doesn't see a total error state.