### PR TITLE
Fix styling conflicts: remove some classless tag selectors

### DIFF
--- a/frontends/infinite-corridor/src/pages/admin/EditFieldAppearanceForm.tsx
+++ b/frontends/infinite-corridor/src/pages/admin/EditFieldAppearanceForm.tsx
@@ -57,6 +57,7 @@ const EditFieldAppearanceForm = (props: FormProps): JSX.Element => {
                 </label>
                 <Field
                   id="field-title"
+                  className="form-field"
                   name="title"
                   type="text"
                   value={values.title}
@@ -74,6 +75,7 @@ const EditFieldAppearanceForm = (props: FormProps): JSX.Element => {
               <Field
                 id="field-description"
                 name="public_description"
+                className="form-field"
                 as="textarea"
                 value={values.public_description}
               />

--- a/frontends/infinite-corridor/src/scss/combined.scss
+++ b/frontends/infinite-corridor/src/scss/combined.scss
@@ -1,5 +1,3 @@
-@use "material-components-web/dist/material-components-web";
-
 @use "theme";
 @use "button" with ( $color: theme.$color-primary );
 @use "main-search";

--- a/frontends/infinite-corridor/src/scss/form.scss
+++ b/frontends/infinite-corridor/src/scss/form.scss
@@ -1,9 +1,15 @@
 @use "theme";
 
+$fontColor: theme.$font-black;
+$fontColorLight: theme.$font-grey-light;
+
+$radius: theme.$std-border-radius;
+$borderColor: theme.$input-border-grey;
+
 .form {
   .form-item {
     margin: 0 0 28px 0;
-    color: theme.$font-black;
+    color: $fontColor;
 
     .label,
     .input {
@@ -15,8 +21,8 @@
     background: #f8f8f8;
     border: 1px solid #bbb;
     font-size: 15px;
-    color: rgba(0, 0, 0, 0.87);
-    border-radius: theme.$std-border-radius;
+    color: $fontColor;
+    border-radius: $radius;
     height: 39px;
     /* If you add too much padding here, the options won't show in IE */
     padding: 8px 20px;
@@ -38,77 +44,83 @@
 
 .form-field {
   margin: 0 0 28px 0;
-  color: rgba(0, 0, 0, 0.87);
-}
-
-.profile-name {
-  height: 110px;
-  width: 100%;
-  margin: 20px 0px 0px 30px;
-  vertical-align: middle;
-}
-
-.bottom-label {
-  margin: 5px 0px 0px 10px;
-  font-size: 11px;
-  color: theme.$font-grey-light;
+  color: $fontColor;
 }
 
 input[type="email"],
 input[type="text"],
 input[type="url"],
 input[type="password"] {
-  width: 100%;
-  padding: 10px 10px;
-  font-size: 15px;
-  border-radius: theme.$std-border-radius;
-  border: 1px solid theme.$input-border-grey;
-  transition: width 0.4s ease-in-out;
-  box-sizing: border-box;
-
-  &:disabled {
-    background: #f7f7f7;
-    border-color: #ccc;
+  &.form-field {
+    width: 100%;
+    padding: 10px 10px;
+    font-size: 15px;
+    border-radius: $radius;
+    border: 1px solid $borderColor;
+    transition: width 0.4s ease-in-out;
+    box-sizing: border-box;
+  
+    &:disabled {
+      background: #f7f7f7;
+      border-color: #ccc;
+    }
   }
 }
 
 textarea,
 input[type="text"] {
-  width: 100%;
-  padding: 12px 10px;
-  box-sizing: border-box;
-  border-radius: theme.$std-border-radius;
-  border: 1px solid theme.$input-border-grey;
-  background-color: #fff;
-  resize: auto;
-  font-size: 15px;
-  font-family: inherit;
-
-  &.no-height {
-    height: auto;
-  }
-
-  &.underlined {
-    border-radius: 6.5px 6.5px 0 0;
-    border-bottom: 2px solid black;
-    border-top: none;
-    border-left: none;
-    border-right: none;
-  }
-
-  &.h1 {
-    font-size: 24px;
-    font-weight: bold;
-    border: none;
-    outline: none;
+  &.form-field {
+    width: 100%;
+    padding: 12px 10px;
+    box-sizing: border-box;
+    border-radius: theme.$std-border-radius;
+    border: 1px solid theme.$input-border-grey;
+    background-color: #fff;
+    resize: auto;
+    font-size: 15px;
+    font-family: inherit;
+  
+    &.no-height {
+      height: auto;
+    }
+  
+    &.underlined {
+      border-radius: 6.5px 6.5px 0 0;
+      border-bottom: 2px solid black;
+      border-top: none;
+      border-left: none;
+      border-right: none;
+    }
+  
+    &.h1 {
+      font-size: 24px;
+      font-weight: bold;
+      border: none;
+      outline: none;
+    }
   }
 }
 
-textarea {
+input[type="checkbox"],
+input[type="radio"] {
+  &.form-field {
+    box-sizing: border-box;
+    font-size: 16px;
+  }
+}
+
+input::placeholder,
+textarea::placeholder {
+  &.form-field {
+    color: #bbb;
+  }
+}
+
+textarea.form-field {
   height: 110px;
 }
 
-label {
+label.form-label {
   display: block;
   margin: 0 0 6px 0;
   font-family: roboto, helvetica, arial, sans-serif;
@@ -127,35 +139,6 @@ label.radiolabel {
   font-family: roboto, helvetica, arial, sans-serif;
   font-weight: 400;
   font-size: 16px;
-}
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
-  font-size: 16px;
-}
-
-.mdc-checkbox::before,
-.mdc-checkbox::after {
-  background-color: theme.$navy;
-}
-
-.mdc-checkbox__background {
-  background-color: theme.$navy !important;
-  border-color: theme.$navy !important;
-}
-
-input::placeholder,
-textarea::placeholder {
-  color: #bbb;
-}
-
-.validationerror {
-  display: none;
-  background: #ffe8ec;
-  color: #f15a74;
-  padding: 8px;
-  font-size: 15px;
 }
 
 .actions {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3672 

#### What's this PR do?
(Required)

#### How should this be manually tested?
Check that these all look reasonable:
- [ ] homepage http://cac.od.odl.local:8063/infinite/
- [ ] field pagehttp://cac.od.odl.local:8063/infinite/fields/puppies/
- [ ] field management http://cac.od.odl.local:8063/infinite/fields/puppies/manage
- [ ] _Check the searchpage, too, but it is not very styled yet._


#### Any background context you want to provide?
The cause of this issue was CSS selectors targeting elements without classes, things like:
```css
input[type="text"] {
  border: 1px solid red;
}
```
Which applies a border to all text inputs. This CSS also has reasonably height specificity (element + attribute type; that's more specific than a single class). The fact that this is more specific than a single class makes it reasonably likely to conflict with external libraries that do (some) styling on their own.

And it does, for example, this turns our MUI searchbar input into:
<img width="796" alt="Screen Shot 2022-08-03 at 12 29 55 PM" src="https://user-images.githubusercontent.com/9010790/182678166-cfa89165-6f59-4fba-9b5d-2a8eaa81aa5c.png">
(note: MUI's input + adornments, e.g., buttons / icons, is not actually a single input field).

Anyway.... This PR makes the form-related CSS selectors apply only to fields with class `.form-field` 

### Screenshots

**Before**:
<img width="1000" alt="Screen Shot 2022-08-03 at 1 38 23 PM" src="https://user-images.githubusercontent.com/9010790/182678715-2310e31b-8d2c-466c-a89a-caa23aa1a984.png">

**Afer**:
<img width="1000" alt="Screen Shot 2022-08-03 at 2 09 19 PM" src="https://user-images.githubusercontent.com/9010790/182678824-6b84954c-06ed-472a-b84c-6e513b03edaa.png">

