### PR TITLE
Recognize fancy double quotes for phrase search

### DIFF
--- a/static/js/lib/search.js
+++ b/static/js/lib/search.js
@@ -235,7 +235,7 @@ const _channelField = (type: ?string) => {
 }
 export { _channelField as channelField }
 import { channelField } from "./search"
-import { emptyOrNil, isDoubleQuoted } from "./util"
+import { emptyOrNil, isDoubleQuoted, normalizeDoubleQuotes } from "./util"
 
 const getTypes = (type: ?(string | Array<string>)) => {
   if (type) {
@@ -267,9 +267,10 @@ export const buildSearchQuery = ({
     builder.sort(field, option)
   }
   const types = getTypes(type)
+  const searchText = normalizeDoubleQuotes(text)
   return emptyOrNil(R.intersection(LR_TYPE_ALL, types))
-    ? buildChannelQuery(builder, text, types, channelName)
-    : buildLearnQuery(builder, text, types, facets)
+    ? buildChannelQuery(builder, searchText, types, channelName)
+    : buildLearnQuery(builder, searchText, types, facets)
 }
 
 export const buildFacetSubQuery = (

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -166,5 +166,8 @@ export const formatPrice = (price: ?string | number | Decimal): string => {
 export const sortBy = (property: string) =>
   R.sortWith([R.ascend(R.prop(property))])
 
+export const normalizeDoubleQuotes = (text: ?string) =>
+  (text || "").replace(/[\u201C\u201D]/g, '"')
+
 export const isDoubleQuoted = (text: ?string) =>
-  !emptyOrNil(R.match(/^".+"$/, text || ""))
+  !emptyOrNil(R.match(/^".+"$/, normalizeDoubleQuotes(text)))

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -18,7 +18,8 @@ import {
   spaceSeparated,
   isValidUrl,
   flatZip,
-  formatPrice
+  formatPrice,
+  normalizeDoubleQuotes
 } from "./util"
 
 describe("utility functions", () => {
@@ -229,6 +230,21 @@ describe("utility functions", () => {
     it("returns an empty string if null or undefined", () => {
       assert.equal(formatPrice(null), "")
       assert.equal(formatPrice(undefined), "")
+    })
+  })
+
+  describe("normalizeDoubleQuotes", () => {
+    it("returns a string with any fancy double quotes removed", () => {
+      [
+        ['"text phrase"', '"text phrase"'],
+        ["\u201Ctext phrase\u201D", '"text phrase"'],
+        ["some text", "some text"],
+        ["text", "text"],
+        [null, ""],
+        [undefined, ""]
+      ].forEach(([inputStr, expectedStr]) => {
+        assert.equal(normalizeDoubleQuotes(inputStr), expectedStr)
+      })
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3521 

#### What's this PR do?
Replaces 'fancy' double quotes (`“”`) with normal double quotes (`""`) in search text.

#### How should this be manually tested?
These two searches should return the same results:
http://localhost:8063/learn/search?q=%E2%80%9Cmechanical%20engineers%E2%80%9D
http://localhost:8063/learn/search?q=%22mechanical%20engineers%22

and the result count should be lower than for this search without any double quotes:
http://localhost:8063/learn/search?q=mechanical%20engineers

Also repeat the first two with `mechical enginer`  as the text inside quotes. They should return no results and suggest `"mechanical engineers"` with quotes.