### PR TITLE
Remove transient errors in start-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "foreach-with-fallback": "yarn workspaces foreach --verbose --topological exec node ${PROJECT_CWD}/scripts/yarn-run-with-fallback.js $0 $1",
         "postinstall": "yarn run build",
-        "start-dev": "yarn workspaces foreach --verbose --parallel --jobs unlimited --interlaced exec node ${PROJECT_CWD}/scripts/yarn-run-with-fallback.js start-dev global:start-dev",
+        "start-dev": "yarn run build && yarn workspaces foreach --verbose --parallel --jobs unlimited --interlaced exec node ${PROJECT_CWD}/scripts/yarn-run-with-fallback.js start-dev global:start-dev",
         "build": "run foreach-with-fallback build global:build",
         "clean": "run foreach-with-fallback clean global:clean",
         "lint-check": "run foreach-with-fallback lint-check global:lint-check",
@@ -18,7 +18,7 @@
         "scss-lint": "run foreach-with-fallback scss-lint global:scss-lint",
         "typecheck": "run foreach-with-fallback typecheck global:typecheck",
         "global:build": "cd $INIT_CWD && yarn global:clean && yarn global:compile",
-        "global:start-dev": "cd $INIT_CWD && yarn global:clean && yarn global:compile-watch",
+        "global:start-dev": "cd $INIT_CWD && yarn global:compile-watch",
         "global:clean": "cd $INIT_CWD && rimraf -rf build/ tsconfig.tsbuildinfo",
         "global:compile": "cd $INIT_CWD && tsc",
         "global:compile-watch": "cd $INIT_CWD && tsc --watch",

--- a/scripts/run-watch-dev.sh
+++ b/scripts/run-watch-dev.sh
@@ -3,7 +3,7 @@
 # This script runs the react devserver, or runs a build, dependent on NODE_ENV
 set -e
 
-yarn install --immutable
+yarn install --immutable --inline-builds
 
 if [[ $NODE_ENV == "production" ]] ; then
     echo "Building frontends for production..."


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3691

#### What's this PR do?
This PR ensures that all projects have been build before the dev servers starts.

For context:
- `yarn run build` would build the all the local packages in using yarn's `--topological` flag, which says to build dependencies before dependents
- Previously, `yarn run start-dev` (which `docker compose up` uses) would start watching all the projects concurrently. Since they all start concurrently, sometimes `ol-search-ui` would try to build before its dependents and fail. 

#### How should this be manually tested?
Run `docker compose up`. Webpack should eventually finish building and you'll be able to visit infinite corridor.

You can use
```
docker compose logs --follow --no-log-prefix  --tail 1000 watch
``` 
to monitor the build with less clutter.