### PR TITLE
ocw-data-parser version 0.26.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.2
 markdown2==2.3.9
 newrelic
-ocw-data-parser==0.25.0
+ocw-data-parser==0.26.0
 Pillow==7.2.0
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -222,7 +222,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.25.0
+ocw-data-parser==0.26.0
     # via -r requirements.in
 parso==0.6.1
     # via jedi


### PR DESCRIPTION
#### Pre-Flight checklist

#### What's this PR do?
upgrades ocw-data-parser to 0.26.0

#### How should this be manually tested?
Run 
```
from course_catalog.api import sync_ocw_courses
sync_ocw_courses(course_prefixes=["PROD/6/6.730/Spring_2003/6-730-physics-for-solid-state-applications-spring-2003/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

It should complete without errors

