### PR TITLE
fix channel settings

### DIFF
--- a/channels/serializers/channels.py
+++ b/channels/serializers/channels.py
@@ -40,7 +40,7 @@ class ChannelSerializer(serializers.Serializer):
     avatar_small = serializers.SerializerMethodField()
     avatar_medium = serializers.SerializerMethodField()
     banner = WriteableSerializerMethodField()
-    ga_tracking_id = WriteableSerializerMethodField()
+    ga_tracking_id = WriteableSerializerMethodField(allow_null=True)
     about = serializers.JSONField(allow_null=True, default=None)
     moderator_notifications = WriteableSerializerMethodField()
 
@@ -111,7 +111,7 @@ class ChannelSerializer(serializers.Serializer):
 
     def validate_ga_tracking_id(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
-        if not isinstance(value, str):
+        if not (value is None or isinstance(value, str)):
             raise ValidationError("Expected ga_tracking_id to be a string")
         return {"ga_tracking_id": value}
 

--- a/channels/serializers/channels_test.py
+++ b/channels/serializers/channels_test.py
@@ -207,7 +207,7 @@ def test_update_channel_moderator_notifications(user, moderator_notifications):
     assert channel.moderator_notifications == moderator_notifications
 
 
-@pytest.mark.parametrize("ga_tracking_id", ["test", ""])
+@pytest.mark.parametrize("ga_tracking_id", ["test", "", None])
 def test_update_channel_moderator_notifications(user, ga_tracking_id):
     """
     Test updating the channel moderator_notifications field


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3349

#### What's this PR do?
This pr fixes the bug preventing updates to channel appearance when ga_tracking_id is null for the channel

#### How should this be manually tested?
Set ga_tracking_id to null for a channel. Go to `http://localhost:8063/manage/c/edit/<channel>/appearance/`. Verify that you can make changes.