### PR TITLE
add fmt:check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,15 @@ jobs:
       - name: Lints
         run: npm run lint
 
+      - name: Code formatting
+        run: npm run fmt:check
+
+      - name: Scss lint
+        run: npm run scss_lint
+
+      - name: Flow
+        run: npm run flow
+
       - name: Tests
         run: npm run test
         env:


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this just adds back a call to `npm run fmt:check` to our JS CI check, which was I think unintentionally omitted from https://github.com/mitodl/open-discussions/pull/3204

#### How should this be manually tested?

The build should pass.