### PR TITLE
Option to force S3 uploads of OCW data via ocw-data-parser

### DIFF
--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -475,7 +475,7 @@ def sync_ocw_course(
         upload_to_s3 (bool): If True, upload course media to S3
         blocklist (list of str): list of course ids that should not be published
         start_timestamp (timestamp): start timestamp of backpoplate. If the updated_on is after this the update already happened
-        force_s3_upload (bool): If True, overwrite courses imported from OCW-Next
+        force_s3_upload (bool): If True, upload parsed JSON even if course imported from OCW-Next
 
     Returns:
         str:
@@ -731,7 +731,7 @@ def sync_ocw_courses(
         force_overwrite (bool): A boolean value to force the incoming course data to overwrite existing data
         upload_to_s3 (bool): If True, upload course media to S3
         start_timestamp (datetime or None): backpopulate start time
-        force_s3_upload (bool): If True, overwrite courses imported from OCW-Next
+        force_s3_upload (bool): If True, upload parsed JSON even if course imported from OCW-Next
     Returns:
         set[str]: All LearningResourceRun.run_id values for course runs which were synced
     """

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -21,6 +21,12 @@ class Command(BaseCommand):
             help="Overwrite any existing records",
         )
         parser.add_argument(
+            "--force-s3",
+            dest="force_s3_upload",
+            action="store_true",
+            help="Force all parsed json to be generated/uploaded to S3",
+        )
+        parser.add_argument(
             "--delete",
             dest="delete",
             action="store_true",
@@ -56,15 +62,17 @@ class Command(BaseCommand):
                 upload_to_s3=options["upload_to_s3"],
                 course_url_substring=course_url_substring,
                 utc_start_timestamp=start.strftime(ISOFORMAT),
+                force_s3_upload=options["force_s3_upload"],
             )
 
             self.stdout.write(
                 "Started task {task} to get ocw course data "
-                "w/force_overwrite={overwrite}, upload_to_s3={s3}, course_url_substring={course_url_substring}".format(
+                "w/force_overwrite={overwrite}, force_s3_upload={force_s3}, upload_to_s3={s3}, course_url_substring={course_url_substring}".format(
                     task=task,
                     overwrite=options["force_overwrite"],
                     s3=options["upload_to_s3"],
                     course_url_substring=course_url_substring,
+                    force_s3=options["force_s3_upload"],
                 )
             )
             self.stdout.write("Waiting on task...")

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -45,6 +45,7 @@ def get_ocw_courses(
     force_overwrite,
     upload_to_s3,
     utc_start_timestamp=None,
+    force_s3_upload=False,
 ):
     """
     Task to sync a batch of OCW courses
@@ -60,6 +61,7 @@ def get_ocw_courses(
         force_overwrite=force_overwrite,
         upload_to_s3=upload_to_s3,
         start_timestamp=utc_start_timestamp,
+        force_s3_upload=force_s3_upload,
     )
 
 
@@ -87,6 +89,7 @@ def get_ocw_data(
     upload_to_s3=True,
     course_url_substring=None,
     utc_start_timestamp=None,
+    force_s3_upload=False,
 ):  # pylint:disable=too-many-locals,too-many-branches
     """
     Task to sync OCW course data with database
@@ -129,6 +132,7 @@ def get_ocw_data(
                 force_overwrite=force_overwrite,
                 upload_to_s3=upload_to_s3,
                 utc_start_timestamp=utc_start_timestamp,
+                force_s3_upload=force_s3_upload,
             )
             for prefixes in chunks(
                 ocw_courses, chunk_size=settings.OCW_ITERATOR_CHUNK_SIZE

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -90,7 +90,7 @@ def get_ocw_data(
     course_url_substring=None,
     utc_start_timestamp=None,
     force_s3_upload=False,
-):  # pylint:disable=too-many-locals,too-many-branches
+):  # pylint:disable=too-many-locals,too-many-branches,too-many-arguments
     """
     Task to sync OCW course data with database
     """

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -304,7 +304,7 @@ def test_get_ocw_force_s3_upload(
         course_prefixes=[TEST_PREFIX],
         blocklist=mock_blocklist.return_value,
         force_overwrite=False,
-        upload_to_s3=True,
+        upload_to_s3=False,
         force_s3_upload=force_s3_upload,
     )
 

--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.3
 markdown2==2.4.0
 newrelic
-ocw-data-parser==0.31.0
+ocw-data-parser==0.32.0
 Pillow==8.3.2
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -217,7 +217,7 @@ lxml==4.6.3
     #   zeep
 markdown2==2.4.0
     # via -r requirements.in
-git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4
+mit-moira @ git+https://github.com/mitodl/mit-moira.git
     # via -r requirements.in
 nested-lookup==0.2.22
     # via -r requirements.in
@@ -227,7 +227,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.31.0
+ocw-data-parser==0.32.0
     # via -r requirements.in
 parso==0.6.1
     # via jedi


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3500 

#### What's this PR do?
Adds a `--force-s3` option to the `backpopulate_ocw_data` command which will parse/upload JSON to S3 for OCW courses even if they have been previously been imported from OCW Studio.  It should not make any changes to the database or search index for the courses.

#### How should this be manually tested?
- Run `docker-compose build` to get the latest version of ocw-data-parser
- Find an OCW course that has already been imported from OCW Studio (`ocw_next_course=True`) or import one if you don't have any (via `backpopulate_ocw_next_data` command).  For example, `18-06-linear-algebra-spring-2010`
- Run `manage.py backpopulate_ocw_data --overwrite --force-s3 --course-url-substring 18-06-linear-algebra-spring-2010`
- When it's done, run this in a shell and verify that it has the following keys: metadata_contributor_list, optional_text, optional_tab_title , resource_index_text, highlights_text and related_content
```
import boto3
from django.conf import settings
s3 = boto3.resource("s3")
bucket = s3.Bucket(settings.OCW_LEARNING_COURSE_BUCKET_NAME)
obj = bucket.Object("18-06-linear-algebra-spring-2010/18-06-linear-algebra-spring-2010_parsed.json")
print(obj.last_modified)
obj_json = obj.get()["Body"].read().decode("utf-8")
for key in ["metadata_contributor_list", "optional_text", "optional_tab_title" , "resource_index_text", "highlights_text",  "related_content"]:
    print(f"{key}: {key in obj_json}")
```

