### PR TITLE
do not send moderator notifications for posts marked as spam automatically

### DIFF
--- a/channels/serializers/posts.py
+++ b/channels/serializers/posts.py
@@ -238,10 +238,10 @@ class PostSerializer(BasePostSerializer):
         if changed or cover_image:
             post = api.get_post(post_id=post.id)
 
-        notify_moderators.delay(post.id, channel_name)
-
         if not api.is_moderator(post.subreddit.display_name, post.author.name):
             task_helpers.check_post_for_spam(self.context["request"], post.id)
+        else:
+            notify_moderators.delay(post.id, channel_name)
 
         return post
 

--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -40,7 +40,7 @@ from open_discussions.celery import app
 from open_discussions.utils import chunks
 from search.exceptions import PopulateUserRolesException, RetryException
 from search import task_helpers
-
+from notifications.tasks import notify_moderators
 
 User = get_user_model()
 log = logging.getLogger()
@@ -497,6 +497,8 @@ def check_post_for_spam(*, user_ip, user_agent, post_id):
 
     if is_spam:
         admin_api.remove_post(post.post_id)
+    else:
+        notify_moderators.delay(post.post_id, post.channel.name)
 
 
 @app.task(acks_late=True)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3308

#### What's this PR do?
This pr updates moderator notifications to only send notifications for posts that are not automatically marked as spam and removed by akismet.

#### How should this be manually tested?
Log in as a moderator. Make a post in the channel you moderate.

Log in as a non-moderator. Make one spammy post and one non-spammy post. Verify that your posts are marked  as intended at http://localhost:8063/admin/channels/spamcheckresult/. Copy spam/non-spam comment text from production if needed.

Run
```
from notifications.tasks import *
send_unsent_email_notifications()
```

from the command line. You should receive notifications for posts made by the moderator and posts that are not marked as spam. You should not receive a notification for posts marked as spam automatically 
