### PR TITLE
Fix backpopulate_ocw_data command without site list

### DIFF
--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -70,6 +70,8 @@ class Command(BaseCommand):
                     for course_url in course_url_substring.split(",")
                     if course_url
                 ]
+            else:
+                course_urls = None
         if options["delete"]:
             self.stdout.write("Deleting all existing OCW courses")
             for course in Course.objects.filter(platform="ocw", ocw_next_course=False):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes the command when no list of sites is specified

#### How should this be manually tested?
Run without `--course-url-substring`
