### PR TITLE
Cc/url widget

### DIFF
--- a/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.tsx
@@ -73,7 +73,7 @@ const EditFieldBasicForm = (props: FormProps): JSX.Element => {
         setFieldValue
       }) => (
         <>
-          <Form onSubmit={handleSubmit} className="form channel-form">
+          <Form onSubmit={handleSubmit} className="channel-form">
             <div className="row form-item">
               <label htmlFor="field-featured_list">
                 <div className="header-padded">Featured learning resources</div>

--- a/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.tsx
@@ -73,7 +73,7 @@ const EditFieldBasicForm = (props: FormProps): JSX.Element => {
         setFieldValue
       }) => (
         <>
-          <Form onSubmit={handleSubmit} className="channel-form">
+          <Form onSubmit={handleSubmit} className="form channel-form">
             <div className="row form-item">
               <label htmlFor="field-featured_list">
                 <div className="header-padded">Featured learning resources</div>

--- a/frontends/infinite-corridor/src/pages/field-details/WidgetsList.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/WidgetsList.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from "react"
 import {
   Widget,
   WidgetsListEditable,
-  WidgetsListEditableProps
+  WidgetsListEditableProps,
+  WidgetDialogClasses
 } from "ol-widgets"
 import { useMutateWidgetsList, useWidgetList } from "../../api/widgets"
 
@@ -11,6 +12,15 @@ interface WidgetsListProps {
   widgetListId: number
   className?: string
   onFinishEditing?: () => void
+}
+
+const dialogClasses: WidgetDialogClasses = {
+  dialog:     "ic-widget-editing-dialog",
+  field:      "form-field",
+  error:      "validation-message",
+  label:      "field-label",
+  detail:     "field-detail",
+  fieldGroup: "form-item"
 }
 
 const WidgetsList: React.FC<WidgetsListProps> = ({
@@ -49,9 +59,7 @@ const WidgetsList: React.FC<WidgetsListProps> = ({
             onCancel={onCancel}
             headerClassName="ic-widget-editing-header"
             widgetClassName="ic-widget"
-            dialogClassName="ic-widget-editing-dialog"
-            fieldClassName="form-field"
-            errorClassName="validation-message"
+            dialogClasses={dialogClasses}
           />
         ) :
         widgets.map(widget => (

--- a/frontends/infinite-corridor/src/scss/form.scss
+++ b/frontends/infinite-corridor/src/scss/form.scss
@@ -6,7 +6,7 @@ $fontColorLight: theme.$font-color-light;
 $radius: theme.$std-border-radius;
 $borderColor: theme.$input-border-grey;
 
-.form {
+form, .form {
   .form-item {
     margin: 0 0 28px 0;
     color: $fontColor;
@@ -35,12 +35,13 @@ $borderColor: theme.$input-border-grey;
 
 }
 
-.form .row,
+form .row,
 .form-header .row {
   margin: 10px 10px 24px 0;
 }
 
 .validation-message {
+  margin-top: 6px;
   background-color: theme.$validation-bg;
   color: theme.$validation-text;
   font-size: 14px;
@@ -48,9 +49,17 @@ $borderColor: theme.$input-border-grey;
 }
 
 .form-field {
-  margin: 0 0 28px 0;
   color: $fontColor;
 }
+
+.field-label {
+  color: theme.$color-gray-4;
+}
+.field-detail {
+  color: theme.$color-gray-4;
+  font-size: theme.$font-size-small;
+}
+
 
 input[type="email"],
 input[type="text"],

--- a/frontends/ol-widgets/assets/widgets.scss
+++ b/frontends/ol-widgets/assets/widgets.scss
@@ -59,3 +59,7 @@ $dialogZIndex: 1300;
     margin-bottom: 0; // no extra space beyond the card padding.
   }
 }
+
+.ol-widget-url-preview {
+  max-width: 300px
+}

--- a/frontends/ol-widgets/package.json
+++ b/frontends/ol-widgets/package.json
@@ -20,12 +20,14 @@
     "@types/ckeditor__ckeditor5-core": "^33.0.3",
     "@types/ckeditor__ckeditor5-editor-classic": "^27.1.2",
     "@types/js-beautify": "^1.13.3",
+    "@types/validator": "^13.7.6",
     "classnames": "^2.3.1",
     "formik": "^2.2.9",
     "js-beautify": "^1.14.6",
     "ol-util": "workspace:*",
     "react-markdown": "^6.0.3",
     "remark-gfm": "^1.0.0",
+    "validator": "^13.7.0",
     "yup": "^0.32.11"
   },
   "peerDependencies": {

--- a/frontends/ol-widgets/src/components/EmbeddedUrlWidgetContent.tsx
+++ b/frontends/ol-widgets/src/components/EmbeddedUrlWidgetContent.tsx
@@ -1,0 +1,17 @@
+import classNames from "classnames"
+import React from "react"
+import type { EmbeddedUrlWidgetInstance } from "../interfaces"
+
+
+const RichTextWdigetContent: React.FC<{
+  className?: string
+  widget: Omit<EmbeddedUrlWidgetInstance, "id">
+}> = ({ widget, className }) => {
+  return (
+    <div className={className}>
+      {widget.configuration.url}
+    </div>
+  )
+}
+
+export default RichTextWdigetContent

--- a/frontends/ol-widgets/src/components/EmbeddedUrlWidgetContent.tsx
+++ b/frontends/ol-widgets/src/components/EmbeddedUrlWidgetContent.tsx
@@ -1,17 +1,12 @@
-import classNames from "classnames"
 import React from "react"
 import type { EmbeddedUrlWidgetInstance } from "../interfaces"
-
+import { EmbedlyCard } from "./embedly"
 
 const RichTextWdigetContent: React.FC<{
   className?: string
   widget: Omit<EmbeddedUrlWidgetInstance, "id">
 }> = ({ widget, className }) => {
-  return (
-    <div className={className}>
-      {widget.configuration.url}
-    </div>
-  )
+  return <EmbedlyCard url={widget.configuration.url} className={className} />
 }
 
 export default RichTextWdigetContent

--- a/frontends/ol-widgets/src/components/Widget-EmbeddedUrl.test.tsx
+++ b/frontends/ol-widgets/src/components/Widget-EmbeddedUrl.test.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { faker } from "@faker-js/faker"
+import { render } from "@testing-library/react"
+import Widget from "./Widget"
+import { makeEmbeddedUrlWidget } from "../factories"
+import { EmbedlyCard } from "./embedly"
+
+jest.mock("./embedly", () => {
+  const actual = jest.requireActual("./embedly")
+  return {
+    __esModule:  true,
+    ...actual,
+    EmbedlyCard: jest.fn(actual.EmbedlyCard)
+  }
+})
+const spyEmbedlyCard = jest.mocked(EmbedlyCard)
+
+describe("Widget-EmbeddedUrl", () => {
+  test("it renderes <EmbedlyCard /> when url is set", () => {
+    const url = new URL(faker.internet.url()).toString()
+    const widget = makeEmbeddedUrlWidget({ configuration: { url } })
+    render(<Widget widget={widget} />)
+    expect(spyEmbedlyCard).toHaveBeenCalledWith(
+      expect.objectContaining({ url }),
+      expect.anything()
+    )
+  })
+})

--- a/frontends/ol-widgets/src/components/Widget-RichText.test.tsx
+++ b/frontends/ol-widgets/src/components/Widget-RichText.test.tsx
@@ -1,27 +1,12 @@
 /* eslint-disable testing-library/no-node-access */
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render } from "@testing-library/react"
 import Widget from "./Widget"
 import { makeRichTextWidget } from "../factories"
 import { html_beautify as htmlBeautify } from "js-beautify"
 import { assertInstanceOf } from "ol-util"
 
 describe("Widget-RichText", () => {
-  test("it accepts classes", () => {
-    const widget = makeRichTextWidget()
-    const { container } = render(
-      <Widget className="some-class other-class" widget={widget} />
-    )
-    expect(container.firstChild).toHaveClass("some-class")
-    expect(container.firstChild).toHaveClass("other-class")
-  })
-
-  test("it renders title classes", () => {
-    const widget = makeRichTextWidget()
-    render(<Widget widget={widget} />)
-    expect(screen.getByRole("heading")).toHaveTextContent(widget.title)
-  })
-
   test("it renders markdown as expected", () => {
     const md = `
 Let's try some markdown. Here is an unordered list:

--- a/frontends/ol-widgets/src/components/Widget.test.tsx
+++ b/frontends/ol-widgets/src/components/Widget.test.tsx
@@ -2,12 +2,37 @@ import React from "react"
 import { render, screen } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import Widget, { btnLabel } from "./Widget"
-import { makeRichTextWidget, makeWidget } from "../factories"
+import {
+  makeEmbeddedUrlWidget,
+  makeRichTextWidget,
+  makeWidget
+} from "../factories"
 
 const queryBtn = (name: string) => screen.queryByRole("button", { name })
 const getBtn = (name: string) => screen.getByRole("button", { name })
 
 describe("Widgets", () => {
+  test.each([
+    { widget: makeEmbeddedUrlWidget() },
+    { widget: makeRichTextWidget() }
+  ])("the widgets accept classes", ({ widget }) => {
+    const { container } = render(
+      <Widget className="some-class other-class" widget={widget} />
+    )
+    // eslint-disable-next-line testing-library/no-node-access
+    const widgetEl = container.firstChild
+    expect(widgetEl).toHaveClass("some-class")
+    expect(widgetEl).toHaveClass("other-class")
+  })
+
+  test.each([
+    { widget: makeEmbeddedUrlWidget() },
+    { widget: makeRichTextWidget() }
+  ])("the widgets render their titles", ({ widget }) => {
+    render(<Widget widget={widget} />)
+    expect(screen.getByRole("heading")).toHaveTextContent(widget.title)
+  })
+
   test.each([
     { isEditing: false },
     { isEditing: undefined },

--- a/frontends/ol-widgets/src/components/Widget.tsx
+++ b/frontends/ol-widgets/src/components/Widget.tsx
@@ -10,7 +10,11 @@ import IconDrag from "@mui/icons-material/DragHandle"
 import IconExpand from "@mui/icons-material/ExpandMore"
 import IconCollapse from "@mui/icons-material/ExpandLess"
 
-import type { AnonymousWidget, EmbeddedUrlWidgetInstance, RichTextWidgetInstance } from "../interfaces"
+import type {
+  AnonymousWidget,
+  EmbeddedUrlWidgetInstance,
+  RichTextWidgetInstance
+} from "../interfaces"
 import { WidgetTypes } from "../interfaces"
 import RichTextWdigetContent from "./RichTextWidgetContent"
 import EmbeddedUrlWidgetContent from "./EmbeddedUrlWidgetContent"

--- a/frontends/ol-widgets/src/components/Widget.tsx
+++ b/frontends/ol-widgets/src/components/Widget.tsx
@@ -10,9 +10,10 @@ import IconDrag from "@mui/icons-material/DragHandle"
 import IconExpand from "@mui/icons-material/ExpandMore"
 import IconCollapse from "@mui/icons-material/ExpandLess"
 
-import type { AnonymousWidget, RichTextWidgetInstance } from "../interfaces"
+import type { AnonymousWidget, EmbeddedUrlWidgetInstance, RichTextWidgetInstance } from "../interfaces"
 import { WidgetTypes } from "../interfaces"
 import RichTextWdigetContent from "./RichTextWidgetContent"
+import EmbeddedUrlWidgetContent from "./EmbeddedUrlWidgetContent"
 
 /**
  * Button labels for Widgets.
@@ -138,6 +139,14 @@ const WidgetContent: React.FC<WidgetContentProps> = ({ className, widget }) => {
     return (
       <RichTextWdigetContent
         {...(props as WidgetContentProps<RichTextWidgetInstance>)}
+      />
+    )
+  }
+
+  if (widget.widget_type === WidgetTypes.EmbeddedUrl) {
+    return (
+      <EmbeddedUrlWidgetContent
+        {...(props as WidgetContentProps<EmbeddedUrlWidgetInstance>)}
       />
     )
   }

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog-EmbeddedUrl.test.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog-EmbeddedUrl.test.tsx
@@ -1,0 +1,129 @@
+import React from "react"
+import { screen, render } from "@testing-library/react"
+import user from "@testing-library/user-event"
+import { assertInstanceOf, assertNotNil } from "ol-util"
+import {
+  makeEmbeddedUrlWidgetSpec,
+  makeEmbeddedUrlWidget
+} from "../../factories"
+import ManageWidgetDialog from "./ManageWidgetDialog"
+import { WIDGET_FIELD_TYPES } from "../../constants"
+import { EmbedlyCard } from "../embedly"
+import { EmbeddedUrlWidgetInstance } from "../../interfaces"
+
+const getErrorFor = (el: HTMLElement) => {
+  const errId = el.getAttribute("aria-errormessage")
+  if (errId === null) {
+    throw new Error(
+      "The specified element does not have an associated errormessage."
+    )
+  }
+  // eslint-disable-next-line testing-library/no-node-access
+  const errEl = document.getElementById(errId)
+  assertInstanceOf(errEl, HTMLElement)
+  return errEl
+}
+
+jest.mock("../embedly", () => {
+  const actual = jest.requireActual("../embedly")
+  return {
+    __esModule:  true,
+    ...actual,
+    EmbedlyCard: jest.fn(actual.EmbedlyCard)
+  }
+})
+const spyEmbedlyCard = jest.mocked(EmbedlyCard)
+
+const setupEmbeddedUrlTest = ({
+  config,
+  fieldProps
+}: {
+  config?: EmbeddedUrlWidgetInstance["configuration"]
+  fieldProps?: Record<string, unknown>
+} = {}) => {
+  const widget = makeEmbeddedUrlWidget()
+  if (config !== undefined) {
+    widget.configuration = config
+  }
+  const spec = makeEmbeddedUrlWidgetSpec()
+  const urlFieldSpec = spec.form_spec.find(
+    s => s.input_type === WIDGET_FIELD_TYPES.url
+  )
+  assertNotNil(urlFieldSpec)
+  urlFieldSpec.props = { ...urlFieldSpec.props, ...fieldProps }
+
+  const spies = { onSubmit: jest.fn(), onCancel: jest.fn() }
+  render(
+    <ManageWidgetDialog
+      isOpen={true}
+      onSubmit={spies.onSubmit}
+      onCancel={spies.onCancel}
+      specs={[spec]}
+      widget={widget}
+    />
+  )
+
+  const input = screen.getByLabelText(urlFieldSpec.label)
+  assertInstanceOf(input, HTMLInputElement)
+  return { spies, urlFieldSpec, input, widget }
+}
+
+describe("URL Field", () => {
+  it("renders the url text", () => {
+    const { input, widget } = setupEmbeddedUrlTest()
+    expect(input.value).toBe(widget.configuration.url)
+  })
+
+  it.each([{ showEmbed: true }, { showEmbed: false }])(
+    "Shows the embed preview if showEmbed=true (case: $showEmbed)",
+    ({ showEmbed }) => {
+      const { widget } = setupEmbeddedUrlTest({ fieldProps: { showEmbed } })
+      expect(spyEmbedlyCard.mock.calls.length > 0).toBe(showEmbed)
+      if (showEmbed) {
+        expect(spyEmbedlyCard).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            url: widget.configuration.url
+          }),
+          expect.anything()
+        )
+      }
+    }
+  )
+})
+
+describe("EmbeddedUrl widget editing", () => {
+  it.each([
+    {
+      url:    "",
+      errMsg: /required/,
+      valid:  false
+    },
+    {
+      url:    "mit-dot-edu",
+      errMsg: /invalid/,
+      valid:  false
+    },
+    {
+      url:    "https://mit.edu",
+      errMsg: null,
+      valid:  true
+    }
+  ])("validates the submitted URL", async ({ url, valid, errMsg }) => {
+    const { spies, urlFieldSpec } = setupEmbeddedUrlTest({ config: { url } })
+    await user.click(screen.getByRole("button", { name: "Submit" }))
+    screen.getAllByRole("textbox")
+
+    const input = screen.getByLabelText(urlFieldSpec.label)
+
+    if (valid) {
+      expect(input).toBeValid()
+      expect(spies.onSubmit).toHaveBeenCalled()
+    } else {
+      expect(input).toBeInvalid()
+      expect(spies.onSubmit).not.toHaveBeenCalled()
+      const error = getErrorFor(input)
+      assertNotNil(errMsg)
+      expect(error).toHaveTextContent(errMsg)
+    }
+  })
+})

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.test.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.test.tsx
@@ -61,14 +61,44 @@ describe("ManageWidgetDialog (Editing)", () => {
   })
 
   it("Displays an error with supplied class if title is empty", async () => {
-    const errorClassName = faker.lorem.word()
-    const { spies } = setupEditingDialog({ errorClassName })
+    const classes = { error: faker.lorem.word() }
+    const { spies } = setupEditingDialog({ classes })
     const title = screen.getByLabelText("Title")
     await user.clear(title)
     await user.click(screen.getByRole("button", { name: "Submit" }))
     expect(spies.onSubmit).toHaveBeenCalledTimes(0)
     const errMsg = screen.getByText("Title is required")
-    expect(errMsg).toHaveClass(errorClassName)
+    expect(errMsg).toHaveClass(classes.error)
+  })
+
+  it("passes classes to relevant elements", () => {
+    const classes = {
+      label:      faker.lorem.word(),
+      field:      faker.lorem.word(),
+      fieldGroup: faker.lorem.word(),
+      dialog:     faker.lorem.word()
+    }
+    setupEditingDialog({ classes })
+    // eslint-disable-next-line testing-library/no-node-access
+    const dialog = document.querySelector(`.${classes.dialog}`) as HTMLElement
+    // eslint-disable-next-line testing-library/no-node-access
+    const labels = dialog.querySelectorAll("label")
+    // eslint-disable-next-line testing-library/no-node-access
+    const inputs = dialog.querySelectorAll("input, textarea")
+    // eslint-disable-next-line testing-library/no-node-access
+    const groups = dialog.querySelectorAll(`.${classes.fieldGroup}`)
+
+    expect(dialog).toHaveClass(classes.dialog)
+
+    expect(labels).toHaveLength(2)
+    expect(labels[0]).toHaveClass(classes.label)
+    expect(labels[1]).toHaveClass(classes.label)
+
+    expect(inputs).toHaveLength(2)
+    expect(inputs[0]).toHaveClass(classes.field)
+    expect(inputs[1]).toHaveClass(classes.field)
+
+    expect(groups).toHaveLength(2)
   })
 
   test.each(Object.values(WidgetTypes))(

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -55,7 +55,29 @@ interface WidgetEditingProps {
   classes?: WidgetDialogClasses
 }
 
-const formFieldAttrs = (fieldId: string, errMsg?: string) => {
+interface FormFieldAttrs {
+  field: {
+    id: string
+    "aria-invalid"?: boolean
+    "aria-errormessage"?: string
+   },
+   label: {
+    htmlFor: string
+   },
+   error: {
+    id: string
+   }
+}
+
+/**
+ * Returns React-style HTML attributes to associate form field labels and error
+ * messages with the field input.
+ *
+ * @param fieldId The id of the form field input
+ * @param errMsg An error message for the form field, if there is one
+ * @returns
+ */
+const formFieldAttrs = (fieldId: string, errMsg?: string): FormFieldAttrs => {
   const errorId = `${fieldId}:error`
   const fieldErrorAttrs = errMsg ?
     { "aria-invalid": true, "aria-errormessage": errorId } :

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -60,13 +60,13 @@ interface FormFieldAttrs {
     id: string
     "aria-invalid"?: boolean
     "aria-errormessage"?: string
-   },
-   label: {
+  }
+  label: {
     htmlFor: string
-   },
-   error: {
+  }
+  error: {
     id: string
-   }
+  }
 }
 
 /**

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -11,7 +11,7 @@ import { useId } from "ol-util"
 import { Formik, Form, Field, ErrorMessage, FieldProps } from "formik"
 import { isNil } from "lodash"
 import { AnonymousWidget, WidgetSpec, WidgetTypes } from "../../interfaces"
-import { getWidgetFieldComponent } from "./getWidgetFieldComponent"
+import { getWidgetFieldComponent, renameFieldProps } from "./widgetFields"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { getWidgetSchema } from "./schemas"
 import classNames from "classnames"
@@ -123,16 +123,16 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
                       value={values.configuration[fieldSpec.field_name]}
                       name={attrName}
                     >
-                      {({ field }: FieldProps) => {
+                      {({ field }: FieldProps<string | null>) => {
                         return (
                           <FieldComponent
                             id={fieldId}
                             className={fieldClassName}
                             name={field.name}
-                            value={field.value}
+                            value={field.value ?? ""}
                             onChange={field.onChange}
                             onBlur={field.onBlur}
-                            {...fieldSpec.props}
+                            {...renameFieldProps(fieldSpec)}
                           />
                         )
                       }}
@@ -214,16 +214,20 @@ const DialogContentAdding: React.FC<WidgetAddingProps> = ({
         {({ handleSubmit, values }) => (
           <Form onSubmit={handleSubmit}>
             <DialogContent>
-              <RadioGroup name="widget_type" value={values.widget_type}>
-                {supportedSpecs.map(spec => (
-                  <FormControlLabel
-                    key={spec.widget_type}
-                    value={spec.widget_type}
-                    control={<Radio />}
-                    label={spec.description}
-                  />
-                ))}
-              </RadioGroup>
+              <Field name="widget_type" value={values.widget_type}>
+                {({ field }: FieldProps) => (
+                  <RadioGroup {...field}>
+                    {supportedSpecs.map(spec => (
+                      <FormControlLabel
+                        key={spec.widget_type}
+                        value={spec.widget_type}
+                        control={<Radio />}
+                        label={spec.description}
+                      />
+                    ))}
+                  </RadioGroup>
+                )}
+              </Field>
             </DialogContent>
             <DialogActions>
               <Button variant="outlined" onClick={onCancel}>

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -34,9 +34,16 @@ interface ManageWidgetDialogProps {
   isOpen: boolean
   onCancel: () => void
   onSubmit: WidgetSubmitHandler
-  className?: string
-  errorClassName?: string
-  fieldClassName?: string
+  classes?: WidgetDialogClasses
+}
+
+type WidgetDialogClasses = {
+  dialog?: string
+  error?: string
+  fieldGroup?: string
+  field?: string
+  label?: string
+  detail?: string
 }
 
 interface WidgetEditingProps {
@@ -44,9 +51,8 @@ interface WidgetEditingProps {
   spec: WidgetSpec
   onSubmit: WidgetSubmitHandler
   onCancel: () => void
-  errorClassName?: string
-  fieldClassName?: string
   isNew: boolean
+  classes?: WidgetDialogClasses
 }
 
 const DialogContentEditing: React.FC<WidgetEditingProps> = ({
@@ -54,8 +60,7 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
   spec,
   onSubmit,
   onCancel,
-  fieldClassName,
-  errorClassName,
+  classes,
   isNew
 }) => {
   const formId = useId()
@@ -96,19 +101,26 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
         {({ handleSubmit, values }) => (
           <Form onSubmit={handleSubmit}>
             <DialogContent>
-              <label htmlFor={`${formId}:${title}`}>Title</label>
-              <Field
-                id={`${formId}:${title}`}
-                className={fieldClassName}
-                name="title"
-                type="text"
-                value={values.title}
-              />
-              <ErrorMessage
-                className={errorClassName}
-                component="div"
-                name="title"
-              />
+              <div className={classes?.fieldGroup}>
+                <label
+                  className={classes?.label}
+                  htmlFor={`${formId}:${title}`}
+                >
+                  Title
+                </label>
+                <Field
+                  id={`${formId}:${title}`}
+                  className={classes?.field}
+                  name="title"
+                  type="text"
+                  value={values.title}
+                />
+                <ErrorMessage
+                  className={classes?.error}
+                  component="div"
+                  name="title"
+                />
+              </div>
               {spec.form_spec.map(fieldSpec => {
                 const fieldName = fieldSpec.field_name
                 // Formik uses dot notation for nested objects as name attrs
@@ -117,8 +129,10 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
                 const fieldId = `${formId}:${attrName}`
                 const FieldComponent = getWidgetFieldComponent(fieldSpec)
                 return (
-                  <React.Fragment key={fieldName}>
-                    <label htmlFor={fieldId}>{fieldSpec.label}</label>
+                  <div className={classes?.fieldGroup} key={fieldName}>
+                    <label className={classes?.label} htmlFor={fieldId}>
+                      {fieldSpec.label}
+                    </label>
                     <Field
                       value={values.configuration[fieldSpec.field_name]}
                       name={attrName}
@@ -127,7 +141,7 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
                         return (
                           <FieldComponent
                             id={fieldId}
-                            className={fieldClassName}
+                            className={classes?.field}
                             name={field.name}
                             value={field.value ?? ""}
                             onChange={field.onChange}
@@ -137,12 +151,17 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
                         )
                       }}
                     </Field>
+                    {fieldSpec.under_text && (
+                      <small className={classes?.detail}>
+                        {fieldSpec.under_text}
+                      </small>
+                    )}
                     <ErrorMessage
-                      className={errorClassName}
+                      className={classes?.error}
                       component="div"
                       name={attrName}
                     />
-                  </React.Fragment>
+                  </div>
                 )
               })}
             </DialogContent>
@@ -165,6 +184,7 @@ interface WidgetAddingProps {
   specs: WidgetSpec[]
   onCancel: () => void
   onSubmit: (widget: AnonymousWidget) => void
+  classes?: WidgetDialogClasses
 }
 
 type AddWidgetFormValues = {
@@ -174,7 +194,8 @@ type AddWidgetFormValues = {
 const DialogContentAdding: React.FC<WidgetAddingProps> = ({
   specs,
   onCancel,
-  onSubmit
+  onSubmit,
+  classes
 }) => {
   const supportedSpecs = useMemo(
     () =>
@@ -214,7 +235,11 @@ const DialogContentAdding: React.FC<WidgetAddingProps> = ({
         {({ handleSubmit, values }) => (
           <Form onSubmit={handleSubmit}>
             <DialogContent>
-              <Field name="widget_type" value={values.widget_type}>
+              <Field
+                className={classes?.field}
+                name="widget_type"
+                value={values.widget_type}
+              >
                 {({ field }: FieldProps) => (
                   <RadioGroup {...field}>
                     {supportedSpecs.map(spec => (
@@ -262,9 +287,7 @@ const ManageWidgetDialog: React.FC<ManageWidgetDialogProps> = ({
   onSubmit,
   isOpen,
   onCancel,
-  className,
-  fieldClassName,
-  errorClassName
+  classes
 }) => {
   const [widget, setWidget] = useState<AnonymousWidget | null>(null)
   const isNew = !initialWidget
@@ -281,7 +304,7 @@ const ManageWidgetDialog: React.FC<ManageWidgetDialogProps> = ({
   return (
     <Dialog
       fullWidth
-      className={classNames("ol-widget-dialog", className)}
+      className={classNames("ol-widget-dialog", classes?.dialog)}
       open={isOpen}
       onClose={onCancel}
       /**
@@ -299,8 +322,7 @@ const ManageWidgetDialog: React.FC<ManageWidgetDialogProps> = ({
           spec={mustFindSpec(specs, widget.widget_type)}
           onSubmit={onSubmit}
           onCancel={onCancel}
-          fieldClassName={fieldClassName}
-          errorClassName={errorClassName}
+          classes={classes}
           isNew={isNew}
         />
       ) : (
@@ -308,6 +330,7 @@ const ManageWidgetDialog: React.FC<ManageWidgetDialogProps> = ({
           specs={specs}
           onSubmit={handlePickNewWidget}
           onCancel={onCancel}
+          classes={classes}
         />
       )}
     </Dialog>
@@ -315,4 +338,8 @@ const ManageWidgetDialog: React.FC<ManageWidgetDialogProps> = ({
 }
 
 export default ManageWidgetDialog
-export type { ManageWidgetDialogProps, WidgetSubmitHandler }
+export type {
+  ManageWidgetDialogProps,
+  WidgetSubmitHandler,
+  WidgetDialogClasses
+}

--- a/frontends/ol-widgets/src/components/editing/UrlField.tsx
+++ b/frontends/ol-widgets/src/components/editing/UrlField.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import { WidgetEditingFieldProps } from "./interfaces"
+
+const UrlField: React.FC<WidgetEditingFieldProps> = props => {
+  return <input type="text" {...props} />
+}
+
+export default UrlField

--- a/frontends/ol-widgets/src/components/editing/UrlField.tsx
+++ b/frontends/ol-widgets/src/components/editing/UrlField.tsx
@@ -1,8 +1,20 @@
 import React from "react"
 import { WidgetEditingFieldProps } from "./interfaces"
+import { EmbedlyCard } from "../embedly"
 
-const UrlField: React.FC<WidgetEditingFieldProps> = props => {
-  return <input type="text" {...props} />
+interface ExtraProps {
+  showEmbed?: boolean
+}
+
+const UrlField: React.FC<WidgetEditingFieldProps & ExtraProps> = props => {
+  const { showEmbed, ...others } = props
+
+  return (
+    <>
+      <input type="text" {...others} />
+      {showEmbed && <EmbedlyCard url={props.value} />}
+    </>
+  )
 }
 
 export default UrlField

--- a/frontends/ol-widgets/src/components/editing/UrlField.tsx
+++ b/frontends/ol-widgets/src/components/editing/UrlField.tsx
@@ -12,7 +12,9 @@ const UrlField: React.FC<WidgetEditingFieldProps & ExtraProps> = props => {
   return (
     <>
       <input type="text" {...others} />
-      {showEmbed && <EmbedlyCard className="ol-widget-url-preview" url={props.value} />}
+      {showEmbed && (
+        <EmbedlyCard className="ol-widget-url-preview" url={props.value} />
+      )}
     </>
   )
 }

--- a/frontends/ol-widgets/src/components/editing/UrlField.tsx
+++ b/frontends/ol-widgets/src/components/editing/UrlField.tsx
@@ -12,7 +12,7 @@ const UrlField: React.FC<WidgetEditingFieldProps & ExtraProps> = props => {
   return (
     <>
       <input type="text" {...others} />
-      {showEmbed && <EmbedlyCard url={props.value} />}
+      {showEmbed && <EmbedlyCard className="ol-widget-url-preview" url={props.value} />}
     </>
   )
 }

--- a/frontends/ol-widgets/src/components/editing/WidgetsListEditable.tsx
+++ b/frontends/ol-widgets/src/components/editing/WidgetsListEditable.tsx
@@ -6,7 +6,10 @@ import { uniqueId, zip } from "lodash"
 import { RenderActive, SortableItem, SortableList, SortEndEvent } from "ol-util"
 import Widget from "../Widget"
 import type { WidgetListResponse, AnonymousWidget } from "../../interfaces"
-import type { WidgetSubmitHandler } from "./ManageWidgetDialog"
+import type {
+  WidgetSubmitHandler,
+  WidgetDialogClasses
+} from "./ManageWidgetDialog"
 import ManageWidgetDialog from "./ManageWidgetDialog"
 
 type SubmitWidgetsEvent = {
@@ -26,9 +29,7 @@ interface WidgetsListEditableProps {
   onCancel: () => void
   headerClassName?: string
   widgetClassName?: string
-  errorClassName?: string
-  fieldClassName?: string
-  dialogClassName?: string
+  dialogClasses?: WidgetDialogClasses
 }
 
 /**
@@ -162,9 +163,7 @@ const WidgetsListEditable: React.FC<WidgetsListEditableProps> = ({
   onCancel,
   headerClassName,
   widgetClassName,
-  dialogClassName,
-  fieldClassName,
-  errorClassName
+  dialogClasses
 }) => {
   const { widgets: savedWidgets, available_widgets: specs } = widgetsList
   /**
@@ -275,9 +274,7 @@ const WidgetsListEditable: React.FC<WidgetsListEditableProps> = ({
       </SortableList>
       <ManageWidgetDialog
         isOpen={dialog.mode !== DialogMode.Closed}
-        className={dialogClassName}
-        fieldClassName={fieldClassName}
-        errorClassName={errorClassName}
+        classes={dialogClasses}
         onSubmit={dialogHandlers.submit}
         widget={dialog.widget}
         specs={specs}

--- a/frontends/ol-widgets/src/components/editing/getWidgetFieldComponent.tsx
+++ b/frontends/ol-widgets/src/components/editing/getWidgetFieldComponent.tsx
@@ -2,6 +2,7 @@ import { WIDGET_FIELD_TYPES } from "../../constants"
 import type { WidgetFieldSpec } from "../../interfaces"
 import type { WidgetFieldComponent } from "./interfaces"
 import MarkdownEditor from "./MarkdownEditor"
+import UrlField from "./UrlField"
 
 const getWidgetFieldComponent = (
   spec: WidgetFieldSpec
@@ -9,7 +10,13 @@ const getWidgetFieldComponent = (
   if (spec.input_type === WIDGET_FIELD_TYPES.markdown) {
     return MarkdownEditor
   }
-  throw new Error("Unrecognized field input type.")
+  if (spec.input_type === WIDGET_FIELD_TYPES.url) {
+    return UrlField
+  }
+  if (spec.input_type === WIDGET_FIELD_TYPES.textarea) {
+    return 'textarea'
+  }
+  throw new Error(`Unrecognized field input type: '${spec.input_type}'`)
 }
 
 export { getWidgetFieldComponent }

--- a/frontends/ol-widgets/src/components/editing/index.tsx
+++ b/frontends/ol-widgets/src/components/editing/index.tsx
@@ -1,7 +1,8 @@
 export { default as ManageWidgetDialog } from "./ManageWidgetDialog"
 export type {
   ManageWidgetDialogProps,
-  WidgetSubmitHandler
+  WidgetSubmitHandler,
+  WidgetDialogClasses
 } from "./ManageWidgetDialog"
 
 export { default as WidgetsListEditable } from "./WidgetsListEditable"

--- a/frontends/ol-widgets/src/components/editing/interfaces.ts
+++ b/frontends/ol-widgets/src/components/editing/interfaces.ts
@@ -1,13 +1,13 @@
 type FormikHandler<T = unknown> = (e: { target: { name: string } & T }) => void
 
-interface WidgetEditingFieldProps {
+type WidgetEditingFieldProps<E = unknown> = {
   className?: string
   id: string
   onChange: FormikHandler<{ value: unknown }>
   onBlur: FormikHandler
   value: string
   name: string
-}
+} & Partial<E>
 
 type WidgetFieldComponent = React.FC<WidgetEditingFieldProps>
 

--- a/frontends/ol-widgets/src/components/editing/schemas.tsx
+++ b/frontends/ol-widgets/src/components/editing/schemas.tsx
@@ -10,7 +10,10 @@ const richTextSchema = Yup.object().shape({
 const embeddedUrlSchema = Yup.object().shape({
   title,
   configuration: Yup.object().shape({
-    url: Yup.string().required("Url is required")
+    url:         Yup.string().required("Url is required"),
+    custom_html: Yup.string()
+      .nullable()
+      .oneOf([null], "custom_html is not allowed.")
   })
 })
 

--- a/frontends/ol-widgets/src/components/editing/schemas.tsx
+++ b/frontends/ol-widgets/src/components/editing/schemas.tsx
@@ -1,5 +1,6 @@
 import * as Yup from "yup"
 import { WidgetTypes } from "../../interfaces"
+import isURL from "validator/lib/isURL"
 
 const title = Yup.string().required("Title is required")
 
@@ -10,7 +11,12 @@ const richTextSchema = Yup.object().shape({
 const embeddedUrlSchema = Yup.object().shape({
   title,
   configuration: Yup.object().shape({
-    url:         Yup.string().required("Url is required"),
+    url: Yup.string()
+      .required("Url is required")
+      // Yup's built-in URL validation requires a protocol, so is stricter than we want.
+      .test("isUrl", "The provided URL is invalid.", value =>
+        isURL(String(value))
+      ),
     custom_html: Yup.string()
       .nullable()
       .oneOf([null], "custom_html is not allowed.")

--- a/frontends/ol-widgets/src/components/editing/schemas.tsx
+++ b/frontends/ol-widgets/src/components/editing/schemas.tsx
@@ -7,9 +7,19 @@ const richTextSchema = Yup.object().shape({
   title
 })
 
+const embeddedUrlSchema = Yup.object().shape({
+  title,
+  configuration: Yup.object().shape({
+    url: Yup.string().required("Url is required")
+  })
+})
+
 const getWidgetSchema = (widgetType: string) => {
   if (widgetType === WidgetTypes.RichText) {
     return richTextSchema
+  }
+  if (widgetType === WidgetTypes.EmbeddedUrl) {
+    return embeddedUrlSchema
   }
   throw new Error("Unrecognized widget type")
 }

--- a/frontends/ol-widgets/src/components/editing/widgetFields.tsx
+++ b/frontends/ol-widgets/src/components/editing/widgetFields.tsx
@@ -1,5 +1,6 @@
+import { mapKeys } from "lodash"
 import { WIDGET_FIELD_TYPES } from "../../constants"
-import type { WidgetFieldSpec } from "../../interfaces"
+import { WidgetFieldSpec } from "../../interfaces"
 import type { WidgetFieldComponent } from "./interfaces"
 import MarkdownEditor from "./MarkdownEditor"
 import UrlField from "./UrlField"
@@ -14,9 +15,22 @@ const getWidgetFieldComponent = (
     return UrlField
   }
   if (spec.input_type === WIDGET_FIELD_TYPES.textarea) {
-    return 'textarea'
+    return "textarea"
   }
   throw new Error(`Unrecognized field input type: '${spec.input_type}'`)
 }
 
-export { getWidgetFieldComponent }
+const propRenames: Record<string, Record<string, string>> = {
+  [WIDGET_FIELD_TYPES.url]: {
+    min_length: "minLength",
+    max_length: "maxLength",
+    show_embed: "showEmbed"
+  }
+}
+
+const renameFieldProps = (fieldSpec: WidgetFieldSpec) => {
+  const renames = propRenames[fieldSpec.field_name] ?? {}
+  return mapKeys(fieldSpec.props, (_value, key) => renames[key] ?? key)
+}
+
+export { getWidgetFieldComponent, renameFieldProps }

--- a/frontends/ol-widgets/src/components/embedly/EmbedlyCard.test.tsx
+++ b/frontends/ol-widgets/src/components/embedly/EmbedlyCard.test.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable testing-library/no-node-access */
+import React from "react"
+import { faker } from "@faker-js/faker"
+import { assertInstanceOf } from "ol-util"
+import { render, screen, waitFor } from "@testing-library/react"
+import EmbedlyCard, { EmbedlyCardProps } from "./EmbedlyCard"
+import { dispatchCardCreated } from "./util"
+
+const emulateEmbedly = (parent: HTMLElement) => {
+  const anchors = parent.querySelectorAll("a.embedly-card")
+  if (anchors.length !== 1) throw new Error("Expected 1 .embedly-card anchor")
+  const [a] = anchors
+  const iframe = document.createElement("iframe")
+  a.remove()
+  parent.appendChild(iframe)
+  dispatchCardCreated(iframe)
+}
+
+describe("EmbedlyCard", () => {
+  const setupTest = ({ url, ...others }: Partial<EmbedlyCardProps> = {}) => {
+    const { container } = render(
+      <EmbedlyCard
+        url={url ?? new URL(faker.internet.url()).toString()}
+        {...others}
+      />
+    )
+    return { container }
+  }
+
+  it("renders an anchor tag with embedly data props", async () => {
+    const url = new URL(faker.internet.url()).toString()
+    setupTest({ url })
+    const a = screen.getByRole("link")
+    assertInstanceOf(a, HTMLAnchorElement)
+    expect(a.href).toBe(url)
+    expect(a.dataset.cardChrome).toBe("0")
+    expect(a.dataset.cardControls).toBe("0")
+    expect(a.dataset.cardKey).toBe("fake-embedly-key")
+    expect(a).toHaveClass("embedly-card")
+    expect(typeof a.dataset.cardKey).toBe("string")
+  })
+
+  it("applies a given class to the card", () => {
+    const { container } = setupTest({ className: "foo" })
+    expect(container.firstChild).toHaveClass("foo")
+  })
+
+  it("Updates correctly when given a new url", async () => {
+    /**
+     * Embedly replaces anchor tags with iframes and this is done outside of
+     * React's normal rendering process.
+     *
+     * The goal here is largely to check that when the url is updated, the old
+     * embedly iframe is remvoed from the DOM.
+     */
+    const url1 = "https://url1.com/"
+    const { rerender } = render(<EmbedlyCard url={url1} className="the-card" />)
+    const card = document.querySelector(".the-card") as HTMLElement
+
+    const a1 = screen.getByRole("link") as HTMLAnchorElement
+    expect(a1.href).toBe(url1)
+    expect(card.querySelectorAll("iframe").length).toBe(0)
+    expect(a1).toBeInTheDocument()
+    emulateEmbedly(card)
+    expect(card.querySelectorAll("iframe").length).toBe(1)
+
+    const url2 = "https://url2.com/"
+    expect(url1).not.toBe(url2)
+    rerender(<EmbedlyCard url={url2} className="the-card" />)
+
+    const a2 = screen.getByRole("link") as HTMLAnchorElement
+    expect(a2.href).toBe(url2)
+    await waitFor(() => {
+      expect(card.querySelectorAll("iframe").length).toBe(0)
+    })
+
+    expect(a2).toBeInTheDocument()
+    emulateEmbedly(card)
+    expect(card.querySelectorAll("iframe").length).toBe(1)
+  })
+
+  it.each([
+    { url: "some-invalid-url", valid: false },
+    { url: "https://valid-url.com", valid: true },
+    { url: "protocol-not-required.com", valid: true }
+  ])("only renders the embedly anchor if url is valid", ({ url, valid }) => {
+    render(<EmbedlyCard url={url} />)
+    expect(document.querySelector("a") !== null).toBe(valid)
+  })
+
+  it("removes old anchor even if new url is invalid", () => {
+    /**
+     * Since EmbedlyCard does DOM manipulation outside of react's usual process,
+     * let's check this explicitly
+     */
+    const url1 = "https://mit.edu"
+    const { rerender } = render(<EmbedlyCard url={url1} />)
+    expect(document.querySelectorAll("a").length).toBe(1)
+    rerender(<EmbedlyCard url="invalidurl" />)
+    expect(document.querySelectorAll("a").length).toBe(0)
+  })
+})

--- a/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
+++ b/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useEffect, useState } from "react"
+import isURL from "validator/lib/isURL"
+import {
+  createStylesheet,
+  EmbedlyEventTypes,
+  ensureEmbedlyPlatform,
+  getEmbedlyKey
+} from "./util"
+
+type EmbedlyCardProps = {
+  url: string
+  className?: string
+}
+
+/**
+ * Embedly cards are contained within an iframe.
+ * Inserts a stylesheet into the card's iframe.
+ */
+const insertCardStylesheet = (e: Event) => {
+  if (!(e.target instanceof HTMLIFrameElement)) return
+  if (!e.target.contentDocument) return
+  const stylesheet = `
+  /* hide card title */
+  .hdr { display: none; }
+  /* reduce card padding */
+  .pair-bd > *:last-child {
+    padding-bottom: 0px;
+  }
+  #cards {
+    padding: 0px;
+  }
+  `
+  createStylesheet(e.target.contentDocument, stylesheet)
+}
+
+const EmbedlyCard: React.FC<EmbedlyCardProps> = ({ className, url }) => {
+  const embedlyKey = getEmbedlyKey()
+  const [container, setContainer] = useState<HTMLElement | null>(null)
+  // TODO: Validate url
+  const renderCard = useCallback((div: HTMLElement | null) => {
+    if (!div) return
+    div.addEventListener(EmbedlyEventTypes.CardCreated, insertCardStylesheet)
+    setContainer(div)
+  }, [])
+
+  useEffect(() => {
+    ensureEmbedlyPlatform()
+  }, [])
+
+  useEffect(() => {
+    console.log(`Hello!: url is... ${url}`)
+    if (!container) return
+    container.innerHTML = ""
+    if (!isURL(url)) return
+    const a = document.createElement("a")
+    a.dataset.cardChrome = "0"
+    a.dataset.cardControls = "0"
+    a.dataset.cardKey = embedlyKey ?? ""
+    a.href = url
+    a.classList.add("embedly-card")
+    container.appendChild(a)
+  }, [embedlyKey, container, url])
+
+  return <div className={className} ref={renderCard} />
+}
+
+export default EmbedlyCard
+export type { EmbedlyCardProps }

--- a/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
+++ b/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
@@ -33,10 +33,17 @@ const insertCardStylesheet = (e: Event) => {
   createStylesheet(e.target.contentDocument, stylesheet)
 }
 
+/**
+ * Renders the given URL as an [embedly card](https://embed.ly/cards).
+ *
+ * @notes
+ *  - If the URL is invalid, nothing is rendered.
+ *
+ */
 const EmbedlyCard: React.FC<EmbedlyCardProps> = ({ className, url }) => {
   const embedlyKey = getEmbedlyKey()
   const [container, setContainer] = useState<HTMLElement | null>(null)
-  // TODO: Validate url
+
   const renderCard = useCallback((div: HTMLElement | null) => {
     if (!div) return
     div.addEventListener(EmbedlyEventTypes.CardCreated, insertCardStylesheet)
@@ -48,6 +55,18 @@ const EmbedlyCard: React.FC<EmbedlyCardProps> = ({ className, url }) => {
   }, [])
 
   useEffect(() => {
+    /**
+     * Embedly cards are generally created via:
+     *  1. Author places an `<a class="embedly-card" href="some-url" />` tag in
+     *     the document.
+     *  2. Author loads Embedly's platform.js script
+     *  3. Platform.js monitors the document and replaces anchors like the above
+     *     with IFrames.
+     *
+     * Since Embedly is manipulating the DOM itself, it's a little bit of a pain
+     * to integrate with React: When the URL changes, we need to manually remove
+     * the IFrame and insert a new anchor, which Embedly can then manipulate.
+     */
     if (!container) return
     container.innerHTML = ""
     if (!isURL(url)) return

--- a/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
+++ b/frontends/ol-widgets/src/components/embedly/EmbedlyCard.tsx
@@ -48,7 +48,6 @@ const EmbedlyCard: React.FC<EmbedlyCardProps> = ({ className, url }) => {
   }, [])
 
   useEffect(() => {
-    console.log(`Hello!: url is... ${url}`)
     if (!container) return
     container.innerHTML = ""
     if (!isURL(url)) return

--- a/frontends/ol-widgets/src/components/embedly/index.ts
+++ b/frontends/ol-widgets/src/components/embedly/index.ts
@@ -1,0 +1,1 @@
+export { default as EmbedlyCard } from "./EmbedlyCard"

--- a/frontends/ol-widgets/src/components/embedly/util.test.ts
+++ b/frontends/ol-widgets/src/components/embedly/util.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable testing-library/no-node-access */
+import { waitFor } from "@testing-library/react"
+import { assertNotNil } from "ol-util"
+import {
+  createStylesheet,
+  EmbedlyEventTypes,
+  ensureEmbedlyPlatform
+} from "./util"
+
+describe("getEmbedly", () => {
+  let embedlySpy: jest.Mock
+  beforeEach(() => {
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+
+    // embedly's insertion requires at least one script on the page
+    const script = document.createElement("script")
+    document.head.appendChild(script)
+    embedlySpy = jest.fn()
+    // @ts-expect-error embedly will grab itself off the window if it's there
+    window.embedly = embedlySpy
+  })
+
+  it("inserts a single script tag loading embedly src", () => {
+    ensureEmbedlyPlatform()
+    const scripts = document.querySelectorAll("script")
+    expect(scripts.length).toBe(2)
+    expect(scripts[0].src).toBe("http://cdn.embedly.com/widgets/platform.js")
+  })
+
+  it("causes embedly to emit custom card creation events", async () => {
+    ensureEmbedlyPlatform()
+    expect(embedlySpy).toHaveBeenCalledWith(
+      "on",
+      "card.rendered",
+      expect.any(Function) // this is the onCardRendered callback
+    )
+
+    /**
+     * Normally, when embedly creates a card, it would call onCardRendered with
+     * an iframe as the argument.
+     *
+     * We don't have embedly in this test environment. But let's test that
+     * `onCardRendered` does the correct thing when given an iframe.
+     *
+     * Set up:
+     * <body>
+     *   <div>
+     *     <iframe />
+     *   </div>
+     * </body>
+     */
+    const onCardRendered = embedlySpy.mock.calls[0][2]
+    const container = document.createElement("div")
+    const iframe = document.createElement("iframe")
+    document.body.appendChild(container)
+    container.appendChild(iframe)
+
+    const listener = jest.fn()
+    container.addEventListener(EmbedlyEventTypes.CardCreated, listener)
+    onCardRendered(iframe)
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: iframe
+        })
+      )
+    })
+  })
+
+  it("only loads embedly once", () => {
+    ensureEmbedlyPlatform()
+    ensureEmbedlyPlatform()
+    ensureEmbedlyPlatform()
+
+    expect(document.querySelectorAll("script").length).toBe(2)
+    expect(embedlySpy).toHaveBeenCalledTimes(1)
+    // @ts-expect-error checking window embedly is still same as original
+    expect(window.embedly).toBe(embedlySpy)
+  })
+})
+
+describe("createStylesheet", () => {
+  it("inserts a stylesheet into an iframe's document", () => {
+    const iframe = document.createElement("iframe")
+    document.body.appendChild(iframe)
+
+    assertNotNil(iframe.contentDocument)
+    createStylesheet(iframe.contentDocument, ".foo { color: blue }")
+    const styles = iframe.contentDocument.querySelectorAll("head style")
+    expect(styles.length).toBe(1)
+    expect(styles[0].innerHTML).toBe(".foo { color: blue }")
+  })
+})

--- a/frontends/ol-widgets/src/components/embedly/util.ts
+++ b/frontends/ol-widgets/src/components/embedly/util.ts
@@ -1,29 +1,97 @@
 /**
- * Inserts a <script> tag to load embedly into the document.
- *
- * This is based on https://docs.embed.ly/reference/platformjs with a few
- * differences around naming and typescript.
+ * Embedly's events
  */
-const ensureEmbedlyPlatform = function ensureEmbedlyPlatform() {
-  const id = 'embedly-platform'
+type RawEmbedlyEventType = "card.rendered"
+type EmbedlyCallback = (iframe: HTMLIFrameElement) => void
+/**
+ * See https://docs.embed.ly/reference/platformjs for more
+ */
+interface Embedly {
+  (action: "on", event: RawEmbedlyEventType, cb: EmbedlyCallback): void
+  q: unknown[]
+}
+
+/**
+ * Our CustomEvent types wrapping embedly's.
+ */
+enum EmbedlyEventTypes {
+  /**
+   * Custom event emitted when embedly creates a card. The event target is the
+   * card's iframe.
+   */
+  CardCreated = "embedly:card.created"
+}
+
+const dispatchCardCreated = (iframe: HTMLIFrameElement) => {
+  const event = new CustomEvent(EmbedlyEventTypes.CardCreated, {
+    bubbles: true
+  })
+  iframe.dispatchEvent(event)
+}
+
+/**
+ * Returns the embedly object, loading it if it has not already been loaded.
+ *
+ * @notes
+ *  - tells emebedly to emit certain CustomEvent; see {@link EmbedlyEventTypes}
+ *  - based on on https://docs.embed.ly/reference/platformjs
+ */
+const ensureEmbedlyPlatform = () => {
+  const id = "embedly-platform"
+  // @ts-expect-error embedly wants itself to be global. Except within this
+  // function, we will access embedly via this function return value, so let's
+  // not extend the global object
+  const w = window as Window & { embedly: Embedly }
+
   if (!document.getElementById(id)) {
-    const protocol = 'https:' === document.location.protocol ? 'https' : 'http'
-    const tagName = 'script'
-    // @ts-expect-error embedly wants itself to be global
-    // **we** don't access it on the global object (maybe it does itself)
-    // so let's not extend the global window object.
-    window.embedly = window.embedly || function() {
-      // @ts-expect-error embedly again
-      // eslint-disable-next-line prefer-rest-params
-      (window.embedly.q = window.embedly.q || []).push(arguments)
-    }
+    const protocol = "https:" === document.location.protocol ? "https" : "http"
+    const tagName = "script"
+    w.embedly =
+      w.embedly ||
+      function(...args) {
+        (w.embedly.q = w.embedly.q || []).push(args)
+      }
     const el = document.createElement(tagName)
     el.id = id
     el.async = true
     el.src = `${protocol}://cdn.embedly.com/widgets/platform.js`
     const s = document.getElementsByTagName(tagName)[0]
-    s.parentNode?.insertBefore(el, s)
+    if (s) {
+      s.parentNode?.insertBefore(el, s)
+    } else {
+      document.head.appendChild(el)
+    }
+
+    w.embedly("on", "card.rendered", dispatchCardCreated)
   }
+
+  return w.embedly
 }
 
-export { ensureEmbedlyPlatform }
+/**
+ * Create a stylesheet in the given with the provided css text. Appends the
+ * stylesheet to document head.
+ *
+ * Useful for adding styles to an IFrame or ShadowRoot
+ */
+const createStylesheet = (doc: Document, css: string) => {
+  const head = doc.head
+  const style = doc.createElement("style")
+  style.innerHTML = css
+  head.appendChild(style)
+}
+
+const getEmbedlyKey = (): string | null => {
+  const key = window.SETTINGS?.embedlyKey
+  if (typeof key === "string") return key
+  console.warn("window.SETTINGS.EMBEDLY_KEY should be a string.")
+  return null
+}
+
+export {
+  createStylesheet,
+  ensureEmbedlyPlatform,
+  getEmbedlyKey,
+  EmbedlyEventTypes,
+  dispatchCardCreated
+}

--- a/frontends/ol-widgets/src/components/embedly/util.ts
+++ b/frontends/ol-widgets/src/components/embedly/util.ts
@@ -1,0 +1,29 @@
+/**
+ * Inserts a <script> tag to load embedly into the document.
+ *
+ * This is based on https://docs.embed.ly/reference/platformjs with a few
+ * differences around naming and typescript.
+ */
+const ensureEmbedlyPlatform = function ensureEmbedlyPlatform() {
+  const id = 'embedly-platform'
+  if (!document.getElementById(id)) {
+    const protocol = 'https:' === document.location.protocol ? 'https' : 'http'
+    const tagName = 'script'
+    // @ts-expect-error embedly wants itself to be global
+    // **we** don't access it on the global object (maybe it does itself)
+    // so let's not extend the global window object.
+    window.embedly = window.embedly || function() {
+      // @ts-expect-error embedly again
+      // eslint-disable-next-line prefer-rest-params
+      (window.embedly.q = window.embedly.q || []).push(arguments)
+    }
+    const el = document.createElement(tagName)
+    el.id = id
+    el.async = true
+    el.src = `${protocol}://cdn.embedly.com/widgets/platform.js`
+    const s = document.getElementsByTagName(tagName)[0]
+    s.parentNode?.insertBefore(el, s)
+  }
+}
+
+export { ensureEmbedlyPlatform }

--- a/frontends/ol-widgets/src/constants.ts
+++ b/frontends/ol-widgets/src/constants.ts
@@ -1,7 +1,7 @@
 const WIDGET_FIELD_TYPES = {
-  markdown:    "markdown_wysiwyg",
-  url:         "url",
-  textarea:     "textarea"
+  markdown: "markdown_wysiwyg",
+  url:      "url",
+  textarea: "textarea"
 }
 
 export { WIDGET_FIELD_TYPES }

--- a/frontends/ol-widgets/src/constants.ts
+++ b/frontends/ol-widgets/src/constants.ts
@@ -1,5 +1,7 @@
 const WIDGET_FIELD_TYPES = {
-  markdown: "markdown_wysiwyg"
+  markdown:    "markdown_wysiwyg",
+  url:         "url",
+  textarea:     "textarea"
 }
 
 export { WIDGET_FIELD_TYPES }

--- a/frontends/ol-widgets/src/factories.ts
+++ b/frontends/ol-widgets/src/factories.ts
@@ -5,7 +5,8 @@ import type {
   RichTextWidgetInstance,
   WidgetListResponse,
   WidgetSpec,
-  WidgetFieldSpec
+  WidgetFieldSpec,
+  EmbeddedUrlWidgetInstance
 } from "./interfaces"
 import { WidgetTypes } from "./interfaces"
 import { WIDGET_FIELD_TYPES } from "./constants"
@@ -49,8 +50,23 @@ const makeRichTextWidgetSpec: Factory<WidgetSpec> = overrides => {
   }
 }
 
+const makeEmbeddedUrlWidgetSpec: Factory<WidgetSpec> = overrides => {
+  return {
+    description: faker.lorem.words(),
+    widget_type: WidgetTypes.EmbeddedUrl,
+    form_spec:   [
+      makeWidgetFieldSpec({
+        field_name: "url",
+        input_type: WIDGET_FIELD_TYPES.url
+      })
+    ],
+    ...overrides
+  }
+}
+
 const widgetSpecMakers = {
-  [WidgetTypes.RichText]: makeRichTextWidgetSpec
+  [WidgetTypes.RichText]:    makeRichTextWidgetSpec,
+  [WidgetTypes.EmbeddedUrl]: makeEmbeddedUrlWidgetSpec
 }
 
 const makeRichTextWidget: Factory<RichTextWidgetInstance> = overrides => ({
@@ -63,8 +79,22 @@ const makeRichTextWidget: Factory<RichTextWidgetInstance> = overrides => ({
   ...overrides
 })
 
+const makeEmbeddedUrlWidget: Factory<
+  EmbeddedUrlWidgetInstance
+> = overrides => ({
+  id:            faker.datatype.number(),
+  title:         faker.lorem.sentence(3),
+  widget_type:   WidgetTypes.EmbeddedUrl,
+  configuration: {
+    url:         new URL(faker.internet.url()).toString(),
+    custom_html: null
+  },
+  ...overrides
+})
+
 const widgetMakers = {
-  [WidgetTypes.RichText]: makeRichTextWidget
+  [WidgetTypes.RichText]:    makeRichTextWidget,
+  [WidgetTypes.EmbeddedUrl]: makeEmbeddedUrlWidget
 }
 
 const makeWidgetListResponse: Factory<
@@ -101,6 +131,8 @@ export {
   makeWidget,
   makeWidgetSpec,
   makeRichTextWidgetSpec,
+  makeEmbeddedUrlWidgetSpec,
   makeRichTextWidget,
+  makeEmbeddedUrlWidget,
   makeWidgetListResponse
 }

--- a/frontends/ol-widgets/src/interfaces.ts
+++ b/frontends/ol-widgets/src/interfaces.ts
@@ -52,9 +52,9 @@ export type RichTextWidgetInstance = WidgetInstance<RichTextWidgetConfig>
 
 interface EmbeddedUrlWidgetConfig {
   url: string
+  custom_html?: null | string
 }
 export type EmbeddedUrlWidgetInstance = WidgetInstance<EmbeddedUrlWidgetConfig>
-
 
 export enum WidgetTypes {
   RichText = "Markdown",

--- a/frontends/ol-widgets/src/interfaces.ts
+++ b/frontends/ol-widgets/src/interfaces.ts
@@ -50,6 +50,13 @@ interface RichTextWidgetConfig {
 }
 export type RichTextWidgetInstance = WidgetInstance<RichTextWidgetConfig>
 
+interface EmbeddedUrlWidgetConfig {
+  url: string
+}
+export type EmbeddedUrlWidgetInstance = WidgetInstance<EmbeddedUrlWidgetConfig>
+
+
 export enum WidgetTypes {
-  RichText = "Markdown"
+  RichText = "Markdown",
+  EmbeddedUrl = "URL"
 }

--- a/frontends/ol-widgets/src/setupJest.ts
+++ b/frontends/ol-widgets/src/setupJest.ts
@@ -1,3 +1,5 @@
 import { setupMockMarkdownEditor } from "./test-utils"
 
 setupMockMarkdownEditor()
+
+window.SETTINGS = { embedlyKey: "fake-embedly-key" }

--- a/frontends/ol-widgets/src/setupJest.ts
+++ b/frontends/ol-widgets/src/setupJest.ts
@@ -2,4 +2,14 @@ import { setupMockMarkdownEditor } from "./test-utils"
 
 setupMockMarkdownEditor()
 
+// eslint-disable-next-line mocha/no-top-level-hooks
+afterEach(() => {
+  /**
+   * Clear all mock call counts between tests.
+   * This does NOT clear mock implementations.
+   * Mock implementations are always cleared between test files.
+   */
+  jest.clearAllMocks()
+})
+
 window.SETTINGS = { embedlyKey: "fake-embedly-key" }

--- a/frontends/ol-widgets/src/types/settings.d.ts
+++ b/frontends/ol-widgets/src/types/settings.d.ts
@@ -1,0 +1,5 @@
+declare interface Window {
+  SETTINGS?: {
+    embedlyKey?: unknown
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,6 +6420,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/validator@npm:^13.7.6":
+  version: 13.7.6
+  resolution: "@types/validator@npm:13.7.6"
+  checksum: f860dd87bc5f90cc33d2802cf2a4da307ddac63c86d86b858a85dd62d457c8fa42fc8756e05b5d24e741376debc13d46ed14bc700006bf7d0cb910118022492b
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.1":
   version: 8.5.3
   resolution: "@types/ws@npm:8.5.3"
@@ -16530,12 +16537,14 @@ __metadata:
     "@types/ckeditor__ckeditor5-core": ^33.0.3
     "@types/ckeditor__ckeditor5-editor-classic": ^27.1.2
     "@types/js-beautify": ^1.13.3
+    "@types/validator": ^13.7.6
     classnames: ^2.3.1
     formik: ^2.2.9
     js-beautify: ^1.14.6
     ol-util: "workspace:*"
     react-markdown: ^6.0.3
     remark-gfm: ^1.0.0
+    validator: ^13.7.0
     yup: ^0.32.11
   peerDependencies:
     react: ^16.10 || 17 || 18
@@ -22539,7 +22548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:13.7.0":
+"validator@npm:13.7.0, validator@npm:^13.7.0":
   version: 13.7.0
   resolution: "validator@npm:13.7.0"
   checksum: 2b83283de1222ca549a7ef57f46e8d49c6669213348db78b7045bce36a3b5843ff1e9f709ebf74574e06223461ee1f264f8cc9a26a0060a79a27de079d8286ef


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
#3695 

#### What's this PR do?
This field enables the Embedded URL widget for infinite corridor

#### How should this be manually tested?
In a field that you have moderator rights for (either from being superuser or explicit permissions):
1. Navigate to field page, click gear icon, click "Manage widgets"
2. Add a new widget of type Embedded URL
3. Paste a URL into the field. Try youtube videos and other sites. The preview is powered by [embedly cards](https://embed.ly/cards), just like in Open Discussions.

    _Note: Not at all sites have great embedly previews... I need to learn more about this._
4. Try editing / saving / viewing
5. Try invalid urls

Known Issues:
- Drag reordering a card with an embedly preview temporarily breaks the preview... It can be fixed by collapsing and expanding the widget. Open Discussions has the same issue. I did not look into it too much.
- The cards get too narrow on Mobile screens. I would like to address this separately and will make a separate issue for it.
- custom_html intentionally does not work right now. We will remove it. See  https://github.com/mitodl/hq/discussions/239

#### Screenshots (if appropriate)
<img width="1502" alt="Screen Shot 2022-09-06 at 7 00 41 AM" src="https://user-images.githubusercontent.com/9010790/188622470-750e18ce-9ed7-4c04-8e42-7af9e1c945d9.png">

<img width="931" alt="Screen Shot 2022-09-06 at 7 14 05 AM" src="https://user-images.githubusercontent.com/9010790/188622503-53475322-d679-4c79-8636-f6196b238b31.png">
