### PR TITLE
fix ocw webhook

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -400,7 +400,7 @@ class WebhookOCWView(APIView):
                 get_ocw_courses.apply_async(
                     countdown=settings.OCW_WEBHOOK_DELAY,
                     kwargs={
-                        "course_prefix": prefix,
+                        "course_prefixes": [prefix],
                         "blocklist": blocklist,
                         "force_overwrite": False,
                         "upload_to_s3": True,

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -626,9 +626,11 @@ def test_ocw_webhook_endpoint(client, mocker, settings, data):
         mock_get_ocw.assert_called_once_with(
             countdown=settings.OCW_WEBHOOK_DELAY,
             kwargs={
-                "course_prefix": OCW_WEBHOOK_RESPONSE["Records"][0]["s3"]["object"][
-                    "key"
-                ].split("0/1.json")[0],
+                "course_prefixes": [
+                    OCW_WEBHOOK_RESPONSE["Records"][0]["s3"]["object"]["key"].split(
+                        "0/1.json"
+                    )[0]
+                ],
                 "blocklist": [],
                 "force_overwrite": False,
                 "upload_to_s3": True,


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
none

#### What's this PR do?
https://github.com/mitodl/open-discussions/pull/3465/files introduced a bug in the ocw webhook. This fixes it

#### How should this be manually tested?
Set OCW_WEBHOOK_KEY to something in your .env file

Using postman or similar post to 
`localhost:8063/api/v0/ocw_webhook/?webhook_key=key`

with body

```
{
    "Records": [
        {
            "s3": {
                "object": {
                    "key": "PROD/2/2.611/Fall_2006/2-611-marine-power-and-propulsion-fall-2006/0/1.json"
                }
            }
        }
    ]
}
```

You should get a 200 response.

Since `force_overwrite=False` on the webhook task, it won't actually update the course since the course didn't change on s3. 

You can temporarily set `force_overwrite=True` in line 405 in `course_catalog/views.py` and push to the webhook again. Then updated_on for the course should be updated.