### PR TITLE
fix facet label

### DIFF
--- a/frontends/open-discussions/scss/search.scss
+++ b/frontends/open-discussions/scss/search.scss
@@ -155,10 +155,14 @@
         flex-direction: row;
         justify-content: space-between;
         width: 100%;
+        overflow: hidden;
       }
 
       .facet-key {
         color: black;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
       }
 
       .facet-key-large {

--- a/frontends/open-discussions/src/components/search/SearchFacetItem.js
+++ b/frontends/open-discussions/src/components/search/SearchFacetItem.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react"
-import Dotdotdot from "react-dotdotdot"
 import LearningResourceIcon from "../LearningResourceIcon"
 
 type Props = {
@@ -54,7 +53,7 @@ export default function SearchFacetItem(props: Props) {
               : "facet-key"
           }
         >
-          <Dotdotdot clamp={1}>{labelText}</Dotdotdot>
+          {labelText}
         </div>
         {featuredFacetNames.includes(name) ? (
           <div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
<img width="1003" alt="Screen Shot 2022-07-28 at 12 20 02 PM" src="https://user-images.githubusercontent.com/1934992/181598042-6ffc05a5-c02e-45af-b49d-df3de7b1a1fa.png">
<img width="283" alt="Screen Shot 2022-07-28 at 1 14 24 PM" src="https://user-images.githubusercontent.com/1934992/181598046-cbeb58c4-2d86-494d-8658-30c85da7cd13.png">

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
None

#### What's this PR do?
Upgrading react-dotdotdot broke using react-dotdotdot to clamp to a single line. This is easily done with css instead

#### How should this be manually tested?
Go to learn/search. You should see facet labels and facet labels that are too long to fit on one line should be truncated. If you don't have any resources with facet labels which are too long to fit on one line, you can create some by running backpopulate_podcast_data
