### PR TITLE
Added server-side 404 page for posts

### DIFF
--- a/cassettes/channels.views.posts_test.test_get_removed_post[None-404].json
+++ b/cassettes/channels.views.posts_test.test_get_removed_post[None-404].json
@@ -1,0 +1,507 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-07-28T15:32:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0VXGN7842ZRP2WGT0QG83"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLVTTQsyY93tsx19rXQ1XUzNjFPDHbPNLBI8Q6xUNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2xefkGBu5ugWlpURWWjqXumb6hJmVB/gnV6R7gnSkpJZlJqfGZ6aAjIVwlGoBzIuHoLQAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:32:47 GMT",
+            "loidcreated=2020-07-28T15%3A32%3A47.210Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:32:47 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0VXGN7842ZRP2WGT0QG83"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:32:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; loidcreated=2020-07-28T15%3A32%3A47.210Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0W0QH6B392N37G7B8GN1W"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLTNfNJjajKdC0rLUw1zfDxDE129i3JTzMqji/wVNJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2mRgbBlqklFVGeBW4BDiWOqWVl5oE5FrmOxb5gnSkpJZlJqfGZ6aAjIVwlGoBcH/fwbQAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0W0QH6B392N37G7B8GN1W"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:32:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=She+according+region+difference+trial+top+hot+visit.+Everything+be+sing+cause+air+energy.%0ASafe+occur+poor+five+participant.+Company+trip+wide+far+rock.%0ABig+model+keep+fly+want+democratic+final.+Why+institution+chair+laugh+bar+relate+campaign+media.+Here+scene+since+choose+against.%0AMe+point+bad+generation+week+your+grow.+Employee+rise+individual+film+wind+mind+attorney.+Style+new+evidence+goal+company+near+perform.&link_type=any&name=1595950370_11_other&public_description=Operation+it+check+team+care+raise.+Affect+population+fly+thank+lot+article.&title=Voice+thought+ground+toward+door+what.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 5-a1to_C9mCM8--F347aSGi08dKT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "674"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; loidcreated=2020-07-28T15%3A32%3A47.210Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "430"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:32:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1595950370_11_other&text=Because+song+movement+left+stay+exist+individual.+Our+fact+put+those+thank+expert+miss.&title=City+democratic+teach+rich+major+law."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 6-6LeXziEvuqe5hLIUcCMtof2s_pI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "214"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; loidcreated=2020-07-28T15%3A32%3A47.210Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1595950370_11_other/comments/f/city_democratic_teach_rich_major_law/\", \"id\": \"f\", \"name\": \"t3_f\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "163"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "427"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:32:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 6-6LeXziEvuqe5hLIUcCMtof2s_pI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; loidcreated=2020-07-28T15%3A32%3A47.210Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/f/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1595950370_11_other\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EBecause song movement left stay exist individual. Our fact put those thank expert miss.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Because song movement left stay exist individual. Our fact put those thank expert miss.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"f\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EEB0W0QH6B392N37G7B8GN1W\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1595950370_11_other\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_6\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1595950370_11_other/comments/f/city_democratic_teach_rich_major_law/\", \"locked\": false, \"name\": \"t3_f\", \"created\": 1595950373.0, \"url\": \"http://reddit.local/r/1595950370_11_other/comments/f/city_democratic_teach_rich_major_law/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"City democratic teach rich major law.\", \"created_utc\": 1595950373.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1756"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:54 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "426"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=AKfafKLwSJ9Ce1lE4ZQWmTsvwLKdDvnrWjcD6FOeZC8EzZaIYcPHpJ9XzpDGymZ6GHh573wvtW4g8Np%2FUrOCvYsTZra0A7bl"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/f/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:32:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_f&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 5-a1to_C9mCM8--F347aSGi08dKT8"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=MQfiK8iDlg6AxKaRVH; loidcreated=2020-07-28T15%3A32%3A47.210Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:32:57 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "423"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.posts_test.test_get_removed_post[client_user1-404].json
+++ b/cassettes/channels.views.posts_test.test_get_removed_post[client_user1-404].json
@@ -1,0 +1,596 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-07-28T15:33:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WA8V7A4PFBGK0BF4F1KQ"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDLXTc9193IK80r3S6wqN3dLLfEIjwhxyooKzcjwVdJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2JZaXuBdb5lVlB1WZ5xv6B2ca5QXlpFZ5Rbhlg3SkpJZlJqfGZ6aAjIVwlGoBUqUWq7QAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=VD2XZKYevrijBN7PFN; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:33:00 GMT",
+            "loidcreated=2020-07-28T15%3A33%3A00.280Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:33:00 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WA8V7A4PFBGK0BF4F1KQ"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WDHATJM4XCFN402M45YZ"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULLQzc00dAwLDgzwMoosSgpyMqmo9C/z181IDil0VdJRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2BXhXJUblByaFuuZUZIaGFRqZmfpXRCWVJbqkg3SkpJZlJqfGZ6aAjIVwlGoBS0kNJLQAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:03 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WDHATJM4XCFN402M45YZ"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Second+language+take+though+market.+Artist+research+their+less+pay+recently.%0ACrime+rest+meet+dinner+student+fire+among.+Research+size+treat+increase+story+heart+address.%0AShould+him+world+though+quickly+country+wind.+East+present+approach.+Left+decision+have+study+scientist+lay.%0AWide+daughter+bank+audience.+Night+nearly+affect+push+attention+Mr+speak.+Face+perform+forward+across.%0AUs+his+history+music+total+ground.+Speak+drug+range+how+fine+decade+age.&link_type=any&name=1595950383_12_step&public_description=Address+visit+right+pick+least+own+rather.&title=Opportunity+between+soon+money+single+material.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 7-gmGJBVJgNazw7FetHWXTBjZUhhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "687"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:04 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "417"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1595950383_12_step&text=Perhaps+oil+field+even+after+pay.+Nearly+though+politics+show+gas.+Carry+say+marriage+should.&title=Majority+cause+mission+perhaps+on+economic."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 8-mi1AVSQPJ2YrbRB4xyOvO-hcTqE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "225"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1595950383_12_step/comments/g/majority_cause_mission_perhaps_on_economic/\", \"id\": \"g\", \"name\": \"t3_g\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "168"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:07 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "413"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 8-mi1AVSQPJ2YrbRB4xyOvO-hcTqE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/g/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1595950383_12_step\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPerhaps oil field even after pay. Nearly though politics show gas. Carry say marriage should.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Perhaps oil field even after pay. Nearly though politics show gas. Carry say marriage should.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"g\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EEB0WDHATJM4XCFN402M45YZ\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1595950383_12_step\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_7\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1595950383_12_step/comments/g/majority_cause_mission_perhaps_on_economic/\", \"locked\": false, \"name\": \"t3_g\", \"created\": 1595950387.0, \"url\": \"http://reddit.local/r/1595950383_12_step/comments/g/majority_cause_mission_perhaps_on_economic/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Majority cause mission perhaps on economic.\", \"created_utc\": 1595950387.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1782"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:07 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "413"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=sJY7ZhzpLfFzpt8W1WT3R2LWy2rUpNEa5Z2%2B9%2BN%2FzQztMQqf2uB38mHmZQ0cqt9VmyTzSBKZ4bBRLmHKZuXyHcmRmotAIiCA"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/g/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_g&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 7-gmGJBVJgNazw7FetHWXTBjZUhhM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "410"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 8-mi1AVSQPJ2YrbRB4xyOvO-hcTqE"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=VD2XZKYevrijBN7PFN; loidcreated=2020-07-28T15%3A33%3A00.280Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1595950383_12_step/about/moderators/?user=01EEB0WDHATJM4XCFN402M45YZ&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "46"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "410"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=cv%2FIU%2BgPIZBn5qx4du4ySvB%2BDeMVUpddEUSMj%2B%2BAMETu4a8TBwJq3wnQr8u0LFzhC2IcHHffk%2BL%2FRPdc2B0Gf6jrTi4g8wU2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1595950383_12_step/about/moderators/?user=01EEB0WDHATJM4XCFN402M45YZ&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.posts_test.test_get_removed_post[client_user2-200].json
+++ b/cassettes/channels.views.posts_test.test_get_removed_post[client_user2-200].json
@@ -1,0 +1,685 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-07-28T15:33:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WQ3H0JJ7WC0PD94V59D1"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULLUNYqKCvQuM/LID00zy0l2N/JPSQ4MDs6LMq8qV9JRUEqtKMgsSi2OzwQpNzYzMACKgXXHl1QWpIKMSEpNLEotAqktTs6HCGmBeEWpaUCNGch2OYZkBYebRMX7m3g7mbiaGeSW5rtVuYSkl5mkg3SkpJZlJqfGZ6aAjIVwlGoBFnmrxLQAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:33:13 GMT",
+            "loidcreated=2020-07-28T15%3A33%3A13.444Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Thu, 28-Jul-2022 15:33:13 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WQ3H0JJ7WC0PD94V59D1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WTBKN36JS3S8BRMNCC4C"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI00PXzzgv2C8z0TDUL1U03i082143MMTIzyUvPylfSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkolkWGuuRmhIWEO+WERmWkV6Z5xge4p3l7Ovk4B4K0pKSWZSanxmemgMyFcJRqAYW79y62AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:16 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EEB0WTBKN36JS3S8BRMNCC4C"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=In+but+fight+question+section+open+whatever+company.%0AChild+most+line.+Her+cultural+place+gun+share+quickly.%0AStill+time+week+standard+dream+sit+learn+standard.+And+serve+minute+game+structure+model.%0ARed+work+range+east+smile+mouth+democratic+lose.+Pattern+character+young+trade+recent+often.+System+school+mind+because+agent+heavy.%0AControl+course+serious.+Sort+degree+cup.%0AStart+book+animal+bit+time+subject+pressure.+Example+despite+before+thought.&link_type=any&name=1595950396_13_Republi&public_description=Century+will+great.+Return+himself+although+exactly+spend.&title=Record+field+fish+produce+realize.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 9-2ZZQKv2HoUf6lcG2OdcQSSnZ7zw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "689"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:17 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "403"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1595950396_13_Republi&text=History+rise+page+conference+meeting.+Order+well+hair.%0AWrong+run+tend+social.&title=Over+five+Democrat+worker."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 10-NKnSNQiIe6U-g6_c7-Yl264ngjo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "197"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1595950396_13_Republi/comments/h/over_five_democrat_worker/\", \"id\": \"h\", \"name\": \"t3_h\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "154"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "400"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 10-NKnSNQiIe6U-g6_c7-Yl264ngjo"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/h/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1595950396_13_Republi\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EHistory rise page conference meeting. Order well hair.\\nWrong run tend social.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"History rise page conference meeting. Order well hair.\\nWrong run tend social.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"h\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EEB0WTBKN36JS3S8BRMNCC4C\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1595950396_13_Republi\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_8\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1595950396_13_Republi/comments/h/over_five_democrat_worker/\", \"locked\": false, \"name\": \"t3_h\", \"created\": 1595950400.0, \"url\": \"http://reddit.local/r/1595950396_13_Republi/comments/h/over_five_democrat_worker/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Over five Democrat worker.\", \"created_utc\": 1595950400.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1713"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:20 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "400"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=CqYVWvYJGMdGIbuaL1OZ%2FhhXQ3xuzkmlOrZ8JsyMVvkfZ%2B2b0gCf5LJ6vWAF8HzyCEwg10%2Bd1UUL10SwIEg%2FCt9vxpAgQqDZ"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/h/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_h&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 9-2ZZQKv2HoUf6lcG2OdcQSSnZ7zw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "397"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 9-2ZZQKv2HoUf6lcG2OdcQSSnZ7zw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1595950396_13_Republi/about/moderators/?user=01EEB0WQ3H0JJ7WC0PD94V59D1&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1595950397.0, \"mod_permissions\": [\"all\"], \"name\": \"01EEB0WQ3H0JJ7WC0PD94V59D1\", \"id\": \"t2_9\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "148"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "397"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=DB1TIqPXU8g6hBkj8HVvhDykisgPaPzotrpI0mIVZuRSYl4U4uwQDMeHZJctmOrcA6%2BtH5T5TrYA%2B4EbGVq44YGjEZLgcBpP"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1595950396_13_Republi/about/moderators/?user=01EEB0WQ3H0JJ7WC0PD94V59D1&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-07-28T15:33:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 9-2ZZQKv2HoUf6lcG2OdcQSSnZ7zw"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=94nmhjLA3Z5Av9Y0cB; loidcreated=2020-07-28T15%3A33%3A13.444Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.135.1 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/h/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": \"01EEB0WQ3H0JJ7WC0PD94V59D1\", \"media_embed\": {}, \"subreddit\": \"1595950396_13_Republi\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EHistory rise page conference meeting. Order well hair.\\nWrong run tend social.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"History rise page conference meeting. Order well hair.\\nWrong run tend social.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"h\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01EEB0WTBKN36JS3S8BRMNCC4C\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1595950396_13_Republi\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_8\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1595950396_13_Republi/comments/h/over_five_democrat_worker/\", \"locked\": false, \"name\": \"t3_h\", \"created\": 1595950400.0, \"url\": \"http://reddit.local/r/1595950396_13_Republi/comments/h/over_five_democrat_worker/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Over five Democrat worker.\", \"created_utc\": 1595950400.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1732"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 28 Jul 2020 15:33:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "397"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=TolGAa82jNzlntNy6qDOJ2wZejD5T5AYCPoLMOjCeyzdlNktZkzBnPiwku1sBBLyIeDyPtsgK6fdR4BjZcz4ipFGVeu8kl7E"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/h/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/channels/proxies.py
+++ b/channels/proxies.py
@@ -70,6 +70,11 @@ class PostProxy(ObjectProxy):
         """Return preview_text for this post"""
         return self._self_post.preview_text
 
