### PR TITLE
Update ocw-data-parser

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ ipython
 lxml==4.6.5
 markdown2==2.4.0
 newrelic
-ocw-data-parser==0.35.0
+ocw-data-parser==0.35.1
 Pillow==9.0.0
 psycopg2==2.8.3
 praw==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -227,7 +227,7 @@ oauthlib==2.0.7
     # via
     #   requests-oauthlib
     #   social-auth-core
-ocw-data-parser==0.35.0
+ocw-data-parser==0.35.1
     # via -r requirements.in
 parso==0.6.1
     # via jedi


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-data-parser/issues/194

#### What's this PR do?
Updates the ocw-data-parser version, fixing an issue with outdated ocw.mit.edu urls

#### How should this be manually tested?
- Run the following command on heroku RC or locally with the master branch:
` python manage.py backpopulate_ocw_data --overwrite --force-s3  --course-url-substring 3-016-mathematics-for-materials-scientists-and-engineers-fall-2005`
- When done, download this file from the RC `settings.OCW_LEARNING_COURSE_BUCKET_NAME` bucket: '3-016-mathematics-for-materials-scientists-and-engineers-fall-2005/d43d16aa2aa00e5ac170ac148986d1e0_Lecture18.zip
It should be small and contain HTML instead of being a proper zip file.
- Run the same management command locally with this branch (after `docker-compose build` to get the latest parser version).  Download the file again, it should be about 35 MB and be a working zip file.

When this is merged, we should probably run the management command on production for the affected sites, then sync the files to ocw studio (there is a concourse pipeline that does the syncing, I turned it off last week to avoid syncing more bad files, and it should probably remain paused except when needed).