### PR TITLE
dont overwrite image_src when upload_to_s3=False

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -261,6 +261,26 @@ def test_deserializing_a_valid_ocw_course_with_existing_newer_run(
     assert course.runs.count() == 4
 
 
+def test_deserializing_a_valid_ocw_course_with_keep_existing_image_src(
+    mock_course_index_functions, ocw_valid_data
+):
+    """
+    Verify that image_src is not overwritten if keep_existing_image_src=True
+    """
+    course = CourseFactory.create(
+        platform=PlatformType.ocw.value,
+        course_id=f'{ocw_valid_data["uid"]}+{ocw_valid_data["course_id"]}',
+        image_src="existing",
+    )
+
+    assert Course.objects.last().image_src == "existing"
+
+    digest_ocw_course(ocw_valid_data, timezone.now(), True, "PROD/RES", True)
+    assert Course.objects.count() == 1
+    course = Course.objects.last()
+    assert course.image_src == "existing"
+
+
 def test_deserialzing_an_invalid_ocw_course(ocw_valid_data):
     """
     Verifies that OCWSerializer validation works correctly if the OCW course has invalid values


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3464

#### What's this PR do?
Since course images are stored on S3, running `backpopulate_ocw_data` with upload_to_s3=False currently clears course thumbnails. We want to keep existing image_src data if a course already exists in our database and `backpopulate_ocw_data` is run with upload_to_s3=False

#### How should this be manually tested?
Run

```
from course_catalog.api import *
from course_catalog.models import *

sync_ocw_courses(course_prefixes=["PROD/6/6.901/Fall_2005/6-901-inventions-and-patents-fall-2005/"], blocklist=[], force_overwrite=True, upload_to_s3=True)

sync_ocw_courses(course_prefixes=["PROD/6/6.901/Fall_2005/6-901-inventions-and-patents-fall-2005/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

Verify that

```
Course.objects.order_by('updated_on').last().image_src
```

is not null

Run

```
Course.objects.order_by('updated_on').last().delete()
sync_ocw_courses(course_prefixes=["PROD/6/6.901/Fall_2005/6-901-inventions-and-patents-fall-2005/"], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

Verify that there are no errors

