### PR TITLE
Mock debounce to try to fix flaky tests

### DIFF
--- a/static/js/components/ArticleEditor.js
+++ b/static/js/components/ArticleEditor.js
@@ -2,7 +2,7 @@
 // @flow
 import React from "react"
 import CustomEditor from "@mitodl/ckeditor-custom-build"
-import debounce from "lodash/debounce"
+import _ from "lodash"
 
 import { getCKEditorJWT } from "../lib/api/ckeditor"
 import { loadEmbedlyPlatform, renderEmbedlyCard } from "../lib/embed"
@@ -57,7 +57,7 @@ export default class ArticleEditor extends React.Component<Props> {
         editor.model.document.on(
           "change:data",
           // editor.getData() is kind of expensive so we debounce
-          debounce(() => {
+          _.debounce(() => {
             if (onChange) {
               onChange(editor.getData())
             }

--- a/static/js/components/auth/AuthEmailForm.js
+++ b/static/js/components/auth/AuthEmailForm.js
@@ -3,7 +3,7 @@
 import React from "react"
 import ReCAPTCHA from "react-google-recaptcha"
 import styled from "styled-components"
-import debounce from "lodash/debounce"
+import _ from "lodash"
 
 import { validationMessage } from "../../lib/validation"
 
@@ -34,7 +34,7 @@ class AuthEmailForm extends React.Component<Props, State> {
     super(props)
     this.recaptcha = null
     // only rescale up to 4x a second to salvage some performance
-    this.scaleRecaptcha = debounce(this.scaleRecaptcha.bind(this), 250)
+    this.scaleRecaptcha = _.debounce(this.scaleRecaptcha.bind(this), 250)
     this.state = {
       recaptchaScale: 1.0
     }

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -7,7 +7,6 @@ import { connect } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 import _ from "lodash"
 import { compose } from "redux"
-import debounce from "lodash/debounce"
 
 import CanonicalLink from "../components/CanonicalLink"
 import { Cell, Grid } from "../components/Grid"
@@ -252,7 +251,7 @@ export class CourseSearchPage extends React.Component<Props, State> {
     })
   }
 
-  debouncedRunSearch = debounce(this.runSearch, 500)
+  debouncedRunSearch = _.debounce(this.runSearch, 500)
 
   setSearchUI = (searchResultLayout: string) => {
     this.setState({

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -538,10 +538,7 @@ describe("CourseSearchPage", () => {
     )
   })
 
-  // THIS IS TEMPORARY UNTIL FULL SEARCH SUPPORT IS IN PLACE!
-  LR_TYPE_ALL.filter(
-    type => type !== LR_TYPE_PODCAST && type !== LR_TYPE_PODCAST_EPISODE
-  ).forEach(resourceType => {
+  LR_TYPE_ALL.forEach(resourceType => {
     it(`overrideObject ${resourceType} is null if not in entities`, async () => {
       const resource = makeLearningResourceResult(resourceType)
       searchResponse.hits.hits[0] = resource

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store"
 import thunk from "redux-thunk"
 import { Provider } from "react-redux"
 import { Provider as ReduxQueryProvider } from "redux-query-react"
+import _ from "lodash"
 
 import Router, { routes } from "../Router"
 
@@ -76,6 +77,9 @@ export default class IntegrationTestHelper {
 
     this.scrollIntoViewStub = this.sandbox.stub()
     this.scrollStub = this.sandbox.stub()
+    this.debounceStub = this.sandbox
+      .stub(_, "debounce")
+      .callsFake((func: Function) => () => func())
     window.HTMLDivElement.prototype.scrollIntoView = this.scrollIntoViewStub
     window.HTMLFieldSetElement.prototype.scrollIntoView = this.scrollIntoViewStub
     window.HTMLDivElement.prototype.scroll = this.scrollStub

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -77,6 +77,7 @@ export default class IntegrationTestHelper {
 
     this.scrollIntoViewStub = this.sandbox.stub()
     this.scrollStub = this.sandbox.stub()
+    // mock debounce to execute without a delay, so that code runs before test completes
     this.debounceStub = this.sandbox
       .stub(_, "debounce")
       .callsFake((func: Function) => () => func())


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Attempts to fix a race condition by mocking out debounce to execute without a delay during testing. I can't reproduce this locally but here it is on travis: https://travis-ci.com/github/mitodl/open-discussions/jobs/378453509#L2728

#### How should this be manually tested?
Nothing should break. For user-facing code, I only changed the imports to use `_` instead of importing debounce directly to make mocking easier.