### PR TITLE
Pass bucket name to ocw parser on initialization

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -476,7 +476,10 @@ def sync_ocw_course(
 
     log.info("Parsing for %s...", course_prefix)
     # pass course contents into parser
-    parser = OCWParser(loaded_jsons=loaded_raw_jsons_for_course)
+    parser = OCWParser(
+        loaded_jsons=loaded_raw_jsons_for_course,
+        s3_bucket_name=settings.OCW_LEARNING_COURSE_BUCKET_NAME,
+    )
     course_json = parser.get_parsed_json()
     course_json["uid"] = uid
     course_json["course_id"] = "{}.{}".format(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #3281

#### What's this PR do?
Passes the S3 bucket name to OCWDataParser on initialization, to prevent an error from being logged (and perhaps prevent incorrect values in the parsed JSON).

#### How should this be manually tested?
Tests should pass

Run `sync_ocw_courses(course_prefixes=["PROD/2/2.04A/Spring_2013/2-04a-systems-and-controls-spring-2013/"], blocklist=[], upload_to_s3=True, force_overwrite=True)`

There should not be a "Please set your s3 bucket name" error logged.