+    @property
+    def removed(self):
+        """Return removed flag for this post"""
+        return self._self_post.removed
+
 
 def proxy_post(submission):
     """

--- a/channels/views/posts.py
+++ b/channels/views/posts.py
@@ -106,6 +106,12 @@ class PostDetailView(APIView):
         """Get post"""
         with translate_praw_exceptions(request.user):
             post = self.get_object()
+            if post.removed and (
+                request.user.is_anonymous
+                or not (self.api.is_moderator(post.channel.name, request.user.username))
+            ):
+                raise NotFound()
+
             users = lookup_users_for_posts([post])
             if not post.author or post.author.name not in users:
                 raise NotFound()

--- a/channels/views/posts_test.py
+++ b/channels/views/posts_test.py
@@ -361,6 +361,37 @@ def test_get_deleted_post(
         assert resp.status_code == status.HTTP_200_OK
 
 
+@pytest.mark.parametrize(
+    "client_user, expected_status",
+    [
+        [None, status.HTTP_404_NOT_FOUND],
+        [pytest.lazy_fixture("user"), status.HTTP_404_NOT_FOUND],
+        [pytest.lazy_fixture("staff_user"), status.HTTP_200_OK],
+    ],
+)
+def test_get_removed_post(
+    client,
+    user,
+    public_channel,
+    reddit_factories,
+    staff_api,
+    client_user,
+    expected_status,
+):  # pylint: disable=too-many-arguments
+    """Get an existing post for a removed post"""
+    post = reddit_factories.text_post("removed", user, channel=public_channel)
+
+    staff_api.remove_post(post.id)
+
+    if client_user is not None:
+        client.force_login(client_user)
+
+    url = reverse("post-detail", kwargs={"post_id": post.id})
+    resp = client.get(url)
+
+    assert resp.status_code == expected_status
+
+
 # pylint: disable=too-many-arguments
 @pytest.mark.parametrize("missing_image", [True, False])
 def test_get_post(

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
+      DEBUG: ${DEBUG:-True}
       NODE_ENV: 'development'
       OPEN_DISCUSSIONS_USE_WEBPACK_DEV_SERVER: 'True'
 
@@ -14,7 +14,7 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
+      DEBUG: ${DEBUG:-True}
       NODE_ENV: 'development'
       OPEN_DISCUSSIONS_USE_WEBPACK_DEV_SERVER: 'True'
 

--- a/factory_data/channels.views.posts_test.test_get_removed_post[None-404].json
+++ b/factory_data/channels.views.posts_test.test_get_removed_post[None-404].json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "She according region difference trial top hot visit. Everything be sing cause air energy.\nSafe occur poor five participant. Company trip wide far rock.\nBig model keep fly want democratic final. Why institution chair laugh bar relate campaign media. Here scene since choose against.\nMe point bad generation week your grow. Employee rise individual film wind mind attorney. Style new evidence goal company near perform.",
+      "name": "1595950370_11_other",
+      "public_description": "Operation it check team care raise. Affect population fly thank lot article.",
+      "title": "Voice thought ground toward door what."
+    }
+  },
+  "posts": {
+    "removed": {
+      "id": "f",
+      "text": "Because song movement left stay exist individual. Our fact put those thank expert miss.",
+      "title": "City democratic teach rich major law."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01EEB0W0QH6B392N37G7B8GN1W"
+    },
+    "staff_user": {
+      "username": "01EEB0VXGN7842ZRP2WGT0QG83"
+    }
+  }
+}

--- a/factory_data/channels.views.posts_test.test_get_removed_post[client_user1-404].json
+++ b/factory_data/channels.views.posts_test.test_get_removed_post[client_user1-404].json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Second language take though market. Artist research their less pay recently.\nCrime rest meet dinner student fire among. Research size treat increase story heart address.\nShould him world though quickly country wind. East present approach. Left decision have study scientist lay.\nWide daughter bank audience. Night nearly affect push attention Mr speak. Face perform forward across.\nUs his history music total ground. Speak drug range how fine decade age.",
+      "name": "1595950383_12_step",
+      "public_description": "Address visit right pick least own rather.",
+      "title": "Opportunity between soon money single material."
+    }
+  },
+  "posts": {
+    "removed": {
+      "id": "g",
+      "text": "Perhaps oil field even after pay. Nearly though politics show gas. Carry say marriage should.",
+      "title": "Majority cause mission perhaps on economic."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01EEB0WDHATJM4XCFN402M45YZ"
+    },
+    "staff_user": {
+      "username": "01EEB0WA8V7A4PFBGK0BF4F1KQ"
+    }
+  }
+}

--- a/factory_data/channels.views.posts_test.test_get_removed_post[client_user2-200].json
+++ b/factory_data/channels.views.posts_test.test_get_removed_post[client_user2-200].json
@@ -1,0 +1,26 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "In but fight question section open whatever company.\nChild most line. Her cultural place gun share quickly.\nStill time week standard dream sit learn standard. And serve minute game structure model.\nRed work range east smile mouth democratic lose. Pattern character young trade recent often. System school mind because agent heavy.\nControl course serious. Sort degree cup.\nStart book animal bit time subject pressure. Example despite before thought.",
+      "name": "1595950396_13_Republi",
+      "public_description": "Century will great. Return himself although exactly spend.",
+      "title": "Record field fish produce realize."
+    }
+  },
+  "posts": {
+    "removed": {
+      "id": "h",
+      "text": "History rise page conference meeting. Order well hair.\nWrong run tend social.",
+      "title": "Over five Democrat worker."
+    }
+  },
+  "users": {
+    "contributor": {
+      "username": "01EEB0WTBKN36JS3S8BRMNCC4C"
+    },
+    "staff_user": {
+      "username": "01EEB0WQ3H0JJ7WC0PD94V59D1"
+    }
+  }
+}

--- a/open_discussions/templates/400.html
+++ b/open_discussions/templates/400.html
@@ -1,0 +1,1 @@
+{% extends "react.html" %}

--- a/open_discussions/templates/403.html
+++ b/open_discussions/templates/403.html
@@ -1,0 +1,1 @@
+{% extends "react.html" %}

--- a/open_discussions/templates/404.html
+++ b/open_discussions/templates/404.html
@@ -1,0 +1,1 @@
+{% extends "react.html" %}

--- a/open_discussions/templates/base.html
+++ b/open_discussions/templates/base.html
@@ -10,12 +10,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
-    {% if js_settings_json %}
-    <script type="text/javascript">
-    var SETTINGS = {{ js_settings_json|safe }};
-    </script>
-    {% render_bundle 'style' %}
-    {% endif %}
+
     <title>{% block title %}{% trans "Open Discussions" %}{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">
     <meta name="keywords" content="{% block keywords %}{% endblock %}">

--- a/open_discussions/templates/index.html
+++ b/open_discussions/templates/index.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-{% load i18n static %}
-
-{% block content %}
-<div id="container"></div>
-{% load render_bundle %}
-{% render_bundle 'root' %}
-{% endblock %}

--- a/open_discussions/templates/react.html
+++ b/open_discussions/templates/react.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load render_bundle %}
+
+{% block extrahead %}
+{{ js_settings|json_script:'js-settings' }}
+<script type="text/javascript">
+var SETTINGS = JSON.parse(document.getElementById('js-settings').textContent);
+</script>
+{% render_bundle 'style' %}
+{% endblock %}
+
+{% block content %}
+<div id="container"></div>
+{% render_bundle 'root' %}
+{% endblock %}

--- a/open_discussions/templates/social.html
+++ b/open_discussions/templates/social.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static %}
+{% load static %}
 
 {% block description %}{{ description_value }}{% endblock %}
 {% block extrahead %}

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -19,13 +19,17 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from rest_framework_jwt.views import refresh_jwt_token
 
-from open_discussions.views import index, saml_metadata, channel_redirect
+from open_discussions.views import index, saml_metadata, channel_redirect, channel_post
 
 # Post slugs can contain unicode characters, so a letter-matching pattern like [A-Za-z] doesn't work.
 # "[^\W]" Matches any character that is NOT a non-alphanumeric character, including underscores.
 # "[^\W]" will match all numbers, underscores, and letters, unicode or otherwise. To accept dashes
 # as well, that character is added to the pattern via an alternation (|).
 POST_SLUG_PATTERN = "([^\\W]|-)+"
+
+handler400 = "open_discussions.views.handle_400"
+handler403 = "open_discussions.views.handle_403"
+handler404 = "open_discussions.views.handle_404"
 
 urlpatterns = [
     url(r"^admin/", admin.site.urls),
@@ -50,17 +54,17 @@ urlpatterns = [
     url(r"^content_policy/$", index),
     url(
         r"^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/"
-        r"(?P<post_slug>{post_slug_pattern})/comment/(?P<comment_id>[A-Za-z0-9_]+)/$".format(
+        r"(?P<post_slug>{post_slug_pattern})/comment/(?P<comment_id>[A-Za-z0-9_]+)/?$".format(
             post_slug_pattern=POST_SLUG_PATTERN
         ),
-        index,
+        channel_post,
         name="channel-post-comment",
     ),
     url(
-        r"^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>{post_slug_pattern})/$".format(
+        r"^c/(?P<channel_name>[A-Za-z0-9_]+)/(?P<post_id>[A-Za-z0-9_]+)/(?P<post_slug>{post_slug_pattern})/?$".format(
             post_slug_pattern=POST_SLUG_PATTERN
         ),
-        index,
+        channel_post,
         name="channel-post",
     ),
     url(r"^c/(?P<channel_name>[A-Za-z0-9_]+)/$", index, name="channel"),

--- a/open_discussions/urls_test.py
+++ b/open_discussions/urls_test.py
@@ -20,7 +20,7 @@ def test_post_slug_match(post_slug):
     assert reverse(
         "channel-post",
         kwargs={"channel_name": "channel1", "post_id": "1n", "post_slug": post_slug},
-    ) == "/c/channel1/1n/{}/".format(quote_plus(post_slug))
+    ) == "/c/channel1/1n/{}".format(quote_plus(post_slug))
     assert reverse(
         "channel-post-comment",
         kwargs={
@@ -29,7 +29,7 @@ def test_post_slug_match(post_slug):
             "post_slug": post_slug,
             "comment_id": "b4",
         },
-    ) == "/c/channel1/1n/{}/comment/b4/".format(quote_plus(post_slug))
+    ) == "/c/channel1/1n/{}/comment/b4".format(quote_plus(post_slug))
 
 
 @pytest.mark.parametrize("post_slug", ["spaced slug", "non-alphanum-$"])

--- a/open_discussions/views.py
+++ b/open_discussions/views.py
@@ -1,14 +1,20 @@
 """
 open_discussions views
 """
-import json
-
 from django.conf import settings
-from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect
-from django.shortcuts import render
+from django.http import (
+    Http404,
+    HttpResponse,
+    HttpResponsePermanentRedirect,
+    HttpResponseNotFound,
+    HttpResponseForbidden,
+    HttpResponseBadRequest,
+)
+from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
 from social_django.utils import load_strategy, load_backend
 
+from channels.models import Post
 from moira_lists.moira_api import is_list_staff
 from open_discussions import features
 
@@ -17,8 +23,8 @@ from sites.api import get_default_site
 from profiles.models import SOCIAL_SITE_NAME_MAP
 
 
-def index(request, **kwargs):  # pylint: disable=unused-argument
-    """Render the react app"""
+def _render_app(request, initial_state=None):
+    """Render the app with settings"""
     if request.META.get("HTTP_USER_AGENT", "").startswith("facebookexternalhit"):
         return render(
             request,
@@ -102,8 +108,50 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
         "podcast_frontpage_enabled": features.is_enabled(features.PODCAST_FRONTPAGE),
     }
 
-    return render(
-        request, "index.html", context={"js_settings_json": json.dumps(js_settings)}
+    return render(request, "react.html", context=dict(js_settings=js_settings))
+
+
+def index(request, **kwargs):  # pylint: disable=unused-argument
+    """Render the react app"""
+    return _render_app(request)
+
+
+def channel_post(request, **kwargs):
+    """Render a channel post's page as long as it isn't removed"""
+    post_id = kwargs.get("post_id", None)
+    if not post_id:
+        raise Http404("No post specified")
+
+    post = get_object_or_404(Post, post_id=post_id)
+    if post.removed and (
+        request.user.is_anonymous
+        or not (
+            request.channel_api.is_moderator(post.channel.name, request.user.username)
+        )
+    ):
+        raise Http404("Post doesn't exist")
+
+    return _render_app(request)
+
+
+def handle_400(request, exception=None):
+    """400 error handler"""
+    return HttpResponseBadRequest(
+        _render_app(request, initial_state={"server": {"statusCode": 400}})
+    )
+
+
+def handle_403(request, exception=None):
+    """403 error handler"""
+    return HttpResponseForbidden(
+        _render_app(request, initial_state={"server": {"statusCode": 403}})
+    )
+
+
+def handle_404(request, exception=None):
+    """404 error handler"""
+    return HttpResponseNotFound(
+        _render_app(request, initial_state={"server": {"statusCode": 404}})
     )
 
 

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -311,6 +311,7 @@ def test_initialized_avatar(client, user):
     assert resp.__getitem__("Content-Type") == "image/png"
 
 
+@pytest.mark.usefixtures("authenticated_site")
 def test_initials_avatar_fake_user(client):
     """
     Test that a default avatar image is returned for a fake user


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2785 

#### What's this PR do?
This adds a server-side 404 page for removed posts for non-moderator users, to ensure that for search engines and anyone else don't see this content perpetually. Also covered 400/403 errors just in case since they were a quick win.

#### How should this be manually tested?
- Remove a post in a public and/or private channel
- You should still be able to view the post as a moderator
- As a logged in user you should get a 404 page
- As an anonymous user you should get a 404 page for the public post

#### Any background context you want to provide?

Intentionally not handled here:

- 500 error pages: not in scope and a bit of effort
- Anonymous users trying to view a removed private post