### PR TITLE
add cache to rss page

### DIFF
--- a/app.json
+++ b/app.json
@@ -416,6 +416,10 @@
       "description": "Number of episodes included in aggregated rss feed",
       "required": false
     },
+    "RSS_FEED_CACHE_MINUTES":{
+      "description": "Minutes that /podcasts/rss_feed will be cached",
+      "required": false
+    },
     "SOCIAL_AUTH_SAML_LOGIN_URL": {
       "description": "Custom login url for SAML",
       "required": false

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -13,6 +13,7 @@ from django.db.models import Prefetch, Count, Q
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.http import HttpResponse
+from django.views.decorators.cache import cache_page
 from rest_framework import viewsets, status
 from rest_framework.decorators import action, api_view
 from rest_framework.pagination import LimitOffsetPagination
@@ -512,6 +513,7 @@ class EpisodesInPodcast(viewsets.ReadOnlyModelViewSet):
         )
 
 
+@cache_page(60 * settings.RSS_FEED_CACHE_MINUTES)
 def podcast_rss_feed(request):
     """
     View to display the combined podcast rss file

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -936,6 +936,7 @@ AKISMET_IS_TESTING = get_string("AKISMET_IS_TESTING", False)
 SPAM_EXEMPT_EMAILS = get_list_of_str("SPAM_EXEMPT_EMAILS", ["[@\\.]mit\\.edu"])
 
 RSS_FEED_EPISODE_LIMIT = get_int("RSS_FEED_EPISODE_LIMIT", 100)
+RSS_FEED_CACHE_MINUTES = get_int("RSS_FEED_CACHE_MINUTES", 15)
 
 if DEBUG:
     # allow for all IPs to be routable, including localhost, for testing


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
http://localhost:8063/podcasts/rss_feed

#### What's this PR do?
This pr caches the rss feed so that it will load faster. The default cache time is set to 15 minutes

#### How should this be manually tested?
Go to http://localhost:8063/podcasts/rss_feed. The page takes a second or two to load initially. On subsequent loads, it should load immediately. 
