### PR TITLE
Fix moira by updating openssl

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ python-dateutil
 python-rapidjson==1.8
 python3-saml==1.14.0
 pygithub==1.44.1
-pyopenssl==17.5.0
+pyopenssl==19.1.0
 pytube==9.5.2
 redis>=3.5.2.3
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==3.3.2
+cryptography==3.4.8
     # via pyopenssl
 cssselect2==0.2.1
     # via cairosvg
@@ -290,7 +290,7 @@ pyjwt==1.5.2
     #   djangorestframework-jwt
     #   pygithub
     #   social-auth-core
-pyopenssl==17.5.0
+pyopenssl==19.1.0
     # via -r requirements.in
 pyparsing==2.4.7
     # via
@@ -357,7 +357,6 @@ sgmllib3k==1.0.0
 six==1.15.0
     # via
     #   click-repl
-    #   cryptography
     #   django-anymail
     #   django-appconf
     #   django-bitfield


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #3767 

#### What's this PR do?
Upgrades openssl

#### How should this be manually tested?
Copy settings for `MIT_WS_CERTIFICATE` and `MIT_WS_PRIVATE_KEY` from heroku RC into your .env, but as one-liners (I can send you the formatted values via keybase).

Run the following, you should not get an ssl exception:
```python
from moira_lists.moira_api import *
get_moira_client()
```
