### PR TITLE
Refactor xpro course file sync

### DIFF
--- a/course_catalog/etl/edx_shared.py
+++ b/course_catalog/etl/edx_shared.py
@@ -1,0 +1,80 @@
+"""Shared functions for EdX sites"""
+import logging
+import os
+import re
+from subprocess import CalledProcessError, check_call
+from tempfile import TemporaryDirectory
+
+from django.contrib.contenttypes.models import ContentType
+
+from course_catalog.etl.loaders import load_content_files
+from course_catalog.etl.utils import get_learning_course_bucket, transform_content_files
+from course_catalog.models import Course, LearningResourceRun
+from course_catalog.utils import get_s3_object_and_read
+
+log = logging.getLogger()
+
+
+def sync_edx_course_files(bucket_name, platform, ids):
+    """
+    Sync all edx course run files for a list of course ids to database
+
+    Args:
+        ids(list of int): list of course ids to process
+    """
+    bucket = get_learning_course_bucket(bucket_name)
+
+    try:
+        course_tar_regex = r".*/courses/.*\.tar\.gz$"
+        most_recent_export_date = next(
+            reversed(
+                sorted(
+                    [
+                        obj
+                        for obj in bucket.objects.filter(Prefix="20")
+                        if re.search(course_tar_regex, obj.key)
+                    ],
+                    key=lambda obj: obj.last_modified,
+                )
+            )
+        ).key.split("/")[0]
+        most_recent_course_zips = [
+            obj
+            for obj in bucket.objects.filter(Prefix=most_recent_export_date)
+            if re.search(course_tar_regex, obj.key)
+        ]
+    except (StopIteration, IndexError):
+        log.warning(
+            "No %s exported courses found in S3 bucket %s", platform, bucket_name
+        )
+        return
+
+    for course_tarfile in most_recent_course_zips:
+        matches = re.search(r"courses/(.+)\.tar\.gz$", course_tarfile.key)
+        run = LearningResourceRun.objects.filter(
+            platform=platform,
+            run_id=matches.group(1),
+            content_type=ContentType.objects.get_for_model(Course),
+            object_id__in=ids,
+        ).first()
+        if not run:
+            log.info(
+                "No %s courses matched course tarfile %s", platform, course_tarfile
+            )
+            continue
+        with TemporaryDirectory() as export_tempdir, TemporaryDirectory() as tar_tempdir:
+            tarbytes = get_s3_object_and_read(course_tarfile)
+            course_tarpath = os.path.join(
+                export_tempdir, course_tarfile.key.split("/")[-1]
+            )
+            with open(course_tarpath, "wb") as f:
+                f.write(tarbytes)
+            try:
+                check_call(["tar", "xf", course_tarpath], cwd=tar_tempdir)
+            except CalledProcessError:
+                log.exception("Unable to untar %s", course_tarfile)
+                continue
+            try:
+                load_content_files(run, transform_content_files(course_tarpath))
+            except:  # pylint: disable=bare-except
+                log.exception("Error ingesting OLX content data for %s", course_tarfile)

