### PR TITLE
Fix typo in logging exception

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -461,7 +461,7 @@ def sync_ocw_course(
                     parser.upload_all_media_to_s3(upload_parsed_json=True)
             except:  # pylint: disable=bare-except
                 log.exception(
-                    ("Error encountered uploading OCW files for %s", course_prefix)
+                    "Error encountered uploading OCW files for %s", course_prefix
                 )
                 raise
         else:


### PR DESCRIPTION
#### What's this PR do?
Fixes a typo I spotted in `log.exception` where a second set of paratheses made the argument a tuple.

#### How should this be manually tested?
Probably not worthwhile to test manually
