### PR TITLE
set ocw-data-parser to 0.28.0 in requirements.in and run pip-compile

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.3
 markdown2==2.3.9
 newrelic
-ocw-data-parser==0.27.0
+ocw-data-parser==0.28.0
 Pillow==8.1.1
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -185,8 +185,6 @@ idna==2.5
     # via
     #   requests
     #   tldextract
-importlib-metadata==3.4.0
-    # via kombu
 ipaddress==1.0.22
     # via elasticsearch-dsl
 ipython-genutils==0.2.0
@@ -223,7 +221,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.27.0
+ocw-data-parser==0.28.0
     # via -r requirements.in
 parso==0.6.1
     # via jedi
@@ -385,8 +383,6 @@ toolz==0.10.0
     # via -r requirements.in
 traitlets==4.3.3
     # via ipython
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 ulid-py==0.0.3
     # via -r requirements.in
 update-checker==0.16
@@ -422,8 +418,6 @@ xmlsec==1.3.3
     # via python3-saml
 zeep==3.4.0
     # via mit-moira
-zipp==3.4.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR updates `ocw-data-parser` to 0.28.0.  It is the result of changing that setting in `requirements.in` and running `pip-compile`.

#### How should this be manually tested?
Run OCW import on some courses and ensure that it does not fail.
