### PR TITLE
set celery worker concurrency

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
 worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=$CELERY_WORKER_CONCURRENCY -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=$CELERY_EXTRA_WORKER_CONCURRENCY -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=$CELERY_WORKER_CONCURRENCY -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=$CELERY_EXTRA_WORKER_CONCURRENCY -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=$CELERY_WORKER_CONCURRENCY -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/app.json
+++ b/app.json
@@ -83,16 +83,6 @@
       "description": "Max memory to be used by celery worker child",
       "required": false      
     },
-    "CELERY_WORKER_CONCURRENCY": {
-      "description": "The max concurrency for the celery worker",
-      "required": true,
-      "value": "2"
-    },
-    "CELERY_EXTRA_WORKER_CONCURRENCY": {
-      "description": "The max concurrency for the celery extra worker",
-      "required": true,
-      "value": "2"
-    },
     "CLOUDFRONT_DIST": {
       "description": "Cloudfront distribution",
       "required": false

--- a/app.json
+++ b/app.json
@@ -83,6 +83,11 @@
       "description": "Max memory to be used by celery worker child",
       "required": false      
     },
+    "CELERY_WORKER_CONCURRENCY": {
+      "description": "The max concurrency for the celery worker",
+      "required": true,
+      "value": 4
+    },
     "CLOUDFRONT_DIST": {
       "description": "Cloudfront distribution",
       "required": false

--- a/app.json
+++ b/app.json
@@ -86,12 +86,12 @@
     "CELERY_WORKER_CONCURRENCY": {
       "description": "The max concurrency for the celery worker",
       "required": true,
-      "value": 2
+      "value": "2"
     },
     "CELERY_EXTRA_WORKER_CONCURRENCY": {
       "description": "The max concurrency for the celery extra worker",
       "required": true,
-      "value": 2
+      "value": "2"
     },
     "CLOUDFRONT_DIST": {
       "description": "Cloudfront distribution",

--- a/app.json
+++ b/app.json
@@ -86,7 +86,12 @@
     "CELERY_WORKER_CONCURRENCY": {
       "description": "The max concurrency for the celery worker",
       "required": true,
-      "value": 4
+      "value": 2
+    },
+    "CELERY_EXTRA_WORKER_CONCURRENCY": {
+      "description": "The max concurrency for the celery extra worker",
+      "required": true,
+      "value": 2
     },
     "CLOUDFRONT_DIST": {
       "description": "Cloudfront distribution",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None.  

#### What's this PR do?
Celery workers on 2x machines run out of memory. This sets the max concurrency on the celery worker to 4 instead of 8. extra_worker, which is currently running on a larger machine is not affected.

#### How should this be manually tested?
I don't think it's possible to test this locally. I will test the PR thoroughly  once it's on RC
