### PR TITLE
Upgrade ocw-data-parser for archived versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.3
 markdown2==2.3.9
 newrelic
-ocw-data-parser==0.28.0
+ocw-data-parser==0.29.1
 Pillow==8.1.1
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -185,6 +185,8 @@ idna==2.5
     # via
     #   requests
     #   tldextract
+importlib-metadata==4.5.0
+    # via kombu
 ipaddress==1.0.22
     # via elasticsearch-dsl
 ipython-genutils==0.2.0
@@ -221,7 +223,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.28.0
+ocw-data-parser==0.29.1
     # via -r requirements.in
 parso==0.6.1
     # via jedi
@@ -383,6 +385,8 @@ toolz==0.10.0
     # via -r requirements.in
 traitlets==4.3.3
     # via ipython
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 ulid-py==0.0.3
     # via -r requirements.in
 update-checker==0.16
@@ -418,6 +422,8 @@ xmlsec==1.3.3
     # via python3-saml
 zeep==3.4.0
     # via mit-moira
+zipp==3.4.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-data-parser/issues/141

#### What's this PR do?
Upgrades ocw-data-parser to include a change which adds support for archived versions

#### How should this be manually tested?
Rebuild the docker container. In a Django shell run:

    from course_catalog.api import sync_ocw_courses
    course_prefixes = [f"PROD/1/1.011/Spring_{year}/1-011-project-evaluation-spring-{year}/" for year in [2003, 2005, 2011]]
    sync_ocw_courses(course_prefixes=course_prefixes, blocklist=[], force_overwrite=True, upload_to_s3=False)
    course = Course.objects.get(url__endswith="1-011-project-evaluation-spring-2011")
    run = course.runs.first()
    print(run.raw_json["is_update_of"])

You should see `['62c63b2702affad73ae56cec96eeb2bc']`