### PR TITLE
Fixed password reset

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -187,7 +187,7 @@ class CustomPasswordResetEmail(DjoserPasswordResetEmail):
 
 class CustomDjoserAPIView(UserViewSet, ActionViewMixin):
     """
-    Overrides the post method of a Djoser view and adds one extra piece of logic:
+    Overrides post methods of a Djoser view and adds one extra piece of logic:
 
     In version 0.30.0, the fetch function in redux-hammock does not handle responses
     with empty response data. Djoser returns 204's with empty response data, so we are
@@ -195,8 +195,26 @@ class CustomDjoserAPIView(UserViewSet, ActionViewMixin):
     when redux-hammock is changed to support 204's.
     """
 
-    def post(self, request):  # pylint: disable=missing-docstring,arguments-differ
+    def post(
+        self, request, **kwargs
+    ):  # pylint: disable=missing-docstring,arguments-differ
         response = super().post(request)
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            return Response({}, status=status.HTTP_200_OK)
+        return response
+
+    @action(["post"], detail=False)
+    def reset_password(self, request, *args, **kwargs):
+        response = super().reset_password(request, *args, **kwargs)
+        # See class docstring for explanation
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            return Response({}, status=status.HTTP_200_OK)
+        return response
+
+    @action(["post"], detail=False)
+    def reset_password_confirm(self, request, *args, **kwargs):
+        response = super().reset_password_confirm(request, *args, **kwargs)
+        # See class docstring for explanation
         if response.status_code == status.HTTP_204_NO_CONTENT:
             return Response({}, status=status.HTTP_200_OK)
         return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       python3 manage.py migrate --no-input &&
       python3 manage.py createcachetable &&
       uwsgi uwsgi.ini --honour-stdin'
+    stdin_open: true
     tty: true
     ports:
       - "8061:8061"

--- a/open_discussions/test_utils.py
+++ b/open_discussions/test_utils.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 import traceback
 from unittest.mock import Mock
 
+from django.http.response import HttpResponse
+
 import pytest
 
 
@@ -50,18 +52,25 @@ def assert_not_raises():
         pytest.fail(f"An exception was not raised: {traceback.format_exc()}")
 
 
-class MockResponse:
+class MockResponse(HttpResponse):
     """
-    Mock requests.Response
+    Mocked HTTP response object that can be used as a stand-in for request.Response and
+    django.http.response.HttpResponse objects
     """
 
     def __init__(self, content, status_code):
-        self.content = content
+        """
+        Args:
+            content (str): The response content
+            status_code (int): the response status code
+        """
         self.status_code = status_code
+        self.decoded_content = content
+        super().__init__(content=(content or "").encode("utf-8"), status=status_code)
 
     def json(self):
         """ Return content as json """
-        return json.loads(self.content)
+        return json.loads(self.decoded_content)
 
 
 def drf_datetime(dt):

--- a/open_discussions/test_utils_test.py
+++ b/open_discussions/test_utils_test.py
@@ -52,7 +52,8 @@ def test_mock_response():
     content = "test"
     response = MockResponse(content, 404)
     assert response.status_code == 404
-    assert response.content == content
+    assert response.decoded_content == content
+    assert response.content == content.encode("utf-8")
 
 
 def test_pickleable_mock():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #3095 

#### What's this PR do?
Fixes the password reset views so the password reset flow works again

#### How should this be manually tested?
Run through a full password reset workflow (fill out the form, click the link in the resulting email, and use the password change form)

#### Any background context you want to provide?
Sooo due to a naming issue, our two Djoser test cases were not being run. It looks like something changed in the Djoser internals which broke our functionality that overrides it, and this wasn't caught because of said test cases being unrecognized 😬 
