### PR TITLE
404 for removed comments

### DIFF
--- a/cassettes/channels.views.comments_test.test_get_removed_comment[None-404].json
+++ b/cassettes/channels.views.comments_test.test_get_removed_comment[None-404].json
@@ -1,0 +1,922 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-11-05T14:43:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSJBB352X9DKFXY72QVYE"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULI01S3zjPAIjKpwMTIsLzcP9wguc8tKD/fXjTSJMFHSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkoljkHZ1lGmFimOjkHeZk5mwcH53sZG6RkeIR7gC1LSS3LTE6Nz0wBmQvhKNUCAKSlGZi2AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:31 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:43:31 GMT",
+            "loidcreated=2020-11-05T14%3A43%3A30.717Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:43:31 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSJBB352X9DKFXY72QVYE"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSNNBM1T2VC3ADCXQPZ72"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULI00w3yNTZwNitLSonITnT0dwvLS/FJjcotiMp39lTSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkolrkFlFaURDpX+RXr5geWJ3o5FaXpmkaZpBtllIO0pKSWZSanxmemgMyFcJRqAYGXHn62AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:34 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSNNBM1T2VC3ADCXQPZ72"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Through+laugh+area+security+mention.+Prepare+factor+western+expert+country.+Party+feel+lawyer+technology+cause+long+blood.%0AOff+none+police+key+beyond+become+lay+town.+Particularly+major+yes+hospital.+Off+listen+hear+top+movie+box.%0ACurrent+future+price+authority+behind.+Even+stay+claim+thus+far+card.+President+unit+machine+share+magazine+environment.%0AEight+might+identify+spend+education+something.+Card+over+force+sense+surface.+Beat+technology+significant+south+since+throughout+process.&link_type=any&name=1604587414_8_hotel&public_description=Agency+away+friend+thus.+Rule+sit+late+smile+stay.+West+gas+especially.&title=American+catch+life+various+fly+child.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 96-RM30C6vbdXkaAOFVndLeZmpZoCI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "741"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:34 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "386"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSVZ8ZX1BFDG6XWFSN7WQ"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULI017UoSizVdS8rtkj18C11D3TJz/aMKjVMdjdKzlbSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkolhlFRHhbBBh4ZhinphnnpZX65JqGVZTmmDrllIO0pKSWZSanxmemgMyFcJRqAdVUFX62AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDSVZ8ZX1BFDG6XWFSN7WQ"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1604587414_8_hotel&text=Art+campaign+cause+lose.+Close+film+large+help+approach.&title=Himself+chance+only+fact+whole+career+so."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 95-vIXHQZxD21ww7WHSvFjgWO-Y4X4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "186"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1604587414_8_hotel/comments/1c/himself_chance_only_fact_whole_career_so/\", \"id\": \"1c\", \"name\": \"t3_1c\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "169"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "380"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 95-vIXHQZxD21ww7WHSvFjgWO-Y4X4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1c/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587414_8_hotel\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EArt campaign cause lose. Close film large help approach.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Art campaign cause lose. Close film large help approach.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1c\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDSJBB352X9DKFXY72QVYE\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587414_8_hotel\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_s\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587414_8_hotel/comments/1c/himself_chance_only_fact_whole_career_so/\", \"locked\": false, \"name\": \"t3_1c\", \"created\": 1604587420.0, \"url\": \"http://reddit.local/r/1604587414_8_hotel/comments/1c/himself_chance_only_fact_whole_career_so/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Himself chance only fact whole career so.\", \"created_utc\": 1604587420.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1706"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:40 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "380"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=0ShE8RNO5KWzucrK4pUg%2Bg3qEVa3qmenDoCPFVJEuqdXThlZHnXjNYnGEz0i2HZgn4saN6NkOwdBfXXGmoNabnqQs10MlN%2F9"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1c/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Brother+level+source+top+know.+Tough+director+more.+Seem+so+really+lawyer+however+senior+hair.&thing_id=t3_1c"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 97-8rau-Gvs8eHMuGQDokIZu1cG2ck"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "128"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_s\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1c\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"x\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDSVZ8ZX1BFDG6XWFSN7WQ\", \"parent_id\": \"t3_1c\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Brother level source top know. Tough director more. Seem so really lawyer however senior hair.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EBrother level source top know. Tough director more. Seem so really lawyer however senior hair.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587414_8_hotel\", \"score_hidden\": false, \"name\": \"t1_x\", \"created\": 1604587423.0, \"author_flair_text\": null, \"created_utc\": 1604587423.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "989"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:44 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "377"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_x&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 96-RM30C6vbdXkaAOFVndLeZmpZoCI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "373"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic b2RfY2xpZW50X2lkOm9kX2NsaWVudF9zZWNyZXQ="
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"-K_tUyGX5_4IPNpgviCU_OzwBf-k\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "106"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "373"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer -K_tUyGX5_4IPNpgviCU_OzwBf-k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_x&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": \"\", \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_s\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1c\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"x\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"[deleted]\", \"parent_id\": \"t3_1c\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"[removed]\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003E[removed]\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587414_8_hotel\", \"score_hidden\": false, \"name\": \"t1_x\", \"created\": 1604587423.0, \"author_flair_text\": null, \"created_utc\": 1604587423.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "845"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "373"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=jQUasHgm8CSHIy%2FhKN0YLwz69ZLYnLK6Gh4wFw5n2g6rqJrr6SWslwntWslZFvzRpyZREux17e4%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_x&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer -K_tUyGX5_4IPNpgviCU_OzwBf-k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=nHLzCJlZV2ug73jvGF; loidcreated=2020-11-05T14%3A43%3A30.717Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1c/_/x?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": \"\", \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587414_8_hotel\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EArt campaign cause lose. Close film large help approach.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Art campaign cause lose. Close film large help approach.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1c\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDSJBB352X9DKFXY72QVYE\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587414_8_hotel\", \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_s\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": true, \"permalink\": \"/r/1604587414_8_hotel/comments/1c/himself_chance_only_fact_whole_career_so/\", \"locked\": false, \"name\": \"t3_1c\", \"created\": 1604587420.0, \"url\": \"http://reddit.local/r/1604587414_8_hotel/comments/1c/himself_chance_only_fact_whole_career_so/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Himself chance only fact whole career so.\", \"created_utc\": 1604587420.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": \"\", \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1701"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:47 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297"
+          ],
+          "x-ratelimit-reset": [
+            "373"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=X4r%2FDv0gi57AUgI6moPtlmlkpT07ArLmZig%2FRItvthliYK2%2Bgo2NZf3wbpyryA2ICJ41GpIJu3uRmiigJcubR%2B16OiNIxG%2Bm"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1c/_/x?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.comments_test.test_get_removed_comment[comment_writer-200].json
+++ b/cassettes/channels.views.comments_test.test_get_removed_comment[comment_writer-200].json
@@ -1,0 +1,934 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-11-05T14:43:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDT5DA29PN7KEX3SYYR9CA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULK00PVKT/UKNkx29nBOKQ92dXIL9XPJdkmOSK8y8lXSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkolnkUOicVpIUk+YUVuXtWlWcVJBUFe/u6V+UYgy1LSS3LTE6Nz0wBmQvhKNUCAG0PONC2AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:50 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=i543MH1IUhkdFz8M7j; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:43:50 GMT",
+            "loidcreated=2020-11-05T14%3A43%3A50.243Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:43:50 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDT5DA29PN7KEX3SYYR9CA"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDT8P32TFT8SWHB1DJJV37"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSULK01M0LMg/xywgyTwyqMA0LTvRKCYsI8Ch3jNINzFbSUVBKrSjILEotjs8EqTc2MzAAioG1x5dUFqSCzEhKTSxKLQKpLU7OhwhpgXhFqWlAjRkolhWWRZQkBZZUehVmhecXFwcZOVVG6Wamllukl4O0pKSWZSanxmemgMyFcJRqAbsJ4aS2AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDT8P32TFT8SWHB1DJJV37"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:43:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Young+move+home+call+hair+skill.+Politics+language+cold+the+quality+speech.+Find+policy+billion+enough+business.+Hundred+effect+space.%0AEstablish+image+less+tend+wrong.+Work+describe+me.+Manager+fine+continue+phone+read+top.+Respond+measure+position+democratic.%0APlay+live+whole+among.+Small+budget+window+eye+girl+approach+professional+loss.+Home+mind+under+music.+Economy+husband+experience+local+student+forget+season+water.&link_type=any&name=1604587433_9_adult&public_description=Five+sell+station+training+throw+hour+minute.&title=Investment+back+probably+message+happy+view.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 99-nR7TNhR7aRx5VSaJdVXPHwAZ-Qk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "654"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:43:53 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "367"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTEYCKH6GX99WRZG6299P"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQvCIBzFv8rwGAWOIFrHNkaxU8QKusjU/0gX09ScFX33Zjt1fD/e7703ahgDa4lTHfRok6AU44USJvDAXzs/3Kim63N5KPMLddnJonmCIGhhwBIRheUK45H9fOKeGuIIhcaAiV3L1IRmMRloR/H6/1bA0OOC7mFb+UdXyzzNWXaXsjrW0eHgBQMieByeAvp8AZ33Yxu4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTEYCKH6GX99WRZG6299P"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1604587433_9_adult&text=If+contain+long+I+full+believe.+Player+minute+new+clearly+until+inside.+Present+democratic+more.&title=Top+then+project.+Dark+nearly+speech+everyone."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 98-JgeJS1cCHCdwSEBFUNDkDcXgz2M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "231"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1604587433_9_adult/comments/1d/top_then_project_dark_nearly_speech_everyone/\", \"id\": \"1d\", \"name\": \"t3_1d\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "173"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "360"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 98-JgeJS1cCHCdwSEBFUNDkDcXgz2M"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1d/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587433_9_adult\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIf contain long I full believe. Player minute new clearly until inside. Present democratic more.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"If contain long I full believe. Player minute new clearly until inside. Present democratic more.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1d\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDT5DA29PN7KEX3SYYR9CA\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587433_9_adult\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_t\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587433_9_adult/comments/1d/top_then_project_dark_nearly_speech_everyone/\", \"locked\": false, \"name\": \"t3_1d\", \"created\": 1604587440.0, \"url\": \"http://reddit.local/r/1604587433_9_adult/comments/1d/top_then_project_dark_nearly_speech_everyone/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Top then project. Dark nearly speech everyone.\", \"created_utc\": 1604587440.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1799"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:00 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "360"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=30N4Kphz7cswuwcB77q7UzDRyRZ61x4APUWIX%2BajcksNi3xX4qmo6Fmb5udmAv4tu%2FogPSwN9vPBuZnM4TeoszSUlRvZ03MN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1d/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Sound+author+his+hundred+result+movie.+Answer+stay+southern.+Stop+use+young+drug+result.&thing_id=t3_1d"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 100-oirxdxdzHvwlbpb8WFQFCZbt9Vs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "122"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_t\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1d\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"y\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDTEYCKH6GX99WRZG6299P\", \"parent_id\": \"t3_1d\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Sound author his hundred result movie. Answer stay southern. Stop use young drug result.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESound author his hundred result movie. Answer stay southern. Stop use young drug result.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587433_9_adult\", \"score_hidden\": false, \"name\": \"t1_y\", \"created\": 1604587443.0, \"author_flair_text\": null, \"created_utc\": 1604587443.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "977"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:03 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "357"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_y&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 99-nR7TNhR7aRx5VSaJdVXPHwAZ-Qk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "354"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 100-oirxdxdzHvwlbpb8WFQFCZbt9Vs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_y&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_t\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1d\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"y\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDTEYCKH6GX99WRZG6299P\", \"parent_id\": \"t3_1d\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Sound author his hundred result movie. Answer stay southern. Stop use young drug result.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESound author his hundred result movie. Answer stay southern. Stop use young drug result.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587433_9_adult\", \"score_hidden\": false, \"name\": \"t1_y\", \"created\": 1604587443.0, \"author_flair_text\": null, \"created_utc\": 1604587443.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1022"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "354"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2BMzr%2B0mvl1IRAeBKYStd2TFz0IOQxGXIH%2FC7uFf9%2BbdrN9E96MgvJz0SIcObufH9MwDCR1YVlzA%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_y&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 100-oirxdxdzHvwlbpb8WFQFCZbt9Vs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1d/_/y?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587433_9_adult\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIf contain long I full believe. Player minute new clearly until inside. Present democratic more.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"If contain long I full believe. Player minute new clearly until inside. Present democratic more.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1d\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDT5DA29PN7KEX3SYYR9CA\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587433_9_adult\", \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_t\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": true, \"permalink\": \"/r/1604587433_9_adult/comments/1d/top_then_project_dark_nearly_speech_everyone/\", \"locked\": false, \"name\": \"t3_1d\", \"created\": 1604587440.0, \"url\": \"http://reddit.local/r/1604587433_9_adult/comments/1d/top_then_project_dark_nearly_speech_everyone/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Top then project. Dark nearly speech everyone.\", \"created_utc\": 1604587440.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_t\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1d\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"y\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDTEYCKH6GX99WRZG6299P\", \"parent_id\": \"t3_1d\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Sound author his hundred result movie. Answer stay southern. Stop use young drug result.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ESound author his hundred result movie. Answer stay southern. Stop use young drug result.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587433_9_adult\", \"score_hidden\": false, \"name\": \"t1_y\", \"created\": 1604587443.0, \"author_flair_text\": null, \"created_utc\": 1604587443.0, \"ups\": 1, \"mod_reports\": [], \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2727"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "354"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=4bgNhZr5u5KR2qefuULKqI%2FVxFIOq5HMDowHZ6Mswpt5wY1S3O4K7aQByvJJyxVtkwtRhNJNHQn7oEuWx%2FQZwV0d6ZHUXZjl"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1d/_/y?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 100-oirxdxdzHvwlbpb8WFQFCZbt9Vs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=i543MH1IUhkdFz8M7j; loidcreated=2020-11-05T14%3A43%3A50.243Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1604587433_9_adult/about/moderators/?user=01EPCDTEYCKH6GX99WRZG6299P&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "46"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:06 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "354"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=ed3IWoHgSA5bkzXjxpkdkloKPqLcD70mntoHJU4sAweoyn7yTgTGpn5FzHyIutTZ1nX8PJLQ%2FQ%2F0kV4IvksbuVEVGjcWvT0E"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1604587433_9_adult/about/moderators/?user=01EPCDTEYCKH6GX99WRZG6299P&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.comments_test.test_get_removed_comment[staff_user-200].json
+++ b/cassettes/channels.views.comments_test.test_get_removed_comment[staff_user-200].json
@@ -1,0 +1,934 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-11-05T14:44:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVBFC808BXDM43QK4JRFK"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNsQrCMBiEX6VkFIWEFGndJA1SrHZwEF1CTH5pUNKQFLUV393GTo73cd/dG0mlIATRtTewaJUggtMFEWynt5UBldEA+aG+Z6ymp4HtSzRPELyc8RCEiQJdYjyyny+63kEcuYD04GM3qHZCs5g8XEex+X+relbkhON1qp9ntSmltZwfB2caHB0ND6NAGB2Hp4A+X0X+FQS4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:29 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:44:29 GMT",
+            "loidcreated=2020-11-05T14%3A44%3A29.215Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:44:29 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVBFC808BXDM43QK4JRFK"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVERKNH4T0ABBKKPNX2J2"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MNU1izIJTjcLzokydbLQDfEKq3JNN8ixiErxMcpW0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLblx/ulh5d5uiY7poSXhbqaJMen+Hr6FVQkhnuC9KSklmUmp8ZnpoAMhnCUagGjNkTDuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:32 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVERKNH4T0ABBKKPNX2J2"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Material+treatment+option+where+wind.+Other+end+reality+against+agree.%0AIf+serve+nothing+lose.+Computer+add+risk+media+hit+fine.+Test+dinner+kind+hospital+safe+just+own.%0AYourself+heavy+long+clearly+direction+money+know.+Campaign+source+understand+modern+everybody+design+continue.+Provide+drive+policy+page+decade+reduce+personal+popular.%0AChair+account+rich+key+site+hand.+Window+education+audience+information+nature+edge+agent.+Much+exactly+wall+report.&link_type=any&name=1604587472_11_lead&public_description=Pull+region+it+court+sister+day+grow.+Billion+exactly+attack+imagine.&title=Successful+address+join+memory.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 105-6Z4Sg6SlZ5B8-TJVzEg0l8ZdL2k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "696"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:32 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "328"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVMZHJMFA9MTSD3QA3NRJ"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQrCMBREr1KyFIXUShF3IipoKZgogptPm/zQKNqYlGAQ725jVy7nMW/mTSoh0Dno2hs+yCIhKc0n6VNd+f4YvC/1Bs6q5Jdizq0s/ImME4Ivoy060FHIckp79vOhCwbjSI2VRRu7TrQDGsVkUfVi8/8WZoe14lvPqrAyd6BZsM1uumSUuehI9FogaBmHh0A+X4P5BDy4AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDVMZHJMFA9MTSD3QA3NRJ"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1604587472_11_lead&text=Win+similar+music+put.&title=Feel+Mr+begin+tend."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 104-1_CMdKLiec83se9SOl8CO3YzCNI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "130"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1604587472_11_lead/comments/1f/feel_mr_begin_tend/\", \"id\": \"1f\", \"name\": \"t3_1f\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "147"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "321"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 104-1_CMdKLiec83se9SOl8CO3YzCNI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1f/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587472_11_lead\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EWin similar music put.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Win similar music put.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1f\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDVBFC808BXDM43QK4JRFK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587472_11_lead\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_v\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587472_11_lead/comments/1f/feel_mr_begin_tend/\", \"locked\": false, \"name\": \"t3_1f\", \"created\": 1604587479.0, \"url\": \"http://reddit.local/r/1604587472_11_lead/comments/1f/feel_mr_begin_tend/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Feel Mr begin tend.\", \"created_utc\": 1604587479.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1572"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:39 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "321"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=WKiVZoNazH85n5OSPym4kSvp1JbSGRXSfV00Un5VSfLc0NkzR0vdCbUK9tNVwLuUbxmI65Vbrpw2ouyctJZccFJekFGM6sIn"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1f/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Yard+address+form+fact+view+him+many.+Three+show+which+thought+billion.&thing_id=t3_1f"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 106-1qfjSKTyvvNiF_WfNSZL8SrdLvU"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "105"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_v\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1f\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"10\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDVMZHJMFA9MTSD3QA3NRJ\", \"parent_id\": \"t3_1f\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Yard address form fact view him many. Three show which thought billion.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EYard address form fact view him many. Three show which thought billion.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587472_11_lead\", \"score_hidden\": false, \"name\": \"t1_10\", \"created\": 1604587482.0, \"author_flair_text\": null, \"created_utc\": 1604587482.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "945"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:42 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "318"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_10&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 105-6Z4Sg6SlZ5B8-TJVzEg0l8ZdL2k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "33"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "315"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 105-6Z4Sg6SlZ5B8-TJVzEg0l8ZdL2k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_10&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_v\", \"banned_by\": \"01EPCDVERKNH4T0ABBKKPNX2J2\", \"removal_reason\": null, \"link_id\": \"t3_1f\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"10\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"01EPCDVMZHJMFA9MTSD3QA3NRJ\", \"parent_id\": \"t3_1f\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Yard address form fact view him many. Three show which thought billion.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EYard address form fact view him many. Three show which thought billion.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587472_11_lead\", \"score_hidden\": false, \"name\": \"t1_10\", \"created\": 1604587482.0, \"author_flair_text\": null, \"created_utc\": 1604587482.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": 0, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1009"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "315"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=NikhI0HYzQHxWWMAMgErPJC%2B2AQ7WZluYCUpQtbtRZEYqH9FDpsXp6i43lc9kDB3611BSXTdWrk%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_10&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 105-6Z4Sg6SlZ5B8-TJVzEg0l8ZdL2k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1f/_/10?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587472_11_lead\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EWin similar music put.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Win similar music put.\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1f\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"01EPCDVBFC808BXDM43QK4JRFK\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587472_11_lead\", \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_v\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587472_11_lead/comments/1f/feel_mr_begin_tend/\", \"locked\": false, \"name\": \"t3_1f\", \"created\": 1604587479.0, \"url\": \"http://reddit.local/r/1604587472_11_lead/comments/1f/feel_mr_begin_tend/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Feel Mr begin tend.\", \"created_utc\": 1604587479.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_v\", \"banned_by\": \"01EPCDVERKNH4T0ABBKKPNX2J2\", \"removal_reason\": null, \"link_id\": \"t3_1f\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"10\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"01EPCDVMZHJMFA9MTSD3QA3NRJ\", \"parent_id\": \"t3_1f\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Yard address form fact view him many. Three show which thought billion.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EYard address form fact view him many. Three show which thought billion.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587472_11_lead\", \"score_hidden\": false, \"name\": \"t1_10\", \"created\": 1604587482.0, \"author_flair_text\": null, \"created_utc\": 1604587482.0, \"ups\": 1, \"mod_reports\": [], \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2483"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "315"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=N6owwlNMcBzzZmxhSfRXyHaxjk2P7uxThNeao01oD5IsL0tCmKpDh4kM8ZH8ZbUX95I1WrFmu0N8CbErOeSHQ19G5AhVnFox"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1f/_/10?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 105-6Z4Sg6SlZ5B8-TJVzEg0l8ZdL2k"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=9fmv4xT8IdTJp6L8on; loidcreated=2020-11-05T14%3A44%3A29.215Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/r/1604587472_11_lead/about/moderators/?user=01EPCDVERKNH4T0ABBKKPNX2J2&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1604587472.0, \"mod_permissions\": [\"all\"], \"name\": \"01EPCDVERKNH4T0ABBKKPNX2J2\", \"id\": \"t2_2x\"}]}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:45 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "295.0"
+          ],
+          "x-ratelimit-reset": [
+            "315"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=%2BRTnamxJm8%2FBbaZhiP5YxmHh014mBUJqYU1LX7i8eDA5QO53zeqtX7I%2BOeXNtYJLAu7lj7HEgEsR%2FotGpbBu5YcvPuCULl7L"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/r/1604587472_11_lead/about/moderators/?user=01EPCDVERKNH4T0ABBKKPNX2J2&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/channels.views.comments_test.test_get_removed_comment[user-404].json
+++ b/cassettes/channels.views.comments_test.test_get_removed_comment[user-404].json
@@ -1,0 +1,845 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-11-05T14:44:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTRDD0S27V71Y9KA5HE5T"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MNT1zTE2LHIrLzKMjDCPKksptEjJdjP39Mp2DzJR0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaVFQaHVDg5Zkelm5okZQV7BmVWBRn5pRiUFpeD9KSklmUmp8ZnpoAMhnCUagEPcsmpuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:10 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "set-cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:44:10 GMT",
+            "loidcreated=2020-11-05T14%3A44%3A09.734Z; Domain=reddit.local; Max-Age=63071999; Path=/; expires=Sat, 05-Nov-2022 14:44:10 GMT"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTRDD0S27V71Y9KA5HE5T"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "python-requests/2.24.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTVQTKJQMPAX0E9B9QZXB"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WNQQuCMACF/4rsGAUrKaSbFhOypA4WdBk6XzVEnZuEFv33XJ46vo/3vfcmqRAwhrd1gYqsHTKni5nqSt8H81R6OtfYsyt/ec0yanbhgUwdgk5JDcOlFdwVpQP7+bztFexIhlRD264R9YgmNmncBvHx/1YV5XaTBJc+YWWAIhYmcpswvkfHxDo5nlKAy9wOj4F8vt4UaK64AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDTVQTKJQMPAX0E9B9QZXB"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "allow_top=True&api_type=json&description=Moment+election+goal+look+response.+Listen+hope+least+south+break+analysis+must.+Short+nation+fast+fund.%0AElection+maybe+but+sense+itself.+Occur+reduce+culture+from+say.+Improve+thus+last+be+friend+whatever+star+condition.%0AMention+service+perform+scene+hot.+Along+this+peace+question+do+together+today.%0AHour+security+discussion+within+often.%0AWhat+difficult+seem+stage+full.+Thousand+indeed+consumer+be+reach+what.&link_type=any&name=1604587453_10_item&public_description=Newspaper+meet+team+enjoy+campaign.+Budget+training+sing+second.&title=Only+cup+at+very+here+team+senior.&type=public&wikimode=disabled"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 102-pxmAAeF8paQVoeLFZ_z8q5KqJGM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "654"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/site_admin/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "24"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:13 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "347"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/site_admin/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDV204J8NZ5WKDCYRGHH8F"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI0MNb1sSwvdfNKzSw2d3EPzDOMzPYN9i8urjAMiPBV0lFQSq0oyCxKLY7PBGkwNjMwAIqB9ceXVBakggxJSk0sSi0CqS1OzocIaYF4RalpQI0ZqLaF51d5uZX5hkcZGKbnlcW7pIWmZ2blhBYUZzqC9KSklmUmp8ZnpoAMhnCUagGlbDtfuAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "text/html; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/v1/generate_refresh_token?username=01EPCDV204J8NZ5WKDCYRGHH8F"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&resubmit=True&sendreplies=True&sr=1604587453_10_item&text=Magazine+thing+range+difficult.+Piece+send+material+off+cover.+Art+tend+guess+away+would.&title=Morning+serious+true."
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 101-Ml31rFwr1YX7Zvdq8dkF7IJkGR4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "199"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://reddit.local/r/1604587453_10_item/comments/1e/morning_serious_true/\", \"id\": \"1e\", \"name\": \"t3_1e\"}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "149"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "341"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 101-Ml31rFwr1YX7Zvdq8dkF7IJkGR4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1e/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587453_10_item\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMagazine thing range difficult. Piece send material off cover. Art tend guess away would.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Magazine thing range difficult. Piece send material off cover. Art tend guess away would.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1e\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDTRDD0S27V71Y9KA5HE5T\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587453_10_item\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_u\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587453_10_item/comments/1e/morning_serious_true/\", \"locked\": false, \"name\": \"t3_1e\", \"created\": 1604587459.0, \"url\": \"http://reddit.local/r/1604587453_10_item/comments/1e/morning_serious_true/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Morning serious true.\", \"created_utc\": 1604587459.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1712"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:19 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "341"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=iiAK5545qlcvGS0Win%2BhPvxZrq%2BDhtBrl6jvgvhboGvb9qrK7WGOLIXuz6Ks7RW4G2QJFlm5rk0q6xHtjPvuWZFOvq4nHkx3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1e/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Fast+guess+keep+reach+at.+Customer+production+hard+two+shoulder.&thing_id=t3_1e"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 103-L9wuFJeis7DGQn1YkMSOssx1PXM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "98"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_u\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1e\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"z\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"01EPCDV204J8NZ5WKDCYRGHH8F\", \"parent_id\": \"t3_1e\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"Fast guess keep reach at. Customer production hard two shoulder.\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFast guess keep reach at. Customer production hard two shoulder.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587453_10_item\", \"score_hidden\": false, \"name\": \"t1_z\", \"created\": 1604587462.0, \"author_flair_text\": null, \"created_utc\": 1604587462.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "929"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:23 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299.0"
+          ],
+          "x-ratelimit-reset": [
+            "338"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_z&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 102-pxmAAeF8paQVoeLFZ_z8q5KqJGM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "32"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://reddit.local/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298.0"
+          ],
+          "x-ratelimit-reset": [
+            "334"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 101-Ml31rFwr1YX7Zvdq8dkF7IJkGR4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/api/info/?id=t1_z&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_u\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_1e\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"z\", \"gilded\": 0, \"archived\": false, \"report_reasons\": null, \"author\": \"[deleted]\", \"parent_id\": \"t3_1e\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"[removed]\", \"edited\": false, \"author_flair_css_class\": null, \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003E[removed]\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"1604587453_10_item\", \"score_hidden\": false, \"name\": \"t1_z\", \"created\": 1604587462.0, \"author_flair_text\": null, \"created_utc\": 1604587462.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": null, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "847"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297.0"
+          ],
+          "x-ratelimit-reset": [
+            "334"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=83hUJk7wE1p2B4DbOrLqGkYPGycdaXj8AbjNrZbU9My6IrOJDZ%2B6DmaEXf1QqH4fXmmOlR7SSJc%3D"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/api/info/?id=t1_z&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-11-05T14:44:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 101-Ml31rFwr1YX7Zvdq8dkF7IJkGR4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "loid=SlytKcEgaXRY8JSh1q; loidcreated=2020-11-05T14%3A44%3A09.734Z"
+          ],
+          "User-Agent": [
+            "MIT-Open: 0.147.2 PRAW/4.5.1 prawcore/0.10.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://reddit.local/comments/1e/_/z?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"1604587453_10_item\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EMagazine thing range difficult. Piece send material off cover. Art tend guess away would.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"Magazine thing range difficult. Piece send material off cover. Art tend guess away would.\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"1e\", \"gilded\": 0, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": null, \"author\": \"01EPCDTRDD0S27V71Y9KA5HE5T\", \"media\": null, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"domain\": \"self.1604587453_10_item\", \"hidden\": false, \"num_comments\": 1, \"thumbnail\": \"\", \"subreddit_id\": \"t5_u\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"downs\": 0, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"is_self\": true, \"hide_score\": false, \"permalink\": \"/r/1604587453_10_item/comments/1e/morning_serious_true/\", \"locked\": false, \"name\": \"t3_1e\", \"created\": 1604587459.0, \"url\": \"http://reddit.local/r/1604587453_10_item/comments/1e/morning_serious_true/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Morning serious true.\", \"created_utc\": 1604587459.0, \"link_flair_text\": null, \"ups\": 1, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"visited\": false, \"num_reports\": null, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1712"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 05 Nov 2020 14:44:26 GMT"
+          ],
+          "Server": [
+            "PasteWSGIServer/0.5 Python/2.7.6"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "296.0"
+          ],
+          "x-ratelimit-reset": [
+            "334"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-reddit-tracking": [
+            "https://reddit.local/pixel/of_destiny.png?v=HkTjOc873F19PHW0ysFtuHDIqqBr%2BvYjuhOv6emdvMzE4Ct5Px6BuIA4g0WaNcnWAeBO1LoYhorCnd46rd%2FgctBno%2BnEfL%2FG"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://reddit.local/comments/1e/_/z?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/factory_data/channels.views.comments_test.test_get_removed_comment[None-404].json
+++ b/factory_data/channels.views.comments_test.test_get_removed_comment[None-404].json
@@ -1,0 +1,38 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Through laugh area security mention. Prepare factor western expert country. Party feel lawyer technology cause long blood.\nOff none police key beyond become lay town. Particularly major yes hospital. Off listen hear top movie box.\nCurrent future price authority behind. Even stay claim thus far card. President unit machine share magazine environment.\nEight might identify spend education something. Card over force sense surface. Beat technology significant south since throughout process.",
+      "name": "1604587414_8_hotel",
+      "public_description": "Agency away friend thus. Rule sit late smile stay. West gas especially.",
+      "title": "American catch life various fly child."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "x",
+      "post_id": "1c",
+      "text": "Brother level source top know. Tough director more. Seem so really lawyer however senior hair."
+    }
+  },
+  "posts": {
+    "my geat post": {
+      "id": "1c",
+      "text": "Art campaign cause lose. Close film large help approach.",
+      "title": "Himself chance only fact whole career so."
+    }
+  },
+  "users": {
+    "comment user": {
+      "username": "01EPCDSVZ8ZX1BFDG6XWFSN7WQ"
+    },
+    "contributor": {
+      "username": "01EPCDSJBB352X9DKFXY72QVYE"
+    },
+    "staff_user": {
+      "username": "01EPCDSNNBM1T2VC3ADCXQPZ72"
+    }
+  }
+}

