### PR TITLE
Add to history stack on changes to search UI, and support back button

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@material/snackbar": "^0.44.0",
     "@material/toolbar": "^0.4.4",
     "@mitodl/ckeditor-custom-build": "0.0.4",
-    "@mitodl/course-search-utils": "^1.0.6",
+    "@mitodl/course-search-utils": "1.2.1",
     "@mitodl/mdl-react-components": "^0.0.3",
     "@reduxjs/toolkit": "^1.4.0",
     "@sentry/browser": "5.5.0",

--- a/static/js/pages/CourseSearchPage.js
+++ b/static/js/pages/CourseSearchPage.js
@@ -5,7 +5,6 @@ import React, { useState, useEffect, useCallback } from "react"
 import InfiniteScroll from "react-infinite-scroller"
 import { useSelector, useDispatch } from "react-redux"
 import { MetaTags } from "react-meta-tags"
-import { useHistory } from "react-router-dom"
 import { createSelector } from "reselect"
 import { useCourseSearch } from "@mitodl/course-search-utils"
 
@@ -174,18 +173,6 @@ export default function CourseSearchPage(props: Props) {
     [dispatch]
   )
 
-  const history = useHistory()
-
-  const updateURLBar = useCallback(
-    search => {
-      history.replace({
-        pathname: window.location.pathname,
-        search
-      })
-    },
-    [history]
-  )
-
   const {
     facetOptions,
     clearAllFilters,
@@ -203,7 +190,6 @@ export default function CourseSearchPage(props: Props) {
   } = useCourseSearch(
     runSearch,
     clearSearchCB,
-    updateURLBar,
     facets,
     loaded,
     SETTINGS.search_page_size

--- a/static/js/pages/CourseSearchPage_test.js
+++ b/static/js/pages/CourseSearchPage_test.js
@@ -43,7 +43,7 @@ const setLocation = (helper, params) => {
 }
 
 describe("CourseSearchPage", () => {
-  let helper, render, searchResponse, initialState, searchCourse, replaceStub
+  let helper, render, searchResponse, initialState, searchCourse, pushStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -97,7 +97,7 @@ describe("CourseSearchPage", () => {
       initialState
     )
 
-    replaceStub = helper.sandbox.spy(helper.browserHistory, "replace")
+    pushStub = helper.sandbox.stub(window.history, "pushState")
   })
 
   afterEach(() => {
@@ -150,7 +150,7 @@ describe("CourseSearchPage", () => {
       assert.isOk(suggestDiv.text().includes(suggestion))
       suggestDiv.find("a").simulate("click")
       await wait(50)
-      const [{ search }] = replaceStub.args[replaceStub.args.length - 1]
+      const search = pushStub.args[pushStub.args.length - 1][2]
       assert.include(search, escape(suggestion))
     })
   })
@@ -184,16 +184,19 @@ describe("CourseSearchPage", () => {
       channelName: null,
       from:        SETTINGS.search_page_size,
       size:        SETTINGS.search_page_size,
-      text:        undefined,
+      text:        "",
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          audience:        [],
-          certification:   [],
-          offered_by:      [],
-          topics:          [],
-          department_name: [],
-          type:            LR_TYPE_ALL
+          audience:            [],
+          certification:       [],
+          offered_by:          [],
+          topics:              [],
+          department_name:     [],
+          type:                LR_TYPE_ALL,
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
         })
       )
     })
@@ -221,12 +224,15 @@ describe("CourseSearchPage", () => {
       type:        LR_TYPE_ALL,
       facets:      new Map(
         Object.entries({
-          audience:        [],
-          certification:   [],
-          type:            LR_TYPE_ALL,
-          department_name: [],
-          offered_by:      ["OCW"],
-          topics:          ["Science", "Engineering"]
+          audience:            [],
+          certification:       [],
+          type:                LR_TYPE_ALL,
+          department_name:     [],
+          offered_by:          ["OCW"],
+          topics:              ["Science", "Engineering"],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
         })
       )
     })
@@ -254,12 +260,15 @@ describe("CourseSearchPage", () => {
       type:        ["podcast", "podcastepisode"],
       facets:      new Map(
         Object.entries({
-          audience:        [],
-          certification:   [],
-          type:            ["podcast", "podcastepisode"],
-          offered_by:      [],
-          department_name: [],
-          topics:          []
+          audience:            [],
+          certification:       [],
+          type:                ["podcast", "podcastepisode"],
+          offered_by:          [],
+          department_name:     [],
+          topics:              [],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
         })
       )
     })
