### PR TITLE
FieldChannel banner menu dropdown

### DIFF
--- a/frontends/infinite-corridor/src/components/FieldMenu.test.tsx
+++ b/frontends/infinite-corridor/src/components/FieldMenu.test.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { BrowserRouter } from "react-router-dom"
+import { render, screen } from "@testing-library/react"
+
+import { urls } from "../api/fields"
+import * as factories from "../api/fields/factories"
+import { setMockResponse, user } from "../test-utils"
+import FieldMenu from "./FieldMenu"
+
+describe("FieldMenu", () => {
+  it("Includes a link to the FieldChannel edit page", async () => {
+    const field = factories.makeField()
+    setMockResponse.get(urls.fieldDetails(field.name), field)
+    render(
+      <BrowserRouter>
+        <FieldMenu field={field} />
+      </BrowserRouter>
+    )
+    const dropdown = await screen.findByText("settings")
+    await user.click(dropdown)
+    const link = (await screen.findByRole("link")) as HTMLLinkElement
+    expect(link.href).toContain(`/infinite/fields/${field.name}/manage/`)
+  })
+})

--- a/frontends/infinite-corridor/src/components/FieldMenu.test.tsx
+++ b/frontends/infinite-corridor/src/components/FieldMenu.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { BrowserRouter } from "react-router-dom"
+import { Router } from "react-router"
+import { createMemoryHistory } from "history"
 import { render, screen } from "@testing-library/react"
 
 import { urls } from "../api/fields"
@@ -11,10 +12,11 @@ describe("FieldMenu", () => {
   it("Includes a link to the FieldChannel edit page", async () => {
     const field = factories.makeField()
     setMockResponse.get(urls.fieldDetails(field.name), field)
+    const history = createMemoryHistory()
     render(
-      <BrowserRouter>
+      <Router history={history}>
         <FieldMenu field={field} />
-      </BrowserRouter>
+      </Router>
     )
     const dropdown = await screen.findByText("settings")
     await user.click(dropdown)

--- a/frontends/infinite-corridor/src/components/FieldMenu.tsx
+++ b/frontends/infinite-corridor/src/components/FieldMenu.tsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import { Link } from "react-router-dom"
+import { Menu } from "@mui/material"
+import MenuItem from "@mui/material/MenuItem"
+
+import { FieldChannel } from "../api/fields"
+import { makeFieldEditPath } from "../pages/urls"
+
+type SettingsMenuProps = {
+  field: FieldChannel
+}
+
+const FieldMenu: React.FC<SettingsMenuProps> = props => {
+  const { field } = props
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  return field ? (
+    <div>
+      <a onClick={handleClick} className="field-edit-button">
+        <i className="material-icons settings">settings</i>
+      </a>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <MenuItem onClick={handleClose} disableRipple>
+          <Link to={makeFieldEditPath(field.name)}>Field Settings</Link>
+        </MenuItem>
+      </Menu>
+    </div>
+  ) : null
+}
+
+export default FieldMenu

--- a/frontends/infinite-corridor/src/pages/FieldPageSkeleton.tsx
+++ b/frontends/infinite-corridor/src/pages/FieldPageSkeleton.tsx
@@ -5,6 +5,7 @@ import { BannerPage } from "ol-util"
 import Container from "@mui/material/Container"
 import { useFieldDetails } from "../api/fields"
 import FieldAvatar from "../components/FieldAvatar"
+import FieldMenu from "../components/FieldMenu"
 
 interface FieldSkeletonProps {
   children: React.ReactNode
@@ -39,6 +40,11 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
                     {field.data.title}
                   </Link>
                 </h1>
+                <div className="field-controls">
+                  {field.data?.is_moderator ? (
+                    <FieldMenu field={field.data} />
+                  ) : null}
+                </div>
               </>
             )}
           </div>

--- a/frontends/infinite-corridor/src/pages/urls.ts
+++ b/frontends/infinite-corridor/src/pages/urls.ts
@@ -8,5 +8,6 @@ export const FIELD_VIEW = `${BASE}/fields/:name/` as const
 export const FIELD_EDIT = `${BASE}/fields/:name/manage/` as const
 export const makeFieldViewPath = (name: string) =>
   generatePath(FIELD_VIEW, { name })
-
+export const makeFieldEditPath = (name: string) =>
+  generatePath(FIELD_EDIT, { name })
 export const SEARCH = `${BASE}/search`

--- a/frontends/infinite-corridor/src/scss/fieldpage.scss
+++ b/frontends/infinite-corridor/src/scss/fieldpage.scss
@@ -156,3 +156,23 @@ $minTabHeigt: 44px;
     padding-top: 0px;
   }
 }
+
+
+.field-controls {
+    position: relative;
+    flex-grow: 0.95;
+    justify-content: flex-end;
+    min-height: 38px;
+    display: flex;
+    align-items: center;
+
+    .field-edit-button {
+      cursor: pointer;
+      color: #fff;
+    }
+}
+
+.field-edit-button {
+  z-index: 2000;
+  color: #fff;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3686 

#### What's this PR do?
Adds a dropdown menu in the field banner with a link to the edit page.

#### How should this be manually tested?
- Go to any field page logged in as a staff user.  There should be a gear icon on the right side of the banner.  Click on it and you should see a dropdown with an 'Edit Field' link.  Click on that and you should end up on the edit page for the field.
- Go to the same edit page logged in as a normal user or anonymously.  The gear icon should not be visible.

#### Screenshots (if appropriate)

<img width="642" alt="Screen Shot 2022-08-15 at 10 58 04 AM" src="https://user-images.githubusercontent.com/187676/184661763-793b434d-3836-457e-8767-0b9bb3176694.png">

--------------

<img width="636" alt="Screen Shot 2022-08-15 at 10 58 11 AM" src="https://user-images.githubusercontent.com/187676/184661823-1c0b1cf6-d272-409f-ad20-1d19bfa9dfbf.png">

