### PR TITLE
manually send gtag events

### DIFF
--- a/static/js/util/withTracker.js
+++ b/static/js/util/withTracker.js
@@ -28,7 +28,7 @@ const withTracker = (WrappedComponent: Class<React.Component<*, *>>) => {
     gaScript2.innerHTML = `window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '${SETTINGS.gaGTrackingID}');`
+      gtag('config', '${SETTINGS.gaGTrackingID}', {send_page_view: false});`
 
     // $FlowFixMe: document.head is not null
     document.head.appendChild(gaScript2)
@@ -36,7 +36,12 @@ const withTracker = (WrappedComponent: Class<React.Component<*, *>>) => {
 
   const HOC = (props: Object) => {
     const page = props.location.pathname
+
     ReactGA.pageview(page)
+
+    if (window.gtag && SETTINGS.gaGTrackingID) {
+      window.gtag("event", "page_view", { page_path: page })
+    }
 
     return <WrappedComponent {...props} />
   }

--- a/static/js/util/withTracker_test.js
+++ b/static/js/util/withTracker_test.js
@@ -8,6 +8,7 @@ import ReactGA from "react-ga"
 
 import withTracker from "./withTracker"
 import { TestPage } from "../lib/test_utils"
+import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("withTracker", () => {
   let sandbox, gaInitStub, gaPageViewStub, WrappedPage
@@ -33,7 +34,7 @@ describe("withTracker", () => {
     assert.ok(gaPageViewStub.calledWith("/c/path"))
   })
 
-  it("should append gtag.js scripts to the header SETTINGS.gaGTrackingID is set ", () => {
+  it("should append gtag.js scripts to the header when SETTINGS.gaGTrackingID is set ", () => {
     SETTINGS.gaGTrackingID = "G-default-1"
     // $FlowFixMe: it's a test
     document.head.innerHTML = ""
@@ -45,6 +46,23 @@ describe("withTracker", () => {
       // $FlowFixMe: it's a test
       document.head.firstChild.src ===
         "https://www.googletagmanager.com/gtag/js?id=G-default-1"
+    )
+  })
+
+  it("should make pageview call when SETTINGS.gaGTrackingID is set ", () => {
+    SETTINGS.gaGTrackingID = "G-default-1"
+    window.location = `http://fake/c/path`
+    const helper = new IntegrationTestHelper()
+    window.gtag = helper.sandbox.stub()
+    const gTagStub = window.gtag
+
+    WrappedPage = withTracker(TestPage)
+    renderPage({ location: window.location })
+    assert.ok(gTagStub.calledOnce)
+    assert.ok(
+      gTagStub.calledWith("event", "page_view", {
+        page_path: window.location.pathname
+      })
     )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3335

#### What's this PR do?
The automatic pageview metric in gtag.js (implemented in https://github.com/mitodl/open-discussions/pull/3319) doesn't pick up everything we consider a page view. This pr turns off automatic pageviews and sends manual pageviews instead.

#### How should this be manually tested?
Set GA_G_TRACKING_ID in your .env file. You can use G-B0EKT59MQF for testing
Go to the network tab in developer tools and search for the tag.
You should see calls to https://www.google-analytics.com with the tag when you click around the app.

