### PR TITLE
ab/remove-course-catalog-acks-late

### DIFF
--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -34,8 +34,27 @@ def get_mitx_data():
 
 
 @app.task(acks_late=True)
+def get_ocw_course_with_retry(
+    *, course_prefix, blocklist, force_overwrite, upload_to_s3
+):
+    """
+    Task to sync a batch of OCW courses. We want acks_late=True for tasks launched
+    with the webhook so that there will be a retry if the task fails or the worker is killed
+    """
+    sync_ocw_courses(
+        course_prefixes=[course_prefix],
+        blocklist=blocklist,
+        force_overwrite=force_overwrite,
+        upload_to_s3=upload_to_s3,
+    )
+
+
+@app.task
 def get_ocw_courses(*, course_prefixes, blocklist, force_overwrite, upload_to_s3):
-    """Task to sync a batch of OCW courses"""
+    """
+    Task to sync a batch of OCW courses. We want to set acks_late=False for refreshes
+    launched by the backpopulate command or the scheduled task
+    """
     sync_ocw_courses(
         course_prefixes=course_prefixes,
         blocklist=blocklist,
@@ -208,44 +227,44 @@ def get_bootcamp_data(force_overwrite=False):
             parse_bootcamp_json_data(bootcamp, force_overwrite=force_overwrite)
 
 
-@app.task(acks_late=True)
+@app.task
 def get_micromasters_data():
     """Execute the MicroMasters ETL pipeline"""
     pipelines.micromasters_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_xpro_data():
     """Execute the xPro ETL pipeline"""
     pipelines.xpro_programs_etl()
     pipelines.xpro_courses_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_oll_data():
     """Execute the OLL ETL pipeline"""
     pipelines.oll_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_see_data():
     """Execute the SEE ETL pipeline"""
     pipelines.see_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_mitpe_data():
     """Execute the MITPE ETL pipeline"""
     pipelines.mitpe_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_csail_data():
     """Execute the CSAIL ETL pipeline"""
     pipelines.csail_etl()
 
 
-@app.task(acks_late=True)
+@app.task
 def get_youtube_data(*, channel_ids=None):
     """
     Execute the YouTube ETL pipeline
@@ -289,7 +308,7 @@ def get_youtube_transcripts(
     youtube.get_youtube_transcripts(videos)
 
 
-@app.task(acks_late=True)
+@app.task
 def get_video_topics(*, video_ids=None):
     """
     Execute the video topics pipeline
@@ -301,7 +320,7 @@ def get_video_topics(*, video_ids=None):
     pipelines.video_topics_etl(video_ids=video_ids)
 
 
-@app.task(acks_late=True)
+@app.task
 def get_podcast_data():
     """
     Execute the Podcast ETL pipeline

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -52,7 +52,7 @@ from course_catalog.serializers import (
     PodcastSerializer,
     PodcastEpisodeSerializer,
 )
-from course_catalog.tasks import get_ocw_courses
+from course_catalog.tasks import get_ocw_course_with_retry
 from course_catalog.utils import load_course_blocklist
 from course_catalog.etl.podcast import generate_aggregate_podcast_rss
 from open_discussions import features, settings
@@ -397,10 +397,10 @@ class WebhookOCWView(APIView):
             for record in content.get("Records"):
                 s3_key = record.get("s3", {}).get("object", {}).get("key")
                 prefix = s3_key.split("0/1.json")[0]
-                get_ocw_courses.apply_async(
+                get_ocw_course_with_retry.apply_async(
                     countdown=settings.OCW_WEBHOOK_DELAY,
                     kwargs={
-                        "course_prefixes": [prefix],
+                        "course_prefix": prefix,
                         "blocklist": blocklist,
                         "force_overwrite": False,
                         "upload_to_s3": True,

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -615,7 +615,7 @@ def test_ocw_webhook_endpoint(client, mocker, settings, webhook_enabled, data):
     settings.FEATURES[features.WEBHOOK_OCW] = webhook_enabled
     settings.OCW_WEBHOOK_KEY = "fake_key"
     mock_get_ocw = mocker.patch(
-        "course_catalog.views.get_ocw_courses.apply_async", autospec=True
+        "course_catalog.views.get_ocw_course_with_retry.apply_async", autospec=True
     )
     mock_log = mocker.patch("course_catalog.views.log.error")
     mocker.patch("course_catalog.views.load_course_blocklist", return_value=[])
@@ -628,11 +628,9 @@ def test_ocw_webhook_endpoint(client, mocker, settings, webhook_enabled, data):
         mock_get_ocw.assert_called_once_with(
             countdown=settings.OCW_WEBHOOK_DELAY,
             kwargs={
-                "course_prefixes": [
-                    OCW_WEBHOOK_RESPONSE["Records"][0]["s3"]["object"]["key"].split(
-                        "0/1.json"
-                    )[0]
-                ],
+                "course_prefix": OCW_WEBHOOK_RESPONSE["Records"][0]["s3"]["object"][
+                    "key"
+                ].split("0/1.json")[0],
                 "blocklist": [],
                 "force_overwrite": False,
                 "upload_to_s3": True,


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
none

#### What's this PR do?
Recently we had an issue on ci with a ocw update job never  exiting successfully and continuously rerunning due to acks_late setting. This pr sets acks_late=False (the default) from most course catalog update tasks. It keeps keep  acks_late=True for ocw updates generated by the webhook since those jobs won't be re-run by themselves.

#### How should this be manually tested?
Test that the ocw webhook still works. Instructions here:
https://github.com/mitodl/open-discussions/pull/2687

Test that backpopulate commands (backpopulate_podcast_data for example) still work
