### PR TITLE
fix to digest email task queue

### DIFF
--- a/open_discussions/celery.py
+++ b/open_discussions/celery.py
@@ -23,8 +23,7 @@ app.conf.task_routes = {
     "notifications.tasks.send_frontpage_email_notification_batch": {
         "queue": "digest_emails"
     },
-    "notifications.tasks.test_send_daily_frontpage_digests": {"queue": "digest_emails"},
-    "notifications.tasks.test_send_weekly_frontpage_digests": {
-        "queue": "digest_emails"
-    },
+    "notifications.tasks.send_daily_frontpage_digests": {"queue": "digest_emails"},
+    "notifications.tasks.send_weekly_frontpage_digests": {"queue": "digest_emails"},
+    "notifications.tasks.attempt_send_notification_batch": {"queue": "digest_emails"},
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
The current code queuing frontpage notifications in a separate celery queue was broken. This fixes the issue.

#### How should this be manually tested?
add
```
import time
@app.task
def sleep(seconds):
    time.sleep(seconds)
```

to `course_catalog/tasks.py`

Fill the celery queues with default priority tasks by running

```
from course_catalog.tasks import *

for i in range(0,1000):
    sleep.delay(15)
```

from the shell run
```
from notifications.tasks import *
send_daily_frontpage_digests.delay()
send_unsent_email_notifications()
```

You should receive a notification email before the sleep tasks finish running


You may need to delete some EmailNotifiation objects if you run this multiple times