--- a/factory_data/channels.views.comments_test.test_get_removed_comment[comment_writer-200].json
+++ b/factory_data/channels.views.comments_test.test_get_removed_comment[comment_writer-200].json
@@ -1,0 +1,38 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Young move home call hair skill. Politics language cold the quality speech. Find policy billion enough business. Hundred effect space.\nEstablish image less tend wrong. Work describe me. Manager fine continue phone read top. Respond measure position democratic.\nPlay live whole among. Small budget window eye girl approach professional loss. Home mind under music. Economy husband experience local student forget season water.",
+      "name": "1604587433_9_adult",
+      "public_description": "Five sell station training throw hour minute.",
+      "title": "Investment back probably message happy view."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "y",
+      "post_id": "1d",
+      "text": "Sound author his hundred result movie. Answer stay southern. Stop use young drug result."
+    }
+  },
+  "posts": {
+    "my geat post": {
+      "id": "1d",
+      "text": "If contain long I full believe. Player minute new clearly until inside. Present democratic more.",
+      "title": "Top then project. Dark nearly speech everyone."
+    }
+  },
+  "users": {
+    "comment user": {
+      "username": "01EPCDTEYCKH6GX99WRZG6299P"
+    },
+    "contributor": {
+      "username": "01EPCDT5DA29PN7KEX3SYYR9CA"
+    },
+    "staff_user": {
+      "username": "01EPCDT8P32TFT8SWHB1DJJV37"
+    }
+  }
+}

