### PR TITLE
fix to salutation pr

### DIFF
--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -264,6 +264,7 @@ class LearningResourceRunSerializer(BaseCourseSerializer):
             instructor = {
                 "first_name": person.get("given_name", person.get("first_name")),
                 "last_name": person.get("family_name", person.get("last_name")),
+                "full_name": None,
             }
 
             if person.get("salutation"):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
  
#### What's this PR do?
While testing 
https://github.com/mitodl/open-discussions/pull/3378
on rc I saw this error:
https://sentry.io/organizations/mit-office-of-digital-learning/issues/2386847463/events/0271f9f2dbf24ecb8b241733c62f5575/?project=216201

This occurs when the is one OCW course with the salutation set and another where it is not set for the same instructor 

#### How should this be manually tested?
```
from course_catalog.api import *
from course_catalog.models import *

CourseInstructor.objects.get_or_create(first_name='Emma', last_name='Teng', full_name=None)

CourseInstructor.objects.get_or_create(first_name='Emma', last_name='Teng', full_name='Prof. Emma Teng')


sync_ocw_courses(course_prefixes=["PROD/21G/21G.030/Fall_2005/21g-030-east-asian-cultures-from-zen-to-pop-fall-2005/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

Errors in the master branch but not in this branch

