### PR TITLE
Don't sync an OCW course if it's in the NON_COURSE_DIRECTORIES list

### DIFF
--- a/course_catalog/management/commands/delete_non_courses.py
+++ b/course_catalog/management/commands/delete_non_courses.py
@@ -1,0 +1,22 @@
+"""Management command for deleting non-course files from S3"""
+from django.core.management import BaseCommand
+
+from course_catalog.constants import NON_COURSE_DIRECTORIES
+from course_catalog.api import get_ocw_learning_course_bucket
+
+
+class Command(BaseCommand):
+    """Delete non-course files from S3"""
+
+    help = """Delete non-course files from S3"""
+
+    def handle(self, *args, **options):
+        bucket = get_ocw_learning_course_bucket()
+        prefixes = [prefix.split("/")[-1] for prefix in NON_COURSE_DIRECTORIES]
+
+        self.stdout.write(f"Searching for non-courses")
+        for bucket_file in bucket.objects.all():
+            if bucket_file.key.split("/")[0] in prefixes:
+                self.stdout.write(f"Deleting {bucket_file.key}")
+                bucket.delete_objects(Delete={"Objects": [{"Key": bucket_file.key}]})
+        self.stdout.write(f"Finished")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3148

#### What's this PR do?
- Skips processing of an OCW course if the prefix starts with one of the prefixes in `course_catalog.constancts.NON_COURSE_DIRECTORIES`

#### How should this be manually tested?
- On master, run `course_catalog.api.sync_ocw_courses(course_prefixes=["PROD/biology"], blocklist=[], force_overwrite=True, upload_to_s3=True)` - the course will be processed and master_json written to S3.
- On this branch, run `python manage.py delete_non_courses`.  You should see a message about a biology master.json file being deleted.
- On this branch run `course_catalog.api.sync_ocw_courses(course_prefixes=["PROD/biology"], blocklist=[], force_overwrite=True, upload_to_s3=True)` again - this time the course should not be processed (`Non-course folder, skipping: PROD/biology`)
