### PR TITLE
update ocw-data-parser to 0.12.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.5.0
 markdown2==2.3.9
 newrelic
-ocw-data-parser==0.11.0
+ocw-data-parser==0.12.0
 Pillow==7.2.0
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ markdown2==2.3.9          # via -r requirements.in
 git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4  # via -r requirements.in
 newrelic==4.2.0.100       # via -r requirements.in
 oauthlib==2.0.7           # via requests-oauthlib, social-auth-core
-ocw-data-parser==0.11.0   # via -r requirements.in
+ocw-data-parser==0.12.0   # via -r requirements.in
 parso==0.6.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/240

#### What's this PR do?
This PR updates open-discussions with the latest version of ocw-data-parser which includes properties related to publishing / retirement dates.

#### How should this be manually tested?
Spin up open and parse an OCW course.  It should install 0.12.0 during setup and master JSON should now include:

 - `last_published_to_production`
 - `last_unpublishing_date`
 - `retirement_date`

