### PR TITLE
separate digest email queue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions.celery:app worker -Q spam,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -86,6 +86,18 @@ def send_email_notification_batch(notification_ids):
 
 
 @app.task
+def send_frontpage_email_notification_batch(notification_ids):
+    """
+    Sends a batch of notifications. This is a separate task from send_email_notification_batch so that
+    frontpage notification tasks, which are not time sensitive, can be queued separately from other tasks
+
+    Args:
+        notification_ids (list of int): notification ids to send
+    """
+    api.send_email_notification_batch(notification_ids)
+
+
+@app.task
 def notify_subscribed_users(post_id, comment_id, new_comment_id):
     """
     Notifies subscribed users of a new comment

--- a/notifications/tasks_test.py
+++ b/notifications/tasks_test.py
@@ -94,6 +94,15 @@ def test_send_email_notification_batch(mocker):
     api_mock.assert_called_once_with(ids)
 
 
+def send_frontpage_email_notification_batch(mocker):
+    """Tests that send_frontpage_email_notification_batch calls the API method"""
+    api_mock = mocker.patch("notifications.api.send_email_notification_batch")
+
+    ids = [1, 2, 3]
+    tasks.send_frontpage_email_notification_batch.delay(ids)
+    api_mock.assert_called_once_with(ids)
+
+
 def test_notify_subscribed_users(mocker):
     """Tests that notify_subscribed_users calls the API method"""
     api_mock = mocker.patch("notifications.api.send_comment_notifications")

--- a/open_discussions/celery.py
+++ b/open_discussions/celery.py
@@ -20,4 +20,11 @@ app.conf.task_routes = {
     "channels.tasks.check_comment_for_spam": {"queue": "spam"},
     "channels.tasks.update_spam": {"queue": "spam"},
     "channels.tasks.retire_user": {"queue": "spam"},
+    "notifications.tasks.send_frontpage_email_notification_batch": {
+        "queue": "digest_emails"
+    },
+    "notifications.tasks.test_send_daily_frontpage_digests": {"queue": "digest_emails"},
+    "notifications.tasks.test_send_weekly_frontpage_digests": {
+        "queue": "digest_emails"
+    },
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3203

#### What's this PR do?
Digest email generation is time consuming and not time sensitive.  This pr moves digest email tasks to a separate queue to prevent them from blocking other tasks. Notification emails letting users know there are comments on their posts and letting moderators know about new posts in their channels are time sensitive and will remain in the default queue.

#### How should this be manually tested?
Verify the new queue exists with
```
from open_discussions.celery import app
app.control.inspect().active_queues()
```

Verify that both digest and comment notification still works by making a some posts and comments, verifying that your user gets both daily digests and comment notifications, then running

```
 from notifications.tasks import *
send_daily_frontpage_digests()
send_unsent_email_notifications()
```
