### PR TITLE
Add resource_type to ES index for ContentFiles

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -337,15 +337,17 @@ def sync_ocw_course_files(ids=None):
         for run in runs.iterator():
             try:
                 s3_parsed_json = rapidjson.loads(
-                    bucket.Object(
-                        "{}/{}_parsed.json".format(run.url.split("/")[-1], run.run_id)
-                    )
+                    bucket.Object(f"{run.slug}/{run.slug}_parsed.json")
                     .get()["Body"]
                     .read()
                 )
                 load_content_files(run, transform_content_files(s3_parsed_json))
             except:  # pylint: disable=bare-except
-                log.exception("Error syncing files for course run %d", run.id)
+                log.exception(
+                    "Error syncing files for course run %d: %s",
+                    run.id,
+                    "{}_parsed.json".format(run.slug),
+                )
 
 
 # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -343,11 +343,7 @@ def sync_ocw_course_files(ids=None):
                 )
                 load_content_files(run, transform_content_files(s3_parsed_json))
             except:  # pylint: disable=bare-except
-                log.exception(
-                    "Error syncing files for course run %d: %s",
-                    run.id,
-                    "{}_parsed.json".format(run.slug),
-                )
+                log.exception("Error syncing files for course run %d", run.id)
 
 
 # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -348,9 +348,7 @@ def test_sync_ocw_course_files(mock_ocw_learning_bucket, mocker, with_error):
     runs = course.runs.all()
     for run in runs:
         mock_ocw_learning_bucket.bucket.put_object(
-            Key="{}/{}_parsed.json".format(run.url.split("/")[-1], run.run_id),
-            Body=fake_data,
-            ACL="public-read",
+            Key=f"{run.slug}/{run.slug}_parsed.json", Body=fake_data, ACL="public-read"
         )
     sync_ocw_course_files(ids=[course.id])
     assert mock_load_content_files.call_count == len(runs)
@@ -560,6 +558,7 @@ def test_sync_ocw_course_published(
     settings, mocker, pub_date, unpub_date, published, blocklisted
 ):
     """ The course should be published or not based on dates, and always uploaded """
+    mocker.patch("course_catalog.etl.ocw.extract_text_metadata", return_value="")
     mocker.patch(
         "course_catalog.api.format_date",
         side_effect=[format_date(pub_date), format_date(unpub_date)],

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -37,6 +37,7 @@ from course_catalog.models import (
     Podcast,
     PodcastEpisode,
 )
+from search.constants import OCW_TYPE_EXAMS, OCW_TYPE_LECTURE_NOTES
 
 
 # pylint: disable=unused-argument
@@ -273,6 +274,7 @@ class ContentFileFactory(DjangoModelFactory):
     short_url = factory.Faker("word")
     content_type = FuzzyChoice((CONTENT_TYPE_FILE, CONTENT_TYPE_PAGE))
     file_type = FuzzyChoice(("application/pdf", "video/mp4", "text"))
+    section = FuzzyChoice((OCW_TYPE_EXAMS, OCW_TYPE_LECTURE_NOTES, None))
 
     class Meta:
         model = ContentFile

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@ addopts = --cov . --cov-report term --cov-report html --cov-report xml --ds=open
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
 markers =
   betamax: test requires betamax
+env =
+  CELERY_TASK_ALWAYS_EAGER=True
+  OPEN_DISCUSSIONS_USE_S3=False

--- a/search/api.py
+++ b/search/api.py
@@ -370,6 +370,7 @@ def transform_results(search_result, user):
         "department_name",
         "level",
         "course_feature_tags",
+        "resource_type",
     ]:
         if f"agg_filter_{aggregation_key}" in search_result.get("aggregations", {}):
             if aggregation_key == "level":

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -788,9 +788,9 @@ def test_transform_level_aggregation():
 
 
 @pytest.mark.django_db
