### PR TITLE
Ensure test_url_widget_serialize sorts entries by reverse date

### DIFF
--- a/widgets/serializers/rss_test.py
+++ b/widgets/serializers/rss_test.py
@@ -18,15 +18,19 @@ def test_url_widget_serialize(
     mocker, raise_exception, timestamp_key, item_count, display_limit
 ):
     """Tests that the rss widget serializes correctly"""
-    entries = [
-        {
-            "title": f"Title {idx}",
-            "description": f"Description {idx}",
-            "link": f"http://example.com/{idx}",
-            timestamp_key: time.gmtime(),
-        }
-        for idx in range(item_count)
-    ]
+    entries = sorted(
+        [
+            {
+                "title": f"Title {idx}",
+                "description": f"Description {idx}",
+                "link": f"http://example.com/{idx}",
+                timestamp_key: time.gmtime(),
+            }
+            for idx in range(item_count)
+        ],
+        reverse=True,
+        key=lambda entry: entry[timestamp_key],
+    )
     mock_parse = mocker.patch("feedparser.parse")
     if raise_exception:
         mock_parse.side_effect = Exception("bad")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes #3275 

#### What's this PR do?
Sorts test entries by reverse date, as the tested function does, to make sure they are always in the same order.

#### How should this be manually tested?
Run `pytest -vv widgets/serializers/rss_test.py` at least a few times, it should always pass.
