### PR TITLE
expose ga tracking id to moderators

### DIFF
--- a/channels/serializers/channels.py
+++ b/channels/serializers/channels.py
@@ -40,7 +40,7 @@ class ChannelSerializer(serializers.Serializer):
     avatar_small = serializers.SerializerMethodField()
     avatar_medium = serializers.SerializerMethodField()
     banner = WriteableSerializerMethodField()
-    ga_tracking_id = serializers.CharField(required=False, allow_blank=True)
+    ga_tracking_id = WriteableSerializerMethodField()
     about = serializers.JSONField(allow_null=True, default=None)
     moderator_notifications = WriteableSerializerMethodField()
 
@@ -87,6 +87,10 @@ class ChannelSerializer(serializers.Serializer):
             channel._self_channel.moderator_notifications  # pylint: disable=protected-access
         )
 
+    def get_ga_tracking_id(self, channel):
+        """Get google analytics tracking id"""
+        return channel.ga_tracking_id
+
     def validate_avatar(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
         if not hasattr(value, "name"):
@@ -104,6 +108,12 @@ class ChannelSerializer(serializers.Serializer):
         if not isinstance(value, bool):
             raise ValidationError("Expected moderator_notifications be a boolean")
         return {"moderator_notifications": value}
+
+    def validate_ga_tracking_id(self, value):
+        """Empty validation function, but this is required for WriteableSerializerMethodField"""
+        if not isinstance(value, str):
+            raise ValidationError("Expected ga_tracking_id to be a string")
+        return {"ga_tracking_id": value}
 
     def get_allowed_post_types(self, channel):
         """Returns a dictionary of allowed post types"""
@@ -202,6 +212,10 @@ class ChannelSerializer(serializers.Serializer):
             channel_obj.moderator_notifications = validated_data.get(
                 "moderator_notifications"
             )
+            channel_obj.save()
+
+        if "ga_tracking_id" in validated_data:
+            channel_obj.ga_tracking_id = validated_data.get("ga_tracking_id")
             channel_obj.save()
 
         avatar = validated_data.get("avatar")

--- a/channels/serializers/channels_test.py
+++ b/channels/serializers/channels_test.py
@@ -48,7 +48,6 @@ def test_serialize_channel(
         avatar=Mock() if has_avatar else None,
         avatar_small=Mock() if has_avatar else None,
         avatar_medium=Mock() if has_avatar else None,
-        ga_tracking_id=ga_tracking_id,
         widget_list_id=123,
         about=Mock() if has_about else None,
     )
@@ -206,3 +205,22 @@ def test_update_channel_moderator_notifications(user, moderator_notifications):
     )
     channel.refresh_from_db()
     assert channel.moderator_notifications == moderator_notifications
+
+
+@pytest.mark.parametrize("ga_tracking_id", ["test", ""])
+def test_update_channel_moderator_notifications(user, ga_tracking_id):
+    """
+    Test updating the channel moderator_notifications field
+    """
+    channel = ChannelFactory.create(about=None)
+    instance = Mock(display_name=channel.name)
+    request = Mock(user=user)
+    api_mock = Mock()
+    api_mock.update_channel.return_value._self_channel = (  # pylint: disable=protected-access
+        channel
+    )
+    ChannelSerializer(context={"channel_api": api_mock, "request": request}).update(
+        instance, {"ga_tracking_id": ga_tracking_id}
+    )
+    channel.refresh_from_db()
+    assert channel.ga_tracking_id == ga_tracking_id