-def test_transform_nested_aggregations():
+def test_transform_topics_aggregations():
     """
-    Aggregations with filters are nested under `agg_filter_<key>`. transform_results should unnest them
+    Topics Aggregations with filters are nested under `agg_filter_topics`. transform_results should unnest them
     """
     results = {
         "hits": {"hits": {}, "total": 15},
@@ -816,6 +816,42 @@ def test_transform_nested_aggregations():
     ] = expected_transformed_results["aggregations"]["agg_filter_topics"]["topics"]
 
     assert transform_results(results, AnonymousUser()) == expected_transformed_results
+
+
+@pytest.mark.django_db
+def test_transform_resource_type_aggregations():
+    """
+    Resource_type Aggregations with filters are nested under `agg_filter_resource_type`.
+    transform_results should unnest them
+    """
+    results = {
+        "hits": {"hits": {}, "total": 15},
+        "suggest": {},
+        "aggregations": {
+            "agg_filter_resource_type": {
+                "doc_count": 660,
+                "resource_type": {
+                    "doc_count_error_upper_bound": 0,
+                    "sum_other_doc_count": 0,
+                    "buckets": [
+                        {"key": "Assignments", "doc_count": 252},
+                        {"key": "Lecture Notes", "doc_count": 207},
+                        {"key": "Recitations", "doc_count": 75},
+                        {"key": "Readings", "doc_count": 71},
+                        {"key": "Exams", "doc_count": 55},
+                    ],
+                },
+            }
+        },
+    }
+
+    expected_transformed_results = results.copy()
+    expected_transformed_results["suggest"] = []
+    expected_transformed_results["aggregations"][
+        "resource_type"
+    ] = expected_transformed_results["aggregations"]["agg_filter_resource_type"][
+        "resource_type"
+    ]
 
 
 @pytest.mark.parametrize("podcast_present_in_aggregate", [True, False])

--- a/search/constants.py
+++ b/search/constants.py
@@ -51,7 +51,6 @@ OCW_TYPE_TEXTBOOKS = "Online Textbooks"
 OCW_TYPE_TOOLS = "Tools"
 OCW_TYPE_TUTORIALS = "Tutorials"
 OCW_TYPE_VIDEOS = "Videos"
