### PR TITLE
limit rss feed episodes

### DIFF
--- a/app.json
+++ b/app.json
@@ -412,6 +412,10 @@
       "description": "Google Recaptcha secret key",
       "required": false
     },
+    "RSS_FEED_EPISODE_LIMIT":{
+      "description": "Number of episodes included in aggregated rss feed",
+      "required": false
+    },
     "SOCIAL_AUTH_SAML_LOGIN_URL": {
       "description": "Custom login url for SAML",
       "required": false

--- a/course_catalog/etl/podcast.py
+++ b/course_catalog/etl/podcast.py
@@ -285,7 +285,7 @@ def generate_aggregate_podcast_rss():
         PodcastEpisode.objects.filter(published=True)
         .order_by("last_modified")
         .reverse()
-        .values_list("rss", flat=True)
+        .values_list("rss", flat=True)[: settings.RSS_FEED_EPISODE_LIMIT]
     )
 
     for episode in episode_rss_list:

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -935,6 +935,8 @@ AKISMET_BLOG_URL = get_string("AKISMET_BLOG_URL", None)
 AKISMET_IS_TESTING = get_string("AKISMET_IS_TESTING", False)
 SPAM_EXEMPT_EMAILS = get_list_of_str("SPAM_EXEMPT_EMAILS", ["[@\\.]mit\\.edu"])
 
+RSS_FEED_EPISODE_LIMIT = get_int("RSS_FEED_EPISODE_LIMIT", 100)
+
 if DEBUG:
     # allow for all IPs to be routable, including localhost, for testing
     IPWARE_PRIVATE_IP_PREFIX = ()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3112

#### What's this PR do?
This pr limits the number of episodes displayed in the aggregated feed at /podcasts/rss_feed to the value of RSS_FEED_EPISODE_LIMIT with a default of 10  

#### How should this be manually tested?
Go to http://localhost:8063/podcasts/rss_feed. Verify that the number of episodes is caped to RSS_FEED_EPISODE_LIMIT most recent ones 
