### PR TITLE
update ocw-data-parser to 0.23.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.2
 markdown2==2.3.9
 newrelic
-ocw-data-parser==0.20.0
+ocw-data-parser==0.23.0
 Pillow==7.2.0
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -220,7 +220,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.20.0
+ocw-data-parser==0.23.0
     # via -r requirements.in
 parso==0.6.1
     # via jedi


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None

#### What's this PR do?
This PR updates the `ocw-data-parser` dependency from 0.20.0 to 0.23.0.

#### How should this be manually tested?
Run `sync_ocw_course` manually and make sure the course is properly synced with no errors.
