### PR TITLE
remove podcast rss authentication

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -512,7 +512,6 @@ class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
         )
 
 
-@api_view(["GET"])
 def podcast_rss_feed(request):
     """
     View to display the combined podcast rss file


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
none

#### What's this PR do?
Removes authentication from the podcast rss

#### How should this be manually tested?
Verify that the http://localhost:8063/podcasts/rss_feed loads for both logged in and logged out users.

 Unfortunately that was the case for me locally before this change as well. Is there anything else I need to make the page available without a login? 
