### PR TITLE
Revert "Bump celery from 4.3.0 to 5.2.2"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ betamax
 betamax_serializers
 boto==2.39.0
 cairosvg
-celery==5.2.2
+celery==4.3.0
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-anymail[mailgun]==3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 akismet==1.1
     # via -r requirements.in
-amqp==5.0.9
+amqp==2.5.2
     # via kombu
 appdirs==1.4.3
     # via zeep
@@ -24,7 +24,7 @@ betamax==0.8.0
     #   betamax-serializers
 betamax-serializers==0.2.0
     # via -r requirements.in
-billiard==3.6.4.0
+billiard==3.6.2.0
     # via celery
 boto==2.39.0
     # via
@@ -43,16 +43,14 @@ botocore==1.17.37
 bz2file==0.98
     # via smart-open
 cached-property==1.5.1
-    # via
-    #   kombu
-    #   zeep
+    # via zeep
 cachetools==3.1.1
     # via google-auth
 cairocffi==0.8.1
     # via cairosvg
 cairosvg==2.5.1
     # via -r requirements.in
-celery==5.2.2
+celery==4.3.0
     # via
     #   -r requirements.in
     #   django-server-status
@@ -66,18 +64,6 @@ cffi==1.14.4
     #   cryptography
 chardet==3.0.4
     # via requests
-click==8.0.3
-    # via
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
-click-didyoumean==0.3.0
-    # via celery
-click-plugins==1.1.1
-    # via celery
-click-repl==0.2.0
-    # via celery
 cryptography==3.3.2
     # via pyopenssl
 cssselect2==0.2.1
@@ -202,9 +188,7 @@ idna==2.5
     #   requests
     #   tldextract
 importlib-metadata==4.5.0
-    # via
-    #   click
-    #   kombu
+    # via kombu
 ipaddress==1.0.22
     # via elasticsearch-dsl
 ipython==7.16.3
@@ -221,7 +205,7 @@ jmespath==0.9.3
     # via
     #   boto3
     #   botocore
-kombu==5.2.3
+kombu==4.6.7
     # via
     #   celery
     #   django-server-status
@@ -264,9 +248,7 @@ praw==4.5.1
 prawcore==0.10.1
     # via praw
 prompt-toolkit==3.0.3
-    # via
-    #   click-repl
-    #   ipython
+    # via ipython
 psycopg2==2.8.3
     # via
     #   -r requirements.in
@@ -354,7 +336,6 @@ sentry-sdk==0.14.1
     # via -r requirements.in
 six==1.15.0
     # via
-    #   click-repl
     #   cryptography
     #   django-anymail
     #   django-appconf
@@ -426,11 +407,10 @@ urllib3==1.25.10
     #   sentry-sdk
 uwsgi==2.0.18
     # via -r requirements.in
-vine==5.0.0
+vine==1.3.0
     # via
     #   amqp
     #   celery
-    #   kombu
 wcwidth==0.1.8
     # via prompt-toolkit
 webencodings==0.5.1


### PR DESCRIPTION
This reverts commit 72ac837fd5ee89f8dabee42646f54f0012d757ba.

This  dependabot commit breaks login and celery jobs. I am reverting it so rc is working again
