### PR TITLE
fix google_tag_manager sentry error

### DIFF
--- a/static/js/hoc/withChannelTracker.js
+++ b/static/js/hoc/withChannelTracker.js
@@ -17,6 +17,7 @@ export const withChannelTracker = (
         channel.ga_tracking_id &&
         window.gtag &&
         (window[`ga-disable-${channel.ga_tracking_id}`] ||
+          !window.google_tag_manager ||
           !window.google_tag_manager[channel.ga_tracking_id])
       ) {
         window[`ga-disable-${channel.ga_tracking_id}`] = false

--- a/static/js/hoc/withChannelTracker_test.js
+++ b/static/js/hoc/withChannelTracker_test.js
@@ -68,6 +68,15 @@ describe("withTracker", () => {
     assert.ok(gTagStub.calledWith("config", channel.ga_tracking_id))
   })
 
+  it("should call GA config if google_tag_manager is not set", async () => {
+    channel.ga_tracking_id = "UA-FAKE-01"
+    window.google_tag_manager = null
+    window[`ga-disable-${channel.ga_tracking_id}`] = true
+
+    await render({}, { location: window.location, channel: channel })
+    assert.ok(gTagStub.calledWith("config", channel.ga_tracking_id))
+  })
+
   it("should disable the previous tracker if the channel changes", async () => {
     channel.ga_tracking_id = "UA-FAKE-01"
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3362

#### What's this PR do?
This pr fixes sentry error which occurs if window.gtag is loaded but window.google_tracking_manager isn't. I'm not 100% sure why users get in that state. 

#### How should this be manually tested?
Set GA_G_TRACKING_ID in your .env file. You can use G-B0EKT59MQF for testing.
Set the GA tracking id for a channel from the admin (http://localhost:8063/admin/channels/). You can use G-BEM7JCXH4D for testing.

Click to the test channel to make sure both the channel tracker and the main tracker are loaded. You should see calls to https://www.google-analytics.com/g/collect with  G-BEM7JCXH4D when you look at the channel's views but not other views.

run `delete window.google_tracking_manager` from the console

Click around the site, both in the channel and outside it. You should not see an error. You should continue to see calls to https://www.google-analytics.com/g/collect with  G-BEM7JCXH4D when you look at the channel's views but not other views.
