### PR TITLE
Add course argument to filter backpopulate_ocw_data

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -196,12 +196,14 @@ def format_date(date_str):
     return None
 
 
-def generate_course_prefix_list(bucket):
+def generate_course_prefix_list(bucket, course_url_substring=None):
     """
     Assembles a list of OCW course prefixes from an S3 Bucket that contains all the raw jsons files
 
     Args:
         bucket (s3.Bucket): Instantiated S3 Bucket object
+        course_url_substring (str or None):
+            If not None, only return course prefixes including this substring
     Returns:
         List of course prefixes
     """
@@ -213,6 +215,14 @@ def generate_course_prefix_list(bucket):
             key_pieces = bucket_file.key.split("/")
             if "/".join(key_pieces[:-2]) != "":
                 ocw_courses.add("/".join(key_pieces[:-2]) + "/")
+
+    if course_url_substring is not None:
+        ocw_courses = [
+            course_path
+            for course_path in ocw_courses
+            if course_url_substring.lower() in course_path.lower()
+        ]
+
     return list(ocw_courses)
 
 

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -32,8 +32,8 @@ class Command(BaseCommand):
             help="skip uploading course files to s3",
         )
         parser.add_argument(
-            "--course",
-            dest="course",
+            "--course-url-substring",
+            dest="course_url_substring",
             required=False,
             help="If set, backpopulate only this course",
         )
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Run Populate ocw courses"""
-        course_url_substring = options.get("course")
+        course_url_substring = options.get("course_url_substring")
         if options["delete"]:
             self.stdout.write("Deleting all existing OCW courses")
             for course in Course.objects.filter(platform="ocw"):

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Run Populate ocw courses"""
-        course_id = options.get("course")
+        course_url_substring = options.get("course")
         if options["delete"]:
             self.stdout.write("Deleting all existing OCW courses")
             for course in Course.objects.filter(platform="ocw"):
@@ -51,15 +51,15 @@ class Command(BaseCommand):
             task = get_ocw_data.delay(
                 force_overwrite=options["force_overwrite"],
                 upload_to_s3=options["upload_to_s3"],
-                match_courses=course_id,
+                course_url_substring=course_url_substring,
             )
             self.stdout.write(
                 "Started task {task} to get ocw course data "
-                "w/force_overwrite={overwrite}, upload_to_s3={s3}, course_id={course}".format(
+                "w/force_overwrite={overwrite}, upload_to_s3={s3}, course_url_substring={course_url_substring}".format(
                     task=task,
                     overwrite=options["force_overwrite"],
                     s3=options["upload_to_s3"],
-                    course=course_id,
+                    course_url_substring=course_url_substring,
                 )
             )
             self.stdout.write("Waiting on task...")

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
             "--course-url-substring",
             dest="course_url_substring",
             required=False,
-            help="If set, backpopulate only this course",
+            help="If set, backpopulate only courses whose urls match with this substring",
         )
         super().add_arguments(parser)
 

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -65,10 +65,7 @@ def get_ocw_courses(*, course_prefixes, blocklist, force_overwrite, upload_to_s3
 
 @app.task(bind=True)
 def get_ocw_data(
-    self,
-    force_overwrite=False,
-    upload_to_s3=True,
-    match_courses=None,
+    self, force_overwrite=False, upload_to_s3=True, course_url_substring=None
 ):  # pylint:disable=too-many-locals,too-many-branches
     """
     Task to sync OCW course data with database
@@ -88,15 +85,11 @@ def get_ocw_data(
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
     ).Bucket(name=settings.OCW_CONTENT_BUCKET_NAME)
-    ocw_courses = generate_course_prefix_list(raw_data_bucket)
+    ocw_courses = generate_course_prefix_list(
+        raw_data_bucket, course_url_substring=course_url_substring
+    )
 
     total_course_count = len(ocw_courses)
-    if match_courses is not None:
-        ocw_courses = [
-            course_path
-            for course_path in ocw_courses
-            if match_courses.lower() in course_path.lower()
-        ]
 
     log.info(
         "Backpopulating %d out of %d OCW courses...",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #3449 

#### What's this PR do?
Adds a `--course` argument to backpopulate only courses which match the prefix string. This is meant to make it easier for developers to backpopulate only specific courses that they are working on, to avoid the hours-long process of backpopulating the whole catalog.

#### How should this be manually tested?
 - Run `./manage.py backpopulate_ocw_data --course 6-890-algorithmic --overwrite --skip-s3`. It should take about 5 minutes.
 - In a shell, find the `LearningResourceRun` for that course via `Course.objects.get(url__contains='6-890-algorithmic').runs.first()`. The `updated_on` value should be close to the current date and time.