### PR TITLE
make learn pages tababble

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react-scrollbar": "^0.5.4",
     "react-select": "^3.0.8",
     "react-share": "^2.2.0",
-    "react-sortable-hoc": "^0.8.4",
+    "react-sortable-hoc": "^1.11.0",
     "react-test-renderer": "^16.4.0",
     "redux": "^4.0.4",
     "redux-actions": "^2.6.5",

--- a/static/js/components/AddToListDialog.js
+++ b/static/js/components/AddToListDialog.js
@@ -166,6 +166,12 @@ export default function AddToListDialog() {
           <button
             className="create-new-list blue-btn"
             onClick={() => setShowUserListFormDialog(true)}
+            onKeyPress={e => {
+              if (e.key === "Enter") {
+                setShowUserListFormDialog(true)
+              }
+            }}
+            tabIndex="0"
           >
             Create New List
           </button>

--- a/static/js/components/CourseSearchbox.js
+++ b/static/js/components/CourseSearchbox.js
@@ -14,15 +14,7 @@ type Props = {
 }
 
 export default function CourseSearchbox(props: Props) {
-  const {
-    autoFocus,
-    children,
-    onChange,
-    onClear,
-    onSubmit,
-    validation,
-    value
-  } = props
+  const { children, onChange, onClear, onSubmit, validation, value } = props
 
   const [text, setText] = useState("")
 
@@ -30,7 +22,6 @@ export default function CourseSearchbox(props: Props) {
     <div className="course-searchbox">
       <div className="input-wrapper">
         <input
-          autoFocus={autoFocus}
           type="text"
           name="query"
           className="search-input"
@@ -54,7 +45,16 @@ export default function CourseSearchbox(props: Props) {
           search
         </i>
         {value ? (
-          <i className="material-icons clear-icon" onClick={onClear}>
+          <i
+            className="material-icons clear-icon"
+            onClick={onClear}
+            onKeyPress={e => {
+              if (e.key === "Enter" && onClear) {
+                onClear()
+              }
+            }}
+            tabIndex="0"
+          >
             clear
           </i>
         ) : null}

--- a/static/js/components/CourseSearchbox_test.js
+++ b/static/js/components/CourseSearchbox_test.js
@@ -57,16 +57,6 @@ describe("CourseSearchbox", () => {
     sinon.assert.called(onSubmitStub)
   })
 
-  //
-  ;[true, false].forEach(autoFocus => {
-    it(`should pass down autoFocus of ${String(
-      autoFocus
-    )} to the input`, () => {
-      const wrapper = renderSearchbox({ autoFocus })
-      assert.equal(autoFocus, wrapper.find("input").prop("autoFocus"))
-    })
-  })
-
   it("should have a little icon", () => {
     renderSearchbox()
       .find(".search-icon")

--- a/static/js/components/Dialog.js
+++ b/static/js/components/Dialog.js
@@ -34,7 +34,16 @@ export default function OurDialog(props: Props) {
     <Dialog open={open} onClose={hideDialog} id={id} className={className}>
       <DialogTitle>
         <span>{title}</span>
-        <i onClick={hideDialog} className="material-icons close">
+        <i
+          onClick={hideDialog}
+          onKeyPress={e => {
+            if (e.key === "Enter") {
+              hideDialog()
+            }
+          }}
+          className="material-icons close"
+          tabIndex="0"
+        >
           close
         </i>
       </DialogTitle>

--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -52,7 +52,8 @@ type CellProps = {
   children?: any,
   width: CellWidth,
   mobileWidth?: CellWidth,
-  className?: string
+  className?: string,
+  tabIndex?: string
 }
 
 const cellClassName = (width, className) =>
@@ -62,7 +63,8 @@ export const Cell = ({
   children,
   width,
   mobileWidth,
-  className
+  className,
+  tabIndex
 }: CellProps) => {
   useResponsive()
 
@@ -72,6 +74,7 @@ export const Cell = ({
         mobileWidth && isMobileGridWidth() ? mobileWidth : width,
         className
       )}
+      tabIndex={tabIndex || "-1"}
     >
       {children}
     </div>

--- a/static/js/components/LearningResourceCard.js
+++ b/static/js/components/LearningResourceCard.js
@@ -233,6 +233,14 @@ export function LearningResourceDisplay(props: Props) {
                       showListDialog(object)
                     }
                   }}
+                  onKeyPress={e => {
+                    if (e.key === "Enter") {
+                      if (!userIsAnonymous()) {
+                        showListDialog(object)
+                      }
+                    }
+                  }}
+                  tabIndex="0"
                 >
                   <i className={`material-icons ${bookmarkIconName}`}>
                     {bookmarkIconName}

--- a/static/js/components/UserListFormDialog.js
+++ b/static/js/components/UserListFormDialog.js
@@ -98,6 +98,7 @@ export default function UserListFormDialog(props: Props) {
                   id="type-list"
                   type="radio"
                   value={LR_TYPE_USERLIST}
+                  tabIndex="0"
                 />
                 <label htmlFor="type-list">
                   <span className="header">Learning List</span>
@@ -110,6 +111,7 @@ export default function UserListFormDialog(props: Props) {
                   type="radio"
                   id="type-lp"
                   value={LR_TYPE_LEARNINGPATH}
+                  tabIndex="0"
                 />
                 <label htmlFor="type-lp">
                   <span className="header">Learning Path</span>
@@ -128,6 +130,7 @@ export default function UserListFormDialog(props: Props) {
                       id="radio-public"
                       type="radio"
                       value={LR_PUBLIC}
+                      tabIndex="0"
                     />
                     <label htmlFor="radio-public">
                       <span className="header">Public</span>
@@ -139,6 +142,7 @@ export default function UserListFormDialog(props: Props) {
                       type="radio"
                       id="radio-private"
                       value={LR_PRIVATE}
+                      tabIndex="0"
                     />
                     <label htmlFor="radio-private">
                       <span className="header">Private</span>

--- a/static/js/components/UserListItems.js
+++ b/static/js/components/UserListItems.js
@@ -70,7 +70,7 @@ const SortItems = ({ userListId, items, className }: ItemsProps) => {
       <Grid className={isPending ? `${className} saving` : className}>
         {items.map((item, i) => (
           <SortableItem key={`item-${item.item.item_id}`} index={i}>
-            <Cell width={12}>
+            <Cell width={12} tabIndex="0">
               <LearningResourceCard
                 object={item.resource}
                 searchResultLayout={SEARCH_LIST_UI}

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -73,7 +73,16 @@ const UserMenu = ({ toggleShowUserMenu, showUserMenu, profile }: Props) => {
 
   return (
     <div className="user-menu">
-      <div className="user-menu-clickarea" onClick={toggleShowUserMenu}>
+      <div
+        className="user-menu-clickarea"
+        onClick={toggleShowUserMenu}
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            toggleShowUserMenu()
+          }
+        }}
+        tabIndex="0"
+      >
         <ProfileImage
           editable={false}
           userName={SETTINGS.username}

--- a/static/js/components/search/CourseFilterDrawer.js
+++ b/static/js/components/search/CourseFilterDrawer.js
@@ -46,7 +46,16 @@ export function FilterDisplay(props: FilterDrawerProps) {
         <div className="active-search-filters">
           <div className="filter-section-title">
             Filters
-            <span className="clear-all-filters" onClick={clearAllFilters}>
+            <span
+              className="clear-all-filters"
+              onClick={clearAllFilters}
+              onKeyPress={e => {
+                if (e.key === "Enter") {
+                  clearAllFilters()
+                }
+              }}
+              tabIndex="0"
+            >
               Clear All
             </span>
           </div>

--- a/static/js/components/search/FilterableSearchFacet.js
+++ b/static/js/components/search/FilterableSearchFacet.js
@@ -110,6 +110,12 @@ function FilterableSearchFacet(props: Props) {
               <i
                 className="material-icons clear-icon"
                 onClick={() => setFilterText("")}
+                onKeyPress={e => {
+                  if (e.key === "Enter") {
+                    setFilterText("")
+                  }
+                }}
+                tabIndex="0"
               >
                 clear
               </i>

--- a/static/js/components/search/SearchFacetItem.js
+++ b/static/js/components/search/SearchFacetItem.js
@@ -13,6 +13,17 @@ type Props = {
 
 const featuredFacetNames = ["audience", "certification"]
 
+function updateFacetCheckbox(props: Props) {
+  const { facet, isChecked, name, onUpdate } = props
+  onUpdate({
+    target: {
+      name,
+      value:   facet.key,
+      checked: !isChecked
+    }
+  })
+}
+
 export default function SearchFacetItem(props: Props) {
   const { facet, isChecked, onUpdate, labelFunction, name } = props
 
@@ -21,14 +32,11 @@ export default function SearchFacetItem(props: Props) {
   return (
     <div
       className={isChecked ? "facet-visible checked" : "facet-visible"}
-      onClick={() => {
-        onUpdate({
-          target: {
-            name,
-            value:   facet.key,
-            checked: !isChecked
-          }
-        })
+      onClick={() => updateFacetCheckbox(props)}
+      onKeyPress={e => {
+        if (e.key === "Space") {
+          updateFacetCheckbox(props)
+        }
       }}
     >
       <input

--- a/static/js/components/search/SearchFilter.js
+++ b/static/js/components/search/SearchFilter.js
@@ -14,7 +14,16 @@ export default function SearchFilter({
 }: Props) {
   return (
     <div className="active-search-filter">
-      <div className="remove-filter" onClick={clearFacet}>
+      <div
+        className="remove-filter"
+        onClick={clearFacet}
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            clearFacet()
+          }
+        }}
+        tabIndex="0"
+      >
         <i className="material-icons">close</i>
       </div>
       <div>{labelFunction ? labelFunction(value) : value}</div>

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -424,6 +424,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
                       onClick={preventDefaultAndInvoke(() =>
                         this.useSuggestion(suggestion)
                       )}
+                      onKeyPress={e => {
+                        if (e.key === "Enter") {
+                          this.useSuggestion(suggestion)
+                        }
+                      }}
+                      tabIndex="0"
                     >
                       {` ${suggestion}`}
                     </a>
@@ -435,6 +441,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
             <div className="layout-buttons">
               <div
                 onClick={() => this.setSearchUI(SEARCH_LIST_UI)}
+                onKeyPress={e => {
+                  if (e.key === "Enter") {
+                    this.setSearchUI(SEARCH_LIST_UI)
+                  }
+                }}
+                tabIndex="0"
                 className={`option ${
                   searchResultLayout === SEARCH_LIST_UI ? "active" : ""
                 }`}
@@ -443,6 +455,12 @@ export class CourseSearchPage extends React.Component<Props, State> {
               </div>
               <div
                 onClick={() => this.setSearchUI(SEARCH_GRID_UI)}
+                onKeyPress={e => {
+                  if (e.key === "Enter") {
+                    this.setSearchUI(SEARCH_GRID_UI)
+                  }
+                }}
+                tabIndex="0"
                 className={`option ${
                   searchResultLayout === SEARCH_GRID_UI ? "active" : ""
                 }`}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.2.0":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -3441,7 +3448,7 @@ babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@6.x, babel-runtime@^6.11.6, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
+babel-runtime@6.x, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -9859,12 +9866,13 @@ react-share@^2.2.0:
     jsonp "^0.2.1"
     prop-types "^15.5.8"
 
-react-sortable-hoc@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-0.8.4.tgz#11aa1f3e07ded79764a8bae9d107990ab9b3954b"
+react-sortable-hoc@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz#fe4022362bbafc4b836f5104b9676608a40a278f"
+  integrity sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==
   dependencies:
-    babel-runtime "^6.11.6"
-    invariant "^2.2.1"
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
     prop-types "^15.5.7"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.4.0:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/pull/3059

#### What's this PR do?
The /learn and /learn/search pages should be accessible via the keyboard using tab.

Currently the only actions that should still be not accessible through the keyboard are the share link and the login tooltip on the favorite link. It is not possible to use tab to access the inside of tooltips. Let me know if  you notice anything else.

#### How should this be manually tested?
Go to the he /learn, /learn/search and user list pages and verify that you can access the content without using your mouse.
`Tab` moves through focusable elements on the page
`Shift + tab` moves through focusable elements backwards
`Enter` interacts with the focusable elements
`Space` checks and unchecks checkboxes
To reorder items in  learning paths: use `Space` to pick up a learning resource, arrow keys to reposition it and `Space` again to drop it
