### PR TITLE
fix: fetching and storing instructor's full name

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -288,7 +288,11 @@ def test_deserializing_a_valid_ocw_course(
 
     expected_course_instructor_values = [
         {"first_name": None, "last_name": "Kokernak", "full_name": "Prof. Kokernak"},
-        {"first_name": "Christine", "last_name": "Sherratt", "full_name": None},
+        {
+            "first_name": "Christine",
+            "last_name": "Sherratt",
+            "full_name": "Christine Sherratt",
+        },
         {
             "first_name": "Michael",
             "last_name": "Short",

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -81,12 +81,12 @@ def load_prices(resource, prices_data):
 
 
 def load_instructors(resource, instructors_data):
-    """Load the prices for a resource into the database"""
+    """Load the instructors for a resource into the database"""
     instructors = []
 
     for instructor_data in instructors_data:
         if "full_name" not in instructor_data:
-            instructor_data["full_name"] = None
+            instructor_data["full_name"] = instructor_data.get("title", None)
 
         instructor, _ = CourseInstructor.objects.get_or_create(**instructor_data)
         instructors.append(instructor)

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -34,6 +34,7 @@ from course_catalog.utils import (
     get_ocw_topics,
     get_year_and_semester,
     semester_year_to_date,
+    parse_instructors,
 )
 from moira_lists.moira_api import is_list_staff
 from open_discussions.serializers import WriteableSerializerMethodField
@@ -281,31 +282,7 @@ class LearningResourceRunSerializer(BaseCourseSerializer):
         if is_published is not None:
             course_fields["published"] = is_published
 
-        self.instructors = []
-
-        for person in data.get("staff"):
-            instructor = {
-                "first_name": person.get("given_name", person.get("first_name")),
-                "last_name": person.get("family_name", person.get("last_name")),
-                "full_name": None,
-            }
-
-            if person.get("salutation"):
-                if instructor["first_name"] and instructor["last_name"]:
-                    instructor[
-                        "full_name"
-                    ] = "{salutation} {first_name} {last_name}".format(
-                        salutation=person.get("salutation"),
-                        first_name=instructor["first_name"],
-                        last_name=instructor["last_name"],
-                    )
-                elif instructor["last_name"]:
-                    instructor["full_name"] = "{salutation} {last_name}".format(
-                        salutation=person.get("salutation"),
-                        last_name=instructor["last_name"],
-                    )
-
-            self.instructors.append(instructor)
+        self.instructors = parse_instructors(data.get("staff"))
 
         self.prices = [
             {

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -291,7 +291,9 @@ def parse_instructors(staff):
         }
 
         if person.get("salutation"):
-            if instructor.get("full_name"):
+            if instructor.get("full_name") and (
+                not instructor.get("full_name").startswith(person.get("salutation"))
+            ):
                 instructor["full_name"] = "{salutation} {full_name}".format(
                     salutation=person.get("salutation"),
                     full_name=instructor.get("full_name"),

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -270,3 +270,62 @@ def safe_load_json(json_string, json_file_key):
     except rapidjson.JSONDecodeError:
         log.exception("%s has a corrupted JSON", json_file_key)
         return {}
+
+
+def parse_instructors(staff):
+    """
+    Parses staff/instructors users including their full name, salutation etc
+
+    Args:
+        array (dict): staff/instructors
+
+    Returns:
+        array (dict): parsed instructors
+    """
+    instructors = []
+    for person in staff:
+        instructor = {
+            "first_name": person.get("given_name", person.get("first_name")),
+            "last_name": person.get("family_name", person.get("last_name")),
+            "full_name": person.get("title"),
+        }
+
+        if person.get("salutation"):
+            if instructor.get("full_name"):
+                instructor["full_name"] = "{salutation} {full_name}".format(
+                    salutation=person.get("salutation"),
+                    full_name=instructor.get("full_name"),
+                )
+            elif instructor.get("last_name"):
+                instructor["full_name"] = "{salutation} {full_name}".format(
+                    salutation=person.get("salutation"),
+                    full_name=" ".join(
+                        [
+                            part
+                            for part in [
+                                person.get("first_name"),
+                                person.get("middle_initial"),
+                                person.get("last_name"),
+                            ]
+                            if part
+                        ]
+                    ),
+                )
+        elif not instructor.get("full_name"):
+            instructor["full_name"] = "{full_name}".format(
+                full_name=" ".join(
+                    [
+                        part
+                        for part in [
+                            person.get("first_name"),
+                            person.get("middle_initial"),
+                            person.get("last_name"),
+                        ]
+                        if part
+                    ]
+                )
+            )
+
+        instructors.append(instructor)
+
+    return instructors

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -295,12 +295,12 @@ def parse_instructors(staff):
                 not instructor.get("full_name").startswith(person.get("salutation"))
             ):
                 instructor["full_name"] = "{salutation} {full_name}".format(
-                    salutation=person.get("salutation"),
+                    salutation=person.get("salutation").strip(),
                     full_name=instructor.get("full_name"),
                 )
             elif instructor.get("last_name"):
                 instructor["full_name"] = "{salutation} {full_name}".format(
-                    salutation=person.get("salutation"),
+                    salutation=person.get("salutation").strip(),
                     full_name=" ".join(
                         [
                             part

--- a/course_catalog/utils_test.py
+++ b/course_catalog/utils_test.py
@@ -1,6 +1,7 @@
 """
 Test course_catalog utils
 """
+import json
 from datetime import datetime
 
 import pytest
@@ -15,7 +16,17 @@ from course_catalog.utils import (
     load_course_duplicates,
     safe_load_json,
     semester_year_to_date,
+    parse_instructors,
 )
+
+
+@pytest.fixture
+def test_instructors_data():
+    """
+    Test instructors data
+    """
+    with open("./test_json/test_instructors_data.json", "r") as test_data:
+        return json.load(test_data)["instructors"]
 
 
 @pytest.mark.parametrize(
@@ -205,3 +216,16 @@ def test_safe_load_bad_json(mocker):
     mock_logger = mocker.patch("course_catalog.utils.log.exception")
     assert safe_load_json("badjson", "key") == {}
     mock_logger.assert_called_with("%s has a corrupted JSON", "key")
+
+
+def test_parse_instructors(test_instructors_data):
+    """
+    Verify that instructors assignment is working as expected
+    """
+
+    for instructor in test_instructors_data:
+        parsed_instructors = parse_instructors([instructor["data"]])
+        parsed_instructor = parsed_instructors[0]
+        assert parsed_instructor.get("first_name") == instructor["result"]["first_name"]
+        assert parsed_instructor.get("last_name") == instructor["result"]["last_name"]
+        assert parsed_instructor.get("full_name") == instructor["result"]["full_name"]

--- a/course_catalog/utils_test.py
+++ b/course_catalog/utils_test.py
@@ -20,8 +20,8 @@ from course_catalog.utils import (
 )
 
 
-@pytest.fixture
-def test_instructors_data():
+@pytest.fixture(name="test_instructors_data")
+def fixture_test_instructors_data():
     """
     Test instructors data
     """
@@ -222,7 +222,6 @@ def test_parse_instructors(test_instructors_data):
     """
     Verify that instructors assignment is working as expected
     """
-
     for instructor in test_instructors_data:
         parsed_instructors = parse_instructors([instructor["data"]])
         parsed_instructor = parsed_instructors[0]

--- a/test_json/test_instructors_data.json
+++ b/test_json/test_instructors_data.json
@@ -1,0 +1,60 @@
+{
+  "instructors": [
+    {
+      "data": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "middle_initial": "Cena",
+        "salutation": "Prof.",
+        "title": "John Cena Smith"
+      },
+      "result": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "full_name": "Prof. John Cena Smith"
+      }
+    },
+    {
+      "data": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "middle_initial": "",
+        "salutation": "",
+        "title": "John Smith"
+      },
+      "result": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "full_name": "John Smith"
+      }
+    },
+    {
+      "data": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "middle_initial": "Cena",
+        "salutation": "",
+        "title": ""
+      },
+      "result": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "full_name": "John Cena Smith"
+      }
+    },
+    {
+      "data": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "middle_initial": "Cena",
+        "salutation": "Dr.",
+        "title": ""
+      },
+      "result": {
+        "first_name": "John",
+        "last_name": "Smith",
+        "full_name": "Dr. John Cena Smith"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/3524

#### What's this PR do?
- Adds a new util: `parse_instructors` in `course catalog` which parses instructors.
- Updates `serializers` in `course catalog` to use this newly added util
- Adds a test to verify that this util works as expected.

#### How should this be manually tested?
- Setup open-discussions locally.
- Checkout to this branch
- run `manage.py backpopulate_ocw_next_data ... ` for any course which has instructors with first, middle, and last names.
- Verify that full name includes first, middle, and last name. 

#### What GIF best describes this PR or how it makes you feel?
<img width="48" alt="image" src="https://user-images.githubusercontent.com/93309234/156633357-bf6b552a-0c64-4fee-80c9-8fbf73b9e1c8.png">
