### PR TITLE
remove read more button

### DIFF
--- a/mail/templates/moderator_posts/body.html
+++ b/mail/templates/moderator_posts/body.html
@@ -41,19 +41,4 @@
        </table>
    </td>
 </tr>
-<!-- 1 Column Text + Button : END -->
-
-<tr>
-    <td style="padding: 10px 20px;">
-        <!-- Button : BEGIN -->
-        <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
-            <tr>
-                <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                     <a class="button-a button-a-primary" href="{{ base_url }}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Read More</a>
-                </td>
-            </tr>
-        </table>
-        <!-- Button : END -->
-    </td>
-</tr>
 {% endblock %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3301

#### What's this PR do?
This pr removes the "read more" button from moderator post notifications.

#### How should this be manually tested?
Make sure moderator notifications are turned on for a channel you moderate and for your user. Make a post in the channel.
Run 
```
from notifications.tasks import *
send_unsent_email_notifications()
```

you should get a notification. It should not have a button with "Read More" on it


<img width="585" alt="Screen Shot 2021-02-05 at 4 14 11 PM" src="https://user-images.githubusercontent.com/1934992/107090334-0df4c100-67ce-11eb-873d-6c9b7a02e4fc.png">