-OCW_TYPE_OTHER = "Other"
 
 
 OCW_SECTION_TYPE_MAPPING = {

--- a/search/constants.py
+++ b/search/constants.py
@@ -51,6 +51,7 @@ OCW_TYPE_TEXTBOOKS = "Online Textbooks"
 OCW_TYPE_TOOLS = "Tools"
 OCW_TYPE_TUTORIALS = "Tutorials"
 OCW_TYPE_VIDEOS = "Videos"
+OCW_TYPE_OTHER = "Other"
 
 
 OCW_SECTION_TYPE_MAPPING = {

--- a/search/constants.py
+++ b/search/constants.py
@@ -20,6 +20,7 @@ LEARNING_RESOURCE_TYPES = (
     VIDEO_TYPE,
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
+    RESOURCE_FILE_TYPE,
 )
 
 VALID_OBJECT_TYPES = (
@@ -34,3 +35,126 @@ VALID_OBJECT_TYPES = (
     PODCAST_EPISODE_TYPE,
 )
 GLOBAL_DOC_TYPE = "_doc"
+
+OCW_TYPE_ASSIGNMENTS = "Assignments"
+OCW_TYPE_EXAMS = "Exams"
+OCW_TYPE_EXERCISES = "Exercises"
+OCW_TYPE_LABS = "Labs"
+OCW_TYPE_LECTURE_AUDIO = "Lecture Audio"
+OCW_TYPE_LECTURE_NOTES = "Lecture Notes"
+OCW_TYPE_LECTURE_VIDEOS = "Lecture Videos"
+OCW_TYPE_PROJECTS = "Projects"
+OCW_TYPE_READINGS = "Readings"
+OCW_TYPE_RECITATIONS = "Recitations"
+OCW_TYPE_RESOURCES = "Resources"
+OCW_TYPE_TEXTBOOKS = "Online Textbooks"
+OCW_TYPE_TOOLS = "Tools"
+OCW_TYPE_TUTORIALS = "Tutorials"
+OCW_TYPE_VIDEOS = "Videos"
+
+
+OCW_SECTION_TYPE_MAPPING = {
+    OCW_TYPE_ASSIGNMENTS: OCW_TYPE_ASSIGNMENTS,
+    OCW_TYPE_EXAMS: OCW_TYPE_EXAMS,
+    OCW_TYPE_EXERCISES: OCW_TYPE_EXERCISES,
+    OCW_TYPE_LABS: OCW_TYPE_LABS,
+    OCW_TYPE_LECTURE_AUDIO: OCW_TYPE_LECTURE_AUDIO,
+    OCW_TYPE_LECTURE_NOTES: OCW_TYPE_LECTURE_NOTES,
+    OCW_TYPE_LECTURE_VIDEOS: OCW_TYPE_LECTURE_VIDEOS,
+    OCW_TYPE_PROJECTS: OCW_TYPE_PROJECTS,
+    OCW_TYPE_READINGS: OCW_TYPE_READINGS,
+    OCW_TYPE_RECITATIONS: OCW_TYPE_RECITATIONS,
+    OCW_TYPE_RESOURCES: OCW_TYPE_RESOURCES,
+    OCW_TYPE_TEXTBOOKS: OCW_TYPE_TEXTBOOKS,
+    OCW_TYPE_TOOLS: OCW_TYPE_TOOLS,
+    OCW_TYPE_TUTORIALS: OCW_TYPE_TUTORIALS,
+    OCW_TYPE_VIDEOS: OCW_TYPE_VIDEOS,
+    "Assignments and Student Work": OCW_TYPE_ASSIGNMENTS,
+    "Audio Lectures and Notes": OCW_TYPE_LECTURE_AUDIO,
+    "Audio Lectures": OCW_TYPE_LECTURE_AUDIO,
+    "Calendar & Assignments": OCW_TYPE_ASSIGNMENTS,
+    "Calendar & Readings": OCW_TYPE_READINGS,
+    "Calendar and Assignments": OCW_TYPE_ASSIGNMENTS,
+    "Calendar and Homework": OCW_TYPE_ASSIGNMENTS,
+    "Calendar and Lecture Summaries": OCW_TYPE_LECTURE_NOTES,
+    "Calendar and Notes": OCW_TYPE_LECTURE_NOTES,
+    "Calendar and Readings": OCW_TYPE_READINGS,
+    "Class Slides": OCW_TYPE_LECTURE_NOTES,
+    "Conference Videos": OCW_TYPE_VIDEOS,
+    "Course Notes": OCW_TYPE_LECTURE_NOTES,
+    "Empirical Exercises": OCW_TYPE_EXERCISES,
+    "Exams & Quizzes": OCW_TYPE_EXAMS,
+    "Exercises": OCW_TYPE_ASSIGNMENTS,
+    "Final Project": OCW_TYPE_PROJECTS,
+    "Final Projects": OCW_TYPE_PROJECTS,
+    "First Paper Assignment": OCW_TYPE_ASSIGNMENTS,
+    "Food Assignment": OCW_TYPE_ASSIGNMENTS,
+    "Homework Assignments": OCW_TYPE_ASSIGNMENTS,
+    "Labs and Exercises": OCW_TYPE_LABS,
+    "Lecture & Recitation Videos": OCW_TYPE_LECTURE_VIDEOS,
+    "Lecture and Studio Notes": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Audio and Slides": OCW_TYPE_LECTURE_AUDIO,
+    "Lecture Handouts": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes & Slides": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes and Files": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes and Handouts": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes and References": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes and Slides": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Notes and Video": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Outlines": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Slides and Code": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Slides and Files": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Slides and Readings": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Slides and Supplemental Readings": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Slides": OCW_TYPE_LECTURE_NOTES,
+    "Lecture slides": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Summaries": OCW_TYPE_LECTURE_NOTES,
+    "Lecture Videos & Notes": OCW_TYPE_LECTURE_VIDEOS,
+    "Lecture Videos & Slides": OCW_TYPE_LECTURE_VIDEOS,
+    "Lecture Videos and Class Notes": OCW_TYPE_LECTURE_VIDEOS,
+    "Lecture Videos and Notes": OCW_TYPE_LECTURE_VIDEOS,
+    "Lecture Videos and Slides": OCW_TYPE_LECTURE_VIDEOS,
+    "Lectures: Audio and Slides": OCW_TYPE_LECTURE_AUDIO,
+    "Lectures": OCW_TYPE_LECTURE_NOTES,
+    "Long Project": OCW_TYPE_PROJECTS,
+    "Major Writing Assignments": OCW_TYPE_ASSIGNMENTS,
+    "MATLAB Exercises": OCW_TYPE_ASSIGNMENTS,
+    "Mini Quizzes": OCW_TYPE_EXAMS,
+    "Ongoing Assignments": OCW_TYPE_ASSIGNMENTS,
+    "Online Textbook": OCW_TYPE_TEXTBOOKS,
+    "Practice Exams": OCW_TYPE_EXAMS,
+    "Prior Year Exams": OCW_TYPE_EXAMS,
+    "Problem Sets": OCW_TYPE_ASSIGNMENTS,
+    "Professional Memorandum Assignments": OCW_TYPE_ASSIGNMENTS,
+    "Quiz": OCW_TYPE_EXAMS,
+    "Quizzes": OCW_TYPE_EXAMS,
+    "Reading Notes": OCW_TYPE_READINGS,
+    "Reading, Viewing, and Listening": OCW_TYPE_READINGS,
+    "Readings & Films": OCW_TYPE_READINGS,
+    "Readings & Listening": OCW_TYPE_READINGS,
+    "Readings & Notes": OCW_TYPE_READINGS,
+    "Readings and Discussion Schedule": OCW_TYPE_READINGS,
+    "Readings and Films Guides": OCW_TYPE_READINGS,
+    "Readings and Films": OCW_TYPE_READINGS,
+    "Readings and Homework Preparation": OCW_TYPE_READINGS,
+    "Readings and Lectures": OCW_TYPE_READINGS,
+    "Readings and Listening": OCW_TYPE_READINGS,
+    "Readings and Materials": OCW_TYPE_READINGS,
+    "Readings and Music": OCW_TYPE_READINGS,
+    "Readings and Other Assigned Materials": OCW_TYPE_READINGS,
+    "Readings and Viewings": OCW_TYPE_READINGS,
+    "Readings Questions": OCW_TYPE_READINGS,
+    "Readings, Notes & Slides": OCW_TYPE_READINGS,
+    "Recitation Notes": OCW_TYPE_RECITATIONS,
+    "Recitation Videos": OCW_TYPE_VIDEOS,
+    "Related Video Lectures": OCW_TYPE_LECTURE_VIDEOS,
+    "Selected Lecture Notes": OCW_TYPE_LECTURE_NOTES,
+    "Student Game Projects": OCW_TYPE_PROJECTS,
+    "Student Projects by Year": OCW_TYPE_PROJECTS,
+    "Studio Resources": OCW_TYPE_RESOURCES,
+    "Team Projects": OCW_TYPE_PROJECTS,
+    "Textbook Contents": OCW_TYPE_TEXTBOOKS,
+    "Textbook": OCW_TYPE_TEXTBOOKS,
+    "Video Lectures and Slides": OCW_TYPE_LECTURE_VIDEOS,
+    "Video Lectures": OCW_TYPE_LECTURE_VIDEOS,
+}

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -186,6 +186,7 @@ COURSE_FILE_OBJECT_TYPE = {
     "content_type": {"type": "keyword"},
     "content": ENGLISH_TEXT_FIELD,
     "location": {"type": "keyword"},
+    "resource_type": {"type": "keyword"},
 }
 
 COURSE_OBJECT_TYPE = {

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -1,6 +1,7 @@
 """Serializers for elasticsearch data"""
 # pylint: disable=unused-argument,too-many-lines
 import logging
+import re
 
 from functools import reduce
 from django.db.models import Prefetch
@@ -45,6 +46,7 @@ from search.constants import (
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
     OCW_SECTION_TYPE_MAPPING,
+    OCW_TYPE_ASSIGNMENTS,
     OCW_TYPE_OTHER,
 )
 
@@ -380,6 +382,8 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
         """Get the resource type of the ContentFile"""
         if not instance.section:
             return None
+        if re.search(r"Assignment($|\s)", instance.section):
+            return OCW_TYPE_ASSIGNMENTS
         return OCW_SECTION_TYPE_MAPPING.get(instance.section, OCW_TYPE_OTHER)
 
     class Meta:

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -44,6 +44,7 @@ from search.constants import (
     RESOURCE_FILE_TYPE,
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
+    OCW_SECTION_TYPE_MAPPING,
 )
 
 from open_discussions.utils import filter_dict_keys, filter_dict_with_renamed_keys
@@ -364,6 +365,7 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
     short_description = serializers.CharField(source="description")
     course_id = serializers.CharField(source="run.content_object.course_id")
     coursenum = serializers.CharField(source="run.content_object.coursenum")
+    resource_type = serializers.SerializerMethodField()
 
     def get_resource_relations(self, instance):
         """ Get resource_relations properties"""
@@ -372,6 +374,12 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
             "name": "resourcefile",
             "parent": gen_course_id(course.platform, course.course_id),
         }
+
+    def get_resource_type(self, instance):
+        """Get the resource type of the ContentFile"""
+        if not instance.section:
+            return None
+        return OCW_SECTION_TYPE_MAPPING.get(instance.section, None)
 
     class Meta:
         model = ContentFile
@@ -401,6 +409,7 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
             "course_id",
             "coursenum",
             "image_src",
+            "resource_type",
         ]
 
 

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -47,7 +47,6 @@ from search.constants import (
     PODCAST_EPISODE_TYPE,
     OCW_SECTION_TYPE_MAPPING,
     OCW_TYPE_ASSIGNMENTS,
-    OCW_TYPE_OTHER,
 )
 
 from open_discussions.utils import filter_dict_keys, filter_dict_with_renamed_keys
@@ -384,7 +383,7 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
             return None
         if re.search(r"Assignment($|\s)", instance.section):
             return OCW_TYPE_ASSIGNMENTS
-        return OCW_SECTION_TYPE_MAPPING.get(instance.section, OCW_TYPE_OTHER)
+        return OCW_SECTION_TYPE_MAPPING.get(instance.section, None)
 
     class Meta:
         model = ContentFile

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -45,6 +45,7 @@ from search.constants import (
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
     OCW_SECTION_TYPE_MAPPING,
+    OCW_TYPE_OTHER,
 )
 
 from open_discussions.utils import filter_dict_keys, filter_dict_with_renamed_keys
@@ -379,7 +380,7 @@ class ESContentFileSerializer(ESResourceFileSerializerMixin, ESModelSerializer):
         """Get the resource type of the ContentFile"""
         if not instance.section:
             return None
-        return OCW_SECTION_TYPE_MAPPING.get(instance.section, None)
+        return OCW_SECTION_TYPE_MAPPING.get(instance.section, OCW_TYPE_OTHER)
 
     class Meta:
         model = ContentFile

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -53,7 +53,8 @@ from search.constants import (
     RESOURCE_FILE_TYPE,
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
-    OCW_SECTION_TYPE_MAPPING,
+    OCW_TYPE_ASSIGNMENTS,
+    OCW_TYPE_LECTURE_NOTES,
     OCW_TYPE_OTHER,
 )
 from search.serializers import (
@@ -408,13 +409,24 @@ def test_es_course_serializer(offered_by, platform, department):
 
 
 @pytest.mark.django_db
-def test_es_content_file_serializer():
+@pytest.mark.parametrize(
+    "section,resource_type",
+    [
+        ["First Paper Assignment", OCW_TYPE_ASSIGNMENTS],
+        ["Assignment 1.2", OCW_TYPE_ASSIGNMENTS],
+        ["Assignments and Exams", OCW_TYPE_OTHER],
+        ["Lecture Summaries", OCW_TYPE_LECTURE_NOTES],
+        [OCW_TYPE_LECTURE_NOTES, OCW_TYPE_LECTURE_NOTES],
+    ],
+)
+def test_es_content_file_serializer(section, resource_type):
     """ Verify that the ESContentFileSerializer has the correct data"""
     content_kwargs = {
         "content": "Some text",
         "content_author": "MIT",
         "content_language": "en",
         "content_title": "test title",
+        "section": section,
     }
     content_file = ContentFileFactory.create(**content_kwargs)
     serialized = ESContentFileSerializer(content_file).data
@@ -455,9 +467,7 @@ def test_es_content_file_serializer():
             "image_src": content_file.image_src,
             "course_id": content_file.run.content_object.course_id,
             "coursenum": content_file.run.content_object.coursenum,
-            "resource_type": OCW_SECTION_TYPE_MAPPING.get(
-                content_file.section, OCW_TYPE_OTHER
-            ),
+            "resource_type": resource_type,
         },
     )
 

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -55,7 +55,6 @@ from search.constants import (
     PODCAST_EPISODE_TYPE,
     OCW_TYPE_ASSIGNMENTS,
     OCW_TYPE_LECTURE_NOTES,
-    OCW_TYPE_OTHER,
 )
 from search.serializers import (
     ESPostSerializer,
@@ -414,7 +413,7 @@ def test_es_course_serializer(offered_by, platform, department):
     [
         ["First Paper Assignment", OCW_TYPE_ASSIGNMENTS],
         ["Assignment 1.2", OCW_TYPE_ASSIGNMENTS],
-        ["Assignments and Exams", OCW_TYPE_OTHER],
+        ["Assignments and Exams", None],
         ["Lecture Summaries", OCW_TYPE_LECTURE_NOTES],
         [OCW_TYPE_LECTURE_NOTES, OCW_TYPE_LECTURE_NOTES],
     ],

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -54,6 +54,7 @@ from search.constants import (
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
     OCW_SECTION_TYPE_MAPPING,
+    OCW_TYPE_OTHER,
 )
 from search.serializers import (
     ESPostSerializer,
@@ -454,7 +455,9 @@ def test_es_content_file_serializer():
             "image_src": content_file.image_src,
             "course_id": content_file.run.content_object.course_id,
             "coursenum": content_file.run.content_object.coursenum,
-            "resource_type": OCW_SECTION_TYPE_MAPPING.get(content_file.section, None),
+            "resource_type": OCW_SECTION_TYPE_MAPPING.get(
+                content_file.section, OCW_TYPE_OTHER
+            ),
         },
     )
 

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -53,6 +53,7 @@ from search.constants import (
     RESOURCE_FILE_TYPE,
     PODCAST_TYPE,
     PODCAST_EPISODE_TYPE,
+    OCW_SECTION_TYPE_MAPPING,
 )
 from search.serializers import (
     ESPostSerializer,
@@ -453,6 +454,7 @@ def test_es_content_file_serializer():
             "image_src": content_file.image_src,
             "course_id": content_file.run.content_object.course_id,
             "coursenum": content_file.run.content_object.coursenum,
+            "resource_type": OCW_SECTION_TYPE_MAPPING.get(content_file.section, None),
         },
     )
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,6 +14,7 @@ pylint==2.1.1
 pylint-django==2.0.2
 pytest==4.6
 pytest-cov>=2.6.1
