### PR TITLE
fix yarn postinstall script

### DIFF
--- a/frontends/infinite-corridor/package.json
+++ b/frontends/infinite-corridor/package.json
@@ -26,7 +26,7 @@
     "node": "16"
   },
   "scripts": {
-    "postinstall": "./webpack_if_prod.sh",
+    "postinstall": "yarn run build",
     "start:dev": "webpack serve --port ${WEBPACK_PORT_INFINITE_CORRIDOR}",
     "build": "webpack --config webpack.config.js --bail",
     "lint": "echo todo: set up lint",

--- a/frontends/infinite-corridor/webpack_if_prod.sh
+++ b/frontends/infinite-corridor/webpack_if_prod.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ef -o pipefail
-if [[ "$NODE_ENV" != "" && "$NODE_ENV" != "development" ]]
-then
-    yarn workspace infinite-corridor run build
-fi

--- a/frontends/open-discussions/package.json
+++ b/frontends/open-discussions/package.json
@@ -170,7 +170,7 @@
     "node": "16"
   },
   "scripts": {
-    "postinstall": "./webpack_if_prod.sh",
+    "postinstall": "yarn run build",
     "build": "webpack --config webpack.config.js --bail",
     "start:dev": "webpack serve --port ${WEBPACK_PORT_OPEN_DISCUSSIONS}",
     "lint": "eslint ./src",

--- a/frontends/open-discussions/webpack_if_prod.sh
+++ b/frontends/open-discussions/webpack_if_prod.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ef -o pipefail
-if [[ "$NODE_ENV" != "" && "$NODE_ENV" != "development" ]]
-then
-    yarn workspace discussions run build
-fi

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -5,7 +5,7 @@
 health_urls=(
     "http://watch:8052/health"
 )
-wait_time=300
+wait_time=600
 
 if [[ $NODE_ENV == "production" ]] ; then
     # kick off healthchecks as background tasks so they can check concurrently


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Followup to #3593 

#### What's this PR do?
Goal is to fix the deploy error here: https://github.com/mitodl/open-discussions/runs/7094209264?check_suite_focus=true#step:3:35012

This fixes the package.json postinstall script for open-discussions. Previously,
- the script only ran if node_env was not dev
- it referenced an incorrect yarn workspace name

Now it runs in prod and dev and does not reference the workspace at all. Running in dev seems OK since it only runs on install anyway.

The reason this slipped through review / my testing is: the build error was only visible if you were installing with node_env was set to something non-empty and not development. I believe in my testing I probably installed in dev mode, then ran the build script directly.

#### How should this be manually tested?
Delete node modules and run `docker compose run --rm watch yarn install`.  Install should succeed. 
