### PR TITLE
Ab/fix channel tracking

### DIFF
--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -4,7 +4,7 @@ import React from "react"
 
 import { makeChannel } from "../factories/channels"
 import { withChannelTracker } from "./withChannelTracker"
-import { shouldIf, TestPage } from "../lib/test_utils"
+import { TestPage } from "../lib/test_utils"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("withTracker", () => {
@@ -21,6 +21,8 @@ describe("withTracker", () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     window.gtag = helper.sandbox.stub()
+    window.location = "http://fake/c/path"
+    window.google_tag_manager = []
     gTagStub = window.gtag
     channel = makeChannel()
   })
@@ -31,54 +33,71 @@ describe("withTracker", () => {
 
   it("should call gtag config and event if channel has a tracking id", async () => {
     channel.ga_tracking_id = "UA-FAKE-01"
-    window.location = "http://fake/c/path"
 
     await render({}, { location: window.location, channel: channel })
-    assert.ok(
-      gTagStub.calledWith("config", channel.ga_tracking_id, {
-        send_page_view: false
-      })
-    )
-    assert.ok(
-      gTagStub.calledWith("event", "page_view", {
-        page_path: window.location.pathname,
-        send_to:   channel.ga_tracking_id
-      })
-    )
+    assert.ok(gTagStub.calledWith("config", channel.ga_tracking_id))
+    assert.isNotTrue(window["ga-disable-UA-FAKE-01"])
   })
 
   it("should not call GA config and event if channel does not have a tracking id", async () => {
     channel.ga_tracking_id = null
-    window.location = "http://fake/c/path"
     await render({}, { location: window.location, channel: channel })
     assert.ok(gTagStub.notCalled)
   })
 
   it("should not call GA config and event if window.gtag is not set", async () => {
     window.gtag = null
-    window.location = "http://fake/c/path"
     await render({}, { location: window.location, channel: channel })
     assert.ok(gTagStub.notCalled)
   })
 
-  //
-  ;[[true, 4], [false, 2]].forEach(([missingPrevChannel, gaCalls]) => {
-    it(`${shouldIf(
-      missingPrevChannel
-    )} call google analytics on componentDidUpdate`, async () => {
-      channel.ga_tracking_id = "UA-FAKE-01"
-      const prevChannel = missingPrevChannel ? null : channel
-      window.location = "http://fake/c/path"
-      const wrapper = await render(
-        {},
-        { location: window.location, channel: channel }
-      )
-      const prevProps = {
-        location: window.location,
-        channel:  prevChannel
-      }
-      wrapper.instance().componentDidUpdate(prevProps)
-      assert.equal(gTagStub.callCount, gaCalls)
-    })
+  it("should not call GA config if channel is already loaded and tracker is not disabled", async () => {
+    channel.ga_tracking_id = "UA-FAKE-01"
+    window.google_tag_manager = { "UA-FAKE-01": true }
+
+    await render({}, { location: window.location, channel: channel })
+    assert.ok(gTagStub.notCalled)
+  })
+
+  it("should call GA config if channel is already loaded and tracker is disabled", async () => {
+    channel.ga_tracking_id = "UA-FAKE-01"
+    window.google_tag_manager = ["UA-FAKE-01"]
+    window[`ga-disable-${channel.ga_tracking_id}`] = true
+
+    await render({}, { location: window.location, channel: channel })
+    assert.ok(gTagStub.calledWith("config", channel.ga_tracking_id))
+  })
+
+  it("should disable the previous tracker if the channel changes", async () => {
+    channel.ga_tracking_id = "UA-FAKE-01"
+
+    const prevChannel = makeChannel()
+    prevChannel.ga_tracking_id = "UA-OLD-FAKE-01"
+
+    const wrapper = await render(
+      {},
+      { location: window.location, channel: channel }
+    )
+    const prevProps = {
+      location: window.location,
+      channel:  prevChannel
+    }
+    wrapper.instance().componentDidUpdate(prevProps)
+
+    assert.isTrue(window["ga-disable-UA-OLD-FAKE-01"])
+    assert.ok(gTagStub.calledWith("config", channel.ga_tracking_id))
+  })
+
+  it("should disable the tracker before unmount", async () => {
+    channel.ga_tracking_id = "UA-FAKE-01"
+
+    const wrapper = await render(
+      {},
+      { location: window.location, channel: channel }
+    )
+
+    wrapper.instance().componentWillUnmount()
+
+    assert.isTrue(window["ga-disable-UA-FAKE-01"])
   })
 })

--- a/static/js/util/withTracker.js
+++ b/static/js/util/withTracker.js
@@ -28,7 +28,7 @@ const withTracker = (WrappedComponent: Class<React.Component<*, *>>) => {
     gaScript2.innerHTML = `window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '${SETTINGS.gaGTrackingID}', {send_page_view: false});`
+      gtag('config', '${SETTINGS.gaGTrackingID}');`
 
     // $FlowFixMe: document.head is not null
     document.head.appendChild(gaScript2)
@@ -38,10 +38,6 @@ const withTracker = (WrappedComponent: Class<React.Component<*, *>>) => {
     const page = props.location.pathname
 
     ReactGA.pageview(page)
-
-    if (window.gtag && SETTINGS.gaGTrackingID) {
-      window.gtag("event", "page_view", { page_path: page })
-    }
 
     return <WrappedComponent {...props} />
   }

--- a/static/js/util/withTracker_test.js
+++ b/static/js/util/withTracker_test.js
@@ -8,7 +8,6 @@ import ReactGA from "react-ga"
 
 import withTracker from "./withTracker"
 import { TestPage } from "../lib/test_utils"
-import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("withTracker", () => {
   let sandbox, gaInitStub, gaPageViewStub, WrappedPage
@@ -34,7 +33,7 @@ describe("withTracker", () => {
     assert.ok(gaPageViewStub.calledWith("/c/path"))
   })
 
-  it("should append gtag.js scripts to the header when SETTINGS.gaGTrackingID is set ", () => {
+  it("should append gtag.js scripts to the header SETTINGS.gaGTrackingID is set ", () => {
     SETTINGS.gaGTrackingID = "G-default-1"
     // $FlowFixMe: it's a test
     document.head.innerHTML = ""
@@ -46,23 +45,6 @@ describe("withTracker", () => {
       // $FlowFixMe: it's a test
       document.head.firstChild.src ===
         "https://www.googletagmanager.com/gtag/js?id=G-default-1"
-    )
-  })
-
-  it("should make pageview call when SETTINGS.gaGTrackingID is set ", () => {
-    SETTINGS.gaGTrackingID = "G-default-1"
-    window.location = `http://fake/c/path`
-    const helper = new IntegrationTestHelper()
-    window.gtag = helper.sandbox.stub()
-    const gTagStub = window.gtag
-
-    WrappedPage = withTracker(TestPage)
-    renderPage({ location: window.location })
-    assert.ok(gTagStub.calledOnce)
-    assert.ok(
-      gTagStub.calledWith("event", "page_view", {
-        page_path: window.location.pathname
-      })
     )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
  
#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3345

#### What's this PR do?
This PR fixes the channel tracker to ensure that events are not sent after the user moves away from the channel.
It also reverses the changes from https://github.com/mitodl/open-discussions/pull/3339 since the extra page views turned out to be automated traffic

#### How should this be manually tested?
Set GA_G_TRACKING_ID in your .env file. You can use G-B0EKT59MQF for testing.
Set the GA tracking id for a channel from the admin (http://localhost:8063/admin/channels/). You can use G-BEM7JCXH4D for testing.

Go to the networks tab and filter for G-BEM7JCXH4D. You should see calls to
`https://www.google-analytics.com/g/collect` when you are in the channel main page or viewing channel posts. You should not see calls when you are viewing a different channel or on other open pages.

If you filter to  G-B0EKT59MQF you should see calls to `https://www.google-analytics.com/g/collect` on all pages