### PR TITLE
fix inactive setting

### DIFF
--- a/notifications/management/commands/populate_notification_settings.py
+++ b/notifications/management/commands/populate_notification_settings.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--username", nargs="?", action="append")
-        parser.add_argument("--inactive", action="store_false", default=False)
+        parser.add_argument("--inactive", action="store_true", default=False)
 
     def handle(self, *args, **options):
         users = get_user_model().objects.all()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
The populate_notification_settings job currently ignores the --inactive flag

#### How should this be manually tested?
Update a user to be inactive and delete notifications for that user

```
from django.contrib.auth.models import User
from notifications.models import NotificationSettings

user = User.objects.last()
profile = User.profile
profile.last_active_on = None
profile.save()

NotificationSettings.objects.filter(user=user).delete()
```

Run
`docker-compose run web ./manage.py populate_notification_settings`

Notification settings should not be created for the user

Run
`docker-compose run web ./manage.py populate_notification_settings --inactive`

Now notification settings should not be created for the user
