### PR TITLE
add post and comment information to spam check admin

### DIFF
--- a/channels/admin.py
+++ b/channels/admin.py
@@ -9,6 +9,7 @@ from channels.models import (
     ChannelMembershipConfig,
     SpamCheckResult,
 )
+from channels.constants import POST_TYPE
 from open_discussions.utils import get_field_names
 
 
@@ -107,11 +108,39 @@ class SpamCheckResultAdmin(admin.ModelAdmin):
     model = SpamCheckResult
     search_fields = ("object_id", "user_ip")
     list_filter = ("content_type", "is_spam")
-    list_display = ("content_type", "object_id", "user_ip", "is_spam")
-    readonly_fields = get_field_names(SpamCheckResult)
+    list_display = (
+        "content_type",
+        "object_id",
+        "user_ip",
+        "is_spam",
+        "title",
+        "truncated_text",
+        "author",
+    )
+    readonly_fields = get_field_names(SpamCheckResult) + ["title", "text", "author"]
 
     def has_add_permission(self, request):
         return False
+
+    def title(self, spam_check):
+        """Title of spam checked post"""
+        if spam_check.content_type.name == POST_TYPE:
+            return spam_check.content_object.title
+        else:
+            return None
+
+    def text(self, spam_check):
+        """Text of spam checked post or comment"""
+
+        return spam_check.content_object.text
+
+    def truncated_text(self, spam_check):
+        """Truncated text of spam checked post or comment"""
+        return spam_check.content_object.text[0:350]
+
+    def author(self, spam_check):
+        """Email text of spam checked post or comment author"""
+        return spam_check.content_object.author.email
 
 
 admin.site.register(SpamCheckResult, SpamCheckResultAdmin)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
<img width="810" alt="Screen Shot 2020-09-14 at 11 23 59 AM" src="https://user-images.githubusercontent.com/1934992/93105278-dd748500-f67c-11ea-981f-570b8dded163.png">
<img width="1291" alt="Screen Shot 2020-09-14 at 11 23 44 AM" src="https://user-images.githubusercontent.com/1934992/93105281-de0d1b80-f67c-11ea-90a4-52179af604ff.png">

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3136

#### What's this PR do?
This pr adds author and post/comment information to the spam check admin

#### How should this be manually tested?
Go to http://localhost:8063/admin/channels/spamcheckresult
Verify that you see information about the post/comment and author info

