### PR TITLE
fix styling of long search filters in course search

### DIFF
--- a/static/scss/search.scss
+++ b/static/scss/search.scss
@@ -100,7 +100,6 @@
       display: inline-flex;
       align-items: center;
       flex-wrap: nowrap;
-      white-space: nowrap;
       border: 1px solid $font-grey-mid;
       border-radius: 14px;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, but see https://github.com/mitodl/hugo-course-publisher/issues/337

(we have the same issue over here)

#### What's this PR do?

this just makes a small styling change to deal with a text overflow issue on longer filter names.

Normally the filters were display here aren't quite long enough to trigger the issue, but we're doing department name over in OCW and that is long enough. But I figured we should fix the styling here too so we're "future proofed"

#### How should this be manually tested?

To repro the issue you need to just edit the text node inside of the `.active-search-filter` to be long enough to trigger the problem. Then confirm checking out this branch fixes it (see screenshots below for reference).

#### Screenshots (if appropriate)

before:

![Screenshot from 2020-11-16 10-29-31](https://user-images.githubusercontent.com/6207644/99273246-c24a0100-27f6-11eb-8610-6b855454724b.png)

after:

![Screenshot from 2020-11-16 10-29-12](https://user-images.githubusercontent.com/6207644/99273248-c2e29780-27f6-11eb-81b1-db7ba6a2755b.png)
