### PR TITLE
Don't show suggestion if it is effectively the same as search text

### DIFF
--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -236,6 +236,7 @@ export default function CourseSearchPage(props: Props) {
         [
           text
             .toLowerCase()
+            .trim()
             .replace(/^"(.*)"$/, "$1")
             .replace(/[\W]+/g, " ")
             .trim()

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -232,7 +232,16 @@ export default function CourseSearchPage(props: Props) {
   const resultsColumnWidth = searchResultLayout === SEARCH_GRID_UI ? 9 : 8
   const suggestions =
     !emptyOrNil(suggest) && !emptyOrNil(text)
-      ? R.without([text], suggest).map(
+      ? R.without(
+        [
+          text
+            .toLowerCase()
+            .replace(/^"(.*)"$/, "$1")
+            .replace(/[\W]+/g, " ")
+            .trim()
+        ],
+        suggest
+      ).map(
         suggestion => (isDoubleQuoted(text) ? `"${suggestion}"` : suggestion)
       )
       : []

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -157,7 +157,7 @@ describe("CourseSearchPage", () => {
 
   it("should not show suggestion if it is the same as query minus quotes, case", async () => {
     const suggestion = "mathematics basic principles"
-    const text = '"Mathematics: Basic Principles!"'
+    const text = ' "Mathematics: Basic Principles!" '
     initialState.search.data.suggest = [suggestion]
     searchResponse.suggest = [suggestion]
     setLocation(helper, { text })

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -155,6 +155,17 @@ describe("CourseSearchPage", () => {
     })
   })
 
+  it("should not show suggestion if it is the same as query minus quotes, case", async () => {
+    const suggestion = "mathematics basic principles"
+    const text = '"Mathematics: Basic Principles!"'
+    initialState.search.data.suggest = [suggestion]
+    searchResponse.suggest = [suggestion]
+    setLocation(helper, { text })
+    const { wrapper } = await render()
+    wrapper.update()
+    assert.isNotOk(wrapper.find(".suggestions").exists())
+  })
+
   //
   ;["", "a"].forEach(query => {
     it(`still runs a search if initial search text is '${query}'`, async () => {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3286 

#### What's this PR do?
Ignores quotes, case, and special characters when comparing a search suggestion to the search text.

#### How should this be manually tested?
Perform a search included a search term in quotes with a colon in between words, that only returns 1 result, like "Fiction: Great Books!" On https://discussions-rc.odl.mit.edu/learn/search?q=%22Fiction%3A%20Great%20Books%21%22 the suggested search term "fiction great books" will display.  On this branch, the suggested search term should not display.  Change the search term to "Fiction: Great Boos!" and it should display.
