### PR TITLE
Fix open discussions channel header issue

### DIFF
--- a/frontends/ol-util/src/components/PageBanner.tsx
+++ b/frontends/ol-util/src/components/PageBanner.tsx
@@ -48,9 +48,13 @@ const imageWrapperHeight = css<ImgProps>`
   }
 `
 
+/**
+ * Prefer direct use of `BannerPage` component.
+ */
 const BannerContainer = styled.div`
   position: absolute;
   width: 100%;
+  z-index: -1;
 `
 
 const imageStylesheet = `
@@ -70,6 +74,9 @@ const PlaceholderDiv = styled.div`
   ${imageWrapperHeight}
 `
 
+/**
+ * Prefer direct use of `BannerPage` component.
+ */
 const BannerImage = ({ src, alt, tall, compactOnMobile }: ImgProps) =>
   src ? (
     <StyledImage
@@ -82,11 +89,17 @@ const BannerImage = ({ src, alt, tall, compactOnMobile }: ImgProps) =>
     <PlaceholderDiv />
   )
 
+/**
+ * Prefer direct use of `BannerPage` component.
+ */
 const BannerPageWrapper = styled.div`
   position: relative;
   width: 100%;
 `
 
+/**
+ * Prefer direct use of `BannerPage` component.
+ */
 const BannerPageHeader = styled.header`
   ${imageWrapperHeight};
 `
@@ -111,35 +124,45 @@ interface BannerPageProps extends ImgProps {
    * Child elements placed below the banner.
    */
   children?: React.ReactNode
+  /**
+   * Child elements within the banner.
+   *
+   * By default, the banner content will be vertically centered. Customize this
+   * behavior with `bannerContainerClass`.
+   */
   bannerContent?: React.ReactNode
+  bannerContainerClass?: string
 }
 
-const BannerContent = styled.div`
-  /*
-  The goal here is to provide a container in which to insert extra content into
-  the banner area. The container should be full width and height of the banner,
-  which makes controlling styling on the consumer side easy.
-  */
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+const BannerPageHeaderFlex = styled.header`
+  ${imageWrapperHeight};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `
 
+/**
+ * Layout a page with a banner at top and content below. Supports optional
+ * content with the banner.
+ */
 const BannerPage: React.FC<BannerPageProps> = ({
   className,
   src,
   tall,
   compactOnMobile,
   bannerContent,
+  bannerContainerClass,
   alt,
   children,
   omitBackground
 }) => {
   return (
     <BannerPageWrapper className={className}>
-      <BannerPageHeader tall={tall} compactOnMobile={compactOnMobile}>
+      <BannerPageHeaderFlex
+        tall={tall}
+        compactOnMobile={compactOnMobile}
+        className={bannerContainerClass}
+      >
         <BannerContainer>
           {!omitBackground && (
             <BannerImage
@@ -149,9 +172,9 @@ const BannerPage: React.FC<BannerPageProps> = ({
               compactOnMobile={compactOnMobile}
             />
           )}
-          <BannerContent>{bannerContent}</BannerContent>
         </BannerContainer>
-      </BannerPageHeader>
+        {bannerContent}
+      </BannerPageHeaderFlex>
       {children}
     </BannerPageWrapper>
   )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/open-discussions/issues/3675

#### What's this PR do?
This PR restores the original `z-index: -1` that was in `BannerContainer`, and updates `PageBanner` (which is only used in infinite-corridor) to achieve the goal of that change in a different way.

#### How should this be manually tested?
- check that channel titles are visible in open-discussions (not infinite-corridor)
- check that the searchbar at http://cac.od.odl.local:8063/learn has an "Explore" button below it
- Check that http://cac.od.odl.local:8063/infinite/fields/your_file_name has a title and that its text can be selected

