### PR TITLE
fix another padding issue with the drawer

### DIFF
--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -51,6 +51,16 @@ $drawer-trans: width 500ms;
 $nav-min-height: calc(100vh - #{$toolbar-height-desktop} - #{$footer-height});
 
 .audio-player-padding-bottom {
+  .scrollarea-content {
+    @include breakpoint(desktop) {
+      padding-bottom: $audio-player-height-desktop;
+    }
+
+    @include breakpoint(mobile) {
+      padding-bottom: $audio-player-height-mobile;
+    }
+  }
+
   .mdc-drawer__content .navigation {
     @include breakpoint(desktop) {
       min-height: calc(#{$nav-min-height} - #{$audio-player-height-desktop});


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #3060

#### What's this PR do?

this adds padding to the `.scrollarea-content` div in the nav drawer to ensure you can always scroll down to see all of the content in it when the podcast player is open.

#### How should this be manually tested?

make sure you can scroll to see the footer with the podcast player open. all other stuff should be normal across the site.

#### Screenshots (if appropriate)

before:
![Screenshot from 2020-07-17 14-40-47](https://user-images.githubusercontent.com/6207644/87820245-bdbb0f00-c83b-11ea-8d1a-389a0ab0b218.png)


after:

![Screenshot from 2020-07-17 14-37-21](https://user-images.githubusercontent.com/6207644/87820124-79c80a00-c83b-11ea-9fe5-f5f4e1f28a19.png)
