### PR TITLE
downgrade the react-dotdotdot package

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-content-loader": "^3.1.2",
     "react-cropper": "^1.0.1",
     "react-dom": "^16.13.1",
-    "react-dotdotdot": "^1.2.3",
+    "react-dotdotdot": "1.2.3",
     "react-dropzone": "^4.2.5",
     "react-ga": "^2.5.3",
     "react-google-recaptcha": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10429,10 +10429,10 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dotdotdot@^1.2.3:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.3.1.tgz#b94324bf66cdb70e4acffe5460e4480a91135e50"
-  integrity sha512-ImqoKTD4ZdyfF/h7jdPCZur01QlZxx3A9/gZSf9mbvseNZwVTvd+dPwi/hg1UTtP+30luy2d5j0KG+XEfdBPLQ==
+react-dotdotdot@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz#45bb264153cee73471f55c51c8d1542f4880a34f"
+  integrity sha512-lYCHCegi76+kqmgqkii/ma2QqsfA1Slf5jTJYWKgnT3uz8EkPaO9hRDPMDEsDHEBua2qOXSxWCHxVf4N740W1w==
   dependencies:
     object.pick "^1.3.0"
 


### PR DESCRIPTION
#### What are the relevant tickets?

none, fixing an issue from #3407

#### What's this PR do?

downgrade react-dotdotdot to 1.2.3, because the newer version doesn't work.

#### How should this be manually tested?

If you look at search on RC you'll see that the labels on facets aren't showing up, like this:

![Screen Shot 2021-05-24 at 2 53 58 PM](https://user-images.githubusercontent.com/6207644/119394200-eb64b600-bc9f-11eb-9a73-3514f97fa990.png)

You should see the same thing locally on the main branch. If you check this out it should fix it.

#### Screenshots (if appropriate)
![Screen Shot 2021-05-24 at 2 41 38 PM](https://user-images.githubusercontent.com/6207644/119394274-fcadc280-bc9f-11eb-8e56-bfc3c0df285e.png)
