### PR TITLE
update-index-command

### DIFF
--- a/search/connection_test.py
+++ b/search/connection_test.py
@@ -1,0 +1,66 @@
+"""
+Tests for the indexing API
+"""
+import pytest
+
+from search.constants import COURSE_TYPE
+from search.connection import get_active_aliases
+
+
+@pytest.mark.parametrize("include_reindexing", [True, False])
+@pytest.mark.parametrize("indexes_exist", [True, False])
+@pytest.mark.parametrize("object_types", [None, [COURSE_TYPE]])
+def test_get_active_aliases(mocker, include_reindexing, indexes_exist, object_types):
+    """Test for get_active_aliases"""
+    conn = mocker.Mock()
+    conn.indices.exists.return_value = indexes_exist
+
+    active_aliases = get_active_aliases(
+        conn, object_types=object_types, include_reindexing=include_reindexing
+    )
+
+    if indexes_exist:
+        if object_types:
+            if include_reindexing:
+                assert active_aliases == [
+                    "testindex_course_default",
+                    "testindex_course_reindexing",
+                ]
+            else:
+                assert active_aliases == ["testindex_course_default"]
+        else:
+            if include_reindexing:
+                assert active_aliases == [
+                    "testindex_post_default",
+                    "testindex_post_reindexing",
+                    "testindex_comment_default",
+                    "testindex_comment_reindexing",
+                    "testindex_profile_default",
+                    "testindex_profile_reindexing",
+                    "testindex_course_default",
+                    "testindex_course_reindexing",
+                    "testindex_program_default",
+                    "testindex_program_reindexing",
+                    "testindex_userlist_default",
+                    "testindex_userlist_reindexing",
+                    "testindex_video_default",
+                    "testindex_video_reindexing",
+                    "testindex_podcast_default",
+                    "testindex_podcast_reindexing",
+                    "testindex_podcastepisode_default",
+                    "testindex_podcastepisode_reindexing",
+                ]
+            else:
+                assert active_aliases == [
+                    "testindex_post_default",
+                    "testindex_comment_default",
+                    "testindex_profile_default",
+                    "testindex_course_default",
+                    "testindex_program_default",
+                    "testindex_userlist_default",
+                    "testindex_video_default",
+                    "testindex_podcast_default",
+                    "testindex_podcastepisode_default",
+                ]
+    else:
+        assert active_aliases == []

--- a/search/management/commands/update_index.py
+++ b/search/management/commands/update_index.py
@@ -1,0 +1,102 @@
+"""Management command to index reddit content"""
+from django.core.management.base import BaseCommand, CommandError
+
+from open_discussions.utils import now_in_utc
+from search.tasks import start_update_index
+from search.constants import VALID_OBJECT_TYPES, RESOURCE_FILE_TYPE
+from course_catalog.constants import PlatformType
+
+valid_object_types = list(VALID_OBJECT_TYPES)
+valid_object_types.append(RESOURCE_FILE_TYPE)
+
+
+class Command(BaseCommand):
+    """Indexes elasticsearch content"""
+
+    help = "Update elasticsearch index"
+
+    def add_arguments(self, parser):
+        allowed_course_platforms = [
+            platform.value
+            for platform in PlatformType
+            if platform.value
+            not in [PlatformType.youtube.value, PlatformType.podcast.value]
+        ]
+
+        parser.add_argument(
+            "--all", dest="all", action="store_true", help="Update all indexes"
+        )
+
+        for object_type in sorted(valid_object_types):
+            parser.add_argument(
+                f"--{object_type}s",
+                dest=object_type,
+                action="store_true",
+                help=f"Update the {object_type} index",
+            )
+
+        parser.add_argument(
+            "--course_platform",
+            action="store",
+            dest="platform",
+            default=None,
+            choices=allowed_course_platforms,
+            help=f"Filter courses and course files update by platform.",
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        """Index the comments and posts for the channels the user is subscribed to"""
+
+        if options["all"]:
+            task = start_update_index.delay(valid_object_types, options["platform"])
+            self.stdout.write(
+                "Started celery task {task} to update index content for all indexes".format(
+                    task=task
+                )
+            )
+            if options["platform"]:
+                self.stdout.write(
+                    "Only updating course and course document indexes for {platform}".format(
+                        platform=options["platform"]
+                    )
+                )
+
+        else:
+            indexes_to_update = list(
+                filter(lambda object_type: options[object_type], valid_object_types)
+            )
+            if not indexes_to_update:
+                self.stdout.write("Must select at least one index to update")
+                self.stdout.write("The following are valid index options:")
+                self.stdout.write("  --all")
+                for object_type in sorted(valid_object_types):
+                    self.stdout.write(f"  --{object_type}s")
+                return
+
+            task = start_update_index.delay(indexes_to_update, options["platform"])
+            self.stdout.write(
+                "Started celery task {task} to update index content for the following indexes: {indexes}".format(
+                    task=task, indexes=indexes_to_update
+                )
+            )
+
+            if options["platform"]:
+                self.stdout.write(
+                    "Only updating course and course document indexes for {platform}".format(
+                        platform=options["platform"]
+                    )
+                )
+
+        self.stdout.write("Waiting on task...")
+        start = now_in_utc()
+        errors = task.get()
+        errors = [error for error in errors if error is not None]
+        if errors:
+            raise CommandError(f"Update index errored: {errors}")
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            "Update index finished, took {} seconds".format(total_seconds)
+        )

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -783,6 +783,20 @@ def serialize_bulk_profiles(ids):
         yield serialize_profile_for_bulk(profile)
 
 
