### PR TITLE
Add accessibility links to footers

### DIFF
--- a/static/js/components/Footer.js
+++ b/static/js/components/Footer.js
@@ -21,6 +21,15 @@ const Footer = () => (
     <div className="row">
       <a href={SETTINGS.authenticated_site.tos_url}>Terms & Conditions</a>
     </div>
+    <div className="row">
+      <a
+        href="https://accessibility.mit.edu/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Accessibility
+      </a>
+    </div>
     <div className="row mit-logo">
       <a href="https://www.mit.edu/" target="_blank" rel="noopener noreferrer">
         <img

--- a/static/js/components/PodcastFooter.js
+++ b/static/js/components/PodcastFooter.js
@@ -40,6 +40,8 @@ export default function PodcastFooter() {
           <Link to="/content_policy">Community Guidelines</Link>
           <div className="bar">{" | "}</div>
           <a href={SETTINGS.authenticated_site.tos_url}>Terms & Conditions</a>
+          <div className="bar">{" | "}</div>
+          <a href="https://accessibility.mit.edu/">Accessibility</a>
         </div>
         <div className="cell title">
           <Link className="home-link" to="/">

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -1,6 +1,6 @@
 $red-link-color: #9a2a33;
 $link-padding: 11px 20px 11px $icon-padding-left;
-$footer-height: 152px;
+$footer-height: 172px;
 
 $drawer-trans: width 500ms;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Fixes #3142 

#### What's this PR do?
Adds a couple of links to the footer on the drawer and the podcast page

#### How should this be manually tested?
Click the links and verify that you go to https://accessibility.mit.edu

#### Screenshots
![Screenshot from 2020-09-10 14-23-35](https://user-images.githubusercontent.com/863262/92781434-20c7ae80-f372-11ea-91c9-156c798a6fb8.png)
![Screenshot from 2020-09-10 14-23-17](https://user-images.githubusercontent.com/863262/92781449-245b3580-f372-11ea-904d-8c95879e6b2a.png)
