### PR TITLE
fix course search textbox behavior

### DIFF
--- a/static/js/components/Grid.js
+++ b/static/js/components/Grid.js
@@ -34,7 +34,7 @@ const ten: 10 = 10
 const eleven: 11 = 11
 const twelve: 12 = 12
 
-type CellWidth =
+export type CellWidth =
   | typeof one
   | typeof two
   | typeof three

--- a/static/js/components/SearchResult.js
+++ b/static/js/components/SearchResult.js
@@ -10,13 +10,13 @@ import ProfileImage, { PROFILE_IMAGE_SMALL } from "./ProfileImage"
 
 import {
   searchResultToComment,
-  searchResultToLearningResource,
   searchResultToPost,
   searchResultToProfile
 } from "../lib/search"
 import { commentPermalink, profileURL } from "../lib/url"
 import { dropdownMenuFuncs } from "../lib/ui"
 import { LR_TYPE_ALL } from "../lib/constants"
+import { useSearchResultToFavoriteLR } from "../hooks/learning_resources"
 
 import type {
   LearningResourceResult,
@@ -94,14 +94,14 @@ type LearningResourceProps = {
 
 const LearningResourceSearchResult = ({
   result,
-  overrideObject,
   searchResultLayout
 }: LearningResourceProps) => {
   // $FlowFixMe: this should only be used for courses
+  const searchResultToFavoriteLR = useSearchResultToFavoriteLR()
 
   return (
     <LearningResourceCard
-      object={searchResultToLearningResource(result, overrideObject)}
+      object={searchResultToFavoriteLR(result)}
       searchResultLayout={searchResultLayout}
     />
   )
@@ -118,7 +118,6 @@ type Props = {
     objectType: string,
     runId: ?number
   }) => void,
-  overrideObject?: Object,
   searchResultLayout?: string
 }
 export default class SearchResult extends React.Component<Props> {
@@ -130,7 +129,6 @@ export default class SearchResult extends React.Component<Props> {
       commentUpvote,
       commentDownvote,
       setShowResourceDrawer,
-      overrideObject,
       searchResultLayout
     } = this.props
     if (result.object_type === "post") {
@@ -167,7 +165,6 @@ export default class SearchResult extends React.Component<Props> {
         <LearningResourceSearchResult
           result={result}
           setShowResourceDrawer={setShowResourceDrawer}
-          overrideObject={overrideObject}
           searchResultLayout={searchResultLayout}
         />
       )

--- a/static/js/hooks/learning_resources.js
+++ b/static/js/hooks/learning_resources.js
@@ -46,9 +46,9 @@ export function useSearchResultToFavoriteLR() {
 
   const getFavoriteOrListedObject = useCallback(
     (searchResult: LearningResourceResult) => {
-      const object = searchResultToLearningResource(searchResult)
-      const storedObject = selector(object.id, object.object_type)
-      return storedObject || object
+      const storedObject = selector(searchResult.id, searchResult.object_type)
+      const object = searchResultToLearningResource(searchResult, storedObject)
+      return object
     },
     [selector]
   )

--- a/static/js/hooks/util.js
+++ b/static/js/hooks/util.js
@@ -10,7 +10,7 @@ import {
   DESKTOP
 } from "../lib/constants"
 
-export const useDeviceCategory = () => {
+export const useWidth = () => {
   const [width, setWidth] = useState(getViewportWidth())
 
   useEffect(() => {
@@ -22,6 +22,12 @@ export const useDeviceCategory = () => {
       window.removeEventListener("resize", cb)
     }
   }, [])
+
+  return width
+}
+
+export const useDeviceCategory = () => {
+  const width = useWidth()
 
   if (width <= PHONE_WIDTH) {
     return PHONE

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -1,12 +1,13 @@
 // @flow
 /* global SETTINGS: false */
 import R from "ramda"
-import React from "react"
+import React, { useState, useEffect, useCallback } from "react"
 import InfiniteScroll from "react-infinite-scroller"
-import { connect } from "react-redux"
+import { useSelector, useDispatch } from "react-redux"
 import { MetaTags } from "react-meta-tags"
 import _ from "lodash"
-import { compose } from "redux"
+import { useLocation, useHistory } from "react-router-dom"
+import { createSelector } from "reselect"
 
 import CanonicalLink from "../components/CanonicalLink"
 import { Cell, Grid } from "../components/Grid"
@@ -25,18 +26,14 @@ import { actions } from "../actions"
 import { clearSearch } from "../actions/search"
 import {
   LR_TYPE_ALL,
-  LR_TYPE_COURSE,
-  LR_TYPE_PROGRAM,
-  LR_TYPE_USERLIST,
   LR_TYPE_LEARNINGPATH,
-  LR_TYPE_VIDEO,
+  LR_TYPE_USERLIST,
   LR_TYPE_PODCAST,
   LR_TYPE_PODCAST_EPISODE
 } from "../lib/constants"
 import {
   emptyOrNil,
   preventDefaultAndInvoke,
-  getViewportWidth,
   GRID_MOBILE_BREAKPOINT,
   isDoubleQuoted
 } from "../lib/util"
@@ -50,57 +47,11 @@ import {
   deserializeSearchParams,
   serializeSearchParams
 } from "../lib/course_search"
+import { useResponsive, useWidth } from "../hooks/util"
 
-import type { Location, Match } from "react-router"
-import type { Dispatch } from "redux"
-import type {
-  SearchInputs,
-  SearchParams,
-  SortParam,
-  Result,
-  FacetResult,
-  LearningResourceResult
-} from "../flow/searchTypes"
-
-type OwnProps = {|
-  dispatch: Dispatch<any>,
-  location: Location,
-  history: Object,
-  isModerator: boolean,
-  match: Match,
-  runSearch: (params: SearchParams) => Promise<*>,
-  clearSearch: () => void
-|}
-
-type StateProps = {|
-  initialLoad: boolean,
-  results: Array<Result>,
-  facets: Map<string, FacetResult>,
-  suggest: Array<string>,
-  loaded: boolean,
-  processing: boolean,
-  total: number,
-  entities: Object
-|}
-
-type DispatchProps = {|
-  runSearch: (params: SearchParams) => Promise<*>,
-  clearSearch: () => Promise<*>,
-  dispatch: Dispatch<*>
-|}
-
-type Props = {|
-  ...OwnProps,
-  ...StateProps,
-  ...DispatchProps
-|}
-
-type State = {
-  from: number,
-  error: ?string,
-  incremental: boolean,
-  searchResultLayout: string
-}
+import type { SortParam, LearningResourceResult } from "../flow/searchTypes"
+import type { Match } from "react-router"
+import type { CellWidth } from "../components/Grid"
 
 export type CourseSearchParams = {
   type?: ?string | ?Array<string>,
@@ -112,415 +63,442 @@ export type CourseSearchParams = {
   sort?: SortParam,
   activeFacets?: Object
 }
-const shouldRunSearch = R.complement(R.eqProps("activeFacets"))
 
 const THREE_CARD_BREAKPOINT = 1100
 
-export class CourseSearchPage extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      incremental:        false,
-      searchResultLayout: SEARCH_LIST_UI,
-      from:               0,
-      error:              null
-    }
-  }
-
-  componentDidMount() {
-    const { clearSearch } = this.props
-    clearSearch()
-    this.runSearch()
-    window.addEventListener("resize", () => this.setState({}))
-  }
-
-  componentDidUpdate(prevProps: Object, prevState: Object) {
-    if (shouldRunSearch(prevState, this.state)) {
-      this.debouncedRunSearch()
-    }
-  }
-
-  clearAllFilters = async () => {
-    this.updateSearchState({
-      text:         null,
-      activeFacets: {
-        audience:      [],
-        certification: [],
-        offered_by:    [],
-        topics:        [],
-        type:          []
-      }
-    })
-  }
-
-  facetOptions = (group: string) => {
-    const { facets, location } = this.props
-    const { activeFacets } = deserializeSearchParams(location)
-    const emptyFacet = { buckets: [] }
-    const emptyActiveFacets = {
-      buckets: (activeFacets[group] || []).map(facet => ({
-        key:       facet,
-        doc_count: 0
-      }))
-    }
-
-    if (!facets) {
-      return null
-    }
-
-    return mergeFacetResults(facets.get(group) || emptyFacet, emptyActiveFacets)
-  }
-
-  loadMore = async () => {
-    const { loaded } = this.props
-
-    if (!loaded) {
-      // this function will be triggered repeatedly by <InfiniteScroll />, filter it to just once at a time
-      return
-    }
-
-    await this.runSearch({
-      incremental: true
-    })
-  }
-
-  updateSearchState = (
-    searchParams: CourseSearchParams,
-    debounce: boolean = false
-  ) => {
-    const { location, history } = this.props
-    const { pathname } = location
-    const { activeFacets } = searchParams
-
-    const oldParams = deserializeSearchParams(location)
-
-    const text = searchParams.hasOwnProperty("text")
-      ? searchParams.text
-      : oldParams.text
-
-    history.replace({
-      pathname: pathname,
-      search:   serializeSearchParams({
-        text,
-        activeFacets: activeFacets || oldParams.activeFacets
-      })
-    })
-    if (debounce) {
-      this.debouncedRunSearch()
-    } else {
-      // this ensures that the `history.replace` update is in place before
-      // we try to pull out the data in `this.runSearch`
-      setTimeout(() => {
-        this.runSearch()
-      })
-    }
-  }
-
-  runSearch = async (params: SearchInputs = { incremental: false }) => {
-    const { clearSearch, runSearch, location } = this.props
-    const { activeFacets, text } = deserializeSearchParams(location)
-
-    let from = this.state.from + SETTINGS.search_page_size
-    const { incremental } = params
-    if (!incremental) {
-      clearSearch()
-      from = 0
-    }
-    this.setState({ from, incremental })
-
-    if (emptyOrNil(activeFacets.type)) {
-      activeFacets.type = LR_TYPE_ALL
-    } else {
-      if (activeFacets.type.includes(LR_TYPE_PODCAST)) {
-        activeFacets.type.push(LR_TYPE_PODCAST_EPISODE)
-      }
-
-      if (activeFacets.type.includes(LR_TYPE_USERLIST)) {
-        activeFacets.type.push(LR_TYPE_LEARNINGPATH)
-      }
-    }
-
-    await runSearch({
-      channelName: null,
-      text,
-      type:        activeFacets.type,
-      // $FlowFixMe: type facet wont be undefined here
-      facets:      new Map(Object.entries(activeFacets)),
-      from,
-      size:        SETTINGS.search_page_size
-    })
-  }
-
-  debouncedRunSearch = _.debounce(this.runSearch, 500)
-
-  setSearchUI = (searchResultLayout: string) => {
-    this.setState({
-      searchResultLayout
-    })
-  }
-
-  toggleFacet = async (name: string, value: string, isEnabled: boolean) => {
-    const { location } = this.props
-    const { activeFacets } = deserializeSearchParams(location)
-
-    if (isEnabled) {
-      activeFacets[name] = _.union(activeFacets[name] || [], [value])
-    } else {
-      activeFacets[name] = _.without(activeFacets[name] || [], value)
-    }
-
-    this.updateSearchState({
-      activeFacets
-    })
-  }
-
-  onUpdateFacets = (e: Object) => {
-    this.toggleFacet(e.target.name, e.target.value, e.target.checked)
-  }
-
-  updateText = async (event: Object) => {
-    const text = event ? event.target.value : ""
-    await this.updateSearchState({ text }, true)
-  }
-
-  useSuggestion = async (text: string) => {
-    await this.updateSearchState({ text })
-    this.runSearch()
-  }
-
-  getFavoriteOrListedObject = (result: LearningResourceResult) => {
-    // Get the latest data from state if any to reflect recent changes in favorites/lists
-    const { entities } = this.props
-    const {
-      courses,
-      programs,
-      userLists,
-      videos,
-      podcasts,
-      podcastEpisodes
-    } = entities
-    switch (result.object_type) {
-    case LR_TYPE_COURSE:
-      return courses ? courses[result.id] || null : null
-    case LR_TYPE_PROGRAM:
-      return programs ? programs[result.id] || null : null
-    case LR_TYPE_USERLIST:
-      return userLists ? userLists[result.id] || null : null
-    case LR_TYPE_VIDEO:
-      return videos ? videos[result.id] || null : null
-    case LR_TYPE_PODCAST:
-      return podcasts ? podcasts[result.id] || null : null
-    case LR_TYPE_PODCAST_EPISODE:
-      return podcastEpisodes ? podcastEpisodes[result.id] || null : null
-    case LR_TYPE_LEARNINGPATH:
-      return userLists ? userLists[result.id] || null : null
-    }
-  }
-
-  getSearchResultCellWidth = () => {
-    const { searchResultLayout } = this.state
-
-    if (searchResultLayout === SEARCH_LIST_UI) {
-      return 12
-    }
-
-    const width = getViewportWidth()
-    if (width < THREE_CARD_BREAKPOINT && width >= GRID_MOBILE_BREAKPOINT) {
-      return 6
-    } else {
-      return 4
-    }
-  }
-
-  renderResults = () => {
-    const { results, processing, loaded, total } = this.props
-    const { from, incremental, searchResultLayout } = this.state
-
-    if ((processing || !loaded) && !incremental) {
-      return <CourseSearchLoading layout={searchResultLayout} />
-    }
-
-    if (total === 0 && !processing && loaded) {
-      return (
-        <div className="empty-list-msg">There are no results to display.</div>
-      )
-    }
-
-    return (
-      <InfiniteScroll
-        hasMore={from + SETTINGS.search_page_size < total}
-        loadMore={this.loadMore}
-        initialLoad={from === 0}
-        loader={<Loading className="infinite" key="loader" />}
-      >
-        <Grid>
-          {results.map((result, i) => (
-            <Cell width={this.getSearchResultCellWidth()} key={i}>
-              <SearchResult
-                result={result}
-                overrideObject={
-                  // $FlowFixMe
-                  this.getFavoriteOrListedObject(result)
-                }
-                toggleFacet={this.toggleFacet}
-                searchResultLayout={searchResultLayout}
-              />
-            </Cell>
-          ))}
-        </Grid>
-      </InfiniteScroll>
-    )
-  }
-
-  render() {
-    const { location, match, total, processing, suggest } = this.props
-    const { error, searchResultLayout } = this.state
-    const { text, activeFacets } = deserializeSearchParams(location)
-
-    const facetColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 3 : 4
-    const resultsColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 9 : 8
-    const suggestions =
-      !emptyOrNil(suggest) && !emptyOrNil(text)
-        ? R.without([text], suggest).map(
-          suggestion =>
-            isDoubleQuoted(text) ? `"${suggestion}"` : suggestion
-        )
-        : []
-
-    return (
-      <BannerPageWrapper>
-        <MetaTags>
-          <CanonicalLink match={match} />
-        </MetaTags>
-        <BannerPageHeader tall compactOnMobile>
-          <BannerContainer tall compactOnMobile>
-            <BannerImage src={COURSE_SEARCH_BANNER_URL} tall compactOnMobile />
-          </BannerContainer>
-          <CourseSearchbox
-            onChange={this.updateText}
-            value={text || ""}
-            onClear={this.updateText}
-            onSubmit={preventDefaultAndInvoke(() => this.runSearch())}
-            validation={error}
-            autoFocus
-          />
-        </BannerPageHeader>
-        <Grid
-          className={`main-content ${
-            searchResultLayout === SEARCH_GRID_UI
-              ? "two-column-extrawide"
-              : "two-column"
-          } search-page`}
-        >
-          <Cell width={facetColumnWidth} />
-          <Cell width={resultsColumnWidth}>
-            {!emptyOrNil(suggestions) ? (
-              <div className="suggestion">
-                Did you mean
-                {suggestions.map((suggestion, i) => (
-                  <span key={i}>
-                    <a
-                      onClick={preventDefaultAndInvoke(() =>
-                        this.useSuggestion(suggestion)
-                      )}
-                      onKeyPress={e => {
-                        if (e.key === "Enter") {
-                          this.useSuggestion(suggestion)
-                        }
-                      }}
-                      tabIndex="0"
-                    >
-                      {` ${suggestion}`}
-                    </a>
-                    {i < suggestions.length - 1 ? " | " : ""}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-            <div className="layout-buttons">
-              <div
-                onClick={() => this.setSearchUI(SEARCH_LIST_UI)}
-                onKeyPress={e => {
-                  if (e.key === "Enter") {
-                    this.setSearchUI(SEARCH_LIST_UI)
-                  }
-                }}
-                tabIndex="0"
-                className={`option ${
-                  searchResultLayout === SEARCH_LIST_UI ? "active" : ""
-                }`}
-              >
-                <i className="material-icons view_list">view_list</i>
-              </div>
-              <div
-                onClick={() => this.setSearchUI(SEARCH_GRID_UI)}
-                onKeyPress={e => {
-                  if (e.key === "Enter") {
-                    this.setSearchUI(SEARCH_GRID_UI)
-                  }
-                }}
-                tabIndex="0"
-                className={`option ${
-                  searchResultLayout === SEARCH_GRID_UI ? "active" : ""
-                }`}
-              >
-                <i className="material-icons view_comfy">view_comfy</i>
-              </div>
-              {processing ? null : (
-                <div className="results-count">
-                  {total} {total === 1 ? "Result" : "Results"}
-                </div>
-              )}
-            </div>
-          </Cell>
-          <Cell className="search-filters" width={facetColumnWidth}>
-            <CourseFilterDrawer
-              activeFacets={activeFacets}
-              clearAllFilters={this.clearAllFilters}
-              toggleFacet={this.toggleFacet}
-              facetOptions={this.facetOptions}
-              onUpdateFacets={this.onUpdateFacets}
-            />
-          </Cell>
-          <Cell width={resultsColumnWidth}>
-            {error ? null : this.renderResults()}
-          </Cell>
-        </Grid>
-      </BannerPageWrapper>
-    )
-  }
+const INITIAL_FACET_STATE = {
+  audience:      [],
+  certification: [],
+  offered_by:    [],
+  topics:        [],
+  type:          []
 }
 
-const mapStateToProps = (state): StateProps => {
-  const { search, entities } = state
-  const { results, total, initialLoad, facets, suggest } = search.data
+const courseSearchSelector = createSelector(
+  state => state.search,
+  search => {
+    const { error, results, total, facets, suggest } = search.data
 
-  return {
+    return {
+      error,
+      results,
+      facets,
+      suggest,
+      total,
+      loaded:     search.loaded,
+      processing: search.processing
+    }
+  }
+)
+
+type ResultProps = {
+  from: number,
+  incremental: boolean,
+  loadMore: Function,
+  loaded: boolean,
+  processing: boolean,
+  results: Array<LearningResourceResult>,
+  searchResultCellWidth: CellWidth,
+  searchResultLayout: string,
+  toggleFacet: Function,
+  total: number
+}
+
+export function Results(props: ResultProps) {
+  const {
+    from,
+    incremental,
+    loadMore,
+    loaded,
+    processing,
+    results,
+    searchResultCellWidth,
+    searchResultLayout,
+    toggleFacet,
+    total
+  } = props
+
+  if ((processing || !loaded) && !incremental) {
+    return <CourseSearchLoading layout={searchResultLayout} />
+  }
+
+  if (total === 0 && !processing && loaded) {
+    return (
+      <div className="empty-list-msg">There are no results to display.</div>
+    )
+  }
+
+  return (
+    <InfiniteScroll
+      hasMore={from + SETTINGS.search_page_size < total}
+      loadMore={loadMore}
+      initialLoad={from === 0}
+      loader={<Loading className="infinite" key="loader" />}
+    >
+      <Grid>
+        {results.map((result, i) => (
+          <Cell width={searchResultCellWidth} key={i}>
+            <SearchResult
+              result={result}
+              toggleFacet={toggleFacet}
+              searchResultLayout={searchResultLayout}
+            />
+          </Cell>
+        ))}
+      </Grid>
+    </InfiniteScroll>
+  )
+}
+
+type Props = {
+  match: Match
+}
+
+export default function CourseSearchPage(props: Props) {
+  const { match } = props
+
+  const {
     results,
     facets,
     suggest,
     total,
-    initialLoad,
-    loaded:     search.loaded,
-    processing: search.processing,
-    entities
-  }
-}
+    loaded,
+    processing,
+    error
+  } = useSelector(courseSearchSelector)
 
-const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
-  runSearch: async (params: SearchParams) => {
-    return await dispatch(actions.search.post(params))
-  },
-  clearSearch: async () => {
-    dispatch(actions.search.clear())
-    await dispatch(clearSearch())
-  },
-  dispatch
-})
+  const [incremental, setIncremental] = useState(false)
+  const [searchResultLayout, setSearchResultLayout] = useState(SEARCH_LIST_UI)
+  const [from, setFrom] = useState(0)
+  const [text, setText] = useState("")
+  const [activeFacets, setActiveFacets] = useState(INITIAL_FACET_STATE)
 
-export default compose(
-  connect<Props, OwnProps, _, _, _, _>(
-    mapStateToProps,
-    mapDispatchToProps
+  const dispatch = useDispatch()
+
+  const clearSearchCB = useCallback(
+    () => {
+      dispatch(actions.search.clear())
+      dispatch(clearSearch())
+    },
+    [dispatch]
   )
-)(CourseSearchPage)
+
+  useResponsive()
+  const location = useLocation()
+  const history = useHistory()
+
+  const facetOptions = useCallback(
+    (group: string) => {
+      const emptyFacet = { buckets: [] }
+      const emptyActiveFacets = {
+        buckets: (activeFacets[group] || []).map(facet => ({
+          key:       facet,
+          doc_count: 0
+        }))
+      }
+
+      if (!facets) {
+        return null
+      }
+
+      return mergeFacetResults(
+        facets.get(group) || emptyFacet,
+        emptyActiveFacets
+      )
+    },
+    [facets, activeFacets]
+  )
+
+  const runSearch = useCallback(
+    async (text, activeFacets, incremental = false) => {
+      let nextFrom = from + SETTINGS.search_page_size
+
+      if (!incremental) {
+        clearSearchCB()
+        nextFrom = 0
+      }
+      setFrom(nextFrom)
+      setIncremental(incremental)
+
+      const searchFacets = R.clone(activeFacets)
+
+      if (emptyOrNil(searchFacets.type)) {
+        searchFacets.type = LR_TYPE_ALL
+      } else {
+        if (searchFacets.type.includes(LR_TYPE_PODCAST)) {
+          searchFacets.type.push(LR_TYPE_PODCAST_EPISODE)
+        }
+
+        if (searchFacets.type.includes(LR_TYPE_USERLIST)) {
+          searchFacets.type.push(LR_TYPE_LEARNINGPATH)
+        }
+      }
+
+      await dispatch(
+        actions.search.post({
+          channelName: null,
+          text,
+          type:        searchFacets.type,
+          facets:      new Map(Object.entries(searchFacets)),
+          from:        nextFrom,
+          size:        SETTINGS.search_page_size
+        })
+      )
+
+      // search is updated, now echo params to URL bar
+      history.replace({
+        pathname: location.pathname,
+        search:   serializeSearchParams({
+          text,
+          activeFacets
+        })
+      })
+    },
+    [from, location, history, setFrom, setIncremental, clearSearchCB, dispatch]
+  )
+
+  const loadMore = useCallback(
+    () => {
+      if (!loaded) {
+        // this function will be triggered repeatedly by <InfiniteScroll />, filter it to just once at a time
+        return
+      }
+
+      runSearch(text, activeFacets, true)
+    },
+    [runSearch, loaded, text, activeFacets]
+  )
+
+  const clearAllFilters = useCallback(
+    () => {
+      setText(null)
+      setActiveFacets(INITIAL_FACET_STATE)
+    },
+    [setText, setActiveFacets]
+  )
+
+  // this effect here basically listens to activeFacets for changes and re-runs
+  // the search whenever it changes. we always want the facet changes to take
+  // effect immediately, so we need to either do this or call runSearch from
+  // our facet-related callbacks. this approach lets us avoid having the
+  // facet-related callbacks (toggleFacet, etc) be dependent on then value of
+  // the runSearch function, which leads to too much needless churn in the
+  // facet callbacks and then causes excessive re-rendering of the facet UI
+  useEffect(
+    () => {
+      runSearch(text, activeFacets)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeFacets]
+  )
+
+  const toggleFacet = useCallback(
+    async (name: string, value: string, isEnabled: boolean) => {
+      const newFacets = R.clone(activeFacets)
+
+      if (isEnabled) {
+        newFacets[name] = _.union(newFacets[name] || [], [value])
+      } else {
+        newFacets[name] = _.without(newFacets[name] || [], value)
+      }
+      setActiveFacets(newFacets)
+    },
+    [activeFacets, setActiveFacets]
+  )
+
+  const onUpdateFacets = useCallback(
+    (e: Object) => {
+      toggleFacet(e.target.name, e.target.value, e.target.checked)
+    },
+    [toggleFacet]
+  )
+
+  const updateText = useCallback(
+    (event: Object) => {
+      const text = event ? event.target.value : ""
+      setText(text)
+    },
+    [setText]
+  )
+
+  const clearText = useCallback(
+    (event: Object) => {
+      event.preventDefault()
+      setText("")
+      runSearch("", activeFacets)
+    },
+    [activeFacets, setText, runSearch]
+  )
+
+  const acceptSuggestion = useCallback(
+    (suggestion: string) => {
+      setText(suggestion)
+      runSearch(suggestion, activeFacets)
+    },
+    [setText, activeFacets, runSearch]
+  )
+
+  const deviceWidth = useWidth()
+  const [searchResultCellWidth, setSearchResultCellWidth] = useState(6)
+
+  useEffect(
+    () => {
+      if (searchResultLayout === SEARCH_LIST_UI) {
+        setSearchResultCellWidth(12)
+      } else if (
+        deviceWidth < THREE_CARD_BREAKPOINT &&
+        deviceWidth >= GRID_MOBILE_BREAKPOINT
+      ) {
+        setSearchResultCellWidth(6)
+      } else {
+        setSearchResultCellWidth(4)
+      }
+    },
+    [setSearchResultCellWidth, deviceWidth, searchResultLayout]
+  )
+
+  // this is our 'on startup' useEffect call
+  useEffect(() => {
+    clearSearchCB()
+    const { text, activeFacets } = deserializeSearchParams(location)
+    setText(text)
+    setActiveFacets(activeFacets)
+    runSearch(text, activeFacets)
+    // dependencies intentionally left blank here, because this effect
+    // needs to run only once - it's just to initialize the search state
+    // based on the value of the URL (if any)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const onSubmit = useCallback(
+    e => {
+      e.preventDefault()
+      runSearch(text, activeFacets)
+    },
+    [runSearch, text, activeFacets]
+  )
+
+  const facetColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 3 : 4
+  const resultsColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 9 : 8
+  const suggestions =
+    !emptyOrNil(suggest) && !emptyOrNil(text)
+      ? R.without([text], suggest).map(
+        suggestion => (isDoubleQuoted(text) ? `"${suggestion}"` : suggestion)
+      )
+      : []
+
+  return (
+    <BannerPageWrapper>
+      <MetaTags>
+        <CanonicalLink match={match} />
+      </MetaTags>
+      <BannerPageHeader tall compactOnMobile>
+        <BannerContainer tall compactOnMobile>
+          <BannerImage src={COURSE_SEARCH_BANNER_URL} tall compactOnMobile />
+        </BannerContainer>
+        <CourseSearchbox
+          onChange={updateText}
+          value={text || ""}
+          onClear={clearText}
+          onSubmit={onSubmit}
+          validation={error}
+          autoFocus
+        />
+      </BannerPageHeader>
+      <Grid
+        className={`main-content ${
+          searchResultLayout === SEARCH_GRID_UI
+            ? "two-column-extrawide"
+            : "two-column"
+        } search-page`}
+      >
+        <Cell width={facetColumnWidth} />
+        <Cell width={resultsColumnWidth}>
+          {!emptyOrNil(suggestions) ? (
+            <div className="suggestion">
+              Did you mean
+              {suggestions.map((suggestion, i) => (
+                <span key={i}>
+                  <a
+                    onClick={preventDefaultAndInvoke(() =>
+                      acceptSuggestion(suggestion)
+                    )}
+                    onKeyPress={e => {
+                      if (e.key === "Enter") {
+                        acceptSuggestion(suggestion)
+                      }
+                    }}
+                    tabIndex="0"
+                  >
+                    {` ${suggestion}`}
+                  </a>
+                  {i < suggestions.length - 1 ? " | " : ""}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          <div className="layout-buttons">
+            <div
+              onClick={() => setSearchResultLayout(SEARCH_LIST_UI)}
+              onKeyPress={e => {
+                if (e.key === "Enter") {
+                  setSearchResultLayout(SEARCH_LIST_UI)
+                }
+              }}
+              tabIndex="0"
+              className={`option ${
+                searchResultLayout === SEARCH_LIST_UI ? "active" : ""
+              }`}
+            >
+              <i className="material-icons view_list">view_list</i>
+            </div>
+            <div
+              onClick={() => setSearchResultLayout(SEARCH_GRID_UI)}
+              onKeyPress={e => {
+                if (e.key === "Enter") {
+                  setSearchResultLayout(SEARCH_GRID_UI)
+                }
+              }}
+              tabIndex="0"
+              className={`option ${
+                searchResultLayout === SEARCH_GRID_UI ? "active" : ""
+              }`}
+            >
+              <i className="material-icons view_comfy">view_comfy</i>
+            </div>
+            {processing ? null : (
+              <div className="results-count">
+                {total} {total === 1 ? "Result" : "Results"}
+              </div>
+            )}
+          </div>
+        </Cell>
+        <Cell className="search-filters" width={facetColumnWidth}>
+          <CourseFilterDrawer
+            activeFacets={activeFacets}
+            clearAllFilters={clearAllFilters}
+            toggleFacet={toggleFacet}
+            facetOptions={facetOptions}
+            onUpdateFacets={onUpdateFacets}
+          />
+        </Cell>
+        <Cell width={resultsColumnWidth}>
+          {error ? null : (
+            <Results
+              from={from}
+              incremental={incremental}
+              loadMore={loadMore}
+              loaded={loaded}
+              processing={processing}
+              results={results}
+              searchResultCellWidth={searchResultCellWidth}
+              searchResultLayout={searchResultLayout}
+              toggleFacet={toggleFacet}
+              total={total}
+            />
+          )}
+        </Cell>
+      </Grid>
+    </BannerPageWrapper>
+  )
+}

--- a/static/js/util/integration_test_helper.js
+++ b/static/js/util/integration_test_helper.js
@@ -212,10 +212,14 @@ export default class IntegrationTestHelper {
     return storeLib.default(initialState)
   }
 
-  configureReduxQueryRenderer(Component, defaultProps = {}) {
+  configureReduxQueryRenderer(Component, defaultProps = {}, defaultState) {
     const history = this.browserHistory
-    return async (extraProps = { history }, beforeRenderActions = []) => {
-      const store = this.createFullStore()
+    return async (
+      extraProps = { history },
+      beforeRenderActions = [],
+      perRenderDefaultState
+    ) => {
+      const store = this.createFullStore(defaultState ?? perRenderDefaultState)
       beforeRenderActions.forEach(action => store.dispatch(action))
 
       const wrapper = await mount(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

no ticket, but basically to accomplish the same thing I did here: https://github.com/mitodl/hugo-course-publisher/pull/190 for the OCW search.

#### What's this PR do?

this removes the automatic search behavior, so that the user has to manually trigger the search instead via the enter key.

I also found a few performance issues on the page and diagnosed those, adding `React.memo` to fix.

also refactored `CourseSearchPage` from class-based to functional component.

#### How should this be manually tested?

This touched a lot of parts of the search, so please test it exhaustively. Facets should all work, should be able to change text search, clear facet values, etc etc.