+def serialize_bulk_profiles_for_deletion(ids):
+    """
+    Serialize profiles for bulk deletion
+
+    Args:
+        ids(list of int): List of profile id's
+
+    Yields:
+        iter of dict: yields an iterable of serialized profiles
+    """
+    for profile in Profile.objects.filter(id__in=ids).prefetch_related("user"):
+        yield serialize_for_deletion(gen_profile_id(profile.user.username))
+
+
 def serialize_profile_for_bulk(profile_obj):
     """
     Serialize a profile for bulk API request
@@ -797,6 +811,19 @@ def serialize_profile_for_bulk(profile_obj):
         "_id": gen_profile_id(profile_obj.user.username),
         **ESProfileSerializer().serialize(profile_obj),
     }
+
+
+def serialize_for_deletion(elasticsearch_object_id):
+    """
+    Serialize content for bulk deletion API request
+
+    Args:
+        elasticsearch_object_id (string): Elasticsearch object id
+
+    Returns:
+        dict: the object deletion data
+    """
+    return {"_id": elasticsearch_object_id, "_op_type": "delete"}
 
 
 def serialize_post_for_bulk(post_obj):
@@ -859,6 +886,19 @@ def serialize_bulk_courses(ids):
         yield serialize_course_for_bulk(course)
 
 
+def serialize_bulk_courses_for_deletion(ids):
+    """
+    Serialize courses for bulk deletion
+
+    Args:
+        ids(list of int): List of course id's
+    """
+    for course_obj in Course.objects.filter(id__in=ids):
+        yield serialize_for_deletion(
+            gen_course_id(course_obj.platform, course_obj.course_id)
+        )
+
+
 def serialize_course_for_bulk(course_obj):
     """
     Serialize a course for bulk API request
@@ -892,7 +932,7 @@ def serialize_content_file_for_bulk_deletion(content_file_obj):
     Args:
         content_file_obj (ContentFile): A content file for a course
     """
-    return {"_id": gen_content_file_id(content_file_obj.key), "_op_type": "delete"}
+    return serialize_for_deletion(gen_content_file_id(content_file_obj.key))
 
 
 def serialize_bulk_programs(ids):
@@ -906,6 +946,17 @@ def serialize_bulk_programs(ids):
         "topics", "offered_by"
     ):
         yield serialize_program_for_bulk(program)
+
+
+def serialize_bulk_programs_for_deletion(ids):
+    """
+    Serialize programs for bulk deletion
+
+    Args:
+        ids(list of int): List of program id's
+    """
+    for program in Program.objects.filter(id__in=ids):
+        yield serialize_for_deletion(gen_program_id(program))
 
 
 def serialize_program_for_bulk(program_obj):
@@ -942,6 +993,17 @@ def serialize_user_list_for_bulk(user_list_obj):
     }
 
 
+def serialize_bulk_user_lists_for_deletion(ids):
+    """
+    Serialize programs for bulk deletion
+
+    Args:
+        ids(list of int): List of program id's
+    """
+    for user_list in UserList.objects.filter(id__in=ids):
+        yield serialize_for_deletion(gen_user_list_id(user_list))
+
+
 def serialize_bulk_videos(ids):
     """
     Serialize Videos for bulk indexing
@@ -953,6 +1015,17 @@ def serialize_bulk_videos(ids):
         "topics", "offered_by"
     ):
         yield serialize_video_for_bulk(video)
+
+
+def serialize_bulk_videos_for_deletion(ids):
+    """
+    Serialize Videos for bulk deletion
+
+    Args:
+        ids(list of int): List of Video id's
+    """
+    for video in Video.objects.filter(id__in=ids):
+        yield serialize_for_deletion(gen_video_id(video))
 
 
 def serialize_video_for_bulk(video_obj):
@@ -978,6 +1051,17 @@ def serialize_bulk_podcasts(ids):
         yield serialize_podcast_for_bulk(podcast)
 
 
