### PR TITLE
Change behavior of course_ui_enabled flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 RUN apt-get update && apt-get install libpq-dev postgresql-client -y
+# The following is required for moira requests to work within docker
+RUN sed -i -E 's/MinProtocol[=\ ]+.*/MinProtocol = TLSv1.0/g' /etc/ssl/openssl.cnf
 
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -

--- a/frontends/open-discussions/src/components/ContentToolbar.js
+++ b/frontends/open-discussions/src/components/ContentToolbar.js
@@ -69,7 +69,7 @@ export default class ContentToolbar extends React.Component<Props> {
             </section>
             <section className="mdc-toolbar__section mdc-toolbar__section--align-end user-menu-section">
               <ResponsiveWrapper onlyOn={[TABLET, DESKTOP]}>
-                {userIsAnonymous() || !SETTINGS.course_ui_enabled ? (
+                {userIsAnonymous() ? (
                   <div />
                 ) : (
                   <Link className="user-list-link" to={userListIndexURL}>

--- a/frontends/open-discussions/src/components/ContentToolbar_test.js
+++ b/frontends/open-discussions/src/components/ContentToolbar_test.js
@@ -44,19 +44,10 @@ describe("ContentToolbar", () => {
     assert.equal(renderToolbar().find("Link").at(2).prop("to"), PODCAST_URL)
   })
 
-  //
-  ;[true, false].forEach(courseUIEnabled => {
-    it("should include a link to the my lists page", () => {
-      SETTINGS.course_ui_enabled = courseUIEnabled
-
-      const link = renderToolbar().find(".user-list-link")
-      if (courseUIEnabled) {
-        assert.equal(link.prop("children")[1], "My Lists")
-        assert.equal(link.prop("to"), userListIndexURL)
-      } else {
-        assert.isNotOk(link.exists())
-      }
-    })
+  it("should include a link to the my lists page", () => {
+    const link = renderToolbar().find(".user-list-link")
+    assert.equal(link.prop("children")[1], "My Lists")
+    assert.equal(link.prop("to"), userListIndexURL)
   })
 
   it("should hide the my lists link when you're anonymous", () => {

--- a/frontends/open-discussions/src/pages/App.js
+++ b/frontends/open-discussions/src/pages/App.js
@@ -325,14 +325,10 @@ class App extends React.Component<Props> {
             path={`${match.url}privacy-statement`}
             component={PrivacyPolicyPage}
           />
-          {SETTINGS.course_ui_enabled ? (
-            <>
-              <Route path={`${match.url}courses`}>
-                <CourseLearnRedirect />
-              </Route>
-              <Route path={`${match.url}learn`} component={LearnRouter} />
-            </>
-          ) : null}
+          <Route path={`${match.url}courses`}>
+            <CourseLearnRedirect />
+          </Route>
+          <Route path={`${match.url}learn`} component={LearnRouter} />
           <Route path={`${match.url}podcasts`}>
             <PodcastFrontpage />
             <LearningResourceDrawer hideSimilarLearningResources />

--- a/frontends/open-discussions/src/pages/App_test.js
+++ b/frontends/open-discussions/src/pages/App_test.js
@@ -141,12 +141,10 @@ describe("App", () => {
 
   //
   ;[true, false].forEach(courseUIEnabled => {
-    it(`${shouldIf(
-      courseUIEnabled
-    )} render something at "/learn"`, async () => {
+    it(`should render something at "/learn regardless of course_ui_enabled setting"`, async () => {
       SETTINGS.course_ui_enabled = courseUIEnabled
       const [wrapper] = await renderComponent("/learn/", [])
-      assert.equal(courseUIEnabled, wrapper.find("LearnRouter").exists())
+      assert.equal(true, wrapper.find("LearnRouter").exists())
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closed #3631 

#### What's this PR do?
Changes the behavior of `course_ui_enabled` so that if `False`, it only hides the "Learn at MIT" section on the home page.  The `/learn` urls should always be accessible now regardless of the setting.

#### How should this be manually tested?
- Set `FEATURE_COURSE_UI=True` in your .env:
  - Go to the discussions home page, there should be a `Learn at MIT` section on the right.
  - Go to `../learn` and `../learn/search`, they should be reachable and have the expected content.
- Set `FEATURE_COURSE_UI=False` in your .env:
  - Go to the discussions home page, there should not be a `Learn at MIT` section on the right.
  - Go to `../learn` and `../learn/search`, they should be reachable and have the expected content.
