### PR TITLE
fix video thumbnails in search

### DIFF
--- a/course_catalog/etl/ocw_next.py
+++ b/course_catalog/etl/ocw_next.py
@@ -113,8 +113,10 @@ def transform_resource(s3_key, resource_data, s3_resource, force_overwrite):
 
     if content_type == "video":
         file_s3_path = resource_data.get("transcript_file")
+        image_src = resource_data.get("thumbnail_file")
     else:
         file_s3_path = resource_data.get("file")
+        image_src = None
 
     if not file_s3_path:
         return
@@ -174,5 +176,8 @@ def transform_resource(s3_key, resource_data, s3_resource, force_overwrite):
 
     if content_json:
         resource_data["content"] = content_json.get("content")
+
+    if image_src:
+        resource_data["image_src"] = image_src
 
     return resource_data

--- a/course_catalog/etl/ocw_next_test.py
+++ b/course_catalog/etl/ocw_next_test.py
@@ -83,6 +83,7 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "title": None,
         "content_title": None,
         "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
+        "image_src": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
     }
 
 

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
@@ -7,5 +7,6 @@
   "youtube_key":  "vKer2U5W5-s",
   "captions_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript_webvtt",
   "transcript_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript.pdf",
+  "thumbnail_file": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
   "archive_url": null
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3511

#### What's this PR do?
This PR populates video thumbnails in resource search

#### How should this be manually tested?
Set
OCW_NEXT_LIVE_BUCKET=ocw-content-live-qa

Run `docker-compose run web ./manage.py backpopulate_ocw_next_data --course-url-substring 14-01-principles-of-microeconomics-fall-2018 --overwrite`

Run ocw-hugo-themes search locally with SEARCH_API_URL=http://localhost:8063/api/v0/search/
Search for "microeconomics" in the the resource search. Verify that the videos coming from course 14.01 have thumbnails

