### PR TITLE
More consistent drawer styling

### DIFF
--- a/frontends/infinite-corridor/src/libs/mui.ts
+++ b/frontends/infinite-corridor/src/libs/mui.ts
@@ -12,8 +12,8 @@ const muiTheme = createTheme({
       main: "#03152d"
     },
     text: {
-      primary: "#03152d",
-    },
+      primary: "#03152d"
+    }
   },
   breakpoints: {
     values: {

--- a/frontends/infinite-corridor/src/libs/mui.ts
+++ b/frontends/infinite-corridor/src/libs/mui.ts
@@ -10,7 +10,10 @@ const muiTheme = createTheme({
     },
     secondary: {
       main: "#03152d"
-    }
+    },
+    text: {
+      primary: "#03152d",
+    },
   },
   breakpoints: {
     values: {

--- a/frontends/infinite-corridor/src/scss/combined.scss
+++ b/frontends/infinite-corridor/src/scss/combined.scss
@@ -30,6 +30,10 @@ body {
   height: 100vh;
 }
 
+button {
+  color: theme.$font-color-default;
+}
+
 a {
   text-decoration: none;
   &:hover {

--- a/frontends/infinite-corridor/src/scss/mui.scss
+++ b/frontends/infinite-corridor/src/scss/mui.scss
@@ -3,7 +3,8 @@
 
 $color: theme.$color-primary;
 
-.app-container {
+// body not #app-root because MUI modals are not in the app root.
+body {
   .MuiTab-root {
     text-transform: none;
   }

--- a/frontends/infinite-corridor/src/scss/theme.scss
+++ b/frontends/infinite-corridor/src/scss/theme.scss
@@ -50,8 +50,6 @@ $shadowOverflowTop: $shadowBlurRadius - $shadowOffsetX;
 $shadowOverflowBottom: $shadowBlurRadius + $shadowOffsetY;
 $channel-avatar-bg: #2aab8b;
 
-// Forms
-$font-black: rgba(0, 0, 0, 0.87);
 $std-border-radius: 3px;
 $validation-bg: #ffe8ec;
 $validation-text: #f07183;

--- a/frontends/ol-search-ui/assets/learning-resource-card.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-card.scss
@@ -28,7 +28,7 @@ $smallFontSize: 0.75em !default;
 
 .ol-lrc-content .clickable-title {
   border: none;
-  background-color: white;
+  background-color: rgba(0, 0, 0, 0);
   display: block;
   text-align: left;
   padding: 0px;

--- a/frontends/ol-search-ui/assets/learning-resource-drawer.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-drawer.scss
@@ -191,24 +191,22 @@ $drawer-trans: width 500ms;
   }
 }
 
-.rc-tooltip {
-  opacity: 1;
-  box-shadow: 0 0 20px 0;
+.ol-tooltip-share {
+  min-width: 250px;
+  max-width: 250px;
 
-  .rc-tooltip-inner {
-    border: none;
-    padding: 0;
+  box-shadow: 0 0 20px 0 black;
+
+  input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 6px;
+    margin-bottom: 12px;
   }
 
-  .rc-tooltip-arrow {
-    border-top-color: white;
+  .ol-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
-
-  position: absolute;
-  z-index: 5000;
-  display: block;
-  line-height: 1.5;
-  font-size: 12px;
-  background-color: rgba(0, 0, 0, 0.05);
-  padding: 1px;
 }

--- a/frontends/ol-search-ui/assets/learning-resource-drawer.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-drawer.scss
@@ -1,9 +1,8 @@
 @use "ol-util/assets/breakpoint" as *;
 
+$lightText: #B0B0B0 !default;
+
 .expanded-lr-summary {
-  flex-direction: column;
-  font-size:  16px;
-  line-height: 1.3;
   padding: 30px;
 
   select {
@@ -16,7 +15,7 @@
     font-size: 13px;
 
     .info-label {
-      color: #B0B0B0;
+      color: $lightText;
       padding-right: 6px;
     }
   }
@@ -27,7 +26,6 @@
 
   .image-div {
     width: 100%;
-    margin-bottom: 10px;
     overflow: hidden;
     margin-top: 10px;
     margin-bottom: 10px;
@@ -45,7 +43,7 @@
     letter-spacing: 0;
     line-height: 19px;
     text-transform: uppercase;
-    color: #b0b0b0;
+    color: $lightText;
   }
 
   .section-label {
@@ -60,7 +58,7 @@
     height: 37px;
     align-items: center;
     .label {
-      color:  #B0B0B0;
+      color:  $lightText;
     }
 
     .offeror {
@@ -74,15 +72,10 @@
   }
 
   .title {
-    font-size: 20px;
-    color: black;
-    font-weight: bold;
     margin: 5px 0;
   }
 
   .description {
-    font-size: 16px;
-    color: black;
 
     .tt-expansion-control {
       @include breakpoint(materialmobile) {
@@ -121,74 +114,11 @@
   }
 }
 
-$red-link-color: #9a2a33;
-$link-padding: 11px 20px 11px 11px;
-$footer-height: 172px;
-
-$drawer-trans: width 500ms;
-
 .lr-drawer.MuiDrawer-root .drawer-close{
   float: right;
   padding: 20px;
   padding-bottom: 0px;
-  .material-icons {
-    font-size: 35px;
-    float: right;
-  }
   border: none;
-  background-color: white;
-}
-
-.drawer-mobile-header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 60px;
-}
-
-
-.tooltip {
-  background: white;
-  padding: 12px;
-  min-width: 250px;
-  max-width: 250px;
-  opacity: 1 !important;
-  z-index: 5000;
-
-  .tooltip-text,
-  h4 {
-    width: 90%;
-  }
-
-  h4 {
-    padding: 0 0 10px 0;
-    margin: 0;
-    font-size: inherit;
-  }
-
-  input {
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .bottom-row {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    margin-top: 15px;
-
-    .tooltip-buttons {
-      display: flex;
-
-      > div {
-        margin-right: 3px;
-      }
-    }
-
-    .copy-url {
-      font-size: 12px;
-    }
-  }
 }
 
 .ol-tooltip-share {

--- a/frontends/ol-search-ui/assets/learning-resource-drawer.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-drawer.scss
@@ -1,8 +1,16 @@
 @use "ol-util/assets/breakpoint" as *;
 
 $lightText: #B0B0B0 !default;
+$semiBoldWeight: 600 !default;
 
-.expanded-lr-summary {
+.ol-lr-details {
+  h2, h3, h4 {
+    margin: 5px 0
+  }
+  dl {
+    margin: 8px 0
+  }
+
   padding: 30px;
 
   select {
@@ -12,7 +20,7 @@ $lightText: #B0B0B0 !default;
 
   .run-selector {
     display: inline-flex;
-    font-size: 13px;
+    font-size: 0.8125em;
 
     .info-label {
       color: $lightText;
@@ -39,24 +47,13 @@ $lightText: #B0B0B0 !default;
   
   .object-type {
     font-size: 15px;
-    font-weight: 600;
-    letter-spacing: 0;
-    line-height: 19px;
+    font-weight: $semiBoldWeight;
     text-transform: uppercase;
     color: $lightText;
   }
 
-  .section-label {
-    color: black;
-    margin-bottom: 10px;
-    font-weight: bold;
-  }
-
   .offered-by {
-    display: inline-flex;
     font-size: 15px;
-    height: 37px;
-    align-items: center;
     .label {
       color:  $lightText;
     }
@@ -65,15 +62,8 @@ $lightText: #B0B0B0 !default;
       font-weight: bold;
     }
 
-    @include breakpoint(desktop) {
-      float: right;
-    }
-
   }
 
-  .title {
-    margin: 5px 0;
-  }
 
   .description {
 
@@ -103,22 +93,22 @@ $lightText: #B0B0B0 !default;
   }
 }
 
-.resource-actions {
+.ol-lrd-actions-row {
   margin-top: 20px;
   margin-bottom: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ol-lrd-actions {
   > *:not(:first-child) {
     margin-left: 5px;
   }
   *:not(:last-child) {
     margin-right: 5px;
   }
-}
-
-.lr-drawer.MuiDrawer-root .drawer-close{
-  float: right;
-  padding: 20px;
-  padding-bottom: 0px;
-  border: none;
 }
 
 .ol-tooltip-share {
@@ -130,8 +120,8 @@ $lightText: #B0B0B0 !default;
   input {
     width: 100%;
     box-sizing: border-box;
-    margin-top: 6px;
-    margin-bottom: 12px;
+    margin-top: 0.5em;
+    margin-bottom: 1em;
   }
 
   .ol-tooltip-row {

--- a/frontends/ol-search-ui/assets/learning-resource-drawer.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-drawer.scss
@@ -94,8 +94,8 @@ $semiBoldWeight: 600 !default;
 }
 
 .ol-lrd-actions-row {
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin-top: 15px;
+  margin-bottom: 15px;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -103,6 +103,10 @@ $semiBoldWeight: 600 !default;
 }
 
 .ol-lrd-actions {
+  > .MuiButton-root {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
   > *:not(:first-child) {
     margin-left: 5px;
   }

--- a/frontends/ol-search-ui/assets/learning-resource-drawer.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-drawer.scss
@@ -38,11 +38,6 @@
       width: 100%;
     }
   }
-
-  .link-share-offered-by {
-    margin-top: 20px;
-    margin-bottom: 20px;
-  }
   
   .object-type {
     font-size: 15px;
@@ -51,30 +46,6 @@
     line-height: 19px;
     text-transform: uppercase;
     color: #b0b0b0;
-  }
-
-  .external-links {
-    display: inline-flex;
-    justify-content: space-between;
-    align-items: center;
-    height: 37px;
-    border-radius: 4px;
-    background-color: #A32034;
-    padding-right: 10px;
-    padding-left: 10px;
-    color: white;
-    text-transform: capitalize;
-    margin: auto;
-    width: 128px;
-    cursor: pointer;
-    float: left;
-    margin-right: 20px;
-
-    a.link-button {
-      margin: auto;
-      font-size: 18px;
-      line-height: 37px
-    }
   }
 
   .section-label {
@@ -139,47 +110,22 @@
   }
 }
 
-.elr-share {
-  display: inline-block;
-  border: 1px solid #D8D8D8;
-  border-radius: 4px;
-  background-color: #FAFAFA;
-  height: 37px;
-  align-items: center;
-  margin: auto;
-  width: 128px;
-  cursor: pointer;
-  font-size: 18px;
-  margin-right: 20px;
-
-  .share-contents {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    font-size: 18px;
-    line-height: 37px;
-
-    i {
-      transform: scaleX(-1);
-      font-size: 30px;
-      margin-left: 23px;
-    }
+.resource-actions {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  > *:not(:first-child) {
+    margin-left: 5px;
+  }
+  *:not(:last-child) {
+    margin-right: 5px;
   }
 }
-
 
 $red-link-color: #9a2a33;
 $link-padding: 11px 20px 11px 11px;
 $footer-height: 172px;
 
 $drawer-trans: width 500ms;
-
-.lr-drawer {
-  .MuiDrawer-paper {
-    width: 100%;
-    max-width: 600px;
-  }
-}
 
 .lr-drawer.MuiDrawer-root .drawer-close{
   float: right;

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -63,18 +63,16 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
   const url = selectedRun?.url ?? resource.url
 
   return (
-    <div className="expanded-lr-summary">
+    <div className="ol-lr-details">
       <div className="object-type">
         {getReadableResourceType(resource.object_type)}
       </div>
-      <h3 className="title">{resource.title}</h3>
-      <div className="run-certification-container">
+      <h2>{resource.title}</h2>
+      <div>
         {selectedRun ? (
           <div className="run-selector">
-            <div>
-              <div className="info-label">
-                {resource.platform === "ocw" ? "As Taught In" : "Start Date"}
-              </div>
+            <div className="info-label">
+              {resource.platform === "ocw" ? "As Taught In" : "Start Date"}
             </div>
             <div className="select-semester-div">
               {objectRuns.length > 1 ? (
@@ -100,20 +98,22 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
           <img src={resourceThumbnailSrc(resource, imgConfig)} alt="" />
         )}
       </div>
-      <div className="resource-actions">
-        {url && isTakeableResource(resource) && (
-          <Button variant="contained" component="a" href={url} target="_blank" rel="noopener noreferrer">
+      <div className="ol-lrd-actions-row ">
+        <div className="ol-lrd-actions">
+          {url && isTakeableResource(resource) && (
+            <Button variant="contained" component="a" href={url} target="_blank" rel="noopener noreferrer">
             Take {capitalize(resource.object_type)}
-          </Button>
-        )}
-        <ShareTooltip
-          url={formatShareLink(resource)}
-          objectType={resource.object_type}
-        >
-          <Button variant="outlined" startIcon={<ReplyIcon sx={invertIconSx} />}>
+            </Button>
+          )}
+          <ShareTooltip
+            url={formatShareLink(resource)}
+            objectType={resource.object_type}
+          >
+            <Button variant="outlined" startIcon={<ReplyIcon sx={invertIconSx} />}>
             Share
-          </Button>
-        </ShareTooltip>
+            </Button>
+          </ShareTooltip>
+        </div>
         <div className="offered-by">
           <span className="label">Offered by -&nbsp;</span>
           <span className="offeror">

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -108,7 +108,6 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
         )}
         <ShareTooltip
           url={formatShareLink(resource)}
-          placement="topLeft"
           objectType={resource.object_type}
         >
           <Button variant="outlined" startIcon={<ReplyIcon sx={invertIconSx} />}>

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useState } from "react"
 import striptags from "striptags"
 import { decode } from "html-entities"
-import { propsNotNil } from "ol-util"
+import { propsNotNil, capitalize } from "ol-util"
+import Button from "@mui/material/Button"
+import ReplyIcon from '@mui/icons-material/Reply'
 
 import TruncatedText from "./TruncatedText"
-
 import ShareTooltip from "./ShareTooltip"
 
 import {
@@ -26,6 +27,9 @@ import {
 
 import { EmbedlyCard, formatDurationClockTime } from "ol-util"
 import moment from "moment"
+
+const invertIconSx = { transform: "scaleX(-1)" }
+const isTakeableResource = (resource: LearningResourceResult): boolean => [LearningResourceType.Course, LearningResourceType.Program].includes(resource.object_type)
 
 type LearningResourceDetailsProps = {
   resource: LearningResourceResult
@@ -91,36 +95,26 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
       </div>
       <div className="image-div">
         {resource.object_type === "video" && resource.url ? (
-          <EmbedlyCard url={resource.url} className="watch-video" />
+          <EmbedlyCard url={resource.url} />
         ) : (
           <img src={resourceThumbnailSrc(resource, imgConfig)} alt="" />
         )}
       </div>
-      <div className="link-share-offered-by">
-        {url && resource.object_type !== "video" ? (
-          <div className="external-links">
-            <a
-              className="link-button blue-btn"
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {`Take ${resource.object_type}`}
-            </a>
-          </div>
-        ) : null}
-        <button className="elr-share">
-          <ShareTooltip
-            url={formatShareLink(resource)}
-            placement="topLeft"
-            objectType={resource.object_type}
-          >
-            <div className="share-contents">
-              <i className="material-icons reply">reply</i>
-              <span>Share</span>
-            </div>
-          </ShareTooltip>
-        </button>
+      <div className="resource-actions">
+        {url && isTakeableResource(resource) && (
+          <Button variant="contained" component="a" href={url} target="_blank" rel="noopener noreferrer">
+            Take {capitalize(resource.object_type)}
+          </Button>
+        )}
+        <ShareTooltip
+          url={formatShareLink(resource)}
+          placement="topLeft"
+          objectType={resource.object_type}
+        >
+          <Button variant="outlined" startIcon={<ReplyIcon sx={invertIconSx} />}>
+            Share
+          </Button>
+        </ShareTooltip>
         <div className="offered-by">
           <span className="label">Offered by -&nbsp;</span>
           <span className="offeror">

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -120,6 +120,7 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
           >
             <Button
               variant="outlined"
+              color="secondary"
               startIcon={<ReplyIcon sx={invertIconSx} />}
             >
               Share

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -3,7 +3,7 @@ import striptags from "striptags"
 import { decode } from "html-entities"
 import { propsNotNil, capitalize } from "ol-util"
 import Button from "@mui/material/Button"
-import ReplyIcon from '@mui/icons-material/Reply'
+import ReplyIcon from "@mui/icons-material/Reply"
 
 import TruncatedText from "./TruncatedText"
 import ShareTooltip from "./ShareTooltip"
@@ -29,7 +29,10 @@ import { EmbedlyCard, formatDurationClockTime } from "ol-util"
 import moment from "moment"
 
 const invertIconSx = { transform: "scaleX(-1)" }
-const isTakeableResource = (resource: LearningResourceResult): boolean => [LearningResourceType.Course, LearningResourceType.Program].includes(resource.object_type)
+const isTakeableResource = (resource: LearningResourceResult): boolean =>
+  [LearningResourceType.Course, LearningResourceType.Program].includes(
+    resource.object_type
+  )
 
 type LearningResourceDetailsProps = {
   resource: LearningResourceResult
@@ -101,16 +104,25 @@ const LearningResourceDetails: React.FC<LearningResourceDetailsProps> = ({
       <div className="ol-lrd-actions-row ">
         <div className="ol-lrd-actions">
           {url && isTakeableResource(resource) && (
-            <Button variant="contained" component="a" href={url} target="_blank" rel="noopener noreferrer">
-            Take {capitalize(resource.object_type)}
+            <Button
+              variant="contained"
+              component="a"
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Take {capitalize(resource.object_type)}
             </Button>
           )}
           <ShareTooltip
             url={formatShareLink(resource)}
             objectType={resource.object_type}
           >
-            <Button variant="outlined" startIcon={<ReplyIcon sx={invertIconSx} />}>
-            Share
+            <Button
+              variant="outlined"
+              startIcon={<ReplyIcon sx={invertIconSx} />}
+            >
+              Share
             </Button>
           </ShareTooltip>
         </div>

--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -4,6 +4,7 @@ import Dotdotdot from "react-dotdotdot"
 import { toQueryString } from "ol-util"
 import classNames from "classnames"
 
+import Button from "@mui/material/Button"
 import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import Chip from "@mui/material/Chip"
@@ -45,6 +46,8 @@ type LearningResourceCardProps<
 type OffererProps = {
   offerers: string[]
 }
+
+const linkButtonSx = { lineHeight: "unset", margin: "unset", padding: "unset" }
 
 const Offerers: React.FC<OffererProps> = ({ offerers }) => {
   return (

--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -4,7 +4,6 @@ import Dotdotdot from "react-dotdotdot"
 import { toQueryString } from "ol-util"
 import classNames from "classnames"
 
-import Button from "@mui/material/Button"
 import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import Chip from "@mui/material/Chip"
@@ -46,8 +45,6 @@ type LearningResourceCardProps<
 type OffererProps = {
   offerers: string[]
 }
-
-const linkButtonSx = { lineHeight: "unset", margin: "unset", padding: "unset" }
 
 const Offerers: React.FC<OffererProps> = ({ offerers }) => {
   return (

--- a/frontends/ol-search-ui/src/components/ShareTooltip.tsx
+++ b/frontends/ol-search-ui/src/components/ShareTooltip.tsx
@@ -22,7 +22,6 @@ const muiCopyButtonSx: ButtonProps["sx"] = {
   fontSize: "100%"
 }
 
-
 export const ShareTooltipHelper: React.FC<HelperProps> = ({
   url,
   hideSocialButtons,
@@ -57,7 +56,11 @@ export const ShareTooltipHelper: React.FC<HelperProps> = ({
             </TwitterShareButton>
           </div>
         )}
-        <Button size="small" sx={muiCopyButtonSx} onClick={selectAndCopyLinkText}>
+        <Button
+          size="small"
+          sx={muiCopyButtonSx}
+          onClick={selectAndCopyLinkText}
+        >
           Copy URL to clipboard
         </Button>
       </div>
@@ -91,7 +94,13 @@ const muiTooltipProps: TooltipProps["componentsProps"] = {
   }
 }
 
-export default function ShareTooltip({ children, placement = "top", objectType, url, hideSocialButtons }: Props) {
+export default function ShareTooltip({
+  children,
+  placement = "top",
+  objectType,
+  url,
+  hideSocialButtons
+}: Props) {
   const [visible, setVisible] = useState(false)
   const setClose = useCallback(() => setVisible(false), [])
   const setOpen = useCallback(() => setVisible(true), [])
@@ -104,7 +113,11 @@ export default function ShareTooltip({ children, placement = "top", objectType, 
           describeChild
           componentsProps={muiTooltipProps}
           title={
-            <ShareTooltipHelper objectType={objectType} hideSocialButtons={hideSocialButtons} url={url} />
+            <ShareTooltipHelper
+              objectType={objectType}
+              hideSocialButtons={hideSocialButtons}
+              url={url}
+            />
           }
           disableFocusListener
           disableHoverListener

--- a/frontends/ol-search-ui/src/components/ShareTooltip.tsx
+++ b/frontends/ol-search-ui/src/components/ShareTooltip.tsx
@@ -1,17 +1,27 @@
-import React, { useRef } from "react"
+import React, { useCallback, useRef, useState } from "react"
 import {
   FacebookShareButton,
   LinkedinShareButton,
   TwitterShareButton
 } from "react-share"
 import { FacebookIcon, TwitterIcon, LinkedinIcon } from "react-share"
-import Tooltip from "rc-tooltip"
+import Tooltip from "@mui/material/Tooltip"
+import type { TooltipProps } from "@mui/material/Tooltip"
+import ClickAwayListener from "@mui/material/ClickAwayListener"
+import { Button } from "@mui/material"
+import type { ButtonProps } from "@mui/material"
 
 type HelperProps = {
   url: string
   hideSocialButtons?: boolean | null | undefined
   objectType?: string | null | undefined
 }
+
+const muiCopyButtonSx: ButtonProps["sx"] = {
+  padding:  "2px",
+  fontSize: "100%"
+}
+
 
 export const ShareTooltipHelper: React.FC<HelperProps> = ({
   url,
@@ -28,14 +38,14 @@ export const ShareTooltipHelper: React.FC<HelperProps> = ({
   }
 
   return (
-    <div className="tooltip">
-      <div className="tooltip-text">
-        {`Share a link to this ${objectType}:`}
-      </div>
-      <input ref={inputRef} readOnly value={url} />
-      <div className="bottom-row">
+    <div>
+      <label>
+        Share a link to this {objectType}
+        <input ref={inputRef} readOnly value={url} />
+      </label>
+      <div className="ol-tooltip-row">
         {hideSocialButtons ? null : (
-          <div className="tooltip-buttons">
+          <div>
             <FacebookShareButton url={url}>
               <FacebookIcon round size={28} />
             </FacebookShareButton>
@@ -47,9 +57,9 @@ export const ShareTooltipHelper: React.FC<HelperProps> = ({
             </TwitterShareButton>
           </div>
         )}
-        <a href="#" className="copy-url" onClick={selectAndCopyLinkText}>
+        <Button size="small" sx={muiCopyButtonSx} onClick={selectAndCopyLinkText}>
           Copy URL to clipboard
-        </a>
+        </Button>
       </div>
     </div>
   )
@@ -58,20 +68,52 @@ export const ShareTooltipHelper: React.FC<HelperProps> = ({
 type Props = {
   url: string
   hideSocialButtons?: boolean
-  children?: React.ReactElement<string>
-  placement?: string
+  placement?: TooltipProps["placement"]
   objectType?: string | null
+  children: React.ReactElement
 }
 
-export default function ShareTooltip({ children, placement, ...props }: Props) {
+const muiTooltipProps: TooltipProps["componentsProps"] = {
+  tooltip: {
+    sx: {
+      color:           "secondary.main",
+      backgroundColor: "white",
+      padding:         "12px"
+    }
+  },
+  popper: {
+    sx: {
+      overflow: "visible"
+    }
+  },
+  transition: {
+    className: "ol-tooltip-share"
+  }
+}
+
+export default function ShareTooltip({ children, placement = "top", objectType, url, hideSocialButtons }: Props) {
+  const [visible, setVisible] = useState(false)
+  const setClose = useCallback(() => setVisible(false), [])
+  const setOpen = useCallback(() => setVisible(true), [])
   return (
-    <Tooltip
-      placement={placement || "top"}
-      trigger={["click"]}
-      overlay={() => <ShareTooltipHelper {...props} />}
-      destroyTooltipOnHide={true}
-    >
-      {children}
-    </Tooltip>
+    <ClickAwayListener onClickAway={setClose}>
+      <span>
+        <Tooltip
+          placement={placement}
+          open={visible}
+          describeChild
+          componentsProps={muiTooltipProps}
+          title={
+            <ShareTooltipHelper objectType={objectType} hideSocialButtons={hideSocialButtons} url={url} />
+          }
+          disableFocusListener
+          disableHoverListener
+          disableTouchListener
+          onClick={setOpen}
+        >
+          {children}
+        </Tooltip>
+      </span>
+    </ClickAwayListener>
   )
 }

--- a/frontends/ol-search-ui/src/components/TruncatedText.tsx
+++ b/frontends/ol-search-ui/src/components/TruncatedText.tsx
@@ -2,7 +2,8 @@ import React, { useState, useRef, useLayoutEffect, useReducer } from "react"
 
 import Dotdotdot from "react-dotdotdot"
 
-type Props = {
+type TruncatedTextProps = {
+  component?: React.ElementType & string
   text: string
   lines: number
   // Estimated maximum number of characters on a single line of text for the element where this
@@ -36,8 +37,8 @@ const RenderedNewlines = React.memo<RenderedNewlinesProps>(({ text }) => (
   </React.Fragment>
 ))
 
-export default function TruncatedText(props: Props) {
-  const { text, lines, estCharsPerLine, className, showExpansionControls } =
+export default function TruncatedText(props: TruncatedTextProps) {
+  const { component: Component = 'p', text, lines, estCharsPerLine, className, showExpansionControls } =
     props
   const [expanded, setExpanded] = useState(false)
   const [hasOverflow, setHasOverflow] = useState(false)
@@ -76,11 +77,11 @@ export default function TruncatedText(props: Props) {
   return (
     <React.Fragment>
       {expanded ? (
-        <div>
+        <Component>
           <RenderedNewlines text={text} />
-        </div>
+        </Component>
       ) : (
-        <Dotdotdot clamp={lines} ref={dotRef} className={className}>
+        <Dotdotdot tagName={Component} as="" clamp={lines} ref={dotRef} className={className}>
           {/* Dotdotdot seems to trip on long, unbroken strings. As a fail-safe, we're limiting
               the input string to a number of characters that is greater than the characters that
               will be shown, but not so long that it will cause issues with Dotdotdot.*/}

--- a/frontends/ol-search-ui/src/components/TruncatedText.tsx
+++ b/frontends/ol-search-ui/src/components/TruncatedText.tsx
@@ -38,8 +38,14 @@ const RenderedNewlines = React.memo<RenderedNewlinesProps>(({ text }) => (
 ))
 
 export default function TruncatedText(props: TruncatedTextProps) {
-  const { component: Component = 'p', text, lines, estCharsPerLine, className, showExpansionControls } =
-    props
+  const {
+    component: Component = "p",
+    text,
+    lines,
+    estCharsPerLine,
+    className,
+    showExpansionControls
+  } = props
   const [expanded, setExpanded] = useState(false)
   const [hasOverflow, setHasOverflow] = useState(false)
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
@@ -81,7 +87,13 @@ export default function TruncatedText(props: TruncatedTextProps) {
           <RenderedNewlines text={text} />
         </Component>
       ) : (
-        <Dotdotdot tagName={Component} as="" clamp={lines} ref={dotRef} className={className}>
+        <Dotdotdot
+          tagName={Component}
+          as=""
+          clamp={lines}
+          ref={dotRef}
+          className={className}
+        >
           {/* Dotdotdot seems to trip on long, unbroken strings. As a fail-safe, we're limiting
               the input string to a number of characters that is greater than the characters that
               will be shown, but not so long that it will cause issues with Dotdotdot.*/}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3754 

#### What's this PR do?
This PR gets updates some styling in the LearningResourceDrawer:
- get rid of some hard-coded colors so that the theme colors are used
- use mui buttons for "Share" and "Take Course"... nicer alignment
- use mui tooltip for share tooltip; improve some alignment within the share tooltip
- gets rid of some CSS that wasn't being used for anything. 

#### How should this be manually tested?
View the learning resource drawer and make sure it looks good and is using the navy color we use elsewhere. 

<img width="1722" alt="Screen Shot 2022-09-27 at 7 28 07 AM" src="https://user-images.githubusercontent.com/9010790/192513807-cdb5c711-1798-4312-9faa-01d810aff599.png">
