### PR TITLE
update django-cors-headers to allow regex

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,14 @@
       "description": "Cloudfront distribution",
       "required": false
     },
+    "CORS_ALLOWED_ORIGINS": {
+      "description": "A list of origins that are authorized to make cross-site HTTP requests",
+      "required": false      
+    },
+    "CORS_ALLOWED_ORIGIN_REGEXES": {
+      "description": "A list of regexes that match origins that are authorized to make cross-site HTTP requests",
+      "required": false      
+    },
     "CSAIL_BASE_URL": {
       "description": "CSAIL courses base URL",
       "required": false

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -129,7 +129,8 @@ MIDDLEWARE = (
 )
 
 # CORS
-CORS_ORIGIN_WHITELIST = get_list_of_str("OPEN_DISCUSSIONS_CORS_ORIGIN_WHITELIST", [])
+CORS_ALLOWED_ORIGINS = get_list_of_str("CORS_ALLOWED_ORIGINS", [])
+CORS_ALLOWED_ORIGIN_REGEXES = get_list_of_str("CORS_ALLOWED_ORIGIN_REGEXES", [])
 CORS_ALLOW_CREDENTIALS = True
 
 # enable the nplusone profiler only in debug mode

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 akismet==1.1
-django-cors-headers==2.1.0
+django-cors-headers==3.6.0
 Django==2.2.13
 base36
 beautifulsoup4==4.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 akismet==1.1              # via -r requirements.in
 amqp==2.5.2               # via kombu
 appdirs==1.4.3            # via zeep
+appnope==0.1.2            # via ipython
 attrs==19.3.0             # via zeep
 backcall==0.1.0           # via ipython
 base36==0.1.1             # via -r requirements.in
@@ -38,7 +39,7 @@ django-appconf==1.0.3     # via django-imagekit
 django-bitfield==2.0.1    # via -r requirements.in
 django-cache-memoize==0.1.6  # via -r requirements.in
 django-compat==1.0.15     # via -r requirements.in, django-hijack, django-hijack-admin
-django-cors-headers==2.1.0  # via -r requirements.in
+django-cors-headers==3.6.0  # via -r requirements.in
 django-filter==2.2.0      # via -r requirements.in
 django-guardian==1.4.9    # via -r requirements.in
 django-hijack-admin==2.1.10  # via -r requirements.in
@@ -51,7 +52,7 @@ django-server-status==0.5.0  # via -r requirements.in
 django-storages==1.6.6    # via -r requirements.in
 django-templated-mail==1.1.1  # via djoser
 django-webpack-loader==0.5.0  # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-anymail, django-appconf, django-bitfield, django-filter, django-redis
+django==2.2.13            # via -r requirements.in, django-anymail, django-appconf, django-bitfield, django-cors-headers, django-filter, django-redis
 djangorestframework-jwt==1.11.0  # via -r requirements.in
 djangorestframework==3.10.3  # via -r requirements.in, drf-extensions
 djoser==2.0.3             # via -r requirements.in
@@ -70,7 +71,6 @@ google-auth==1.6.3        # via google-api-python-client, google-auth-httplib2
 html5lib==0.999999999     # via -r requirements.in
 httplib2==0.18.0          # via google-api-python-client, google-auth-httplib2
 idna==2.5                 # via requests, tldextract
-importlib-metadata==2.0.0  # via kombu
 ipaddress==1.0.22         # via elasticsearch-dsl
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.12.0           # via -r requirements.in
@@ -142,7 +142,6 @@ wrapt==1.10.11            # via -r requirements.in, deprecated
 xbundle==0.3.1            # via -r requirements.in
 xmlsec==1.3.3             # via python3-saml
 zeep==3.4.0               # via mit-moira
-zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3284

#### What's this PR do?
This pr allow approving CORS domains using regex to allow ocw-www domains to be allowed to make cross origin http requests

#### How should this be manually tested?
Run xpro. From the javascript console run
`fetch("http://localhost:8063/api/v0/frontpage/", { credentials: "include" })`
confirm that you get a CORS error.

Add `CORS_ALLOWED_ORIGINS=['http://localhost:8053']` to your open-discussions env file. Run the command again. The fetch should succeed.

Remove `CORS_ALLOWED_ORIGINS` from your env file.  Set `CORS_ALLOWED_ORIGIN_REGEXES=['^http://localhost:\d+$']`.
Run the fetch command again. It should succeed again