### PR TITLE
fix spam check admin

### DIFF
--- a/channels/admin.py
+++ b/channels/admin.py
@@ -136,7 +136,10 @@ class SpamCheckResultAdmin(admin.ModelAdmin):
 
     def truncated_text(self, spam_check):
         """Truncated text of spam checked post or comment"""
-        return spam_check.content_object.text[0:350]
+        if spam_check.content_object.text:
+            return spam_check.content_object.text[0:350]
+        else:
+            return ""
 
     def author(self, spam_check):
         """Email text of spam checked post or comment author"""


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
NA

#### What's this PR do?
Fixes https://sentry.io/organizations/mit-office-of-digital-learning/issues/1901469218/?project=216201&query=is%3Aunresolved

https://github.com/mitodl/open-discussions/pull/3150 breaks the spam check admin for Link posts which have text=None 

#### How should this be manually tested?
Either create a link post with a non-moderator user or just set text=None for the content_object of one of your existing spam check results. 

Go to http://localhost:8063/admin/channels/spamcheckresult/

The page should load