@@ -288,12 +297,15 @@ describe("CourseSearchPage", () => {
       type:        ["userlist", "learningpath"],
       facets:      new Map(
         Object.entries({
-          audience:        [],
-          certification:   [],
-          type:            ["userlist", "learningpath"],
-          offered_by:      [],
-          department_name: [],
-          topics:          []
+          audience:            [],
+          certification:       [],
+          type:                ["userlist", "learningpath"],
+          offered_by:          [],
+          department_name:     [],
+          topics:              [],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
         })
       )
     })
@@ -364,8 +376,8 @@ describe("CourseSearchPage", () => {
       preventDefault: helper.sandbox.stub()
     })
     await wait(1)
-    const [{ search }] = replaceStub.args[replaceStub.args.length - 1]
-    assert.equal(search, `q=${escape(text)}`)
+    const search = pushStub.args[pushStub.args.length - 1][2]
+    assert.equal(search, `/?q=${escape(text)}`)
   })
 
   it("displays filters and clicking 'Clear all filters' removes all active facets", async () => {
@@ -379,8 +391,8 @@ describe("CourseSearchPage", () => {
     const { wrapper } = await render()
     wrapper.find(".clear-all-filters").simulate("click")
     await wait(1)
-    const [{ search }] = replaceStub.args[replaceStub.args.length - 1]
-    assert.deepEqual(search, "")
+    const search = pushStub.args[pushStub.args.length - 1][2]
+    assert.deepEqual(search, "/?")
   })
 
   it("triggers a non-incremental search from textbox input", async () => {
@@ -395,16 +407,19 @@ describe("CourseSearchPage", () => {
       preventDefault: helper.sandbox.stub()
     })
     await wait(1)
-    const [{ search }] = replaceStub.args[replaceStub.args.length - 1]
+    const search = pushStub.args[pushStub.args.length - 1][2].slice(1) // cut off leading /
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        audience:        [],
-        certification:   [],
-        topics:          [],
-        offered_by:      [],
-        department_name: [],
-        type:            []
+        audience:            [],
+        certification:       [],
+        topics:              [],
+        offered_by:          [],
+        department_name:     [],
+        type:                [],
+        level:               [],
+        course_feature_tags: [],
+        resource_type:       []
       }
     })
   })
@@ -421,17 +436,20 @@ describe("CourseSearchPage", () => {
         target: { name: "topics", value: "Physics", checked: true }
       })
     await wait(10)
-    const [{ search }] = replaceStub.args[replaceStub.args.length - 1]
+    const search = pushStub.args[pushStub.args.length - 1][2].slice(1) // cut off leading /
 
     assert.deepEqual(deserializeSearchParams({ search }), {
       text,
       activeFacets: {
-        audience:        [],
-        certification:   [],
-        topics:          ["Physics"],
-        offered_by:      [],
-        department_name: [],
-        type:            []
+        audience:            [],
+        certification:       [],
+        topics:              ["Physics"],
+        offered_by:          [],
+        department_name:     [],
+        type:                [],
+        level:               [],
+        course_feature_tags: [],
+        resource_type:       []
       }
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.7.6":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2289,11 +2296,12 @@
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@mitodl/ckeditor-custom-build/-/ckeditor-custom-build-0.0.4.tgz#544cab8b1491ee702e99a84800f2c965f95e5474"
 
-"@mitodl/course-search-utils@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.0.6.tgz#5a43d40651ca4345d57c1ae19ee52346b704fbe7"
-  integrity sha512-KvND5VHnBpohcvxLQQ1mFBOvXDygSNXcZJBxyrr0jYXTZGYcVL6zlpvE26+gFlkNEiIPWn+KsP77kqNnN/Z6+w==
+"@mitodl/course-search-utils@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.2.1.tgz#d230f9c9755f291408084e453f404f2c5240fdf0"
+  integrity sha512-Mnsnn5BtuXSREB4B2nq14aPIsVDvP+1QjdtOox3wdt2XJZ3jlQYamvi4rsan2Mpta8E21oj0mNJ7CsYHCl3XCA==
   dependencies:
+    history "^5.0.0"
     query-string "^6.13.1"
     ramda "^0.27.1"
 
@@ -6659,6 +6667,13 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
+
+history@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-www/issues/94
Related to https://github.com/mitodl/course-search-utils/pull/17

#### What's this PR do?
Previously the search page would replace the URL when a change was made, like a facet being clicked or text being entered in a textbox. This changes that behavior to push changed onto the browser stack, and correctly handle back and forwards buttons in the browser

This is waiting on merging https://github.com/mitodl/course-search-utils/pull/17 first. Once that merges and is published, this PR will point at the updated version.

#### How should this be manually tested?
See instructions in https://github.com/mitodl/course-search-utils/pull/17