### PR TITLE
fix department import

### DIFF
--- a/course_catalog/api_test.py
+++ b/course_catalog/api_test.py
@@ -188,7 +188,7 @@ def ocw_next_valid_data():
             ["Business", "Project Management"],
         ],
         "primary_course_number": "16.01",
-        "extra_course_numbers": "16.02, 16.03, 16.04",
+        "extra_course_numbers": "16.02, 16.03, 16.04, 17.01",
         "term": "Fall",
         "year": "2005",
         "level": ["Undergraduate"],
@@ -410,7 +410,7 @@ def test_deserializing_a_valid_ocw_next_course(
         == ocw_next_valid_data["course_image_metadata"]["description"]
     )
     assert course.department == ["16"]
-    assert course.extra_course_numbers == ["16.02", "16.03", "16.04"]
+    assert course.extra_course_numbers == ["16.02", "16.03", "16.04", "17.01"]
     assert course.offered_by.count() == 1
     assert course.offered_by.first().name == OfferedBy.ocw.value
     assert course.runs.first().offered_by.count() == 1

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -406,21 +406,20 @@ class OCWNextSerializer(CourseSerializer):
 
         topics = [{"name": topic_name} for topic_name in topics]
 
-        department_numbers = [data.get("primary_course_number", "").split(".")[0]]
-
         extra_course_numbers = data.get("extra_course_numbers", None)
 
         if extra_course_numbers:
             extra_course_numbers = extra_course_numbers.split(", ")
-            for extra_course_number in extra_course_numbers:
-                department_number = extra_course_number.split(".")[0]
-                if department_number not in department_numbers:
-                    department_numbers.append(department_number)
         else:
             extra_course_numbers = []
 
+        if data.get("primary_course_number"):
+            course_id = f"{data.get('uid')}+{data.get('primary_course_number')}"
+        else:
+            course_id = None
+
         course_fields = {
-            "course_id": f"{data.get('uid')}+{data.get('primary_course_number')}",
+            "course_id": course_id,
             "title": data.get("course_title"),
             "short_description": data.get("course_description"),
             "image_src": data.get("image_src"),
@@ -432,7 +431,7 @@ class OCWNextSerializer(CourseSerializer):
             "ocw_next_course": True,
             "course_feature_tags": data.get("learning_resource_types", []),
             "platform": PlatformType.ocw.value,
-            "department": department_numbers,
+            "department": data.get("department_numbers", []),
             "extra_course_numbers": extra_course_numbers,
         }
 

--- a/course_catalog/serializers_test.py
+++ b/course_catalog/serializers_test.py
@@ -359,7 +359,7 @@ def test_ocw_next_serializer(
         ],
         "course_id": "97db384ef34009a64df7cb86cf701970+16.01",
         "department": ["16"],
-        "extra_course_numbers": ["16.02", "16.03", "16.04"],
+        "extra_course_numbers": ["16.02", "16.03", "16.04", "17.01"],
         "image_description": "An abstracted aircraft wing with illustrated systems. (Image by MIT OCW.)",
         "image_src": "https://open-learning-course-data-production.s3.amazonaws.com/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg",
         "last_modified": None,

--- a/search/api.py
+++ b/search/api.py
@@ -480,13 +480,14 @@ def _transform_search_results_coursenum(search_result, department_filters):
                 if department_course_number["department"] in department_filters
             ]
 
-            filtered_department_course_numbers = sorted(
-                filtered_department_course_numbers, key=itemgetter("sort_coursenum")
-            )
+            if len(filtered_department_course_numbers) > 0:
+                filtered_department_course_numbers = sorted(
+                    filtered_department_course_numbers, key=itemgetter("sort_coursenum")
+                )
 
-            hit["_source"]["coursenum"] = filtered_department_course_numbers[0][
-                "coursenum"
-            ]
+                hit["_source"]["coursenum"] = filtered_department_course_numbers[0][
+                    "coursenum"
+                ]
 
 
 def find_related_documents(*, user, post_id):

--- a/search/api_test.py
+++ b/search/api_test.py
@@ -707,7 +707,7 @@ def test_transform_results(
     )
 
 
-@pytest.mark.parametrize("department_fitler", [["Chemistry", "Biology"], []])
+@pytest.mark.parametrize("department_fitler", [["Chemistry", "Biology"], [], ["Math"]])
 @pytest.mark.django_db
 def test_transform_department_filter(department_fitler):
     """
@@ -748,7 +748,7 @@ def test_transform_department_filter(department_fitler):
 
     transformed_results = transform_results(results, AnonymousUser(), department_fitler)
 
-    if department_fitler:
+    if department_fitler == ["Chemistry", "Biology"]:
         expected_course_num = "5.1"
     else:
         expected_course_num = "1.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3550

#### What's this PR do?
This pr updates open-discussions to use the department field to populate OCW next departments.

#### How should this be manually tested?
Run
```
docker-compose run web ./manage.py backpopulate_ocw_next_data  --course-url-substring 21w-755-writing-and-reading-short-stories-spring-2012 --overwrite
```
Run ocw-hugo themes www locally with SEARCH_API_URL=http://localhost:8063/api/v0/search/

Verify that when you filter for Comparative Media Studies/Writing course 21w-755-writing-and-reading-short-stories-spring-2012 is shown in the search
