### PR TITLE
Import OCW level 3 topics (specialities)

### DIFF
--- a/course_catalog/management/commands/backpopulate_ocw_topics.py
+++ b/course_catalog/management/commands/backpopulate_ocw_topics.py
@@ -1,0 +1,27 @@
+"""Management command for backpopulating ocw topics"""
+
+from django.core.management import BaseCommand
+from django.db.models import Q
+
+from course_catalog.models import Course, CourseTopic
+from course_catalog.utils import get_ocw_topics
+from search.task_helpers import upsert_course
+
+
+class Command(BaseCommand):
+    """Populate ocw course run topics"""
+
+    help = "Populate ocw course run topics"
+
+    def handle(self, *args, **options):
+        for course in Course.objects.filter(Q(platform="ocw") & Q(published=True)):
+            course_topics = set()
+            for run in course.runs.filter(published=True):
+                run_topics = [
+                    CourseTopic.objects.get_or_create(name=topic)[0]
+                    for topic in get_ocw_topics(run.raw_json["course_collections"])
+                ]
+                run.topics.set(run_topics)
+                course_topics.update(set(run_topics))
+            course.topics.set([course_topic.id for course_topic in course_topics])
+            upsert_course(course.id)

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -161,7 +161,7 @@ def test_get_ocw_courses(
     assert Course.objects.count() == 1
     assert CoursePrice.objects.count() == 1
     assert CourseInstructor.objects.count() == 1
-    assert CourseTopic.objects.count() == 5
+    assert CourseTopic.objects.count() == 7
     course = Course.objects.first()
     assert course.published is not blocklisted
 
@@ -200,7 +200,7 @@ def test_get_ocw_overwrite(
     assert Course.objects.count() == 1
     assert CoursePrice.objects.count() == 1
     assert CourseInstructor.objects.count() == 1
-    assert CourseTopic.objects.count() == 5
+    assert CourseTopic.objects.count() == 7
 
     mock_digest = mocker.patch("course_catalog.api.digest_ocw_course")
     get_ocw_courses.delay(

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -47,6 +47,8 @@ def get_ocw_topics(topics_collection):
             topics.append(topic_object["ocw_feature"])
         if topic_object["ocw_subfeature"]:
             topics.append(topic_object["ocw_subfeature"])
+        if topic_object["ocw_speciality"]:
+            topics.append(topic_object["ocw_speciality"])
 
     return list(set(topics))
 

--- a/course_catalog/utils_test.py
+++ b/course_catalog/utils_test.py
@@ -9,6 +9,7 @@ import pytz
 from course_catalog.constants import PlatformType
 from course_catalog.utils import (
     get_course_url,
+    get_ocw_topics,
     semester_year_to_date,
     load_course_blocklist,
     load_course_duplicates,
@@ -148,3 +149,27 @@ mitx:
                 "course_id": "MITx+1",
             }
         ]
+
+
+def test_get_ocw_topics():
+    """ get_ocw_topics should return the expected list of topics """
+    collection = [
+        {
+            "ocw_feature": "Engineering",
+            "ocw_subfeature": "Mechanical Engineering",
+            "ocw_speciality": "Dynamics and Control",
+        },
+        {
+            "ocw_feature": "Engineering",
+            "ocw_subfeature": "Electrical Engineering",
+            "ocw_speciality": "Signal Processing",
+        },
+    ]
+
+    assert sorted(get_ocw_topics(collection)) == [
+        "Dynamics and Control",
+        "Electrical Engineering",
+        "Engineering",
+        "Mechanical Engineering",
+        "Signal Processing",
+    ]


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Partially addresses https://github.com/mitodl/hugo-course-publisher/issues/308

#### What's this PR do?
- Imports level 3 OCW topics (specialities)
- Provides a backpopulate_ocw_topics command

#### How should this be manually tested?
Run `python manage.py backpopulate_ocw_topics` - it should work and additional topics should be created, show up in the topic facet, and be searchable (the number depends on how many OCW courses you've imported).
