### PR TITLE
check for gtag in channel tracker

### DIFF
--- a/static/js/hoc/withChannelTracker.js
+++ b/static/js/hoc/withChannelTracker.js
@@ -20,7 +20,7 @@ export const withChannelTracker = (
     loadGA() {
       const { channel, location } = this.props
 
-      if (channel && channel.ga_tracking_id) {
+      if (channel && channel.ga_tracking_id && window.gtag) {
         window.gtag("config", channel.ga_tracking_id, {
           send_page_view: false
         })

--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -54,6 +54,13 @@ describe("withTracker", () => {
     assert.ok(gTagStub.notCalled)
   })
 
+  it("should not call GA config and event if window.gtag is not set", async () => {
+    window.gtag = null
+    window.location = "http://fake/c/path"
+    await render({}, { location: window.location, channel: channel })
+    assert.ok(gTagStub.notCalled)
+  })
+
   //
   ;[[true, 4], [false, 2]].forEach(([missingPrevChannel, gaCalls]) => {
     it(`${shouldIf(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3316

#### What's this PR do?
This fixes a bug in https://github.com/mitodl/open-discussions/pull/3319 which causes an error if a channel has a tracking id
set but GA_G_TRACKING_ID is not set.

#### How should this be manually tested?
Remove GA_G_TRACKING_ID from your env file. 
Set a tracking id for a channel from the channel admin. 
Click around the channel. Verify that you do not see errors.


