### PR TITLE
Fix deploy...no devdeps, only dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     },
     "version": "0.0.0",
     "packageManager": "yarn@3.2.0",
-    "devDependencies": {
+    "dependencies": {
+        "@swc/core": "^1.2.207",
         "@swc/jest": "^0.2.21",
         "@testing-library/react": "12",
+        "@testing-library/jest-dom": "^5.16.4",
         "@types/jest": "^28.1.3",
         "@types/styled-components": "^5.1.25",
         "@typescript-eslint/eslint-plugin": "^5.30.0",
@@ -53,9 +55,5 @@
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.4"
-    },
-    "dependencies": {
-        "@swc/core": "^1.2.207",
-        "@testing-library/jest-dom": "^5.16.4"
     }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested *Needs to be tested on heroku*

#### What are the relevant tickets?
Should fix deploy failure on heroku.

#### What's this PR do?
Heroku was building the frontend at least twice, and the final build was post devDependency pruning, and it was failing since  `@swc/core` had been pruned.

This PR moves all js `devDependencies` to `dependencies`...  `open-discussions` already had this, but I previously moved some shared dependencies (though, apparently, not very many) to root dev deps.  So, this restores the "everything in dependencies" status quo.

#### How should this be manually tested?
We should deploy it to heroku :/ 

#### Any background context you want to provide?
Here's an excerpt from the heroku logs https://dashboard.heroku.com/apps/odl-open-discussions-rc/activity/builds/90f6e1bb-68bb-4328-a650-233d88d7ccc6 :
```
-----> Installing dependencies
       Running 'yarn install' with yarn.lock
        ...

-----> Build
       Running build (yarn)
        ...
       ➤ YN0000: [open-discussions]: webpack 5.73.0 compiled with 2 warnings in 80867 ms
       ➤ YN0000: [open-discussions]: Process exited (exit code 0), completed in 1m 24s
       ➤ YN0000: Done in 2m 12s

-----> Pruning devDependencies
       Running 'yarn heroku prune'
        ...
       ➤ YN0000: ┌ Link step
       ➤ YN0008: │ open-discussions-root@workspace:. must be rebuilt because its dependency tree changed
       ➤ YN0008: │ styled-components@npm:5.3.5 [9bd41] must be rebuilt because its dependency tree changed
       ➤ YN0009: │ open-discussions-root@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-735457c6/build.log)
       ➤ YN0000: └ Completed in 8s 58ms
       ➤ YN0000: Failed with errors in 9s 461ms
```

There's a postinstall script that runs after install. I'm concerned that we're installing three times: once when Heroku calls `install` (triggered by postinstall). Once when Heroku calls build (which I believe its buildpack does). And once AFTER pruning since the dev depenencies have been removed and yarn says
```
open-discussions-root@workspace:. must be rebuilt because its dependency tree changed
```

The post-prune build was failing because webpack et al had been pruned.

I am pretty sure that this will get rid of the post-prune build entirely, since there will be no pruning. Subsequently, I'll try to figure out if Heroku is still building twice.
