### PR TITLE
Always bulk delete content files from search index

### DIFF
--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -881,10 +881,6 @@ def test_load_content_files(mocker, is_published):
         "course_catalog.etl.loaders.search_task_helpers.delete_run_content_files",
         autospec=True,
     )
-    mocker.patch(
-        "course_catalog.etl.loaders.search_task_helpers.delete_content_file",
-        autospec=True,
-    )
     load_content_files(course_run, content_data)
     assert mock_load_content_file.call_count == len(content_data)
     assert mock_bulk_index.call_count == (1 if is_published else 0)

--- a/search/task_helpers.py
+++ b/search/task_helpers.py
@@ -5,9 +5,7 @@ import logging
 from functools import wraps, partial
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 
-from course_catalog.models import ContentFile
 from open_discussions.features import INDEX_UPDATES, if_feature_enabled
 from channels.constants import POST_TYPE, COMMENT_TYPE, VoteActions
 from channels.models import Comment
@@ -22,7 +20,6 @@ from search.api import (
     gen_program_id,
     gen_user_list_id,
     gen_video_id,
-    gen_content_file_id,
     gen_podcast_id,
     gen_podcast_episode_id,
 )

--- a/search/task_helpers_test.py
+++ b/search/task_helpers_test.py
@@ -47,7 +47,6 @@ from search.task_helpers import (
     delete_video,
     upsert_user_list,
     delete_user_list,
-    delete_content_file,
     upsert_content_file,
     delete_course,
     index_run_content_files,
@@ -443,17 +442,14 @@ def test_delete_course(mocker):
     """
     Tests that delete_course calls the delete tasks for the course and its content files
     """
-    patched_delete_task = mocker.patch("search.task_helpers.delete_document")
+    patched_delete_task = mocker.patch("search.task_helpers.delete_run_content_files")
     course = CourseFactory.create()
     course_es_id = gen_course_id(course.platform, course.course_id)
-    content_files = [ContentFileFactory.create(run=run) for run in course.runs.all()]
 
     delete_course(course)
     patched_delete_task.delay.assert_any_call(course_es_id, COURSE_TYPE)
-    for content_file in content_files:
-        patched_delete_task.delay.assert_any_call(
-            gen_content_file_id(content_file.key), COURSE_TYPE, routing=course_es_id
-        )
+    for run in course.runs:
+        patched_delete_task.delay.assert_any_call(run.id)
 
 
 @pytest.mark.django_db
@@ -535,19 +531,6 @@ def test_upsert_content_file(mocker):
     content_file = ContentFileFactory.create()
     upsert_content_file(content_file.id)
     patched_task.delay.assert_called_once_with(content_file.id)
-
-
-@pytest.mark.django_db
-def test_delete_content_file(mocker):
-    """Tests that deleting a content_file triggers the correct ES delete task"""
-    patched_delete_task = mocker.patch("search.task_helpers.delete_document")
-    content_file = ContentFileFactory.create()
-    delete_content_file(content_file)
-    assert patched_delete_task.delay.called is True
-    assert patched_delete_task.delay.call_args[0] == (
-        gen_content_file_id(content_file.key),
-        COURSE_TYPE,
-    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3815 

#### What's this PR do?
Uses bulk delete on all of a course run's content files instead of individual deletes (for the search index)
Removes the function to delete individual content files from the search index (no longer called from anywhere)

#### How should this be manually tested?
If you don't have any xpro courses locally, run both the following:
```
manage.py backpopulate_xpro_date
manage.py backpopulate_xpro_files
```
The last one may take a while.

If you have xpro courses but no content files, run them in reverse order.

`backpopulate_xpro_data` should finish within a couple minutes either way.

Also try this to mimic removing a recently unpublished course from the search index:
```python
from course_catalog.models import Course
from search.task_helpers import delete_course
course = Course.objects.get(course_id='course-v1:xPRO+BioEngx')
delete_course(course)
```
Check the celery logs and make sure that `search.tasks.delete_run_content_files` completed successfully.
