### PR TITLE
Handle non-numerical status codes from elasticsearch

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -27,7 +27,7 @@ class ESView(APIView):
 
     def handle_exception(self, exc):
         if isinstance(exc, TransportError):
-            if 400 <= exc.status_code < 500:
+            if isinstance(exc.status_code, int) and 400 <= exc.status_code < 500:
                 log.exception("Received a 4xx error from Elasticsearch")
                 return Response(status=exc.status_code)
         raise exc


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes #3690 

#### What's this PR do?
Handles non-numerical status codes returned from Elasticsearch transport errors

#### How should this be manually tested?
Tests should pass