+def serialize_bulk_podcasts_for_deletion(ids):
+    """
+    Serialize Podcasts for bulk deletion
+
+    Args:
+        ids(list of int): List of Podcast id's
+    """
+    for podcast in Podcast.objects.filter(id__in=ids):
+        yield serialize_for_deletion(gen_podcast_id(podcast))
+
+
 def serialize_podcast_for_bulk(podcast_obj):
     """
     Serialize a Podcast for bulk API request
@@ -999,6 +1083,17 @@ def serialize_bulk_podcast_episodes(ids):
         "podcast", "topics", "offered_by"
     ):
         yield serialize_podcast_episode_for_bulk(podcast_episode)
+
+
+def serialize_bulk_podcast_episodes_for_deletion(ids):
+    """
+    Serialize podcast episodes for bulk deletion
+
+    Args:
+        ids(list of int): List of Podcast episode ids
+    """
+    for podcast_episode in PodcastEpisode.objects.filter(id__in=ids):
+        yield serialize_for_deletion(gen_podcast_episode_id(podcast_episode))
 
 
 def serialize_podcast_episode_for_bulk(podcast_episode_obj):

--- a/search/serializers_test.py
+++ b/search/serializers_test.py
@@ -45,6 +45,9 @@ from search.api import (
     gen_content_file_id,
     gen_podcast_id,
     gen_podcast_episode_id,
+    gen_profile_id,
+    gen_user_list_id,
+    gen_program_id,
 )
 from search.constants import (
     PROFILE_TYPE,
@@ -84,6 +87,13 @@ from search.serializers import (
     ESPodcastEpisodeSerializer,
     serialize_bulk_podcast_episodes,
     serialize_podcast_episode_for_bulk,
+    serialize_bulk_profiles_for_deletion,
+    serialize_bulk_courses_for_deletion,
+    serialize_bulk_programs_for_deletion,
+    serialize_bulk_user_lists_for_deletion,
+    serialize_bulk_videos_for_deletion,
+    serialize_bulk_podcasts_for_deletion,
+    serialize_bulk_podcast_episodes_for_deletion,
 )
 
 
@@ -844,3 +854,79 @@ def test_serialize_podcast_episode_for_bulk():
         "_id": gen_podcast_episode_id(podcast_episode),
         **ESPodcastEpisodeSerializer(podcast_episode).data,
     }
+
+
+@pytest.mark.django_db
+def test_serialize_profiles_file_for_bulk_deletion(user):
+    """
+    Test that serialize_profiles_file_for_bulk_deletion yield correct data
+    """
+    assert list(serialize_bulk_profiles_for_deletion([user.profile.id])) == [
+        {"_id": gen_profile_id(user.username), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_courses_for_deletion():
+    """
+    Test that serialize_bulk_courses_for_deletion yields correct data
+    """
+    course = CourseFactory.create()
+    assert list(serialize_bulk_courses_for_deletion([course.id])) == [
+        {"_id": gen_course_id(course.platform, course.course_id), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_programs_for_deletion():
+    """
+    Test that serialize_bulk_programs_for_deletion yields correct data
+    """
+    program = ProgramFactory.create()
+    assert list(serialize_bulk_programs_for_deletion([program.id])) == [
+        {"_id": gen_program_id(program), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_user_lists_for_deletion():
+    """
+    Test that serialize_bulk_user_lists_for_deletion yields correct data
+    """
+    userlist = UserListFactory.create()
+    assert list(serialize_bulk_user_lists_for_deletion([userlist.id])) == [
+        {"_id": gen_user_list_id(userlist), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_videos_for_deletion():
+    """
+    Test that serialize_bulk_videos_for_deletion yields correct data
+    """
+    video = VideoFactory.create()
+    assert list(serialize_bulk_videos_for_deletion([video.id])) == [
+        {"_id": gen_video_id(video), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_podcasts_for_deletion():
+    """
+    Test that serialize_bulk_podcasts_for_deletion yields correct data
+    """
+    podcast = PodcastFactory.create()
+    assert list(serialize_bulk_podcasts_for_deletion([podcast.id])) == [
+        {"_id": gen_podcast_id(podcast), "_op_type": "delete"}
+    ]
+
+
+@pytest.mark.django_db
+def test_serialize_bulk_podcast_episodes_for_deletion():
+    """
+    Test that serialize_bulk_podcasts_for_deletion yields correct data
+    """
+    podcast_episode = PodcastEpisodeFactory.create()
+    assert list(serialize_bulk_podcast_episodes_for_deletion([podcast_episode.id])) == [
+        {"_id": gen_podcast_episode_id(podcast_episode), "_op_type": "delete"}
+    ]


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3361

#### What's this PR do?
This pr adds a `update_index` command that updates indexes in place instead of recreating them

Allowed options are
  --all                 Update all indexes
  --comments            Update the comment index
  --courses             Update the course index
  --podcasts            Update the podcast index
  --podcastepisodes     Update the podcastepisode index
  --posts               Update the post index
  --profiles            Update the profile index
  --programs            Update the program index
  --userlists           Update the userlist index
  --resourcefiles   Update course resource files
There is also a `--course_platform` option that filters course and resource file updates to a specific platform

#### How should this be manually tested?
Test this by running `manage.py update_index` with different resource options


