### PR TITLE
Do not publish courses without runs

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -193,7 +193,7 @@ def load_course(course_data, blocklist, duplicates, *, config=CourseLoaderConfig
     topics_data = course_data.pop("topics", None)
     offered_bys_data = course_data.pop("offered_by", [])
 
-    if course_id in blocklist:
+    if course_id in blocklist or not runs_data:
         course_data["published"] = False
 
     deduplicated_course_id = next(

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -235,7 +235,9 @@ def test_load_program(
 @pytest.mark.parametrize("is_published", [True, False])
 @pytest.mark.parametrize("is_run_published", [True, False])
 @pytest.mark.parametrize("blocklisted", [True, False])
-def test_load_course(mock_upsert_tasks, course_exists, is_published, is_run_published, blocklisted):
+def test_load_course(
+    mock_upsert_tasks, course_exists, is_published, is_run_published, blocklisted
+):
     """Test that load_course loads the course"""
     course = (
         CourseFactory.create(runs=None, published=is_published)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3261 

#### What's this PR do?
Sets a course to unpublished if it has no runs.

#### How should this be manually tested?
- On master, run `manage.py backpopulate_edx_data` (use the same `EDX_` env variables as on RC).
- Wait for all indexing tasks to finish (will take longer than the command above).
- Search courses for 'app inventor'.  There will be 2 results for "MIT App Inventor Certification Exam – Level 1".  One of them will work correctly (clicking it will show details in the drawer), the other will not (blank drawer, 404 API call).
- Switch to this branch, run `manage.py backpopulate_edx_data` again, and wait for indexing to finish.
- Repeat the search.  There should be only 1 "MIT App Inventor Certification Exam – Level 1" result and its link should work correctly.