+pytest-env==0.6.2
 pytest-django==3.4.8
 pytest-freezegun==0.4.2
 pytest-mock==1.10.1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Closes #3343 
- Fixes backpopulate_ocw_files command

#### What's this PR do?
Adds "resource_type" to OCW `ContentFile` docs in Elasticsearch, based on the course section that the ContentFile falls under (if any), and includes it in aggregations.

#### How should this be manually tested?
- Reindex (`python manage.py recreate_index`)
- Most importantly, nothing should break afterward in open.
- Spin up `ocw-www` with `SEARCH_API_URL` pointing to your local open instance and try resource search, it should still work, and hits should include `resource_type` (though many of them might have a value of "Other")
- Using postman or curl send a POST request to http://localhost:8063/api/v0/search/ with this body:
```
{
    "from": 0,
    "size": 10,
    "post_filter": {
        "bool": {
            "must": [
                {
                    "bool": {
                        "should": [
                            {
                                "term": {
                                    "object_type.keyword": "resourcefile"
                                }
                            }
                        ]
                    }
                },
                {
                    "bool": {
                        "should": [
                            {
                                "has_parent": {
                                    "parent_type": "resource",
                                    "query": {
                                        "bool": {
                                            "should": [
                                                {
                                                    "term": {
                                                        "offered_by": "OCW"
                                                    }
                                                }
                                            ]
                                        }
                                    }
                                }
                            }
                        ]
                    }
                }
            ]
        }
    },
    "query": {
        "bool": {
            "should": [
                {
                    "bool": {
                        "filter": {
                            "bool": {
                                "must": [
                                    {
                                        "term": {
                                            "object_type": "resourcefile"
                                        }
                                    },
                                    {
                                        "bool": {
                                            "should": [
                                                {
                                                    "term": {
                                                        "content_type": "pdf"
                                                    }
                                                },
                                                {
                                                    "term": {
                                                        "content_type": "file"
                                                    }
                                                },                                                
                                                {
                                                    "term": {
                                                        "content_type": "page"
                                                    }
                                                },
                                                {
                                                    "term": {
                                                        "content_type": "video"
                                                    }
                                                }
                                            ]
                                        }
                                    }
                                ]
                            }
                        }
                    }
                }
            ]
        }
    },
    "aggs": {
        "agg_filter_resource_type": {
            "filter": {
                "bool": {
                    "should": [
                        {
                            "bool": {
                                "filter": {
                                    "bool": {
                                        "must": [
                                            {
                                                "bool": {
                                                    "should": [
                                                        {
                                                            "term": {
                                                                "object_type.keyword": "resourcefile"
                                                            }
                                                        }
                                                    ]
                                                }
                                            },
                                            {
                                                "bool": {
                                                    "should": [
                                                        {
                                                            "has_parent": {
                                                                "parent_type": "resource",
                                                                "query": {
                                                                    "bool": {
                                                                        "should": [
                                                                            {
                                                                                "term": {
                                                                                    "offered_by": "OCW"
                                                                                }
                                                                            }
                                                                        ]
                                                                    }
                                                                }
                                                            }
                                                        }
                                                    ]
                                                }
                                            }
                                        ]
                                    }
                                }
                            }
                        }
                    ]
                }
            },
            "aggs": {
                "resource_type": {
                    "terms": {
                        "field": "resource_type",
                        "size": 10000
                    }
                }
            }
        }
    }
}
```

You should get a valid response back with >0 hits and `resource_type` should be present under `aggregations`.


#### Any background context you want to provide?
The mapping is based on [a spreadsheet of ~2000 OCW distinct sections](https://docs.google.com/spreadsheets/d/1Hyur72NNBVvTcuqknciEokrORBn9TR-EHAtOJpbe36g/).  Only a handful of these are mapped, as it was decided by OCW that it is better to have no "resource_type" assigned than an ambiguous/incorrect one.  The mapping handles most of them, but a regex is used for sections containing "Assignment" ("Assignment 3: Fractal Tree Bag", "Assignment 4", etc).


