### PR TITLE
content file fixes

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -688,10 +688,10 @@ def load_content_files(course_run, content_files_data):
             run=course_run, published=True
         ).exclude(pk__in=content_files_ids)
 
-        for file in deleted_files:
-            search_task_helpers.delete_content_file(file)
-
         deleted_files.update(published=False)
+
+        for file in ContentFile.objects.filter(run=course_run, published=False):
+            search_task_helpers.delete_content_file(file)
 
         if course_run.published:
             search_task_helpers.index_run_content_files(course_run.id)

--- a/course_catalog/etl/ocw_next_test.py
+++ b/course_catalog/etl/ocw_next_test.py
@@ -42,7 +42,8 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "key": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
         "published": True,
         "title": "Pages",
-        "url": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
+        "content_title": "Pages",
+        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
     }
 
     assert content_data[1] == {
@@ -51,7 +52,8 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "key": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
         "published": True,
         "title": "Syllabus",
-        "url": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
+        "content_title": "Syllabus",
+        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
     }
 
     assert content_data[2] == {
@@ -66,7 +68,8 @@ def test_transform_ocw_next_content_files(settings, mocker):
         ],
         "published": True,
         "title": "Resource Title",
-        "url": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
+        "content_title": "Resource Title",
+        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
     }
 
     assert content_data[3] == {
@@ -78,7 +81,8 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "learning_resource_types": ["Competition Videos"],
         "published": True,
         "title": None,
-        "url": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
+        "content_title": None,
+        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
     }
 
 

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -679,7 +679,9 @@ def index_run_content_files(run_id, update_only=False):
 
     """
     run = LearningResourceRun.objects.get(pk=run_id)
-    content_file_ids = run.content_files.values_list("id", flat=True)
+    content_file_ids = run.content_files.filter(published=True).values_list(
+        "id", flat=True
+    )
 
     for ids_chunk in chunks(
         content_file_ids, chunk_size=settings.ELASTICSEARCH_DOCUMENT_INDEXING_CHUNK_SIZE

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/3play_file/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/3play_file/data.json
@@ -1,0 +1,7 @@
+{
+	"title": "3play pdf file",
+	"description": "",
+	"file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/4c8e55761ff90b76649c88ddefd76f8e_ZLnj2cnCPGE.pdf",
+	"resource_type": "Document",
+	"file_type": "application/pdf"
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3507

#### What's this PR do?
This pr fixes some issues with the resource search

#### How should this be manually tested?
Run docker-compose run web ./manage.py backpopulate_ocw_next_data  --course-url-substring 14-01-principles-of-microeconomics-fall-2018 --overwrite

In ocw-hugo-themes set 
SEARCH_API_URL=http://localhost:8063/api/v0/search/
and run `npm run start:www`
In the resource search search for "Lecture 23: Market Failures I: Externalities" 
Verify that you see a video result
Verify that the (non-working) link goes to http://localhost:3000/courses/14-01-principles-of-microeconomics-fall-2018/resources/lec-23-market-failures-i/
