### PR TITLE
add support for the level facet to course search

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -368,11 +368,31 @@ def transform_results(search_result, user):
         "audience",
         "certification",
         "department_name",
+        "level",
     ]:
         if f"agg_filter_{aggregation_key}" in search_result.get("aggregations", {}):
-            search_result["aggregations"][aggregation_key] = search_result[
-                "aggregations"
-            ][f"agg_filter_{aggregation_key}"][aggregation_key]
+            if aggregation_key == "level":
+                levels = (
+                    search_result.get("aggregations", {})
+                    .get(f"agg_filter_{aggregation_key}", {})
+                    .get("level", {})
+                    .get("level", {})
+                )
+                if levels:
+                    search_result["aggregations"]["level"] = {
+                        "buckets": [
+                            {
+                                "key": bucket["key"],
+                                "doc_count": bucket["courses"]["doc_count"],
+                            }
+                            for bucket in levels.get("buckets", [])
+                            if bucket["courses"]["doc_count"] > 0
+                        ]
+                    }
+            else:
+                search_result["aggregations"][aggregation_key] = search_result[
+                    "aggregations"
+                ][f"agg_filter_{aggregation_key}"][aggregation_key]
 
     types = search_result.get("aggregations", {}).get("type", {})
 

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -726,6 +726,56 @@ def test_transform_department_name_aggregations():
 
 
 @pytest.mark.django_db
+def test_transform_level_aggregation():
+    """
+    Aggregations with filters are nested under `agg_filter_<key>`. transform_results should unnest them
+    """
+    results = {
+        "hits": {"hits": {}, "total": 15},
+        "suggest": {},
+        "aggregations": {
+            "agg_filter_level": {
+                "doc_count": 691,
+                "level": {
+                    "doc_count": 879,
+                    "level": {
+                        "doc_count_error_upper_bound": 0,
+                        "sum_other_doc_count": 0,
+                        "buckets": [
+                            {
+                                "key": "Undergraduate",
+                                "doc_count": 512,
+                                "courses": {"doc_count": 399},
+                            },
+                            {
+                                "key": "Graduate",
+                                "doc_count": 364,
+                                "courses": {"doc_count": 291},
+                            },
+                            {
+                                "key": "Non Credit",
+                                "doc_count": 3,
+                                "courses": {"doc_count": 3},
+                            },
+                        ],
+                    },
+                },
+            }
+        },
+    }
+
+    expected_transformed_results = results.copy()
+    expected_transformed_results["suggest"] = []
+    expected_transformed_results["aggregations"][
+        "level"
+    ] = expected_transformed_results["aggregations"]["agg_filter_level"]["level"][
+        "level"
+    ]
+
+    assert transform_results(results, AnonymousUser()) == expected_transformed_results
+
+
+@pytest.mark.django_db
 def test_transform_nested_aggregations():
     """
     Aggregations with filters are nested under `agg_filter_<key>`. transform_results should unnest them


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

this is required for a PR on OCW (https://github.com/mitodl/hugo-course-publisher/pull/267) to work

this is to address this issue: https://github.com/mitodl/hugo-course-publisher/issues/216

#### What's this PR do?

In order to add the level facet I needed to add a transform for its aggregation into `search/api.py`

#### How should this be manually tested?

You could check out the hugo-course-publisher PR linked above and ensure that it works with this change.

