### PR TITLE
add spam management commands

### DIFF
--- a/channels/factories/models.py
+++ b/channels/factories/models.py
@@ -11,6 +11,7 @@ from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
 import pytz
 
+from django.contrib.contenttypes.models import ContentType
 from channels import api
 from channels.constants import (
     VALID_CHANNEL_TYPES,
@@ -31,6 +32,7 @@ from channels.models import (
     Post,
     Comment,
     Article,
+    SpamCheckResult,
 )
 from open_discussions.factories import UserFactory
 
@@ -267,3 +269,17 @@ class SubscriptionFactory(DjangoModelFactory):
 
     class Params:
         is_comment = False
+
+
+class SpamCheckResultFactory(DjangoModelFactory):
+    """Factory for SpamCheckResult"""
+
+    content_object = SubFactory(CommentFactory)
+    object_id = factory.SelfAttribute("content_object.id")
+    content_type = factory.LazyAttribute(
+        lambda o: ContentType.objects.get_for_model(o.content_object)
+    )
+    user_ip = "111.11.111.1"
+
+    class Meta:
+        model = SpamCheckResult

--- a/channels/management/commands/reclassify_spam.py
+++ b/channels/management/commands/reclassify_spam.py
@@ -1,0 +1,80 @@
+"""Reclassify posts/comments as spam or ham"""
+from django.core.management.base import BaseCommand
+
+from channels import tasks
+from open_discussions.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Reclassify posts/comments as spam or ham"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--spam",
+            dest="is_spam",
+            action="store_true",
+            help="Mark comments and posts as spam.",
+        )
+
+        parser.add_argument(
+            "--ham",
+            dest="is_ham",
+            action="store_true",
+            help="Mark comments and posts as ham",
+        )
+
+        parser.add_argument(
+            "-c",
+            "--comment-id",
+            dest="comment_ids",
+            action="append",
+            default=[],
+            help="Comment ids to reclassify",
+        )
+        parser.add_argument(
+            "-p",
+            "--post-id",
+            dest="post_ids",
+            action="append",
+            default=[],
+            help="Post ids to reclassify",
+        )
+        parser.add_argument(
+            "--retire-users",
+            dest="retire_users",
+            action="store_true",
+            default=False,
+            help="Retire users",
+        )
+        parser.add_argument(
+            "--skip-akismet",
+            dest="skip_akismet",
+            action="store_true",
+            default=False,
+            help="Skip submitting spam/ham reclassification to askimet",
+        )
+
+    def handle(self, *args, **options):
+        if options["is_spam"]:
+            is_spam = True
+        elif options["is_ham"]:
+            is_spam = False
+        else:
+            self.stdout.write("Either --spam or --ham flag is required")
+            return
+
+        task = tasks.update_spam.delay(
+            spam=is_spam,
+            comment_ids=options["comment_ids"],
+            post_ids=options["post_ids"],
+            retire_users=options["retire_users"],
+            skip_akismet=options["skip_akismet"],
+        )
+
+        self.stdout.write("Waiting on task...")
+        start = now_in_utc()
+        task.get()
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write("Updated spam, took {} seconds".format(total_seconds))

--- a/channels/spam.py
+++ b/channels/spam.py
@@ -69,7 +69,7 @@ def exempt_from_spamcheck(email):
     )
 
 
-def _create_akismet_client():
+def create_akismet_client():
     """Initialize the akismet client"""
     if not all([settings.AKISMET_API_KEY, settings.AKISMET_BLOG_URL]):
         log.info(
@@ -93,7 +93,7 @@ class SpamChecker:
     """Spam checking for posts and comments"""
 
     def __init__(self):
-        self._client = SimpleLazyObject(_create_akismet_client)
+        self._client = SimpleLazyObject(create_akismet_client)
 
     def _can_spam_check(self):
         """Returns True if the spam checker is properly configured and can operate"""


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3100

#### What's this PR do?
This pr adds a management command for reclassifying posts and comments incorrectly marked as spam or not marked as spam by akismet

#### How should this be manually tested?
Go to http://localhost:8063/admin/channels/spamcheckresult/

If you don't have a spam check result for a post and a comment create a post and comment with a non-moderator user to generate some

`docker-compose run web ./manage.py reclassify_spam --spam --post-id <object id of post> --comment-id <object id of comment>`

Should mark the SpamCheckResults as spam and hide the posts/comments in the discussions ui

`docker-compose run web ./manage.py reclassify_spam --ham --post-id <object id of post> --comment-id <object id of comment>`

Should mark the SpamCheckResults as not spam and make the post/comment visible if they were previously hidden

You can run the command with multiple post ids and comments ids

The `--retire-users` flag should retire all the authors of the  posts/comments and add those user's emails as records in the BlockedIpRange table if the posts/comments are being marked as spam
