### PR TITLE
fix similar items error

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -515,9 +515,10 @@ def find_similar_resources(*, user, value_doc):
     objects = []
 
     for hit in response.hits:
-        if hit["id"] != value_doc.get("id", None) or hit[
-            "object_type"
-        ] != value_doc.get("object_type", None):
+        if getattr(hit, "id", False) and (
+            hit["id"] != value_doc.get("id", None)
+            or hit["object_type"] != value_doc.get("object_type", None)
+        ):
             if user.is_anonymous:
                 hit["is_favorite"] = False
                 hit["lists"] = []

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -15,6 +15,7 @@ from course_catalog.factories import (
     UserListItemFactory,
     VideoFactory,
     ProgramFactory,
+    ContentFileFactory,
 )
 from course_catalog.models import FavoriteItem
 from open_discussions import features
@@ -48,6 +49,7 @@ from search.serializers import (
     ESUserListSerializer,
     ESVideoSerializer,
     ESProgramSerializer,
+    ESContentFileSerializer,
 )
 
 
@@ -526,6 +528,7 @@ def test_find_similar_resources(settings, is_anonymous, elasticsearch, user):
                 {"_source": ESVideoSerializer(VideoFactory.create()).data},
                 {"_source": ESProgramSerializer(ProgramFactory.create()).data},
                 {"_source": ESUserListSerializer(UserListFactory.create()).data},
+                {"_source": ESContentFileSerializer(ContentFileFactory.create()).data},
             ]
         }
     }

--- a/static/js/components/LearningResourceDrawer.js
+++ b/static/js/components/LearningResourceDrawer.js
@@ -119,7 +119,12 @@ export default function LearningResourceDrawer(props: Props) {
 
   const embedly = useSelector(getEmbedlyForObject)
 
-  useRequest(object ? similarResourcesRequest(object) : null)
+  useRequest(
+    object && !hideSimilarLearningResources
+      ? similarResourcesRequest(object)
+      : null
+  )
+
   const similarResources = useSelector(getSimilarResourcesForObject)
 
   const audioPlayerLoaded = useSelector(isAudioPlayerLoadedSelector)

--- a/static/js/components/LearningResourceDrawer_test.js
+++ b/static/js/components/LearningResourceDrawer_test.js
@@ -34,7 +34,7 @@ import { mockHTMLElHeight } from "../lib/test_utils"
 import { makeSearchResult } from "../factories/search"
 
 describe("LearningResourceDrawer", () => {
-  let course, helper, render, similarItems
+  let course, helper, render, similarItems, similarItemsRequest
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -49,10 +49,12 @@ describe("LearningResourceDrawer", () => {
       "LearningResourceRow",
       "LearningResourceRow"
     )
-    helper.handleRequestStub.withArgs(similarResourcesURL).returns({
-      status: 200,
-      body:   similarItems
-    })
+    similarItemsRequest = helper.handleRequestStub
+      .withArgs(similarResourcesURL)
+      .returns({
+        status: 200,
+        body:   similarItems
+      })
     helper.handleRequestStub.withArgs(interactionsApiURL).returns({
       status: 201,
       body:   {} // body is ignored
@@ -232,5 +234,13 @@ describe("LearningResourceDrawer", () => {
         .find(ExpandedLearningResourceDisplay)
         .prop("hideSimilarLearningResources")
     )
+  })
+
+  it("should not make a requst to similarResourcesURL if hideSimilarLearningResources is true", async () => {
+    const url = courseDetailApiURL.param({ courseId: course.id }).toString()
+    await renderWithObject(course, url, {
+      hideSimilarLearningResources: true
+    })
+    sinon.assert.notCalled(similarItemsRequest)
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
  
#### What are the relevant tickets?
none 

#### What's this PR do?
This pr fixes https://sentry.io/organizations/mit-office-of-digital-learning/issues/2311151869/?project=216201&query=is%3Aunresolved

`api.search.find_similar_resources()` errors when a ContentFile object is returned as a similar resource.

Also, the podcasts page makes calls to fetch similar resources even though that data is never used.

This fixes both those issues.

#### How should this be manually tested?
Go to http://localhost:8063/podcasts/ 
Click on a podcast. Then click on a podcast episode.
You shouldn't see any network calls to `similar/`

Go to http://localhost:8063/learn/search
Click on a few learning resources
You shouldn't see network calls to `similar/` error

