### PR TITLE
Added spam checking to posts and comments (#3062)

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,14 @@
   ],
   "description": "open-discussions",
   "env": {
+    "AKISMET_API_KEY": {
+      "description": "API key for Akismet",
+      "required": false
+    },
+    "AKISMET_BLOG_URL": {
+      "description": "Blog urlfor Akismet",
+      "required": false
+    },
     "ALGOLIA_APP_ID": {
       "description": "Algolia Places app ID",
       "required": false

--- a/channels/spam.py
+++ b/channels/spam.py
@@ -1,0 +1,119 @@
+"""Check for spam"""
+import logging
+from types import SimpleNamespace
+
+import akismet
+from django.conf import settings
+from django.utils.functional import SimpleLazyObject
+from ipware import get_client_ip
+
+log = logging.getLogger()
+
+
+def extract_spam_check_headers(request):
+    """Extract and validate the headers"""
+    user_ip, _ = get_client_ip(request)
+    user_agent = request.META.get("HTTP_USER_AGENT", "")
+
+    return SimpleNamespace(user_ip=user_ip, user_agent=user_agent)
+
+
+def _create_akismet_client():
+    """Initialize the akismet client"""
+    if not all([settings.AKISMET_API_KEY, settings.AKISMET_BLOG_URL]):
+        log.info(
+            "One or more of AKISMET_API_KEY and AKISMET_BLOG_URL is not configured"
+        )
+        return None
+
+    try:
+        return akismet.Akismet(
+            key=settings.AKISMET_API_KEY, blog_url=settings.AKISMET_BLOG_URL
+        )
+    except akismet.AkismetError:
+        log.exception("Akismet is not configured correctly")
+    except:  # pylint: disable=bare-except
+        log.exception("Error initializing Akismet client")
+
+    return None
+
+
+class SpamChecker:
+    """Spam checking for posts and comments"""
+
+    def __init__(self):
+        self._client = SimpleLazyObject(_create_akismet_client)
+
+    def _can_spam_check(self):
+        """Returns True if the spam checker is properly configured and can operate"""
+        return hasattr(self._client, "comment_check")
+
+    def is_post_spam(self, *, user_ip, user_agent, post):
+        """
+        Detect if a post is spam
+
+        Args:
+            user_ip(str): user's ip address
+            user_agent(str): user's browser agent
+            post(channels.models.Post): the post to check
+
+        Returns:
+            bool: True if the post is spam
+        """
+        if not self._can_spam_check():
+            # if we can't verify it, assume it's not spam
+            return False
+
+        if not user_ip or not user_agent:
+            log.info("Couldn't determine user agent or ip, assuming to be spam")
+            return True
+
+        try:
+            log.debug("Spam checking post content")
+            return self._client.comment_check(
+                user_ip=user_ip,
+                user_agent=user_agent,
+                comment_content=post.plain_text,
+                comment_type="forum-post",
+                comment_author=post.author.profile.name,
+                comment_author_email=post.author.email,
+                is_test=settings.AKISMET_IS_TESTING,
+            )
+        except:  # pylint: disable=bare-except
+            log.exception("Error trying to spam check w/ Akismet")
+            return False
+
+    def is_comment_spam(self, *, user_ip, user_agent, comment):
+        """
+        Detect if a comment is spam
+
+        Args:
+            user_ip(str): user's ip address
+            user_agent(str): user's browser agent
+            comment(channels.models.Comment): the comment to check
+
+        Returns:
+            bool: True if the comment is spam
+        """
+        if not self._can_spam_check():
+            # if we can't verify it, assume it's not spam
+            return False
+
+        if not user_ip or not user_agent:
+            log.info("Couldn't determine user agent or ip, assuming to be spam")
+            return True
+
+        try:
+            log.debug("Spam checking comment content")
+            return self._client.comment_check(
+                user_ip=user_ip,
+                user_agent=user_agent,
+                comment_content=comment.text,
+                comment_type="reply",
+                comment_author=comment.author.profile.name,
+                comment_author_email=comment.author.email,
+                is_test=settings.AKISMET_IS_TESTING,
+            )
+        except:  # pylint: disable=bare-except
+            log.exception("Error trying to spam check w/ Akismet")
+            return False

--- a/channels/spam_test.py
+++ b/channels/spam_test.py
@@ -1,0 +1,186 @@
+"""Spam verification tests"""
+from types import SimpleNamespace
+
+from akismet import AkismetError
+import pytest
+
+from channels.factories.models import PostFactory, CommentFactory
+from channels.spam import SpamChecker, extract_spam_check_headers
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture(autouse=True)
+def default_settings(settings):
+    """Default settings for tests"""
+    settings.AKISMET_API_KEY = "test-key"
+    settings.AKISMET_BLOG_URL = "http://mit.edu"
+    # just in case we somehow execute it if a test fails
+    settings.AKISMET_IS_TESTING = True
+
+
+@pytest.fixture()
+def user_request_args():
+    """User request args extracted from headers"""
+    return SimpleNamespace(user_agent="UserAgent", user_ip="127.0.0.1")
+
+
+@pytest.fixture()
+def mock_akismet(mocker):  # pylint: disable=unused-argument
+    """Fixture for a valid request and checker"""
+    return mocker.patch("channels.spam.akismet.Akismet", autospec=True)
+
+
+@pytest.fixture
+def post_checker(
+    user, user_request_args, mock_akismet
+):  # pylint: disable=unused-argument
+    """Fixture for post check"""
+    post = PostFactory.create(author=user)
+
+    def _check(**kwargs):
+        resolved_kwargs = {**vars(user_request_args), "post": post, **kwargs}
+
+        checker = SpamChecker()
+
+        return checker.is_post_spam(**resolved_kwargs)
+
+    return SimpleNamespace(post=post, check=_check)
+
+
+@pytest.fixture
+def comment_checker(
+    user, user_request_args, mock_akismet
+):  # pylint: disable=unused-argument
+    """Fixture for post check"""
+    comment = CommentFactory.create(author=user)
+
+    def _check(**kwargs):
+        resolved_kwargs = {**vars(user_request_args), "comment": comment, **kwargs}
+
+        checker = SpamChecker()
+
+        return checker.is_comment_spam(**resolved_kwargs)
+
+    return SimpleNamespace(comment=comment, check=_check)
+
+
+@pytest.mark.parametrize(
+    "headers, expected",
+    [
+        [
+            dict(HTTP_X_FORWARDED_FOR="127.0.0.7"),
+            SimpleNamespace(user_agent="", user_ip="127.0.0.7"),
+        ],
+        [
+            dict(HTTP_USER_AGENT="user-agent", HTTP_X_FORWARDED_FOR="127.0.0.7"),
+            SimpleNamespace(user_agent="user-agent", user_ip="127.0.0.7"),
+        ],
+    ],
+)
+def test_extract_spam_check_headers(rf, headers, expected):
+    """Test that extract_spam_check_headers extracts user agent and ip from request headers"""
+    request = rf.post("/api", **headers)
+
+    assert extract_spam_check_headers(request) == expected
+
+
+@pytest.mark.parametrize(
+    "checker",
+    [pytest.lazy_fixture("post_checker"), pytest.lazy_fixture("comment_checker")],
+)
+def test_not_configured(settings, mock_akismet, checker):
+    """Verify that Akismet doesn't mark anything as spam if it's not configured"""
+    settings.AKISMET_API_KEY = None
+    settings.AKISMET_BLOG_URL = None
+
+    assert checker.check() is False
+
+    mock_akismet.return_value.comment_check.assert_not_called()
+
+
+@pytest.mark.parametrize("side_effect", [AkismetError(), Exception()])
+@pytest.mark.parametrize(
+    "checker",
+    [pytest.lazy_fixture("post_checker"), pytest.lazy_fixture("comment_checker")],
+)
+def test_client_init_exception(mocker, mock_akismet, side_effect, checker):
+    """Validation should pass if we can't initialize"""
+    mock_log = mocker.patch("channels.spam.log")
+
+    mock_akismet.side_effect = side_effect
+
+    assert checker.check() is False
+
+    mock_log.exception.assert_called_once()
+    mock_akismet.return_value.comment_check.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "checker",
+    [pytest.lazy_fixture("post_checker"), pytest.lazy_fixture("comment_checker")],
+)
+def test_check_raises_exception(mocker, mock_akismet, checker):
+    """Verify that if the request to check fails, we log a message but allow it through"""
+    mock_log = mocker.patch("channels.spam.log")
+    mock_akismet.return_value.comment_check.side_effect = Exception()
+
+    assert checker.check() is False
+
+    mock_log.exception.assert_called_once_with("Error trying to spam check w/ Akismet")
+
+
+@pytest.mark.parametrize(
+    "checker",
+    [pytest.lazy_fixture("post_checker"), pytest.lazy_fixture("comment_checker")],
+)
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    [
+        pytest.param(dict(user_agent="", user_ip=""), id="no_headers"),
+        pytest.param(dict(user_ip=""), id="no_ip"),
+        pytest.param(dict(user_agent=""), id="no_useragent"),
+    ],
+)
+def test_invalid_headers(mocker, mock_akismet, checker, extra_kwargs):
+    """Verify that is_comment_spam returns false for requests with no IP or UA"""
+    mock_log = mocker.patch("channels.spam.log")
+
+    assert checker.check(**extra_kwargs) is True
+
+    mock_log.info.assert_called_once_with(
+        "Couldn't determine user agent or ip, assuming to be spam"
+    )
+    mock_akismet.return_value.comment_check.assert_not_called()
+
+
+def test_is_comment_spam(mock_akismet, comment_checker, user_request_args, user):
+    """Verify is_comment_spam calls the Akismet API correctly"""
+    assert (
+        comment_checker.check() == mock_akismet.return_value.comment_check.return_value
+    )
+
+    mock_akismet.return_value.comment_check.assert_called_once_with(
+        user_agent=user_request_args.user_agent,
+        user_ip=user_request_args.user_ip,
+        comment_content=comment_checker.comment.text,
+        comment_type="reply",
+        comment_author=user.profile.name,
+        comment_author_email=user.email,
+        is_test=True,
+    )
+
+
+def test_is_text_post_spam(mock_akismet, post_checker, user_request_args, user):
+    """Verify is_post_spam calls the Akismet API correctly for a post"""
+    assert post_checker.check() == mock_akismet.return_value.comment_check.return_value
+
+    mock_akismet.return_value.comment_check.assert_called_once_with(
+        user_agent=user_request_args.user_agent,
+        user_ip=user_request_args.user_ip,
+        comment_content=post_checker.post.plain_text,
+        comment_type="forum-post",
+        comment_author=user.profile.name,
+        comment_author_email=user.email,
+        is_test=True,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ x-environment:
   WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
   TIKA_SERVER_ENDPOINT: ${TIKA_SERVER_ENDPOINT:-http://tika:9998/}
   TIKA_CLIENT_ONLY: 'True'
+  AKISMET_IS_TESTING: 'True'
 x-extra-hosts:
   &default-extra-hosts
   # see reddit.local in /etc/hosts

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -165,3 +165,10 @@ def mocked_responses():
     """Mock responses fixture"""
     with responses.RequestsMock() as rsps:
         yield rsps
+
+
+@pytest.fixture(autouse=True)
+def default_settings(settings):
+    """Default settings for tests"""
+    settings.AKISMET_API_KEY = None
+    settings.AKISMET_BLOG_URL = None

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -929,6 +929,14 @@ MIT_WS_PRIVATE_KEY_FILE = os.path.join(STATIC_ROOT, "mit_x509.key")
 
 STAFF_MOIRA_LISTS = get_list_of_str("STAFF_MOIRA_LISTS", [])
 
+AKISMET_API_KEY = get_string("AKISMET_API_KEY", None)
+AKISMET_BLOG_URL = get_string("AKISMET_BLOG_URL", None)
+AKISMET_IS_TESTING = get_string("AKISMET_IS_TESTING", False)
+
+if DEBUG:
+    # allow for all IPs to be routable, including localhost, for testing
+    IPWARE_PRIVATE_IP_PREFIX = ()
+
 
 def setup_x509():
     """ write the moira x509 certification & key to files"""

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+akismet==1.1
 django-cors-headers==2.1.0
 Django==2.2.13
 base36
@@ -18,6 +19,7 @@ django-guardian==1.4.9
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
 django-imagekit==4.0.2
+django-ipware==3.0.0
 django-json-widget==1.0.0
 django-redis==4.10.0
 django-server-status==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile
 #
+akismet==1.1              # via -r requirements.in
 amqp==2.5.2               # via kombu
 appdirs==1.4.3            # via zeep
 attrs==19.3.0             # via zeep
@@ -43,6 +44,7 @@ django-guardian==1.4.9    # via -r requirements.in
 django-hijack-admin==2.1.10  # via -r requirements.in
 django-hijack==2.1.10     # via -r requirements.in, django-hijack-admin
 django-imagekit==4.0.2    # via -r requirements.in
+django-ipware==3.0.0      # via -r requirements.in
 django-json-widget==1.0.0  # via -r requirements.in
 django-redis==4.10.0      # via -r requirements.in
 django-server-status==0.5.0  # via -r requirements.in
@@ -111,7 +113,7 @@ redis==3.2.1              # via -r requirements.in, django-redis, django-server-
 requests-file==1.4.3      # via tldextract
 requests-oauthlib==0.8.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
-requests==2.21.0          # via -r requirements.in, betamax, django-anymail, ocw-data-parser, prawcore, pygithub, requests-file, requests-oauthlib, requests-toolbelt, smart-open, social-auth-core, tika, tldextract, update-checker, zeep
+requests==2.21.0          # via -r requirements.in, akismet, betamax, django-anymail, ocw-data-parser, prawcore, pygithub, requests-file, requests-oauthlib, requests-toolbelt, smart-open, social-auth-core, tika, tldextract, update-checker, zeep
 rsa==4.0                  # via google-auth
 s3transfer==0.1.13        # via boto3
 sentry-sdk==0.14.1        # via -r requirements.in


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Part of #3062

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Create an account for [Akismet](https://akismet.com/)
  - Change your plan to "Personal", which requires a wordpress.org account
  - Configure a new site with a blog url (I used `<username>.github.io` since that's something i control)
- Add the access key and blog url to `.env` under `AKISMET_API_KEY` and `AKISMET_BLOG_URL`
- Verify you can create a post with reasonable content (try copy/pasting content from production)
- Verify a post with spammy content is removed after the async task fires

#### Any background context you want to provide?

The async task with a delay is necessary because we need to remove the psot after reddit's own async tasks which update the channel/frontpage listings.

