### PR TITLE
Cc/styling 2

### DIFF
--- a/frontends/infinite-corridor/src/pages/FieldPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/FieldPage.test.tsx
@@ -112,8 +112,8 @@ describe("FieldPage", () => {
 
     // Basic carousel check
     expect(spyTitledCarousel).toHaveBeenCalled()
-    const prev = within(section).getByTitle("Show previous courses")
-    const next = within(section).getByTitle("Show next courses")
+    const prev = within(section).getByText("Previous")
+    const next = within(section).getByText("Next")
     expect(prev).toBeInstanceOf(HTMLButtonElement)
     expect(next).toBeInstanceOf(HTMLButtonElement)
   })

--- a/frontends/infinite-corridor/src/pages/FieldPage.tsx
+++ b/frontends/infinite-corridor/src/pages/FieldPage.tsx
@@ -13,9 +13,8 @@ import { TitledCarousel } from "ol-util"
 import { useFieldDetails, useFieldListItems, UserList } from "../api/fields"
 import { Link } from "react-router-dom"
 import FieldPageSkeleton from "./FieldPageSkeleton"
-import IconButton from "@mui/material/IconButton"
-import NavigateNextIcon from "@mui/icons-material/NavigateNext"
-import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore"
+import ArrowForward from "@mui/icons-material/ArrowForward"
+import ArrowBack from "@mui/icons-material/ArrowBack"
 import { imgConfigs } from "../util/constants"
 
 type RouteParams = {
@@ -66,17 +65,20 @@ const FieldCarousel: React.FC<FieldListProps> = ({ list }) => {
       cellSpacing={0} // we'll handle it with css
       title={<h3>{list.title}</h3>}
       previous={
-        <IconButton
-          title="Show previous courses"
-          className="ic-carousel-button"
+        <button
+          type="button"
+          className="ic-carousel-button outlined-button"
         >
-          <NavigateBeforeIcon />
-        </IconButton>
+          <ArrowBack fontSize="inherit" /> Previous
+        </button>
       }
       next={
-        <IconButton title="Show next courses" className="ic-carousel-button">
-          <NavigateNextIcon />
-        </IconButton>
+        <button
+          type="button"
+          className="ic-carousel-button outlined-button"
+        >
+          Next <ArrowForward fontSize="inherit" />
+        </button>
       }
     >
       {items.map(item => (

--- a/frontends/infinite-corridor/src/pages/FieldPage.tsx
+++ b/frontends/infinite-corridor/src/pages/FieldPage.tsx
@@ -61,16 +61,23 @@ const FieldCarousel: React.FC<FieldListProps> = ({ list }) => {
     <TitledCarousel
       as="section"
       carouselClassName="ic-carousel"
+      headerClassName="ic-carousel-header"
       pageSize={pageSize}
       cellSpacing={0} // we'll handle it with css
       title={<h3>{list.title}</h3>}
       previous={
-        <button type="button" className="ic-carousel-button outlined-button">
+        <button
+          type="button"
+          className="ic-carousel-button-prev outlined-button"
+        >
           <ArrowBack fontSize="inherit" /> Previous
         </button>
       }
       next={
-        <button type="button" className="ic-carousel-button outlined-button">
+        <button
+          type="button"
+          className="ic-carousel-button-next outlined-button"
+        >
           Next <ArrowForward fontSize="inherit" />
         </button>
       }

--- a/frontends/infinite-corridor/src/pages/FieldPage.tsx
+++ b/frontends/infinite-corridor/src/pages/FieldPage.tsx
@@ -65,18 +65,12 @@ const FieldCarousel: React.FC<FieldListProps> = ({ list }) => {
       cellSpacing={0} // we'll handle it with css
       title={<h3>{list.title}</h3>}
       previous={
-        <button
-          type="button"
-          className="ic-carousel-button outlined-button"
-        >
+        <button type="button" className="ic-carousel-button outlined-button">
           <ArrowBack fontSize="inherit" /> Previous
         </button>
       }
       next={
-        <button
-          type="button"
-          className="ic-carousel-button outlined-button"
-        >
+        <button type="button" className="ic-carousel-button outlined-button">
           Next <ArrowForward fontSize="inherit" />
         </button>
       }

--- a/frontends/infinite-corridor/src/scss/buttons.scss
+++ b/frontends/infinite-corridor/src/scss/buttons.scss
@@ -1,0 +1,22 @@
+@use "sass:color";
+@use "theme";
+
+.outlined-button {
+  border-radius: theme.$border-radius;
+  border-width: 1px;
+  background-color: rgba(0,0,0,0);
+  display: flex;
+  flex-direction:row;
+  justify-content: center;
+  align-items: center;
+  &:not([disabled]) {
+    color: theme.$font-color-default;
+    border-color: theme.$font-color-default;
+    &:hover {
+      background-color: color.adjust(theme.$font-color-default, $alpha: -0.9);
+    }
+    &:active {
+      background-color: color.adjust(theme.$font-color-default, $alpha: -0.95);
+    }
+  }
+}

--- a/frontends/infinite-corridor/src/scss/buttons.scss
+++ b/frontends/infinite-corridor/src/scss/buttons.scss
@@ -1,6 +1,10 @@
 @use "sass:color";
 @use "theme";
 
+%button-cursor:not([disabled]) {
+  cursor: pointer;
+}
+
 .outlined-button {
   border-radius: theme.$border-radius;
   border-width: 1px;
@@ -9,14 +13,9 @@
   flex-direction:row;
   justify-content: center;
   align-items: center;
+  @extend %button-cursor;
   &:not([disabled]) {
     color: theme.$font-color-default;
     border-color: theme.$font-color-default;
-    &:hover {
-      background-color: color.adjust(theme.$font-color-default, $alpha: -0.9);
-    }
-    &:active {
-      background-color: color.adjust(theme.$font-color-default, $alpha: -0.95);
-    }
   }
 }

--- a/frontends/infinite-corridor/src/scss/combined.scss
+++ b/frontends/infinite-corridor/src/scss/combined.scss
@@ -8,6 +8,7 @@
 @use "searchpage";
 @use "form";
 @use "admin";
+@use "buttons";
 
 html {
   font-family: theme.$font-family-default;

--- a/frontends/infinite-corridor/src/scss/fieldpage.scss
+++ b/frontends/infinite-corridor/src/scss/fieldpage.scss
@@ -61,11 +61,13 @@ $carouselSpacing: 24px;
 
 .ic-carousel-button.MuiButtonBase-root {
   border: 0.125em solid currentcolor;
-  color: theme.$font-color-default;
   height: 1.25em;
   width: 1.25em;
   margin-left: 0.5em;
   margin-right: 0.5em;
+  &:not([disabled]) {
+    color: theme.$font-color-default;
+  }
 }
 
 $avatar-dimension-medium: 57px;

--- a/frontends/infinite-corridor/src/scss/fieldpage.scss
+++ b/frontends/infinite-corridor/src/scss/fieldpage.scss
@@ -59,15 +59,9 @@ $carouselSpacing: 24px;
   transform: translateX(-$carouselSpacing/2)
 }
 
-.ic-carousel-button.MuiButtonBase-root {
-  border: 0.125em solid currentcolor;
-  height: 1.25em;
-  width: 1.25em;
+.ic-carousel-button {
   margin-left: 0.5em;
   margin-right: 0.5em;
-  &:not([disabled]) {
-    color: theme.$font-color-default;
-  }
 }
 
 $avatar-dimension-medium: 57px;

--- a/frontends/infinite-corridor/src/scss/fieldpage.scss
+++ b/frontends/infinite-corridor/src/scss/fieldpage.scss
@@ -56,12 +56,27 @@ $carouselSpacing: 24px;
   Caveat: This is not a good solution if there is content within $carouselSpacing
   of the carousel's left edge. But...there's not.
   */
-  transform: translateX(-$carouselSpacing/2)
+  transform: translateX(-$carouselSpacing/2);
+  /*
+  We also want the carousel contents (cards) to appear as if they are full
+  width. By default, the width is 100% and since there's cell-spacing, the
+  right-most card does not line up with the right-hand margin, it's short by 
+  half the spacing.
+
+  But since we also translated the contents leftwards (see above) we're actually
+  off by a full cellSpacing.
+
+  This needs to be !important because Nuke Carousel applies width: 100% as an
+  inline style.
+  */
+  width: calc(100% + #{$carouselSpacing}) !important;
 }
 
-.ic-carousel-button {
-  margin-left: 0.5em;
+.ic-carousel-button-prev {
   margin-right: 0.5em;
+}
+.ic-carousel-button-next {
+  margin-left: 0.5em;
 }
 
 $avatar-dimension-medium: 57px;

--- a/frontends/infinite-corridor/src/scss/learning-resources.scss
+++ b/frontends/infinite-corridor/src/scss/learning-resources.scss
@@ -9,7 +9,7 @@ $cardListSpacer: 1.5em;
 
 .ic-resource-card {
   &.MuiCard-root {
-    color: theme.$color-gray-5;
+    color: theme.$font-color-default;
 
     transition-duration: theme.$transition-duration;
     transition-property: box-shadow;

--- a/frontends/ol-search-ui/assets/learning-resource-card.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-card.scss
@@ -43,7 +43,16 @@ $smallFontSize: 0.75em !default;
       margin-top: 0; 
     }
     &:last-child {
-      margin-bottom: 0; 
+      margin-bottom: 0;
+      /*
+      Last child of ol-lrc-content will take up any extra space (flex: 1) but
+      with its contents at the bottom of its box.
+      */
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-start; // The default is stretch, we we do not want.
     }
   }
 }
@@ -68,9 +77,6 @@ $smallFontSize: 0.75em !default;
   padding-right: 0.25em;
 }
 
-.ol-lrc-title-box {
-  flex: 1;
-}
 .ol-lrc-title {
   font-weight: $boldWeight;
   margin:0;

--- a/frontends/ol-search-ui/assets/learning-resource-card.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-card.scss
@@ -1,6 +1,6 @@
 $lightText: #8c8c8c !default;
 $spacer: 0.75rem !default;
-$boldWeight: 500 !default;
+$boldWeight: bold !default;
 $smallFontSize: 0.75em !default;
 
 .ol-lrc-root {

--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -121,11 +121,9 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
           </span>
           {hasCertificate && <CertificateIcon />}
         </div>
-        <div className="ol-lrc-title-box">
-          <Dotdotdot className="ol-lrc-title" tagName="h3" clamp={3}>
-            {resource.title}
-          </Dotdotdot>
-        </div>
+        <Dotdotdot className="ol-lrc-title" tagName="h3" clamp={3}>
+          {resource.title}
+        </Dotdotdot>
         <div>
           <span className="ol-lrc-offered-by">Offered by &ndash;</span>
           {offerers.length && <Offerers offerers={offerers} />}

--- a/frontends/ol-util/src/components/TitledCarousel.tsx
+++ b/frontends/ol-util/src/components/TitledCarousel.tsx
@@ -39,6 +39,12 @@ const HeaderContainer = styled.div`
   align-items: center;
 `
 
+const ButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
 const defaultAnimationDuration = 800
 
 const TitledCarousel: React.FC<TitledCarouselProps> = ({
@@ -82,7 +88,7 @@ const TitledCarousel: React.FC<TitledCarouselProps> = ({
     <ContainerComponent className={className}>
       <HeaderContainer>
         {title}
-        <div>
+        <ButtonsContainer>
           {React.cloneElement(previous, {
             disabled: !canPageDown,
             onClick:  pageDown
@@ -91,7 +97,7 @@ const TitledCarousel: React.FC<TitledCarouselProps> = ({
             disabled: !canPageUp,
             onClick:  pageUp
           })}
-        </div>
+        </ButtonsContainer>
       </HeaderContainer>
       <Carousel
         slideIndex={index}

--- a/frontends/ol-util/src/components/TitledCarousel.tsx
+++ b/frontends/ol-util/src/components/TitledCarousel.tsx
@@ -10,6 +10,7 @@ type TitledCarouselProps = {
   as?: ElementType
   className?: string
   carouselClassName?: string
+  headerClassName?: string
   pageSize: number
   /**
    * Animation duration in milliseconds.
@@ -52,6 +53,7 @@ const TitledCarousel: React.FC<TitledCarouselProps> = ({
   title,
   className,
   carouselClassName,
+  headerClassName,
   pageSize,
   cellSpacing,
   animationDuration = defaultAnimationDuration,
@@ -86,7 +88,7 @@ const TitledCarousel: React.FC<TitledCarouselProps> = ({
 
   return (
     <ContainerComponent className={className}>
-      <HeaderContainer>
+      <HeaderContainer className={headerClassName}>
         {title}
         <ButtonsContainer>
           {React.cloneElement(previous, {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested _These changes are all styling / layout, and could probably only be tested in e2e tests with screenshots_
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3672 

#### What's this PR do?
A few more styling updates to infinite corridor

#### How should this be manually tested?
On field pages, check that the vertical cards still load and the carousel buttons work, and that the screenshots I posted look accurate.

#### Screenshots (if appropriate)

<img width="976" alt="Screen Shot 2022-08-15 at 11 53 10 AM" src="https://user-images.githubusercontent.com/9010790/184669965-baaa7c51-b207-498c-85ce-69555b260aeb.png">

Mobile:

<img width="406" alt="Screen Shot 2022-08-15 at 11 57 11 AM" src="https://user-images.githubusercontent.com/9010790/184670471-33d75322-50b9-444f-80a2-656206cbfe7f.png">



@Ferdi These are the changes we talked about before I went on leave... I didn't quite finish them that afternoon. Also an improvement to carousel alignment that I noticed...buttons and right-hand card now line up better with right-hand margin (but without clipping shadows like /learn does.)