### PR TITLE
filter offerors

### DIFF
--- a/frontends/infinite-corridor/src/pages/SearchPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/SearchPage.test.tsx
@@ -13,7 +13,7 @@ const expectedFacets = {
   audience:            [],
   certification:       [],
   type:                ["program", "course"],
-  offered_by:          [],
+  offered_by:          ["OCW", "MITx", "Open Learning Library", "MicroMasters", "xPRO"],
   topics:              [],
   department_name:     [],
   level:               [],
@@ -143,6 +143,25 @@ describe("SearchPage", () => {
       course_feature_tags: [],
       resource_type:       []
     }
+
+    const expectedFacetsAfterClear = {
+      audience:      [],
+      certification: [],
+      offered_by:    [
+        "OCW",
+        "MITx",
+        "Open Learning Library",
+        "MicroMasters",
+        "xPRO"
+      ],
+      type:                ["program", "course"],
+      topics:              [],
+      department_name:     [],
+      level:               [],
+      course_feature_tags: [],
+      resource_type:       []
+    }
+
     expect(makeRequest.mock.calls[1][0]).toEqual("post")
     expect(makeRequest.mock.calls[1][1]).toEqual("search/")
     expect(makeRequest.mock.calls[1][2]).toMatchObject(
@@ -161,7 +180,7 @@ describe("SearchPage", () => {
       buildSearchQuery({
         text:         "",
         from:         0,
-        activeFacets: expectedFacets,
+        activeFacets: expectedFacetsAfterClear,
         sort:         null,
         size:         4
       })

--- a/frontends/infinite-corridor/src/pages/SearchPage.tsx
+++ b/frontends/infinite-corridor/src/pages/SearchPage.tsx
@@ -89,7 +89,10 @@ const SearchPage: React.FC = () => {
         activeFacets["type"] = ALLOWED_TYPES
       }
 
-      if (activeFacets["offered_by"]?.length && activeFacets["offered_by"].length > 0) {
+      if (
+        activeFacets["offered_by"]?.length &&
+        activeFacets["offered_by"].length > 0
+      ) {
         activeFacets["offered_by"] = intersection(
           ALLOWED_OFFERORS,
           activeFacets["offered_by"]

--- a/frontends/infinite-corridor/src/pages/SearchPage.tsx
+++ b/frontends/infinite-corridor/src/pages/SearchPage.tsx
@@ -27,6 +27,14 @@ import {
 import axios from "../libs/axios"
 
 const ALLOWED_TYPES = ["program", "course"]
+const ALLOWED_OFFERORS = [
+  "OCW",
+  "MITx",
+  "Open Learning Library",
+  "MicroMasters",
+  "xPRO"
+]
+
 const pageSize = SETTINGS.search_page_size
 
 const facetMap: FacetManifest = [
@@ -80,6 +88,16 @@ const SearchPage: React.FC = () => {
       } else {
         activeFacets["type"] = ALLOWED_TYPES
       }
+
+      if (activeFacets["offered_by"]?.length && activeFacets["offered_by"].length > 0) {
+        activeFacets["offered_by"] = intersection(
+          ALLOWED_OFFERORS,
+          activeFacets["offered_by"]
+        )
+      } else {
+        activeFacets["offered_by"] = ALLOWED_OFFERORS
+      }
+
       setRequestInFlight(true)
       const newResults = await search({
         text,
@@ -171,6 +189,7 @@ const SearchPage: React.FC = () => {
               onUpdateFacets={onUpdateFacets}
               clearAllFilters={clearAllFilters}
               toggleFacet={toggleFacet}
+              facetOptionsFilter={{ offered_by: ALLOWED_OFFERORS }}
             />
           </Grid>
           <Grid

--- a/frontends/ol-search-ui/src/components/FacetDisplay.test.tsx
+++ b/frontends/ol-search-ui/src/components/FacetDisplay.test.tsx
@@ -1,17 +1,23 @@
 import FacetDisplay, { Props } from "./FacetDisplay"
 import { render, screen } from "@testing-library/react"
 import React from "react"
+import { when } from "jest-when"
 
 describe("FacetDisplay", () => {
   const facetMap = [
     ["topics", "Topics"],
     ["type", "Types"],
-    ["department_name", "Departments"]
+    ["offered_by", "Offered By"]
   ]
 
   const renderFacetDisplay = (props: Partial<Props> = {}) => {
     const activeFacets = {}
     const facetOptions = jest.fn()
+
+    when(facetOptions)
+      .calledWith("offered_by")
+      .mockReturnValue({ buckets: [{ key: "OCW" }, { key: "MITx" }] })
+
     const onUpdateFacets = jest.fn()
     const clearAllFilters = jest.fn()
     const toggleFacet = jest.fn()
@@ -33,6 +39,19 @@ describe("FacetDisplay", () => {
     renderFacetDisplay()
     expect(screen.getByText("Topics")).toBeInTheDocument()
     expect(screen.getByText("Types")).toBeInTheDocument()
-    expect(screen.getByText("Departments")).toBeInTheDocument()
+    expect(screen.getByText("Offered By")).toBeInTheDocument()
+    expect(screen.getByText("OCW")).toBeInTheDocument()
+    expect(screen.getByText("MITx")).toBeInTheDocument()
+  })
+
+  it("Excludes options that should be filtered out", () => {
+    const facetOptionsFilter = { offered_by: ["MITx"] }
+
+    renderFacetDisplay({ facetOptionsFilter })
+    expect(screen.getByText("Topics")).toBeInTheDocument()
+    expect(screen.getByText("Types")).toBeInTheDocument()
+    expect(screen.getByText("Offered By")).toBeInTheDocument()
+    expect(screen.queryByText("OCW")).not.toBeInTheDocument()
+    expect(screen.getByText("MITx")).toBeInTheDocument()
   })
 })

--- a/frontends/ol-search-ui/src/components/FacetDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/FacetDisplay.tsx
@@ -12,6 +12,7 @@ interface Props {
   onUpdateFacets: React.ChangeEventHandler<HTMLInputElement>
   clearAllFilters: () => void
   toggleFacet: (name: string, value: string, isEnabled: boolean) => void
+  facetOptionsFilter?: { [key: string | FacetKey]: string[] }
 }
 
 const FacetDisplay = React.memo(
@@ -22,8 +23,24 @@ const FacetDisplay = React.memo(
       activeFacets,
       onUpdateFacets,
       clearAllFilters,
-      toggleFacet
+      toggleFacet,
+      facetOptionsFilter
     } = props
+
+    function filterFacetOptions(
+      results: Aggregation | null,
+      allowedOptions: (string | FacetKey)[]
+    ) {
+      if (results?.buckets) {
+        return {
+          buckets: results.buckets.filter(
+            item => item.key && allowedOptions.includes(item.key)
+          )
+        }
+      } else {
+        return results
+      }
+    }
 
     return (
       <React.Fragment>
@@ -62,7 +79,14 @@ const FacetDisplay = React.memo(
             key={key}
             title={title}
             name={name as string}
-            results={facetOptions(name)}
+            results={
+              facetOptionsFilter && name in facetOptionsFilter ?
+                filterFacetOptions(
+                  facetOptions(name),
+                  facetOptionsFilter[name]
+                ) :
+                facetOptions(name)
+            }
             onUpdate={onUpdateFacets}
             currentlySelected={activeFacets[name] || []}
           />

--- a/frontends/ol-search-ui/src/components/SearchFilterDrawer.tsx
+++ b/frontends/ol-search-ui/src/components/SearchFilterDrawer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react"
 
 import FacetDisplay from "./FacetDisplay"
 import { useDeviceCategory, DESKTOP } from "ol-util"
-import { FacetManifest } from "../interfaces"
+import { FacetManifest, FacetKey } from "../interfaces"
 
 import { Aggregation, Facets } from "@mitodl/course-search-utils"
 
@@ -13,6 +13,7 @@ interface Props {
   onUpdateFacets: React.ChangeEventHandler<HTMLInputElement>
   clearAllFilters: () => void
   toggleFacet: (name: string, value: string, isEnabled: boolean) => void
+  facetOptionsFilter: { [key: string | FacetKey]: string[] }
 }
 
 export default function SearchFilterDrawer(props: Props) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3746

#### What's this PR do?
This pr filters the allowed offerors for infinite search to the ones we want to OCW, MITx, Open Learning Library, MicroMasters and xPRO

#### How should this be manually tested?
If you don't already have some courses that should be excluded in your database run `manage.py backpopulate_bootcamp_data`

Verify that bootcamps show up in /learn/search but not /infinite/search