--- a/factory_data/channels.views.comments_test.test_get_removed_comment[staff_user-200].json
+++ b/factory_data/channels.views.comments_test.test_get_removed_comment[staff_user-200].json
@@ -1,0 +1,38 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Material treatment option where wind. Other end reality against agree.\nIf serve nothing lose. Computer add risk media hit fine. Test dinner kind hospital safe just own.\nYourself heavy long clearly direction money know. Campaign source understand modern everybody design continue. Provide drive policy page decade reduce personal popular.\nChair account rich key site hand. Window education audience information nature edge agent. Much exactly wall report.",
+      "name": "1604587472_11_lead",
+      "public_description": "Pull region it court sister day grow. Billion exactly attack imagine.",
+      "title": "Successful address join memory."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "10",
+      "post_id": "1f",
+      "text": "Yard address form fact view him many. Three show which thought billion."
+    }
+  },
+  "posts": {
+    "my geat post": {
+      "id": "1f",
+      "text": "Win similar music put.",
+      "title": "Feel Mr begin tend."
+    }
+  },
+  "users": {
+    "comment user": {
+      "username": "01EPCDVMZHJMFA9MTSD3QA3NRJ"
+    },
+    "contributor": {
+      "username": "01EPCDVBFC808BXDM43QK4JRFK"
+    },
+    "staff_user": {
+      "username": "01EPCDVERKNH4T0ABBKKPNX2J2"
+    }
+  }
+}

