### PR TITLE
Return False if reddit API is_moderator call raises a Forbidden error

### DIFF
--- a/channels/api.py
+++ b/channels/api.py
@@ -1572,13 +1572,16 @@ class Api:
             # So we have to be explicit here.
             raise ValueError("Missing moderator_name")
         # generators always eval True, so eval as list first and then as bool
-        return bool(
-            list(
-                self._list_moderators(
-                    channel_name=channel_name, moderator_name=moderator_name
+        try:
+            return bool(
+                list(
+                    self._list_moderators(
+                        channel_name=channel_name, moderator_name=moderator_name
+                    )
                 )
             )
-        )
+        except PrawForbidden:
+            return False
 
     def add_subscriber(self, subscriber_name, channel_name):
         """


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3119 

#### What's this PR do?
If the reddit API function to determine if a user is a channel moderator raises a Forbidden error, then return False.

#### How should this be manually tested?
- Create a spam post in a private channel as user # 1 (contributor, not moderator)
- If it isn't auto classified as spam by akismet, manually spamify it with `docker-compose run web ./manage.py reclassify_spam --spam --post-id <post_id>`
- Log in as user # 2 (who should also be a contributor to the above channel).  Go to the URL for the spam post created in step 1.  You should get a 404 page.  On master you should get a 500 error.