--- a/course_catalog/etl/edx_shared_test.py
+++ b/course_catalog/etl/edx_shared_test.py
@@ -1,0 +1,161 @@
+"""ETL utils test"""
+from subprocess import CalledProcessError
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from course_catalog.constants import PlatformType
+from course_catalog.etl.edx_shared import sync_edx_course_files
+from course_catalog.factories import LearningResourceRunFactory
+from course_catalog.models import Course
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_edx_course_files(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """sync mitxonline courses from a tarball stored in S3"""
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.edx_shared.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
+    fake_data = '{"key": "data"}'
+    mock_transform = mocker.patch(
+        "course_catalog.etl.edx_shared.transform_content_files", return_value=fake_data
+    )
+    run_ids = ("course-v1:MITxT+8.01.3x+3T2022", "course-v1:MITxT+8.01.4x+3T2022")
+    course_ids = []
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    for run_id in run_ids:
+        bucket.put_object(
+            Key=f"20220101/courses/{run_id}.tar.gz",
+            Body=open(f"test_json/{run_id}.tar.gz", "rb").read(),
+            ACL="public-read",
+        )
+        run = LearningResourceRunFactory.create(
+            platform=platform,
+            run_id=run_id,
+            content_type=ContentType.objects.get_for_model(Course),
+        )
+        course_ids.append(run.object_id)
+    sync_edx_course_files(bucket.name, platform, course_ids)
+    assert mock_transform.call_count == 2
+    assert mock_transform.call_args[0][0].endswith(f"{run_id}.tar.gz") is True
+    mock_load_content_files.assert_any_call(run, fake_data)
+    mock_log.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_edx_course_files_invalid_tarfile(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """an invalid mitxonline tarball should be skipped"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key=f"20220101/courses/{run.run_id}.tar.gz",
+        Body=b"".join([b"x" for _ in range(100)]),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.edx_shared.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    mocker.patch(
+        "course_catalog.etl.edx_shared.check_call",
+        side_effect=CalledProcessError(0, ""),
+    )
+    mock_log = mocker.patch("course_catalog.etl.edx_shared.log.exception")
+
+    sync_edx_course_files(bucket.name, platform, [run.object_id])
+    mock_load_content_files.assert_not_called()
+    mock_log.assert_called_once()
+    assert mock_log.call_args[0][0].startswith("Unable to untar ") is True
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_edx_course_files_empty_bucket(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """If the mitxonline bucket has no tarballs matching a filename, it should be skipped"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key="20220101/courses/some_other_course.tar.gz",
+        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.edx_shared.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    sync_edx_course_files(bucket.name, platform, [run.object_id])
+    mock_load_content_files.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_edx_course_files_error(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """Exceptions raised during sync_mitxonline_course_files should be logged"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key=f"20220101/courses/{run.run_id}.tar.gz",
+        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.edx_shared.load_content_files",
+        autospec=True,
+        side_effect=Exception,
+    )
+    fake_data = '{"key": "data"}'
+    mock_log = mocker.patch("course_catalog.etl.edx_shared.log.exception")
+    mock_transform = mocker.patch(
+        "course_catalog.etl.edx_shared.transform_content_files", return_value=fake_data
+    )
+    sync_edx_course_files(bucket.name, platform, [run.object_id])
+    assert mock_transform.call_count == 1
+    assert mock_transform.call_args[0][0].endswith(f"{run.run_id}.tar.gz") is True
+    mock_load_content_files.assert_called_once_with(run, fake_data)
+    assert mock_log.call_args[0][0].startswith("Error ingesting OLX content data for ")

--- a/course_catalog/etl/mitxonline_test.py
+++ b/course_catalog/etl/mitxonline_test.py
@@ -4,22 +4,14 @@ import json
 # pylint: disable=redefined-outer-name
 from datetime import datetime
 from itertools import chain
-from subprocess import CalledProcessError
 from urllib.parse import urljoin
 
 import pytest
-from django.contrib.contenttypes.models import ContentType
 
 from course_catalog.constants import PlatformType
 from course_catalog.etl import mitxonline
-from course_catalog.etl.mitxonline import (
-    _parse_datetime,
-    parse_page_attribute,
-    sync_mitxonline_course_files,
-)
+from course_catalog.etl.mitxonline import _parse_datetime, parse_page_attribute
 from course_catalog.etl.utils import UCC_TOPIC_MAPPINGS
-from course_catalog.factories import LearningResourceRunFactory
-from course_catalog.models import Course
 from open_discussions.test_utils import any_instance_of
 
 pytestmark = pytest.mark.django_db
@@ -37,16 +29,6 @@ def mock_mitxonline_courses_data():
     """Mock mitxonline data"""
     with open("./test_json/mitxonline_courses.json", "r") as f:
         return json.loads(f.read())
-
-
-@pytest.fixture
-def mitx_online_run():
-    """Test MITX Online course run"""
-    return LearningResourceRunFactory.create(
-        platform=PlatformType.mitxonline.value,
-        run_id="course-v1:MITxT+8.01.3x+3T2022",
-        content_type=ContentType.objects.get_for_model(Course),
-    )
 
 
 @pytest.fixture
@@ -101,7 +83,7 @@ def test_mitxonline_extract_courses_disabled(settings):
     assert mitxonline.extract_courses() == []
 
 
-def test_mitxonline_transform_programs(settings, mock_mitxonline_programs_data):
+def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
     """Test that mitxonline program data is correctly transformed into our normalized structure"""
     result = mitxonline.transform_programs(mock_mitxonline_programs_data)
     expected = [
@@ -243,9 +225,7 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
             ),
             "short_description": course_data.get("page", {}).get("description", None),
             "offered_by": mitxonline.OFFERED_BY,
-            "published": True
-            if course_data.get("page", {}).get("page_url", None) is not None
-            else False,
+            "published": course_data.get("page", {}).get("page_url", None) is not None,
             "topics": [
                 {"name": topic_name}
                 for topic_name in chain.from_iterable(
@@ -310,109 +290,3 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
         if "PROCTORED EXAM" not in course_data["title"]
     ]
     assert expected == result
-
-
-def test_sync_mitxonline_course_files(mock_mitxonline_learning_bucket, mocker):
-    """sync mitxonline courses from a tarball stored in S3"""
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.mitxonline.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    mock_log = mocker.patch("course_catalog.etl.mitxonline.log.exception")
-    fake_data = '{"key": "data"}'
-    mock_transform = mocker.patch(
-        "course_catalog.etl.mitxonline.transform_content_files", return_value=fake_data
-    )
-    run_ids = ("course-v1:MITxT+8.01.3x+3T2022", "course-v1:MITxT+8.01.4x+3T2022")
-    course_ids = []
-    for run_id in run_ids:
-        mock_mitxonline_learning_bucket.bucket.put_object(
-            Key=f"20220101/courses/{run_id}.tar.gz",
-            Body=open(f"test_json/{run_id}.tar.gz", "rb").read(),
-            ACL="public-read",
-        )
-        run = LearningResourceRunFactory.create(
-            platform=PlatformType.mitxonline.value,
-            run_id=run_id,
-            content_type=ContentType.objects.get_for_model(Course),
-        )
-        course_ids.append(run.object_id)
-    sync_mitxonline_course_files(ids=course_ids)
-    assert mock_transform.call_count == 2
-    assert mock_transform.call_args[0][0].endswith(f"{run_id}.tar.gz") is True
-    mock_load_content_files.assert_any_call(run, fake_data)
-    mock_log.assert_not_called()
-
-
-def test_sync_mitxonline_course_files_invalid_tarfile(
-    mock_mitxonline_learning_bucket, mitx_online_run, mocker
-):
-    """an invalid mitxonline tarball should be skipped"""
-    mock_mitxonline_learning_bucket.bucket.put_object(
-        Key=f"20220101/courses/{mitx_online_run.run_id}.tar.gz",
-        Body=b"".join([b"x" for _ in range(100)]),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.mitxonline.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    mocker.patch(
-        "course_catalog.etl.mitxonline.check_call",
-        side_effect=CalledProcessError(0, ""),
-    )
-    mock_log = mocker.patch("course_catalog.etl.mitxonline.log.exception")
-
-    sync_mitxonline_course_files(ids=[mitx_online_run.object_id])
-    mock_load_content_files.assert_not_called()
-    mock_log.assert_called_once()
-    assert mock_log.call_args[0][0].startswith("Unable to untar ") is True
-
-
-def test_sync_mitxonline_course_files_empty_bucket(
-    mock_mitxonline_learning_bucket, mitx_online_run, mocker
-):
-    """If the mitxonline bucket has no tarballs matching a filename, it should be skipped"""
-    mock_mitxonline_learning_bucket.bucket.put_object(
-        Key="20220101/courses/some_other_course.tar.gz",
-        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.mitxonline.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    sync_mitxonline_course_files(ids=[mitx_online_run.object_id])
-    mock_load_content_files.assert_not_called()
-
-
-def test_sync_mitxonline_course_files_error(
-    mock_mitxonline_learning_bucket, mitx_online_run, mocker
-):
-    """Exceptions raised during sync_mitxonline_course_files should be logged"""
-    mock_mitxonline_learning_bucket.bucket.put_object(
-        Key=f"20220101/courses/{mitx_online_run.run_id}.tar.gz",
-        Body=open(f"test_json/{mitx_online_run.run_id}.tar.gz", "rb").read(),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.mitxonline.load_content_files",
-        autospec=True,
-        side_effect=Exception,
-    )
-    fake_data = '{"key": "data"}'
-    mock_log = mocker.patch("course_catalog.etl.mitxonline.log.exception")
-    mock_transform = mocker.patch(
-        "course_catalog.etl.mitxonline.transform_content_files", return_value=fake_data
-    )
-    sync_mitxonline_course_files(ids=[mitx_online_run.object_id])
-    assert mock_transform.call_count == 1
-    assert (
-        mock_transform.call_args[0][0].endswith(f"{mitx_online_run.run_id}.tar.gz")
-        is True
-    )
-    mock_load_content_files.assert_called_once_with(mitx_online_run, fake_data)
-    assert mock_log.call_args[0][0].startswith("Error ingesting OLX content data for ")

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime
 from functools import wraps
 from itertools import chain
-from subprocess import check_call
+from subprocess import CalledProcessError, check_call
 from tempfile import TemporaryDirectory
 
 import boto3
@@ -18,6 +18,7 @@ import pytz
 import rapidjson
 import requests
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.utils.functional import SimpleLazyObject
 from tika import parser as tika_parser
 from xbundle import XBundle
@@ -27,7 +28,9 @@ from course_catalog.constants import (
     CONTENT_TYPE_VERTICAL,
     VALID_TEXT_FILE_TYPES,
 )
-from course_catalog.models import get_max_length
+from course_catalog.etl.loaders import load_content_files
+from course_catalog.models import Course, LearningResourceRun, get_max_length
+from course_catalog.utils import get_s3_object_and_read
 
 log = logging.getLogger()
 
@@ -438,3 +441,70 @@ def transform_topics(topics):
             [UCC_TOPIC_MAPPINGS.get(topic["name"], [topic["name"]]) for topic in topics]
         )
     ]
+
+
+def sync_olx_course_files(bucket_name, platform, ids):
+    """
+    Sync all edx course run files for a list of course ids to database
+
+    Args:
+        ids(list of int): list of course ids to process
+    """
+    bucket = get_learning_course_bucket(bucket_name)
+
+    try:
+        course_tar_regex = r".*/courses/.*\.tar\.gz$"
+        most_recent_export_date = next(
+            reversed(
+                sorted(
+                    [
+                        obj
+                        for obj in bucket.objects.filter(Prefix="20")
+                        if re.search(course_tar_regex, obj.key)
+                    ],
+                    key=lambda obj: obj.last_modified,
+                )
+            )
+        ).key.split("/")[0]
+        most_recent_course_zips = [
+            obj
+            for obj in bucket.objects.filter(Prefix=most_recent_export_date)
+            if re.search(course_tar_regex, obj.key)
+        ]
+    except (StopIteration, IndexError):
+        log.warning(
+            "No %s exported courses found in S3 bucket %s", platform, bucket_name
+        )
+        return
+
+    course_content_type = ContentType.objects.get_for_model(Course)
+    for course_tarfile in most_recent_course_zips:
+        matches = re.search(r"courses/(.+)\.tar\.gz$", course_tarfile.key)
+        run_id = matches.group(1)
+        run = LearningResourceRun.objects.filter(
+            platform=platform,
+            run_id=run_id,
+            content_type=course_content_type,
+            object_id__in=ids,
+        ).first()
+        if not run:
+            log.info(
+                "No %s courses matched course tarfile %s", platform, course_tarfile
+            )
+            continue
+        with TemporaryDirectory() as export_tempdir, TemporaryDirectory() as tar_tempdir:
+            tarbytes = get_s3_object_and_read(course_tarfile)
+            course_tarpath = os.path.join(
+                export_tempdir, course_tarfile.key.split("/")[-1]
+            )
+            with open(course_tarpath, "wb") as f:
+                f.write(tarbytes)
+            try:
+                check_call(["tar", "xf", course_tarpath], cwd=tar_tempdir)
+            except CalledProcessError:
+                log.exception("Unable to untar %s", course_tarfile)
+                continue
+            try:
+                load_content_files(run, transform_content_files(course_tarpath))
+            except:  # pylint: disable=bare-except
+                log.exception("Error ingesting OLX content data for %s", course_tarfile)

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -3,14 +3,19 @@ import datetime
 import json
 import os
 import pathlib
-from subprocess import check_call
+from subprocess import CalledProcessError, check_call
 from tempfile import TemporaryDirectory
 
 import pytest
 import pytz
+from django.contrib.contenttypes.models import ContentType
 from lxml import etree
 
-from course_catalog.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_VERTICAL
+from course_catalog.constants import (
+    CONTENT_TYPE_FILE,
+    CONTENT_TYPE_VERTICAL,
+    PlatformType,
+)
 from course_catalog.etl.utils import (
     documents_from_olx,
     extract_text_from_url,
@@ -21,9 +26,14 @@ from course_catalog.etl.utils import (
     map_topics,
     parse_dates,
     strip_extra_whitespace,
+    sync_olx_course_files,
     sync_s3_text,
     transform_content_files,
 )
+from course_catalog.factories import LearningResourceRunFactory
+from course_catalog.models import Course
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize("side_effect", ["One", Exception("error")])
@@ -296,3 +306,152 @@ def test_documents_from_olx():
     assert formula2do[1]["key"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
     assert formula2do[1]["mime_type"] == "application/xml"
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_olx_course_files(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """sync mitxonline courses from a tarball stored in S3"""
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.utils.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
+    fake_data = '{"key": "data"}'
+    mock_transform = mocker.patch(
+        "course_catalog.etl.utils.transform_content_files", return_value=fake_data
+    )
+    run_ids = ("course-v1:MITxT+8.01.3x+3T2022", "course-v1:MITxT+8.01.4x+3T2022")
+    course_ids = []
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    for run_id in run_ids:
+        bucket.put_object(
+            Key=f"20220101/courses/{run_id}.tar.gz",
+            Body=open(f"test_json/{run_id}.tar.gz", "rb").read(),
+            ACL="public-read",
+        )
+        run = LearningResourceRunFactory.create(
+            platform=platform,
+            run_id=run_id,
+            content_type=ContentType.objects.get_for_model(Course),
+        )
+        course_ids.append(run.object_id)
+    sync_olx_course_files(bucket.name, platform, course_ids)
+    assert mock_transform.call_count == 2
+    assert mock_transform.call_args[0][0].endswith(f"{run_id}.tar.gz") is True
+    mock_load_content_files.assert_any_call(run, fake_data)
+    mock_log.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_olx_course_files_invalid_tarfile(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """an invalid mitxonline tarball should be skipped"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key=f"20220101/courses/{run.run_id}.tar.gz",
+        Body=b"".join([b"x" for _ in range(100)]),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.utils.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    mocker.patch(
+        "course_catalog.etl.utils.check_call",
+        side_effect=CalledProcessError(0, ""),
+    )
+    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
+
+    sync_olx_course_files(bucket.name, platform, [run.object_id])
+    mock_load_content_files.assert_not_called()
+    mock_log.assert_called_once()
+    assert mock_log.call_args[0][0].startswith("Unable to untar ") is True
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_olx_course_files_empty_bucket(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """If the mitxonline bucket has no tarballs matching a filename, it should be skipped"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key="20220101/courses/some_other_course.tar.gz",
+        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.utils.load_content_files",
+        autospec=True,
+        return_value=[],
+    )
+    sync_olx_course_files(bucket.name, platform, [run.object_id])
+    mock_load_content_files.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
+)
+def test_sync_olx_course_files_error(
+    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
+):
+    """Exceptions raised during sync_mitxonline_course_files should be logged"""
+    run = LearningResourceRunFactory.create(
+        platform=platform,
+        content_type=ContentType.objects.get_for_model(Course),
+    )
+    bucket = (
+        mock_mitxonline_learning_bucket
+        if platform == PlatformType.mitxonline.value
+        else mock_xpro_learning_bucket
+    ).bucket
+    bucket.put_object(
+        Key=f"20220101/courses/{run.run_id}.tar.gz",
+        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
+        ACL="public-read",
+    )
+    mock_load_content_files = mocker.patch(
+        "course_catalog.etl.utils.load_content_files",
+        autospec=True,
+        side_effect=Exception,
+    )
+    fake_data = '{"key": "data"}'
+    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
+    mock_transform = mocker.patch(
+        "course_catalog.etl.utils.transform_content_files", return_value=fake_data
+    )
+    sync_olx_course_files(bucket.name, platform, [run.object_id])
+    assert mock_transform.call_count == 1
+    assert mock_transform.call_args[0][0].endswith(f"{run.run_id}.tar.gz") is True
+    mock_load_content_files.assert_called_once_with(run, fake_data)
+    assert mock_log.call_args[0][0].startswith("Error ingesting OLX content data for ")

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -3,19 +3,14 @@ import datetime
 import json
 import os
 import pathlib
-from subprocess import CalledProcessError, check_call
+from subprocess import check_call
 from tempfile import TemporaryDirectory
 
 import pytest
 import pytz
-from django.contrib.contenttypes.models import ContentType
 from lxml import etree
 
-from course_catalog.constants import (
-    CONTENT_TYPE_FILE,
-    CONTENT_TYPE_VERTICAL,
-    PlatformType,
-)
+from course_catalog.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_VERTICAL
 from course_catalog.etl.utils import (
     documents_from_olx,
     extract_text_from_url,
@@ -26,12 +21,9 @@ from course_catalog.etl.utils import (
     map_topics,
     parse_dates,
     strip_extra_whitespace,
-    sync_olx_course_files,
     sync_s3_text,
     transform_content_files,
 )
-from course_catalog.factories import LearningResourceRunFactory
-from course_catalog.models import Course
 
 pytestmark = pytest.mark.django_db
 
@@ -306,152 +298,3 @@ def test_documents_from_olx():
     assert formula2do[1]["key"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
     assert formula2do[1]["mime_type"] == "application/xml"
-
-
-@pytest.mark.parametrize(
-    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
-)
-def test_sync_olx_course_files(
-    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
-):
-    """sync mitxonline courses from a tarball stored in S3"""
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.utils.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
-    fake_data = '{"key": "data"}'
-    mock_transform = mocker.patch(
-        "course_catalog.etl.utils.transform_content_files", return_value=fake_data
-    )
-    run_ids = ("course-v1:MITxT+8.01.3x+3T2022", "course-v1:MITxT+8.01.4x+3T2022")
-    course_ids = []
-    bucket = (
-        mock_mitxonline_learning_bucket
-        if platform == PlatformType.mitxonline.value
-        else mock_xpro_learning_bucket
-    ).bucket
-    for run_id in run_ids:
-        bucket.put_object(
-            Key=f"20220101/courses/{run_id}.tar.gz",
-            Body=open(f"test_json/{run_id}.tar.gz", "rb").read(),
-            ACL="public-read",
-        )
-        run = LearningResourceRunFactory.create(
-            platform=platform,
-            run_id=run_id,
-            content_type=ContentType.objects.get_for_model(Course),
-        )
-        course_ids.append(run.object_id)
-    sync_olx_course_files(bucket.name, platform, course_ids)
-    assert mock_transform.call_count == 2
-    assert mock_transform.call_args[0][0].endswith(f"{run_id}.tar.gz") is True
-    mock_load_content_files.assert_any_call(run, fake_data)
-    mock_log.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
-)
-def test_sync_olx_course_files_invalid_tarfile(
-    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
-):
-    """an invalid mitxonline tarball should be skipped"""
-    run = LearningResourceRunFactory.create(
-        platform=platform,
-        content_type=ContentType.objects.get_for_model(Course),
-    )
-    bucket = (
-        mock_mitxonline_learning_bucket
-        if platform == PlatformType.mitxonline.value
-        else mock_xpro_learning_bucket
-    ).bucket
-    bucket.put_object(
-        Key=f"20220101/courses/{run.run_id}.tar.gz",
-        Body=b"".join([b"x" for _ in range(100)]),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.utils.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    mocker.patch(
-        "course_catalog.etl.utils.check_call",
-        side_effect=CalledProcessError(0, ""),
-    )
-    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
-
-    sync_olx_course_files(bucket.name, platform, [run.object_id])
-    mock_load_content_files.assert_not_called()
-    mock_log.assert_called_once()
-    assert mock_log.call_args[0][0].startswith("Unable to untar ") is True
-
-
-@pytest.mark.parametrize(
-    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
-)
-def test_sync_olx_course_files_empty_bucket(
-    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
-):
-    """If the mitxonline bucket has no tarballs matching a filename, it should be skipped"""
-    run = LearningResourceRunFactory.create(
-        platform=platform,
-        content_type=ContentType.objects.get_for_model(Course),
-    )
-    bucket = (
-        mock_mitxonline_learning_bucket
-        if platform == PlatformType.mitxonline.value
-        else mock_xpro_learning_bucket
-    ).bucket
-    bucket.put_object(
-        Key="20220101/courses/some_other_course.tar.gz",
-        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.utils.load_content_files",
-        autospec=True,
-        return_value=[],
-    )
-    sync_olx_course_files(bucket.name, platform, [run.object_id])
-    mock_load_content_files.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "platform", [PlatformType.mitxonline.value, PlatformType.xpro.value]
-)
-def test_sync_olx_course_files_error(
-    mock_mitxonline_learning_bucket, mock_xpro_learning_bucket, mocker, platform
-):
-    """Exceptions raised during sync_mitxonline_course_files should be logged"""
-    run = LearningResourceRunFactory.create(
-        platform=platform,
-        content_type=ContentType.objects.get_for_model(Course),
-    )
-    bucket = (
-        mock_mitxonline_learning_bucket
-        if platform == PlatformType.mitxonline.value
-        else mock_xpro_learning_bucket
-    ).bucket
-    bucket.put_object(
-        Key=f"20220101/courses/{run.run_id}.tar.gz",
-        Body=open("test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz", "rb").read(),
-        ACL="public-read",
-    )
-    mock_load_content_files = mocker.patch(
-        "course_catalog.etl.utils.load_content_files",
-        autospec=True,
-        side_effect=Exception,
-    )
-    fake_data = '{"key": "data"}'
-    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
-    mock_transform = mocker.patch(
-        "course_catalog.etl.utils.transform_content_files", return_value=fake_data
-    )
-    sync_olx_course_files(bucket.name, platform, [run.object_id])
-    assert mock_transform.call_count == 1
-    assert mock_transform.call_args[0][0].endswith(f"{run.run_id}.tar.gz") is True
-    mock_load_content_files.assert_called_once_with(run, fake_data)
-    assert mock_log.call_args[0][0].startswith("Error ingesting OLX content data for ")

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -21,8 +21,7 @@ from course_catalog.api import (
 )
 from course_catalog.constants import PlatformType
 from course_catalog.etl import enrollments, pipelines, youtube
-from course_catalog.etl.mitxonline import sync_mitxonline_course_files
-from course_catalog.etl.xpro import sync_xpro_course_files
+from course_catalog.etl.utils import sync_olx_course_files
 from course_catalog.models import Course
 from course_catalog.utils import load_course_blocklist
 from open_discussions.celery import app
@@ -250,7 +249,9 @@ def get_xpro_files(ids):
     ):
         log.warning("Required settings missing for get_xpro_files")
         return
-    sync_xpro_course_files(ids)
+    sync_olx_course_files(
+        settings.XPRO_LEARNING_COURSE_BUCKET_NAME, PlatformType.xpro.value, ids
+    )
 
 
 @app.task(bind=True)
@@ -290,7 +291,11 @@ def get_mitxonline_files(ids):
     ):
         log.warning("Required settings missing for get_mitxonline_files")
         return
-    sync_mitxonline_course_files(ids)
+    sync_olx_course_files(
+        settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME,
+        PlatformType.mitxonline.value,
+        ids,
+    )
 
 
 @app.task(bind=True)
@@ -370,8 +375,8 @@ def get_micromasters_data():
 @app.task
 def get_xpro_data():
     """Execute the xPro ETL pipeline"""
-    pipelines.xpro_programs_etl()
     pipelines.xpro_courses_etl()
+    pipelines.xpro_programs_etl()
 
 
 @app.task

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -21,7 +21,7 @@ from course_catalog.api import (
 )
 from course_catalog.constants import PlatformType
 from course_catalog.etl import enrollments, pipelines, youtube
-from course_catalog.etl.utils import sync_olx_course_files
+from course_catalog.etl.edx_shared import sync_edx_course_files
 from course_catalog.models import Course
 from course_catalog.utils import load_course_blocklist
 from open_discussions.celery import app
@@ -249,7 +249,7 @@ def get_xpro_files(ids):
     ):
         log.warning("Required settings missing for get_xpro_files")
         return
-    sync_olx_course_files(
+    sync_edx_course_files(
         settings.XPRO_LEARNING_COURSE_BUCKET_NAME, PlatformType.xpro.value, ids
     )
 
@@ -291,7 +291,7 @@ def get_mitxonline_files(ids):
     ):
         log.warning("Required settings missing for get_mitxonline_files")
         return
-    sync_olx_course_files(
+    sync_edx_course_files(
         settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME,
         PlatformType.mitxonline.value,
         ids,

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -469,25 +469,27 @@ def test_import_all_ocw_files(settings, mocker, mocked_celery, mock_blocklist):
 
 @mock_s3
 def test_get_xpro_files(mocker, settings):
-    """Test that get_xpro_files calls api.sync_xpro_course_files with the correct ids"""
-    mock_sync_xpro_course_files = mocker.patch(
-        "course_catalog.tasks.sync_xpro_course_files"
+    """Test that get_xpro_files calls api.sync_olx_course_files with the correct ids"""
+    mock_sync_olx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_olx_course_files"
     )
     setup_s3(settings)
     ids = [1, 2, 3]
     get_xpro_files(ids)
-    mock_sync_xpro_course_files.assert_called_with(ids)
+    mock_sync_olx_course_files.assert_called_with(
+        settings.XPRO_LEARNING_COURSE_BUCKET_NAME, "xpro", ids
+    )
 
 
 def test_get_xpro_files_missing_settings(mocker, settings):
     """Test that get_xpro_files does nothing without required settings"""
-    mock_sync_xpro_course_files = mocker.patch(
-        "course_catalog.tasks.sync_xpro_course_files"
+    mock_sync_olx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_olx_course_files"
     )
     mock_log = mocker.patch("course_catalog.tasks.log.warning")
     settings.XPRO_LEARNING_COURSE_BUCKET_NAME = None
     get_xpro_files([1, 2])
-    mock_sync_xpro_course_files.assert_not_called()
+    mock_sync_olx_course_files.assert_not_called()
     mock_log.assert_called_once_with("Required settings missing for get_xpro_files")
 
 
@@ -511,24 +513,26 @@ def test_import_all_xpro_files(settings, mocker, mocked_celery, mock_blocklist):
 
 def test_get_mitxonline_files(mocker, settings):
     """Test that get_mitxonline_files calls api.sync_mitxonline_course_files with the correct ids"""
-    mock_sync_mitxonline_course_files = mocker.patch(
-        "course_catalog.tasks.sync_mitxonline_course_files"
+    mock_sync_olx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_olx_course_files"
     )
     setup_s3(settings)
     ids = [1, 2, 3]
     get_mitxonline_files(ids)
-    mock_sync_mitxonline_course_files.assert_called_with(ids)
+    mock_sync_olx_course_files.assert_called_with(
+        settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME, "mitxonline", ids
+    )
 
 
 def test_get_mitxonline_files_missing_settings(mocker, settings):
     """Test that get_mitxonline_files does nothing without required settings"""
-    mock_sync_mitxonline_course_files = mocker.patch(
-        "course_catalog.tasks.sync_mitxonline_course_files"
+    mock_sync_olx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_olx_course_files"
     )
     mock_log = mocker.patch("course_catalog.tasks.log.warning")
     settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME = None
     get_mitxonline_files([1, 2])
-    mock_sync_mitxonline_course_files.assert_not_called()
+    mock_sync_olx_course_files.assert_not_called()
     mock_log.assert_called_once_with(
         "Required settings missing for get_mitxonline_files"
     )

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -469,27 +469,27 @@ def test_import_all_ocw_files(settings, mocker, mocked_celery, mock_blocklist):
 
 @mock_s3
 def test_get_xpro_files(mocker, settings):
-    """Test that get_xpro_files calls api.sync_olx_course_files with the correct ids"""
-    mock_sync_olx_course_files = mocker.patch(
-        "course_catalog.tasks.sync_olx_course_files"
+    """Test that get_xpro_files calls api.sync_edx_course_files with the correct ids"""
+    mock_sync_edx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_edx_course_files"
     )
     setup_s3(settings)
     ids = [1, 2, 3]
     get_xpro_files(ids)
-    mock_sync_olx_course_files.assert_called_with(
+    mock_sync_edx_course_files.assert_called_with(
         settings.XPRO_LEARNING_COURSE_BUCKET_NAME, "xpro", ids
     )
 
 
 def test_get_xpro_files_missing_settings(mocker, settings):
     """Test that get_xpro_files does nothing without required settings"""
-    mock_sync_olx_course_files = mocker.patch(
-        "course_catalog.tasks.sync_olx_course_files"
+    mock_sync_edx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_edx_course_files"
     )
     mock_log = mocker.patch("course_catalog.tasks.log.warning")
     settings.XPRO_LEARNING_COURSE_BUCKET_NAME = None
     get_xpro_files([1, 2])
-    mock_sync_olx_course_files.assert_not_called()
+    mock_sync_edx_course_files.assert_not_called()
     mock_log.assert_called_once_with("Required settings missing for get_xpro_files")
 
 
@@ -513,26 +513,26 @@ def test_import_all_xpro_files(settings, mocker, mocked_celery, mock_blocklist):
 
 def test_get_mitxonline_files(mocker, settings):
     """Test that get_mitxonline_files calls api.sync_mitxonline_course_files with the correct ids"""
-    mock_sync_olx_course_files = mocker.patch(
-        "course_catalog.tasks.sync_olx_course_files"
+    mock_sync_edx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_edx_course_files"
     )
     setup_s3(settings)
     ids = [1, 2, 3]
     get_mitxonline_files(ids)
-    mock_sync_olx_course_files.assert_called_with(
+    mock_sync_edx_course_files.assert_called_with(
         settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME, "mitxonline", ids
     )
 
 
 def test_get_mitxonline_files_missing_settings(mocker, settings):
     """Test that get_mitxonline_files does nothing without required settings"""
-    mock_sync_olx_course_files = mocker.patch(
-        "course_catalog.tasks.sync_olx_course_files"
+    mock_sync_edx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_edx_course_files"
     )
     mock_log = mocker.patch("course_catalog.tasks.log.warning")
     settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME = None
     get_mitxonline_files([1, 2])
-    mock_sync_olx_course_files.assert_not_called()
+    mock_sync_edx_course_files.assert_not_called()
     mock_log.assert_called_once_with(
         "Required settings missing for get_mitxonline_files"
     )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3740

#### What's this PR do?
Refactors the course file syncing for xpro to use the same function as for mitxonline - expecting individual course tarballs on S3 instead of a bundled tarball containing all courses.

#### How should this be manually tested?
- Set `XPRO_` and `MITX_ONLINE_` .env values to the same as on RC.  Ditto for `AWS_`.
- Run `backpopulate_xpro_data` followed by `backpopulate_xpro_files`.  Both should succeed.  
- Check that you have some `LearningResourceRun` objects and `Course` objects with `platform=xpro`, as well as numerous `ContentFile` objects with `run__platform=xpro`
- Run `backpopulate_mitxonline_data` followed by `backpopulate_mitxonline_files`.  Both should succeed.
- Check that you have some `LearningResourceRun` objectss and `Course` objects with `platform=mitxonline`, as well as numerous `ContentFile` objects with `run__platform=mitxonline`
