### PR TITLE
add the department_name field to search aggregation transform

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -367,6 +367,7 @@ def transform_results(search_result, user):
         "offered_by",
         "audience",
         "certification",
+        "department_name",
     ]:
         if f"agg_filter_{aggregation_key}" in search_result.get("aggregations", {}):
             search_result["aggregations"][aggregation_key] = search_result[

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -693,6 +693,39 @@ def test_transform_results(
 
 
 @pytest.mark.django_db
+def test_transform_department_name_aggregations():
+    """
+    Aggregations with filters are nested under `agg_filter_<key>`. transform_results should unnest them
+    """
+    results = {
+        "hits": {"hits": {}, "total": 15},
+        "suggest": {},
+        "aggregations": {
+            "agg_filter_department_name": {
+                "doc_count": 11680,
+                "department_name": {
+                    "buckets": [
+                        {"key": "Professional Cake Decoration", "doc_count": 72},
+                        {"key": "Cat and Dog Studies", "doc_count": 44},
+                        {"key": "Professional Wrestling", "doc_count": 269},
+                    ]
+                },
+            }
+        },
+    }
+
+    expected_transformed_results = results.copy()
+    expected_transformed_results["suggest"] = []
+    expected_transformed_results["aggregations"][
+        "department_name"
+    ] = expected_transformed_results["aggregations"]["agg_filter_department_name"][
+        "department_name"
+    ]
+
+    assert transform_results(results, AnonymousUser()) == expected_transformed_results
+
+
+@pytest.mark.django_db
 def test_transform_nested_aggregations():
     """
     Aggregations with filters are nested under `agg_filter_<key>`. transform_results should unnest them


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

I need to do this for https://github.com/mitodl/hugo-course-publisher/issues/217

#### What's this PR do?

this adds the `department_name` field to 

#### How should this be manually tested?

I think just read the code and make sure it makes sense? not sure exactly how this could be tested manually. you could try using `/api/v0/search` and adding a `department_name` facet to your search I suppose.