### PR TITLE
fix reclassify spam for moderator comments

### DIFF
--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -547,7 +547,7 @@ def update_spam(*, spam, comment_ids, post_ids, retire_users, skip_akismet):
     akismet_client = create_akismet_client()
 
     for comment in Comment.objects.filter(id__in=comment_ids).iterator():
-        result = SpamCheckResult.objects.get(
+        result, _ = SpamCheckResult.objects.get_or_create(
             content_type=comment_content_type, object_id=comment.id
         )
 
@@ -579,7 +579,7 @@ def update_spam(*, spam, comment_ids, post_ids, retire_users, skip_akismet):
             retire_user(comment.author)
 
     for post in Post.objects.filter(id__in=post_ids).iterator():
-        result = SpamCheckResult.objects.get(
+        result, _ = SpamCheckResult.objects.get_or_create(
             content_type=post_content_type, object_id=post.id
         )
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3199

#### What's this PR do?
Currently the reclassify spam management command breaks for moderator comments which do not have a SpamCheckResult. This fixes the issue

#### How should this be manually tested?
Create a comment and post with a moderator account

run
`docker-compose run web ./manage.py reclassify_spam --spam --comment-id <id>  --post-id <id>`

there should not be an error