### PR TITLE
Ab/fewer indexing jobs

### DIFF
--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -690,9 +690,6 @@ def load_content_files(course_run, content_files_data):
 
         deleted_files.update(published=False)
 
-        for file in ContentFile.objects.filter(run=course_run, published=False):
-            search_task_helpers.delete_content_file(file)
-
         if course_run.published:
             search_task_helpers.index_run_content_files(course_run.id)
         else:

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -861,18 +861,12 @@ def test_load_programs(mocker, mock_blocklist, mock_duplicates):
     mock_duplicates.assert_called_once_with("mitx")
 
 
-@pytest.mark.parametrize("existing_non_match", [True, False])
 @pytest.mark.parametrize("is_published", [True, False])
-def test_load_content_files(mocker, is_published, existing_non_match):
+def test_load_content_files(mocker, is_published):
     """Test that load_content_files calls the expected functions"""
     course_run = LearningResourceRunFactory.create(published=is_published)
-    if existing_non_match:
-        existing_content_file = ContentFileFactory.create(
-            published=True, run=course_run
-        )
-        returned_content_file_id = existing_content_file.id + 1
-    else:
-        returned_content_file_id = 1
+
+    returned_content_file_id = 1
 
     content_data = [{"a": "b"}, {"a": "c"}]
     mock_load_content_file = mocker.patch(
@@ -896,13 +890,6 @@ def test_load_content_files(mocker, is_published, existing_non_match):
     assert mock_load_content_file.call_count == len(content_data)
     assert mock_bulk_index.call_count == (1 if is_published else 0)
     assert mock_bulk_delete.call_count == (0 if is_published else 1)
-
-    if existing_non_match:
-        existing_content_file.refresh_from_db()
-        assert existing_content_file.published == False
-        mock_delete.assert_called_once()
-    else:
-        mock_delete.assert_not_called()
 
 
 def test_load_content_file():

--- a/search/management/commands/remove_course_hits_with_no_database_record.py
+++ b/search/management/commands/remove_course_hits_with_no_database_record.py
@@ -1,0 +1,50 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from course_catalog.models import Course
+from search.connection import get_default_alias_name
+from search.constants import COURSE_TYPE
+from search.indexing_api import es_iterate_all_documents, gen_course_id
+from search.tasks import delete_document
+
+
+class Command(BaseCommand):
+    """Delete es course records that don't have a database object"""
+
+    help = "Remove courses with no database record from the elasticsearch index"
+
+    def handle(self, *args, **options):
+        """Delete es course records that don't have a database object """
+        index = get_default_alias_name(COURSE_TYPE)
+
+        es_course_ids = set()
+        bad_courses = []
+        bad_documents = []
+
+        for course_obj in Course.objects.filter(published=True):
+            es_course_ids.add(gen_course_id(course_obj.platform, course_obj.course_id))
+
+        query = {"term": {"object_type": "course"}}
+
+        for listing in es_iterate_all_documents(index, query):
+            es_id = listing["_id"]
+            if es_id not in es_course_ids:
+                bad_courses.append(listing)
+
+        for course in bad_courses:
+            query = {"parent_id": {"type": "resourcefile", "id": course["_id"]}}
+            for document in es_iterate_all_documents(index, query):
+                bad_documents.append(document)
+
+        self.stdout.write("Removing {} document records".format(len(bad_documents)))
+
+        for doc in bad_documents:
+            delete_document(
+                doc["_id"],
+                COURSE_TYPE,
+                routing=doc["_source"]["resource_relations"]["parent"],
+            )
+
+        self.stdout.write("Removing {} course records".format(len(bad_courses)))
+
+        for course in bad_courses:
+            delete_document(course["_id"], COURSE_TYPE)

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -475,6 +475,7 @@ def index_run_content_files(run_id, update_only=False):
     """
     try:
         api.index_run_content_files(run_id, update_only)
+        api.delete_run_content_files(run_id, True)
     except (RetryException, Ignore):
         raise
     except:  # pylint: disable=bare-except

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -601,12 +601,18 @@ def test_index_run_content_files(mocker, with_error, update_only):
     index_run_content_files_mock = mocker.patch(
         "search.indexing_api.index_run_content_files"
     )
+    delete_run_content_files_mock = mocker.patch(
+        "search.indexing_api.delete_run_content_files"
+    )
     if with_error:
         index_run_content_files_mock.side_effect = TabError
     result = index_run_content_files.delay(1, update_only).get()
     assert result == ("index_run_content_files threw an error" if with_error else None)
 
     index_run_content_files_mock.assert_called_once_with(1, update_only)
+
+    if not with_error:
+        delete_run_content_files_mock.assert_called_once_with(1, True)
 
 
 @pytest.mark.parametrize("with_error", [True, False])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3530

#### What's this PR do?
This PR 
1) Consolidates all elasticsearch ContentFile updates into one celery job. Previously the step making sure unpublished documents are removed from the index created a job per document. This caused ocw updates to spend a long time in the celery queue when there were concurrent email jobs.

2) Adds a management command for removing courses without database records. We currently don't have a mechanism for removing courses from the elasticsearch index if they are now longer linked to a course database record. We had a few courses for which that was the case and I wrote a script to fix the issue. I'm adding it as a management command so we don't have to recreate it if the problem happens again.

#### How should this be manually tested?
1) Run `docker-compose run web ./manage.py backpopulate_ocw_next_data --overwrite --course-url-substring 1-060-engineering-mechanics-ii-spring-2006` verify that everything runs correctly. Run ocw-hugo-themes with SEARCH_API_URL=http://localhost:8063/api/v0/search/ and verify that searching for "Engineering Mechanics II" returns the course 1.060 and returns course documents for course 1.060

2) Find one of the ContentFile records for Engineering Mechanics II in the database and change it's key. Run `docker-compose run web ./manage.py backpopulate_ocw_next_data --overwrite --course-url-substring 1-060-engineering-mechanics-ii-spring-2006` again. Verify that the original ContentFile now has published=False, there is a new ContentFile with the original key and the resource record appears in search only once

3) Find the Course record for Engineering Mechanics II in the database. Delete it. Run `docker-compose run web ./manage.py remove_courses_with_no_database_record`. Verify that both the course and it's resources are removed from the search index

