### PR TITLE
Ab/resource filters for recreate index

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ To enable searching the course catalog on elasticsearch, run through these steps
 1. Start the services with `docker-compose up`
 2. With the above running, run this management command, which kicks off a celery task, to create an elasticsearch index:
 ```
-docker-compose  run web python manage.py recreate_index
+docker-compose  run web python manage.py recreate_index --all
 ```
 If there is an error running the above command, observe what traceback gets logged in the celery service.
 3. Once created and with `docker-compose up`  running, hit this endpoint in your browser to see if the index exists: `http://localhost:9101/discussions_local_all_default/_search`

--- a/search/management/commands/recreate_index.py
+++ b/search/management/commands/recreate_index.py
@@ -3,19 +3,56 @@ from django.core.management.base import BaseCommand, CommandError
 
 from open_discussions.utils import now_in_utc
 from search.tasks import start_recreate_index
+from search.constants import VALID_OBJECT_TYPES
 
 
 class Command(BaseCommand):
     """Indexes reddit content"""
 
-    help = "Add content to elasticsearch index"
+    help = "Recreate elasticsearch index"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--all", dest="all", action="store_true", help="Recreate all indexes"
+        )
+
+        for object_type in sorted(VALID_OBJECT_TYPES):
+            parser.add_argument(
+                f"--{object_type}s",
+                dest=object_type,
+                action="store_true",
+                help=f"Recreate the {object_type} index",
+            )
+        super().add_arguments(parser)
 
     def handle(self, *args, **options):
         """Index the comments and posts for the channels the user is subscribed to"""
-        task = start_recreate_index.delay()
-        self.stdout.write(
-            "Started celery task {task} to index content".format(task=task)
-        )
+        if options["all"]:
+            task = start_recreate_index.delay(list(VALID_OBJECT_TYPES))
+            self.stdout.write(
+                "Started celery task {task} to index content for all indexes".format(
+                    task=task
+                )
+            )
+        else:
+            indexes_to_update = list(
+                filter(lambda object_type: options[object_type], VALID_OBJECT_TYPES)
+            )
+            if not indexes_to_update:
+                self.stdout.write("Must select at least one index to update")
+                self.stdout.write("The following are valid index options:")
+                self.stdout.write("  --all")
+                for object_type in sorted(VALID_OBJECT_TYPES):
+                    self.stdout.write(f"  --{object_type}s")
+                return
+
+            task = start_recreate_index.delay(indexes_to_update)
+            self.stdout.write(
+                "Started celery task {task} to index content for the following indexes: {indexes}".format(
+                    task=task, indexes=indexes_to_update
+                )
+            )
+
         self.stdout.write("Waiting on task...")
         start = now_in_utc()
         error = task.get()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3360

#### What's this PR do?
This pr adds a resource type flag to the recreate index script to only recreate a subset of subindexes.
Allowed options are
  --all                 Recreate all indexes
  --comments            Recreate the comment index
  --courses             Recreate the course index
  --podcasts            Recreate the podcast index
  --podcastepisodes     Recreate the podcastepisode index
  --posts               Recreate the post index
  --profiles            Recreate the profile index
  --programs            Recreate the program index
  --userlists           Recreate the userlist index

#### How should this be manually tested?
Test this by running `manage.py recreate_index` with different resource options