--- a/factory_data/channels.views.comments_test.test_get_removed_comment[user-404].json
+++ b/factory_data/channels.views.comments_test.test_get_removed_comment[user-404].json
@@ -1,0 +1,38 @@
+{
+  "channels": {
+    "public_channel": {
+      "channel_type": "public",
+      "description": "Moment election goal look response. Listen hope least south break analysis must. Short nation fast fund.\nElection maybe but sense itself. Occur reduce culture from say. Improve thus last be friend whatever star condition.\nMention service perform scene hot. Along this peace question do together today.\nHour security discussion within often.\nWhat difficult seem stage full. Thousand indeed consumer be reach what.",
+      "name": "1604587453_10_item",
+      "public_description": "Newspaper meet team enjoy campaign. Budget training sing second.",
+      "title": "Only cup at very here team senior."
+    }
+  },
+  "comments": {
+    "comment": {
+      "children": [],
+      "comment_id": null,
+      "id": "z",
+      "post_id": "1e",
+      "text": "Fast guess keep reach at. Customer production hard two shoulder."
+    }
+  },
+  "posts": {
+    "my geat post": {
+      "id": "1e",
+      "text": "Magazine thing range difficult. Piece send material off cover. Art tend guess away would.",
+      "title": "Morning serious true."
+    }
+  },
+  "users": {
+    "comment user": {
+      "username": "01EPCDV204J8NZ5WKDCYRGHH8F"
+    },
+    "contributor": {
+      "username": "01EPCDTRDD0S27V71Y9KA5HE5T"
+    },
+    "staff_user": {
+      "username": "01EPCDTVQTKJQMPAX0E9B9QZXB"
+    }
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3087

#### What's this PR do?
This adds a server-side 404 page for removed comments for non-moderator users

#### How should this be manually tested?
Make a comment as a non-moderator user
Get the share url for the comment it should be something like `http://localhost:8063/c/public_channel/5/i-like-robotics/comment/3/`
Mark the comment as spam using 
 `docker-compose run web ./manage.py reclassify_spam --spam --comment-id <object id of comment>`
Go to the comment url. You should be able to see the comment as a moderator but get a 404 as a non-mderator or anonymous user