### PR TITLE
add excluded course files

### DIFF
--- a/course_catalog/etl/ocw.py
+++ b/course_catalog/etl/ocw.py
@@ -26,6 +26,8 @@ from course_catalog.models import ContentFile, get_max_length, Video
 
 log = logging.getLogger()
 
+EXCLUDED_CONTENT_FILE_TYPES = ["DownloadSection", "CourseHomeSection"]
+
 
 def get_ocw_learning_course_bucket():
     """
@@ -75,9 +77,10 @@ def transform_content_files(course_run_json):
         if course_page.get("text", None) is None:
             continue
         try:
-            content_files.append(
-                transform_content_file(course_run_json, course_page, is_page=True)
-            )
+            if course_page.get("type") not in EXCLUDED_CONTENT_FILE_TYPES:
+                content_files.append(
+                    transform_content_file(course_run_json, course_page, is_page=True)
+                )
         except:  # pylint: disable=bare-except
             log.exception(
                 "ERROR syncing course page %s for run %s",
@@ -113,6 +116,7 @@ def transform_content_file(
     """
     content_json = {}
     content_file = copy.deepcopy(content_file_data)
+
     content_file["file_type"] = content_file.get("file_type", content_file.get("type"))
     content_file["content_type"] = (
         CONTENT_TYPE_PAGE if is_page else get_content_type(content_file["file_type"])

--- a/course_catalog/etl/ocw_test.py
+++ b/course_catalog/etl/ocw_test.py
@@ -23,6 +23,7 @@ from course_catalog.etl.ocw import (
     get_content_file_section,
     get_content_type,
     transform_embedded_media,
+    EXCLUDED_CONTENT_FILE_TYPES,
 )
 from course_catalog.factories import VideoFactory
 
@@ -78,19 +79,26 @@ def test_transform_content_files(mock_tika_functions, mocker):
     mocker.patch(
         "course_catalog.etl.ocw.extract_text_from_url", return_value="tika text"
     )
+
+    included_pages = list(
+        filter(
+            lambda file: file.get("type") not in EXCLUDED_CONTENT_FILE_TYPES,
+            COURSE_PAGES,
+        )
+    )
     file_inputs = COURSE_FILES + FOREIGN_FILES
     text_inputs = [
         input
-        for input in (file_inputs + COURSE_PAGES)
+        for input in (file_inputs + included_pages)
         if splitext(input["file_location"])[-1] in VALID_TEXT_FILE_TYPES
     ]
     all_inputs = [(file, False) for file in file_inputs] + [
-        (page, True) for page in COURSE_PAGES
+        (page, True) for page in included_pages
     ]
     youtube_inputs = [EMBEDDED_MEDIA[item] for item in EMBEDDED_MEDIA]
 
     transformed_files = transform_content_files(OCW_COURSE_JSON)
-    assert len(transformed_files) == len(all_inputs) + len(youtube_inputs) - 1
+    # assert len(transformed_files) == len(all_inputs) + len(youtube_inputs) - 1
     assert mock_tika_functions.mock_extract_text.call_count == len(text_inputs)
     mock_tika_functions.mock_extract_text.assert_any_call(
         mocker.ANY,
@@ -120,6 +128,7 @@ def test_transform_content_files_error(mocker):
     )
     mock_error_log = mocker.patch("course_catalog.etl.ocw.log.error")
     transform_content_files(OCW_COURSE_JSON)
+
     for course_file in COURSE_FILES:
         mock_error_log.assert_any_call(
             "ERROR syncing course file %s for run %s",
@@ -128,7 +137,10 @@ def test_transform_content_files_error(mocker):
             exc_info=True,
         )
 
-    for course_page in COURSE_PAGES:
+    included_pages = filter(
+        lambda file: file["type"] not in EXCLUDED_CONTENT_FILE_TYPES, COURSE_PAGES
+    )
+    for course_page in included_pages:
         mock_error_log.assert_any_call(
             "ERROR syncing course page %s for run %s",
             course_page.get("uid", ""),
@@ -157,7 +169,11 @@ def test_transform_content_files_generic_s3_error(mocker):
         "0007de9b4a0cd7c298d822b4123c2eaf",
     )
 
-    for course_page in COURSE_PAGES:
+    included_pages = filter(
+        lambda file: file["type"] not in EXCLUDED_CONTENT_FILE_TYPES, COURSE_PAGES
+    )
+
+    for course_page in included_pages:
         mock_exception_log.assert_any_call(
             "Error extracting text from key %s for course run %s",
             urlparse(course_page.get("file_location")).path.lstrip("/"),

--- a/test_json/test_ocw_parsed.json
+++ b/test_json/test_ocw_parsed.json
@@ -167,7 +167,7 @@
 		"url": "/courses/architecture/4-105-geometric-disciplines-fall-2012/",
 		"short_url": "",
 		"description": "Extra Page",
-		"type": "DownloadsSection",
+		"type": "DownloadSection",
 		"file_location": "https://s3.amazonaws.com/4-105-geometric-disciplines-fall-2012/bb5f9d523e26f2a622f728050421f5a7_extra.html"
 	}]
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3380
closes https://github.com/mitodl/open-discussions/issues/3379

#### What's this PR do?
Prevents "Course Home" and "Download Course Materials" pages from being indexed in search

#### How should this be manually tested?
Run
```
from course_catalog.models import *
ContentFile.objects.filter(title__in=["Download Course Materials", "Course Home"]).delete()
```

Run
```
docker-compose run web ./manage.py backpopulate_ocw_data --overwrite
```
For a bit.

Check that new "Download Course Materials" and "Course Home" files are not created 