--- a/static/js/components/admin/EditChannelBasicForm.js
+++ b/static/js/components/admin/EditChannelBasicForm.js
@@ -106,7 +106,7 @@ export default function EditChannelBasicForm(props: Props) {
           {validationMessage(validation.allowed_post_types)}
         </div>
       </Card>
-      <Card title="Other">
+      <Card title="Notifications">
         <div className="moderator_notifications">
           <Checkbox
             name="moderator_notifications"
@@ -116,6 +116,19 @@ export default function EditChannelBasicForm(props: Props) {
             Notify channel moderators when new articles are posted in this
             channel
           </Checkbox>
+        </div>
+      </Card>
+      <Card title="Analytics">
+        <div className="analytics">
+          <input
+            type="text"
+            name="ga_tracking_id"
+            className="input"
+            placeholder="Enter a UTM- or G- code for google analytics"
+            value={form.ga_tracking_id || ""}
+            onChange={onUpdate}
+          />
+          {validationMessage(validation.ga_tracking_id)}
         </div>
       </Card>
       <div className="row actions">

--- a/static/js/components/admin/EditChannelBasicForm_test.js
+++ b/static/js/components/admin/EditChannelBasicForm_test.js
@@ -72,7 +72,8 @@ describe("EditChannelBasicForm", () => {
     ;[
       ["channel_type", CHANNEL_TYPE_PUBLIC],
       ["allowed_post_types", LINK_TYPE_TEXT],
-      ["moderator_notifications", true]
+      ["moderator_notifications", true],
+      ["ga_tracking_id", "fake"]
     ].forEach(([name, value]) => {
       describe("onUpdate", () => {
         it(`should be called when ${name} input is modified`, () => {

--- a/static/js/flow/discussionTypes.js
+++ b/static/js/flow/discussionTypes.js
@@ -54,6 +54,7 @@ export type ChannelForm = {
   avatar?:                  FormImage,
   banner?:                  FormImage,
   moderator_notifications?: boolean,
+  ga_tracking_id?:          ?string,
 }
 
 export type ChannelAppearanceEditValidation = {
@@ -62,7 +63,8 @@ export type ChannelAppearanceEditValidation = {
 }
 
 export type ChannelBasicEditValidation = {
-  allowed_post_types: string
+  allowed_post_types: string,
+  ga_tracking_id?:    string
 }
 
 export type AddMemberForm = {

--- a/static/js/lib/api/channels.js
+++ b/static/js/lib/api/channels.js
@@ -52,7 +52,8 @@ export function updateChannel(channel: Channel): Promise<Channel> {
           "channel_type",
           "allowed_post_types",
           "about",
-          "moderator_notifications"
+          "moderator_notifications",
+          "ga_tracking_id"
         ],
         channel
       )

--- a/static/js/lib/channels.js
+++ b/static/js/lib/channels.js
@@ -50,7 +50,8 @@ export const editChannelForm = (channel: Channel): ChannelForm =>
       "public_description",
       "channel_type",
       "allowed_post_types",
-      "moderator_notifications"
+      "moderator_notifications",
+      "ga_tracking_id"
     ],
     channel
   )

--- a/static/js/lib/channels_test.js
+++ b/static/js/lib/channels_test.js
@@ -38,7 +38,8 @@ describe("Channel utils", () => {
       public_description:      channel.public_description,
       channel_type:            channel.channel_type,
       allowed_post_types:      channel.allowed_post_types,
-      moderator_notifications: false
+      moderator_notifications: false,
+      ga_tracking_id:          channel.ga_tracking_id
     })
   })
 

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -186,6 +186,14 @@ export const validateChannelBasicEditForm = validate([
     R.isEmpty,
     formLens("allowed_post_types"),
     "At least one of the post type options must be selected"
+  ),
+  validation(
+    R.compose(
+      R.gt(R.__, 30),
+      R.length
+    ),
+    formLens("ga_tracking_id"),
+    "Tracking id length is limited to 30 characters"
   )
 ])
 

--- a/static/js/lib/validation_test.js
+++ b/static/js/lib/validation_test.js
@@ -265,6 +265,21 @@ describe("validation library", () => {
       channel.value.allowed_post_types = [LINK_TYPE_LINK]
       assert.deepEqual(validateChannelBasicEditForm(channel), {})
     })
+
+    it("should complain if tracking id is too long", () => {
+      const channel = {
+        value: {
+          ga_tracking_id: "a".repeat(31)
+        }
+      }
+      assert.deepEqual(validateChannelBasicEditForm(channel), {
+        value: {
+          ga_tracking_id: "Tracking id length is limited to 30 characters"
+        }
+      })
+      channel.value.ga_tracking_id = "short"
+      assert.deepEqual(validateChannelBasicEditForm(channel), {})
+    })
   })
 
   describe("validateContentReportForm", () => {

--- a/static/js/pages/admin/EditChannelBasicPage.js
+++ b/static/js/pages/admin/EditChannelBasicPage.js
@@ -116,7 +116,8 @@ class EditChannelBasicPage extends React.Component<Props> {
           "name",
           "channel_type",
           "allowed_post_types",
-          "moderator_notifications"
+          "moderator_notifications",
+          "ga_tracking_id"
         ],
         channelForm.value
       )

--- a/static/js/pages/admin/EditChannelBasicPage_test.js
+++ b/static/js/pages/admin/EditChannelBasicPage_test.js
@@ -112,7 +112,8 @@ describe("EditChannelBasicPage", () => {
       "name",
       "channel_type",
       "allowed_post_types",
-      "moderator_notifications"
+      "moderator_notifications",
+      "ga_tracking_id"
     ])
 
     assert.equal(helper.currentLocation.pathname, channelURL(channel.name))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
 
<img width="1098" alt="Screen Shot 2021-03-10 at 8 56 51 AM" src="https://user-images.githubusercontent.com/1934992/110640366-c1125a80-817e-11eb-9b54-f48d242e9f91.png">
<img width="376" alt="Screen Shot 2021-03-10 at 8 57 01 AM" src="https://user-images.githubusercontent.com/1934992/110640369-c1aaf100-817e-11eb-9a90-9fadeeae3870.png">


- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3305

#### What's this PR do?
(Required)

#### How should this be manually tested?
This pr adds the ga_tracking_id property to the channel management ui

#### Where should the reviewer start?
Go to http://localhost:8063/manage/c/edit/<channel>/basic/
Ensure that you can set and unset the tag

