### PR TITLE
speparate celery queue for spam checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions.celery:app worker -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app worker -Q spam,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/open_discussions/celery.py
+++ b/open_discussions/celery.py
@@ -12,4 +12,12 @@ from django.conf import settings  # noqa pylint: disable=wrong-import-position
 
 app = Celery("open_discussions")
 app.config_from_object("django.conf:settings", namespace="CELERY")
+app.conf.task_default_queue = "default"
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)  # pragma: no cover
+
+app.conf.task_routes = {
+    "channels.tasks.check_post_for_spam": {"queue": "spam"},
+    "channels.tasks.check_comment_for_spam": {"queue": "spam"},
+    "channels.tasks.update_spam": {"queue": "spam"},
+    "channels.tasks.retire_user": {"queue": "spam"},
+}


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3188

#### What's this PR do?
Adds a separate queue for spam tasks. Since the spam queue should have fewer items, spam tasks will run sooner.

#### How should this be manually tested?
add
```
import time
@app.task
def sleep(seconds):
    time.sleep(seconds)
```

to `course_catalog/tasks.py`

Fill the celery queues with default priority tasks by running

```
from course_catalog.tasks import *

for i in range(0,1000):
    sleep.delay(15)
```

from the shell

`docker-compose run web ./manage.py reclassify_spam --spam --post-id <object id of post>`

should still run fairly quickly and if you create a post or comment with a non-moderator account a `check_post_for_spam` job should run to create a SpamCheckResult record

All other celery tasks will be queued behind the sleep jobs and will not run until those finish
