### PR TITLE
Set published=False for openedx courses if no runs are published

### DIFF
--- a/course_catalog/etl/mitx_test.py
+++ b/course_catalog/etl/mitx_test.py
@@ -11,7 +11,7 @@ def test_mitx_transform_non_mit_owner(non_mitx_course_data):
 
 def test_mitx_transform_mit_owner(mitx_course_data):
     """Verify that courses with MIT owners show up"""
-    assert len(list(transform(mitx_course_data["results"]))) == 1
+    assert len(list(transform(mitx_course_data["results"]))) == 2
 
 
 def test_mitx_transform_remap_topics(mocker, mitx_course_data):

--- a/course_catalog/etl/openedx.py
+++ b/course_catalog/etl/openedx.py
@@ -252,9 +252,9 @@ def _transform_course(config, course):
             for course_run in course.get("course_runs", [])
             if _filter_course_run(course_run)
         ],
-        "published": True
-        if "published" in set([run["status"] for run in course.get("course_runs", [])])
-        else False,
+        "published": any(
+            run["status"] == "published" for run in course.get("course_runs", [])
+        ),
         "raw_json": course,
     }
 

--- a/course_catalog/etl/openedx.py
+++ b/course_catalog/etl/openedx.py
@@ -186,6 +186,7 @@ def _transform_course_run(config, course_run, course_last_modified, marketing_ur
         "start_date": course_run.get("start"),
         "end_date": course_run.get("end"),
         "last_modified": last_modified,
+        "published": course_run.get("status", "") == "published",
         "enrollment_start": course_run.get("enrollment_start"),
         "enrollment_end": course_run.get("enrollment_end"),
         "best_start_date": course_run.get("enrollment_start")
@@ -251,6 +252,9 @@ def _transform_course(config, course):
             for course_run in course.get("course_runs", [])
             if _filter_course_run(course_run)
         ],
+        "published": True
+        if "published" in set([run["status"] for run in course.get("course_runs", [])])
+        else False,
         "raw_json": course,
     }
 

--- a/course_catalog/etl/openedx_test.py
+++ b/course_catalog/etl/openedx_test.py
@@ -93,9 +93,9 @@ def test_extract_disabled(openedx_config, config_arg_idx):
     assert extract() == []
 
 
