### PR TITLE
fix salutation

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -87,10 +87,10 @@ def ocw_valid_data():
                 "department": "",
                 "directory_title": "",
                 "uid": "d9ca5631c6936252866d63683c0c452e",
+                "salutation": "Dr.",
             },
             {
                 "middle_initial": "",
-                "first_name": "Jane",
                 "last_name": "Kokernak",
                 "suffix": "",
                 "title": "",
@@ -98,6 +98,7 @@ def ocw_valid_data():
                 "department": "",
                 "directory_title": "",
                 "uid": "bb1e26b5f5c9c054ddae8a2988ad7b42",
+                "salutation": "Prof.",
             },
             {
                 "middle_initial": "",
@@ -201,8 +202,25 @@ def test_deserializing_a_valid_ocw_course(
     assert course.runs.first().offered_by.count() == 1
     assert course.runs.first().offered_by.first().name == OfferedBy.ocw.value
 
-    course_instructors_count = CourseInstructor.objects.count()
-    assert course_instructors_count == len(ocw_valid_data.get("instructors"))
+    course_instructors = CourseInstructor.objects.order_by("last_name").all()
+    assert len(course_instructors) == 3
+
+    expected_course_instructor_values = [
+        {"first_name": None, "last_name": "Kokernak", "full_name": "Prof. Kokernak"},
+        {"first_name": "Christine", "last_name": "Sherratt", "full_name": None},
+        {
+            "first_name": "Michael",
+            "last_name": "Short",
+            "full_name": "Dr. Michael Short",
+        },
+    ]
+
+    for instructor, expected_values in zip(
+        course_instructors, expected_course_instructor_values
+    ):
+        assert instructor.first_name == expected_values["first_name"]
+        assert instructor.last_name == expected_values["last_name"]
+        assert instructor.full_name == expected_values["full_name"]
 
     course_prices_count = CoursePrice.objects.count()
     assert course_prices_count == 1

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -85,6 +85,9 @@ def load_instructors(resource, instructors_data):
     instructors = []
 
     for instructor_data in instructors_data:
+        if "full_name" not in instructor_data:
+            instructor_data["full_name"] = None
+
         instructor, _ = CourseInstructor.objects.get_or_create(**instructor_data)
         instructors.append(instructor)
 

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -258,13 +258,31 @@ class LearningResourceRunSerializer(BaseCourseSerializer):
         if is_published is not None:
             course_fields["published"] = is_published
 
-        self.instructors = [
-            {
+        self.instructors = []
+
+        for person in data.get("staff"):
+            instructor = {
                 "first_name": person.get("given_name", person.get("first_name")),
                 "last_name": person.get("family_name", person.get("last_name")),
             }
-            for person in data.get("staff")
-        ]
+
+            if person.get("salutation"):
+                if instructor["first_name"] and instructor["last_name"]:
+                    instructor[
+                        "full_name"
+                    ] = "{salutation} {first_name} {last_name}".format(
+                        salutation=person.get("salutation"),
+                        first_name=instructor["first_name"],
+                        last_name=instructor["last_name"],
+                    )
+                elif instructor["last_name"]:
+                    instructor["full_name"] = "{salutation} {last_name}".format(
+                        salutation=person.get("salutation"),
+                        last_name=instructor["last_name"],
+                    )
+
+            self.instructors.append(instructor)
+
         self.prices = [
             {
                 "price": seat.get("price"),


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3375

#### What's this PR do?
This pr stores the correct salutation in the full_name field for OCW course instructors

#### How should this be manually tested?
Run
```
from course_catalog.api import *

sync_ocw_courses(course_prefixes=["PROD/8/8.01/Fall_2016/8-01sc-classical-mechanics-fall-2016/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

Go to \learn\search and find the "Classical Mechanics" course on OCW

Verify that the instructors field is
```
Prof. Deepto Chakrabarty, Dr. Peter Dourmashkin, Prof. Anna Frebel, Dr. Michelle Tomasik, Prof. Vladan Vuletic
```

