### PR TITLE
Ab/add ocw next courses fixes

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -883,9 +883,7 @@ def test_sync_ocw_next_course_already_synched(
     bucket = boto3.resource("s3").Bucket(settings.OCW_NEXT_LIVE_BUCKET)
 
     course = CourseFactory.create(
-        platform=PlatformType.ocw.value,
-        course_id="97db384ef34009a64df7cb86cf701979+16.01",
-        title="Existing",
+        platform=PlatformType.ocw.value, course_id="Existing", title="Existing"
     )
 
     run = course.runs.last()
@@ -908,9 +906,14 @@ def test_sync_ocw_next_course_already_synched(
 
     if overwrite and start_timestamp != datetime(2020, 11, 15, tzinfo=pytz.utc):
         assert Course.objects.last().title == "Unified Engineering I, II, III, & IV"
+        assert (
+            Course.objects.last().course_id == "97db384ef34009a64df7cb86cf701979+16.01"
+        )
         mock_upsert.assert_called_once()
     else:
         assert Course.objects.last().title == "Existing"
+        assert Course.objects.last().course_id == "Existing"
+
         mock_upsert.assert_not_called()
 
 

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -66,6 +66,13 @@ def get_year_and_semester(course_run):
     """
     year = course_run.get("year")
     semester = course_run.get("semester")
+
+    if year == "":
+        year = None
+
+    if semester == "":
+        semester = None
+
     if not semester and not year:
         match = re.search(
             "[1|2|3]T[0-9]{4}", course_run.get("key")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None

#### What's this PR do?
This PR fixes the following sentry errors that I observed when running backpopulate_ocw_data
https://sentry.io/organizations/mit-office-of-digital-learning/issues/2960910100/?environment=rc&project=216201&query=is%3Aunresolved&statsPeriod=14d

https://sentry.io/organizations/mit-office-of-digital-learning/issues/2960890827/?environment=rc&project=216201&query=is%3Aunresolved&statsPeriod=14d

https://sentry.io/organizations/mit-office-of-digital-learning/issues/2960890817/?environment=rc&project=216201&query=is%3Aunresolved&statsPeriod=14d

The first error is caused by a course with and empty string for the "year" field in the metadata.

The second and third are actually the same issue being logged twice. This is caused by the "Primary Course Number" field in  ocw-studio being changed after a course is imported. This fix updates the course_id for the existing course to have the new "Primary Course Number" instead of creating a new course with a run that fails to save because it has a duplicate run_id.

This PR fixes both problems.

#### How should this be manually tested?
Set OCW_NEXT_LIVE_BUCKET=ocw-content-live-qa in your .env file

Run

 ```
docker-compose run web ./manage.py backpopulate_ocw_next_data  --course-url-substring anastasia-test-site-20 --overwrite
```

There shouldn't be an error, even though https://ocwnext-rc.odl.mit.edu/courses/anastasia-test-site-20/data.json has "" for the year.

Either in shell, or from the admin interface change the "course_id" field of the course you imported to anything. You can search by title="Anastasia Test Site 20"

Run
 ```
docker-compose run web ./manage.py backpopulate_ocw_next_data  --course-url-substring anastasia-test-site-20 --overwrite
```
again. Again, there shouldn't be and error. The course_id field will change back to `718de6fd0336476c9dd2fa7639e0e413+AB.2021`