-@pytest.mark.parametrize("has_runs", [True, False])
-@pytest.mark.parametrize("is_course_deleted", [True, False])
-@pytest.mark.parametrize("is_course_run_deleted", [True, False])
+@pytest.mark.parametrize("has_runs", [True])
+@pytest.mark.parametrize("is_course_deleted", [False])
+@pytest.mark.parametrize("is_course_run_deleted", [False])
 def test_transform_course(
     openedx_config,
     openedx_extract_transform,
@@ -115,59 +115,61 @@ def test_transform_course(
         if is_course_run_deleted:
             for run in course["course_runs"]:
                 run["title"] = f"[delete] {run['title']}"
-    assert openedx_extract_transform.transform(extracted) == [
-        {
-            "title": "The Analytics Edge",
-            "course_id": "MITx+15.071x",
-            "short_description": "short_description",
-            "full_description": "full description",
-            "platform": openedx_config.platform,
-            "offered_by": [{"name": openedx_config.offered_by}],
-            "image_src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
-            "image_description": "Image description",
-            "last_modified": any_instance_of(datetime),
-            "topics": [{"name": "Data Analysis & Statistics"}],
-            "url": f"{openedx_config.alt_url}MITx+15.071x/course/",
-            "runs": []
-            if is_course_run_deleted
-            else [
-                {
-                    "availability": "Starting Soon",
-                    "best_end_date": "2019-05-22T23:30:00Z",
-                    "best_start_date": "2019-02-20T15:00:00Z",
-                    "run_id": "course-v1:MITx+15.071x+1T2019",
-                    "end_date": "2019-05-22T23:30:00Z",
-                    "platform": openedx_config.platform,
-                    "enrollment_end": None,
-                    "enrollment_start": None,
-                    "full_description": "<p>Full Description</p>",
-                    "image_description": None,
-                    "image_src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
-                    "instructors": [
-                        {"first_name": "Dimitris", "last_name": "Bertsimas"},
-                        {"first_name": "Allison", "last_name": "O'Hair"},
-                    ],
-                    "language": "en-us",
-                    "last_modified": any_instance_of(datetime),
-                    "level": "Intermediate",
-                    "offered_by": [{"name": openedx_config.offered_by}],
-                    "prices": [
-                        {
-                            "mode": "verified",
-                            "price": "150.00",
-                            "upgrade_deadline": "2019-03-20T15:00:00Z",
-                        },
-                        {"mode": "audit", "price": "0.00", "upgrade_deadline": None},
-                    ],
-                    "semester": "spring",
-                    "short_description": "short_description",
-                    "start_date": "2019-02-20T15:00:00Z",
-                    "title": "The Analytics Edge",
-                    "url": f"{openedx_config.alt_url}course-v1:MITx+15.071x+1T2019/course/",
-                    "year": 2019,
-                }
-            ],
-            "raw_json": course,
-        }
-        for course in expected
-    ]
+    transformed_courses = openedx_extract_transform.transform(extracted)
+    assert transformed_courses[0] == {
+        "title": "The Analytics Edge",
+        "course_id": "MITx+15.071x",
+        "short_description": "short_description",
+        "full_description": "full description",
+        "platform": openedx_config.platform,
+        "offered_by": [{"name": openedx_config.offered_by}],
+        "image_src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+        "image_description": "Image description",
+        "last_modified": any_instance_of(datetime),
+        "topics": [{"name": "Data Analysis & Statistics"}],
+        "url": f"{openedx_config.alt_url}MITx+15.071x/course/",
+        "published": True,
+        "runs": []
+        if is_course_run_deleted
+        else [
+            {
+                "availability": "Starting Soon",
+                "best_end_date": "2019-05-22T23:30:00Z",
+                "best_start_date": "2019-02-20T15:00:00Z",
+                "run_id": "course-v1:MITx+15.071x+1T2019",
+                "end_date": "2019-05-22T23:30:00Z",
+                "platform": openedx_config.platform,
+                "enrollment_end": None,
+                "enrollment_start": None,
+                "full_description": "<p>Full Description</p>",
+                "image_description": None,
+                "image_src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+                "instructors": [
+                    {"first_name": "Dimitris", "last_name": "Bertsimas"},
+                    {"first_name": "Allison", "last_name": "O'Hair"},
+                ],
+                "language": "en-us",
+                "last_modified": any_instance_of(datetime),
+                "level": "Intermediate",
+                "offered_by": [{"name": openedx_config.offered_by}],
+                "prices": [
+                    {
+                        "mode": "verified",
+                        "price": "150.00",
+                        "upgrade_deadline": "2019-03-20T15:00:00Z",
+                    },
+                    {"mode": "audit", "price": "0.00", "upgrade_deadline": None},
+                ],
+                "semester": "spring",
+                "short_description": "short_description",
+                "start_date": "2019-02-20T15:00:00Z",
+                "title": "The Analytics Edge",
+                "url": f"{openedx_config.alt_url}course-v1:MITx+15.071x+1T2019/course/",
+                "year": 2019,
+                "published": True,
+            }
+        ],
+        "raw_json": extracted[0],
+    }
+    assert transformed_courses[1]["published"] is False
+    assert transformed_courses[1]["runs"][0]["published"] is False

--- a/test_json/test_mitx_course.json
+++ b/test_json/test_mitx_course.json
@@ -1,213 +1,358 @@
 {
-	"next": "",
-	"results": [{
-		"key": "MITx+15.071x",
-		"uuid": "ff1df27b-3c97-42ee-a9b3-e031ffd41a4f",
-		"title": "The Analytics Edge",
-		"course_runs": [{
-			"key": "course-v1:MITx+15.071x+1T2019",
-			"uuid": "f4b7be41-352f-4c0d-afc5-424dcf498ed6",
-			"title": "The Analytics Edge",
-			"image": {
-				"src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
-				"height": null,
-				"width": null,
-				"description": null
-			},
-			"short_description": "short_description",
-			"marketing_url": "https://www.edx.org/course/the-analytics-edge",
-			"seats": [{
-					"type": "verified",
-					"price": "150.00",
-					"currency": "USD",
-					"upgrade_deadline": "2019-03-20T15:00:00Z",
-					"credit_provider": null,
-					"credit_hours": null,
-					"sku": "E110665",
-					"bulk_sku": "5B37144"
-				},
-				{
-					"type": "audit",
-					"price": "0.00",
-					"currency": "USD",
-					"upgrade_deadline": null,
-					"credit_provider": null,
-					"credit_hours": null,
-					"sku": "98D6AA9",
-					"bulk_sku": null
-				}
-			],
-			"start": "2019-02-20T15:00:00Z",
-			"end": "2019-05-22T23:30:00Z",
-			"enrollment_start": null,
-			"enrollment_end": null,
-			"pacing_type": "instructor_paced",
-			"type": "verified",
-			"status": "published",
-			"course": "MITx+15.071x",
-			"full_description": "<p>Full Description</p>",
-			"announcement": "2018-12-19T15:50:34Z",
-			"video": {
-				"src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
-				"description": null,
-				"image": {
-					"src": "image_source",
-					"description": null,
-					"height": null,
-					"width": null
-				}
-			},
-			"content_language": "en-us",
-			"license": "",
-			"outcome": "outcome",
-			"transcript_languages": ["en-us"],
-			"instructors": [],
-			"staff": [{
-					"uuid": "32720429-8290-4ac5-a62d-386fb3c4be80",
-					"salutation": null,
-					"given_name": "Dimitris",
-					"family_name": "Bertsimas",
-					"bio": "Dimitris Bertsimas bio",
-					"slug": "dimitris-bertsimas",
-					"position": {
-						"title": "Boeing Professor of Operations Research ",
-						"organization_name": "MIT",
-						"organization_id": 27,
-						"organization_override": "MIT",
-						"organization_marketing_url": "https://www.edx.org/school/mitx"
-					},
-					"areas_of_expertise": [],
-					"profile_image": {
-						"medium": {
-							"height": 110,
-							"url": "profile_image",
-							"width": 110
-						}
-					},
-					"works": [],
-					"urls": {
-						"facebook": null,
-						"blog": null,
-						"twitter": null
-					},
-					"urls_detailed": [],
-					"email": null,
-					"profile_image_url": "profile_image_url",
-					"major_works": "",
-					"published": true
-				},
-				{
-					"uuid": "5bb098d8-76fb-450b-9e59-3a60b041f645",
-					"salutation": null,
-					"given_name": "Allison",
-					"family_name": "O'Hair",
-					"bio": "bio",
-					"slug": "allison-ohair",
-					"position": {
-						"title": "Lecturer",
-						"organization_name": "Stanford University",
-						"organization_id": null,
-						"organization_override": "Stanford University",
-						"organization_marketing_url": null
-					},
-					"areas_of_expertise": [],
-					"profile_image": {
-						"medium": {
-							"height": 110,
-							"url": "profile_image_url",
-							"width": 110
-						}
-					},
-					"works": [],
-					"urls": {
-						"facebook": null,
-						"blog": null,
-						"twitter": null
-					},
-					"urls_detailed": [],
-					"email": null,
-					"profile_image_url": "profile_image_url",
-					"major_works": "",
-					"published": true
-				}
-			],
-			"min_effort": 10,
-			"max_effort": 15,
-			"weeks_to_complete": 13,
-			"modified": "2019-01-11T18:27:16.466621Z",
-			"level_type": "Intermediate",
-			"availability": "Starting Soon",
-			"mobile_available": true,
-			"hidden": false,
-			"reporting_type": "mooc",
-			"eligible_for_financial_aid": true,
-			"first_enrollable_paid_seat_price": 150,
-			"has_ofac_restrictions": false,
-			"enrollment_count": 1619,
-			"recent_enrollment_count": 1619
-		}],
-		"entitlements": [],
-		"owners": [{
-			"uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
-			"key": "MITx",
-			"name": "Massachusetts Institute of Technology",
-			"certificate_logo_image_url": "https://edxuploads.s3.amazonaws.com/organization_logos/logo-mitx.png",
-			"description": "description",
-			"homepage_url": "",
-			"tags": ["charter", "founder"],
-			"logo_image_url": "logo_image_url",
-			"marketing_url": "https://www.edx.org/school/mitx"
-		}],
-		"image": {
-			"src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
-			"height": null,
-			"width": null,
-			"description": "Image description"
-		},
-		"short_description": "short_description",
-		"full_description": "full description",
-		"level_type": "Intermediate",
-		"subjects": [{
-			"name": "Data Analysis & Statistics",
-			"subtitle": "subtitle",
-			"description": "description",
-			"banner_image_url": "banner_image_url",
-			"card_image_url": "https://www.edx.org/sites/default/files/subject/image/card/data-science.jpg",
-			"slug": "data-analysis-statistics",
-			"uuid": "a168a80a-4b6c-4d92-9f1d-4c235206feaf"
-		}],
-		"prerequisites": [],
-		"prerequisites_raw": "prerequisites_raw",
-		"expected_learning_items": [],
-		"video": {
-			"src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
-			"description": null,
-			"image": {
-				"src": "video_image_src",
-				"description": null,
-				"height": null,
-				"width": null
-			}
-		},
-		"sponsors": [],
-		"modified": "2019-01-11T18:07:29.593570Z",
-		"marketing_url": "marketing_url",
-		"syllabus_raw": "",
-		"outcome": "outcome",
-		"original_image": {
-			"src": "original_image_src",
-			"height": null,
-			"width": null,
-			"description": null
-		},
-		"card_image_url": "card_image_url",
-		"canonical_course_run_key": "MITx/15.071x/1T2014",
-		"extra_description": null,
-		"additional_information": "",
-		"faq": "faq",
-		"learner_testimonials": "",
-		"enrollment_count": 90600,
-		"recent_enrollment_count": 14365,
-		"topics": []
-	}]
+  "next": "",
+  "results": [
+    {
+      "key": "MITx+15.071x",
+      "uuid": "ff1df27b-3c97-42ee-a9b3-e031ffd41a4f",
+      "title": "The Analytics Edge",
+      "course_runs": [
+        {
+          "key": "course-v1:MITx+15.071x+1T2019",
+          "uuid": "f4b7be41-352f-4c0d-afc5-424dcf498ed6",
+          "title": "The Analytics Edge",
+          "image": {
+            "src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+            "height": null,
+            "width": null,
+            "description": null
+          },
+          "short_description": "short_description",
+          "marketing_url": "https://www.edx.org/course/the-analytics-edge",
+          "seats": [
+            {
+              "type": "verified",
+              "price": "150.00",
+              "currency": "USD",
+              "upgrade_deadline": "2019-03-20T15:00:00Z",
+              "credit_provider": null,
+              "credit_hours": null,
+              "sku": "E110665",
+              "bulk_sku": "5B37144"
+            },
+            {
+              "type": "audit",
+              "price": "0.00",
+              "currency": "USD",
+              "upgrade_deadline": null,
+              "credit_provider": null,
+              "credit_hours": null,
+              "sku": "98D6AA9",
+              "bulk_sku": null
+            }
+          ],
+          "start": "2019-02-20T15:00:00Z",
+          "end": "2019-05-22T23:30:00Z",
+          "enrollment_start": null,
+          "enrollment_end": null,
+          "pacing_type": "instructor_paced",
+          "type": "verified",
+          "status": "published",
+          "course": "MITx+15.071x",
+          "full_description": "<p>Full Description</p>",
+          "announcement": "2018-12-19T15:50:34Z",
+          "video": {
+            "src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
+            "description": null,
+            "image": {
+              "src": "image_source",
+              "description": null,
+              "height": null,
+              "width": null
+            }
+          },
+          "content_language": "en-us",
+          "license": "",
+          "outcome": "outcome",
+          "transcript_languages": [
+            "en-us"
+          ],
+          "instructors": [],
+          "staff": [
+            {
+              "uuid": "32720429-8290-4ac5-a62d-386fb3c4be80",
+              "salutation": null,
+              "given_name": "Dimitris",
+              "family_name": "Bertsimas",
+              "bio": "Dimitris Bertsimas bio",
+              "slug": "dimitris-bertsimas",
+              "position": {
+                "title": "Boeing Professor of Operations Research ",
+                "organization_name": "MIT",
+                "organization_id": 27,
+                "organization_override": "MIT",
+                "organization_marketing_url": "https://www.edx.org/school/mitx"
+              },
+              "areas_of_expertise": [],
+              "profile_image": {
+                "medium": {
+                  "height": 110,
+                  "url": "profile_image",
+                  "width": 110
+                }
+              },
+              "works": [],
+              "urls": {
+                "facebook": null,
+                "blog": null,
+                "twitter": null
+              },
+              "urls_detailed": [],
+              "email": null,
+              "profile_image_url": "profile_image_url",
+              "major_works": "",
+              "published": true
+            },
+            {
+              "uuid": "5bb098d8-76fb-450b-9e59-3a60b041f645",
+              "salutation": null,
+              "given_name": "Allison",
+              "family_name": "O'Hair",
+              "bio": "bio",
+              "slug": "allison-ohair",
+              "position": {
+                "title": "Lecturer",
+                "organization_name": "Stanford University",
+                "organization_id": null,
+                "organization_override": "Stanford University",
+                "organization_marketing_url": null
+              },
+              "areas_of_expertise": [],
+              "profile_image": {
+                "medium": {
+                  "height": 110,
+                  "url": "profile_image_url",
+                  "width": 110
+                }
+              },
+              "works": [],
+              "urls": {
+                "facebook": null,
+                "blog": null,
+                "twitter": null
+              },
+              "urls_detailed": [],
+              "email": null,
+              "profile_image_url": "profile_image_url",
+              "major_works": "",
+              "published": true
+            }
+          ],
+          "min_effort": 10,
+          "max_effort": 15,
+          "weeks_to_complete": 13,
+          "modified": "2019-01-11T18:27:16.466621Z",
+          "level_type": "Intermediate",
+          "availability": "Starting Soon",
+          "mobile_available": true,
+          "hidden": false,
+          "reporting_type": "mooc",
+          "eligible_for_financial_aid": true,
+          "first_enrollable_paid_seat_price": 150,
+          "has_ofac_restrictions": false,
+          "enrollment_count": 1619,
+          "recent_enrollment_count": 1619
+        }
+      ],
+      "entitlements": [],
+      "owners": [
+        {
+          "uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
+          "key": "MITx",
+          "name": "Massachusetts Institute of Technology",
+          "certificate_logo_image_url": "https://edxuploads.s3.amazonaws.com/organization_logos/logo-mitx.png",
+          "description": "description",
+          "homepage_url": "",
+          "tags": [
+            "charter",
+            "founder"
+          ],
+          "logo_image_url": "logo_image_url",
+          "marketing_url": "https://www.edx.org/school/mitx"
+        }
+      ],
+      "image": {
+        "src": "https://prod-discovery.edx-cdn.org/media/course/image/ff1df27b-3c97-42ee-a9b3-e031ffd41a4f-747c9c2f216e.small.jpg",
+        "height": null,
+        "width": null,
+        "description": "Image description"
+      },
+      "short_description": "short_description",
+      "full_description": "full description",
+      "level_type": "Intermediate",
+      "subjects": [
+        {
+          "name": "Data Analysis & Statistics",
+          "subtitle": "subtitle",
+          "description": "description",
+          "banner_image_url": "banner_image_url",
+          "card_image_url": "https://www.edx.org/sites/default/files/subject/image/card/data-science.jpg",
+          "slug": "data-analysis-statistics",
+          "uuid": "a168a80a-4b6c-4d92-9f1d-4c235206feaf"
+        }
+      ],
+      "prerequisites": [],
+      "prerequisites_raw": "prerequisites_raw",
+      "expected_learning_items": [],
+      "video": {
+        "src": "http://www.youtube.com/watch?v=1BMSOBCe07k",
+        "description": null,
+        "image": {
+          "src": "video_image_src",
+          "description": null,
+          "height": null,
+          "width": null
+        }
+      },
+      "sponsors": [],
+      "modified": "2019-01-11T18:07:29.593570Z",
+      "marketing_url": "marketing_url",
+      "syllabus_raw": "",
+      "outcome": "outcome",
+      "original_image": {
+        "src": "original_image_src",
+        "height": null,
+        "width": null,
+        "description": null
+      },
+      "card_image_url": "card_image_url",
+      "canonical_course_run_key": "MITx/15.071x/1T2014",
+      "extra_description": null,
+      "additional_information": "",
+      "faq": "faq",
+      "learner_testimonials": "",
+      "enrollment_count": 90600,
+      "recent_enrollment_count": 14365,
+      "topics": []
+    },
+    {
+      "faq": null,
+      "key": "MITx+8.370.3x_review",
+      "type": "e85a9f60-2da5-4413-96b7-dcb9b8c0e9f1",
+      "uuid": "e8d36b4e-69e1-40d3-89e5-d534cc4409fe",
+      "image": null,
+      "title": "Quantum Information Science I, Part 3 REVIEW",
+      "video": null,
+      "owners": [
+        {
+          "key": "MITx",
+          "name": "Massachusetts Institute of Technology",
+          "slug": "mitx",
+          "tags": [
+            "charter",
+            "founder",
+            "displayed_on_schools_and_partners_page",
+            "displayed_on_sitemap_page"
+          ],
+          "uuid": "2a73d2ce-c34a-4e08-8223-83bca9d2f01d",
+          "description": "<p>Course Description</p>",
+          "homepage_url": null,
+          "marketing_url": "https://www.edx.org/school/mitx",
+          "description_es": "Course Description ES",
+          "logo_image_url": "https://prod-discovery.edx-cdn.org/organization/logos/2a73d2ce-c34a-4e08-8223-83bca9d2f01d-2cc8854c6fee.png",
+          "banner_image_url": "https://prod-discovery.edx-cdn.org/organization/banner_images/2a73d2ce-c34a-4e08-8223-83bca9d2f01d-af92c193a9fa.jpg",
+          "certificate_logo_image_url": "https://prod-discovery.edx-cdn.org/organization/certificate_logos/2a73d2ce-c34a-4e08-8223-83bca9d2f01d-239e27d970f5.png",
+          "auto_generate_course_run_keys": true,
+          "enterprise_subscription_inclusion": true
+        }
+      ],
+      "skills": [],
+      "topics": [],
+      "editors": [],
+      "outcome": null,
+      "modified": "2022-09-09T12:21:19.071442Z",
+      "sponsors": [],
+      "subjects": [],
+      "url_slug": "quantum-information-science-i-part-3-review",
+      "level_type": null,
+      "course_runs": [
+        {
+          "end": "2018-05-11T23:30:00Z",
+          "key": "course-v1:MITx+8.370.3x_review+1T2018",
+          "type": null,
+          "uuid": "a771c5d4-4efe-4f20-bf98-bba875ea6b2c",
+          "image": null,
+          "seats": [],
+          "staff": [],
+          "start": "2018-04-09T15:00:00Z",
+          "title": "Quantum Information Science I, Part 3 REVIEW",
+          "video": null,
+          "course": "MITx+8.370.3x_review",
+          "hidden": true,
+          "status": "unpublished",
+          "license": "",
+          "outcome": null,
+          "modified": "2022-09-09T12:21:19.088969Z",
+          "run_type": "a2b97526-a13e-4eda-985a-a5ef2eef5414",
+          "level_type": null,
+          "max_effort": null,
+          "min_effort": null,
+          "course_uuid": "e8d36b4e-69e1-40d3-89e5-d534cc4409fe",
+          "instructors": [],
+          "pacing_type": "instructor_paced",
+          "announcement": null,
+          "availability": "Archived",
+          "external_key": null,
+          "go_live_date": null,
+          "ofac_comment": "",
+          "is_enrollable": false,
+          "is_marketable": false,
+          "marketing_url": "https://courses.edx.org//courses/course-v1:MITx+8.370.3x_review+1T2018/course/",
+          "enrollment_end": "2018-05-11T00:00:00Z",
+          "reporting_type": "mooc",
+          "estimated_hours": 0,
+          "content_language": null,
+          "enrollment_count": 0,
+          "enrollment_start": null,
+          "full_description": null,
+          "mobile_available": false,
+          "short_description": null,
+          "weeks_to_complete": null,
+          "transcript_languages": [],
+          "expected_program_name": "",
+          "expected_program_type": null,
+          "has_ofac_restrictions": false,
+          "recent_enrollment_count": 0,
+          "eligible_for_financial_aid": true,
+          "first_enrollable_paid_seat_price": null,
+          "enterprise_subscription_inclusion": false,
+          "content_language_search_facet_name": null
+        }
+      ],
+      "course_type": "verified-audit",
+      "geolocation": null,
+      "skill_names": [],
+      "entitlements": [],
+      "syllabus_raw": null,
+      "collaborators": [],
+      "in_year_value": null,
+      "marketing_url": "https://www.edx.org/course/quantum-information-science-i-part-3-review?utm_source=ocwprod-mit-opencourseware&utm_medium=affiliate_partner",
+      "prerequisites": [],
+      "url_redirects": [
+        "node/53896",
+        "courses/course-v1:MITx+8.370.3x_review+1T2018/about"
+      ],
+      "card_image_url": null,
+      "key_for_reruns": "",
+      "original_image": null,
+      "enrollment_count": 0,
+      "full_description": null,
+      "url_slug_history": [
+        "quantum-information-science-i-part-3-review"
+      ],
+      "extra_description": null,
+      "prerequisites_raw": null,
+      "short_description": null,
+      "additional_metadata": null,
+      "course_run_statuses": [],
+      "learner_testimonials": null,
+      "location_restriction": null,
+      "additional_information": null,
+      "expected_learning_items": [],
+      "recent_enrollment_count": 0,
+      "canonical_course_run_key": "course-v1:MITx+8.370.3x_review+1T2018",
+      "organization_logo_override_url": null,
+      "organization_short_code_override": "",
+      "enterprise_subscription_inclusion": false
+    }
+  ]
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3731

#### What's this PR do?
For openedx-based courses (Open Learning Library, MITx courses on EdX) - set `published=False` if no runs for a course have a status of `published`.

#### How should this be manually tested?
- Copy `EDX_API_`  values from heroku prod to your local .env file. 
- Run `heroku run python manage.py backpopulate_edx_data`
- Using django admin or shell, check that the courses with `platform=mitx` have `published=True` if any of their runs in the `raw_json` have `status: "published"`; or `published=False` otherwise (example: course with `url=https://courses.edx.org/courses/MITx+8.370.3x_review/course/`)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
Ideally it would be good to test with `backpopulate_oll_data` too for Open Learning Library courses, but the .env authorization values we have for those are no longer valid and it may take some time to get new ones.
