### PR TITLE
Upload OCW course JSON to S3 regardless of publish state

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -482,10 +482,12 @@ def sync_ocw_course(
     course_json["course_id"] = "{}.{}".format(
         course_json.get("department_number"), course_json.get("master_course_number")
     )
-    if course_json["course_id"] in blocklist:
+
+    blocklisted = course_json["course_id"] in blocklist
+    if blocklisted:
         is_published = False
 
-    if upload_to_s3 and is_published:
+    if upload_to_s3 and not blocklisted:
         try:
             parser.setup_s3_uploading(
                 settings.OCW_LEARNING_COURSE_BUCKET_NAME,
@@ -514,7 +516,7 @@ def sync_ocw_course(
         log.info("Course and run not returned, skipping")
         return None
 
-    if upload_to_s3 and is_published:
+    if upload_to_s3 and not blocklisted:
         load_content_files(run, transform_content_files(course_json))
 
     course.published = is_published or (

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -556,7 +556,7 @@ def test_sync_ocw_course_skip(mocker, prefix, skip):
         ["", "", False],
         ["2020-12-01 00:00:00 US/Eastern", None, True],
         [None, "2020-12-02 00:00:00 US/Eastern", False],
-    ]  # pylint:disable=too-many-arguments
+    ],  # pylint:disable=too-many-arguments
 )
 def test_sync_ocw_course_published(
     settings, mocker, pub_date, unpub_date, published, blocklisted

--- a/course_catalog/conftest.py
+++ b/course_catalog/conftest.py
@@ -1,7 +1,17 @@
 """Common fixtures for course_catalog"""
+from os import listdir
+from os.path import isfile, join
 from types import SimpleNamespace
 
+import boto3
 import pytest
+
+TEST_PREFIX = "PROD/9/9.15/Fall_2007/9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007/"
+
+TEST_JSON_PATH = f"./test_json/{TEST_PREFIX}0"
+TEST_JSON_FILES = [
+    f for f in listdir(TEST_JSON_PATH) if isfile(join(TEST_JSON_PATH, f))
+]
 
 
 @pytest.fixture
@@ -10,3 +20,36 @@ def mock_course_index_functions(mocker):
     return SimpleNamespace(
         upsert_course=mocker.patch("course_catalog.api.upsert_course")
     )
+
+
+def setup_s3(settings):
+    """
+    Set up the fake s3 data
+    """
+    # Fake the settings
+    settings.AWS_ACCESS_KEY_ID = "abc"
+    settings.AWS_SECRET_ACCESS_KEY = "abc"
+    settings.OCW_CONTENT_BUCKET_NAME = "test_bucket"
+    settings.OCW_LEARNING_COURSE_BUCKET_NAME = "testbucket2"
+    # Create our fake bucket
+    conn = boto3.resource(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+    )
+    conn.create_bucket(Bucket=settings.OCW_CONTENT_BUCKET_NAME)
+
+    # Add data to the fake bucket
+    test_bucket = conn.Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
+    for file in TEST_JSON_FILES:
+        file_key = TEST_JSON_PATH.replace("./test_json/", "") + "/" + file
+        with open(TEST_JSON_PATH + "/" + file, "r") as f:
+            test_bucket.put_object(Key=file_key, Body=f.read())
+
+    # Create our upload bucket
+    conn = boto3.resource(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+    )
+    conn.create_bucket(Bucket=settings.OCW_LEARNING_COURSE_BUCKET_NAME)

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -133,18 +133,19 @@ def test_get_ocw_courses(
     course = Course.objects.first()
     assert course.published is not blocklisted
 
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+    )
+    # The filename was pulled from the uid 1.json in the TEST_JSON_PATH files.
+    obj = s3.Object(
+        settings.OCW_LEARNING_COURSE_BUCKET_NAME,
+        "9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007/9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007_parsed.json",
+    )
+    assert json.loads(obj.get()["Body"].read())
+
     if not blocklisted:
-        s3 = boto3.resource(
-            "s3",
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-        )
-        # The filename was pulled from the uid 1.json in the TEST_JSON_PATH files.
-        obj = s3.Object(
-            settings.OCW_LEARNING_COURSE_BUCKET_NAME,
-            "9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007/9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007_parsed.json",
-        )
-        assert json.loads(obj.get()["Body"].read())
         assert course.image_src.startswith("http")
     else:
         assert course.image_src == ""

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -2,14 +2,13 @@
 Test tasks
 """
 import json
-from os import listdir
-from os.path import isfile, join
 from unittest.mock import Mock
 
 import boto3
 import pytest
 from moto import mock_s3
 
+from course_catalog.conftest import setup_s3, TEST_PREFIX
 from course_catalog.constants import PlatformType
 from course_catalog.factories import CourseFactory
 from course_catalog.models import Course, CoursePrice, CourseInstructor, CourseTopic
@@ -39,13 +38,6 @@ from course_catalog.tasks import (
 pytestmark = pytest.mark.django_db
 # pylint:disable=redefined-outer-name,unused-argument,too-many-arguments
 
-TEST_PREFIX = "PROD/9/9.15/Fall_2007/9-15-biochemistry-and-pharmacology-of-synaptic-transmission-fall-2007/"
-
-TEST_JSON_PATH = f"./test_json/{TEST_PREFIX}0"
-TEST_JSON_FILES = [
-    f for f in listdir(TEST_JSON_PATH) if isfile(join(TEST_JSON_PATH, f))
-]
-
 
 @pytest.fixture
 def mock_logger(mocker):
@@ -73,39 +65,6 @@ def mock_get_bootcamps(mocker):
 def mock_blocklist(mocker):
     """Mock the load_course_blocklist function"""
     return mocker.patch("course_catalog.tasks.load_course_blocklist", return_value=[])
-
-
-def setup_s3(settings):
-    """
-    Set up the fake s3 data
-    """
-    # Fake the settings
-    settings.AWS_ACCESS_KEY_ID = "abc"
-    settings.AWS_SECRET_ACCESS_KEY = "abc"
-    settings.OCW_CONTENT_BUCKET_NAME = "test_bucket"
-    settings.OCW_LEARNING_COURSE_BUCKET_NAME = "testbucket2"
-    # Create our fake bucket
-    conn = boto3.resource(
-        "s3",
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-    )
-    conn.create_bucket(Bucket=settings.OCW_CONTENT_BUCKET_NAME)
-
-    # Add data to the fake bucket
-    test_bucket = conn.Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
-    for file in TEST_JSON_FILES:
-        file_key = TEST_JSON_PATH.replace("./test_json/", "") + "/" + file
-        with open(TEST_JSON_PATH + "/" + file, "r") as f:
-            test_bucket.put_object(Key=file_key, Body=f.read())
-
-    # Create our upload bucket
-    conn = boto3.resource(
-        "s3",
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-    )
-    conn.create_bucket(Bucket=settings.OCW_LEARNING_COURSE_BUCKET_NAME)
 
 
 def test_get_mitx_data_valid(mocker):
@@ -142,14 +101,23 @@ def test_get_ocw_data(
 @mock_s3
 @pytest.mark.parametrize("blocklisted", [True, False])
 def test_get_ocw_courses(
-    settings, mock_course_index_functions, mocked_celery, mock_blocklist, blocklisted
+    settings,
+    mocker,
+    mock_course_index_functions,
+    mocked_celery,
+    mock_blocklist,
+    blocklisted,
 ):
     """
     Test ocw sync task
     """
     setup_s3(settings)
+
     if blocklisted:
         mock_blocklist.return_value = ["9.15"]
+
+    mocker.patch("course_catalog.api.load_content_files")
+    mocker.patch("course_catalog.api.transform_content_files")
 
     # run ocw sync
     get_ocw_courses.delay(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3263 

#### What's this PR do?
- Always uploads an OCW course's parsed JSON to S3 even if it is unpublished.  

#### How should this be manually tested?

Import the course, then check the parsed JSON file on S3 to make sure it has an unpublished date and the file was recently modified.

```python
from course_catalog.api import *
import json

sync_ocw_courses(
    course_prefixes=["PROD/18/18.783/Spring_2015/18-783-elliptic-curves-spring-2015/"], 
    upload_to_s3=True, 
    force_overwrite=True, 
    blocklist=[]
)

s3 = boto3.resource("s3").Bucket(settings.OCW_LEARNING_COURSE_BUCKET_NAME)
course_json = s3.Object('18-783-elliptic-curves-spring-2015/18-783-elliptic-curves-spring-2015_parsed.json')

print(course_json.last_modified)
print(json.loads(course_json.get()['Body'].read())["last_unpublishing_date"])
```



