### PR TITLE
Fix mgmt commands for importing content files

### DIFF
--- a/course_catalog/management/commands/backpopulate_edx_files.py
+++ b/course_catalog/management/commands/backpopulate_edx_files.py
@@ -1,6 +1,7 @@
 """Management command for populating MITx course run file data"""
 
 from django.core.management import BaseCommand
+from django.conf import settings
 
 from course_catalog.tasks import import_all_mitx_files
 from open_discussions.utils import now_in_utc
@@ -16,7 +17,8 @@ class Command(BaseCommand):
             "-c",
             "--chunk-size",
             dest="chunk_size",
-            default=1000,
+            default=settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE,
+            type=int,
             help="Chunk size for batch import task",
         )
 

--- a/course_catalog/management/commands/backpopulate_mitxonline_files.py
+++ b/course_catalog/management/commands/backpopulate_mitxonline_files.py
@@ -3,6 +3,7 @@
 from django.core.management import BaseCommand
 
 from course_catalog.tasks import import_all_mitxonline_files
+from open_discussions import settings
 from open_discussions.utils import now_in_utc
 
 
@@ -16,7 +17,8 @@ class Command(BaseCommand):
             "-c",
             "--chunk-size",
             dest="chunk_size",
-            default=1000,
+            default=settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE,
+            type=int,
             help="Chunk size for batch import task",
         )
 

--- a/course_catalog/management/commands/backpopulate_ocw_files.py
+++ b/course_catalog/management/commands/backpopulate_ocw_files.py
@@ -3,6 +3,7 @@
 from django.core.management import BaseCommand
 
 from course_catalog.tasks import import_all_ocw_files
+from open_discussions import settings
 from open_discussions.utils import now_in_utc
 
 
@@ -16,7 +17,8 @@ class Command(BaseCommand):
             "-c",
             "--chunk-size",
             dest="chunk_size",
-            default=1000,
+            default=settings.OCW_ITERATOR_CHUNK_SIZE,
+            type=int,
             help="Chunk size for batch import task",
         )
 

--- a/course_catalog/management/commands/backpopulate_xpro_files.py
+++ b/course_catalog/management/commands/backpopulate_xpro_files.py
@@ -1,5 +1,6 @@
 """Management command for populating xpro course run file data"""
 
+from django.conf import settings
 from django.core.management import BaseCommand
 
 from course_catalog.tasks import import_all_xpro_files
@@ -16,7 +17,8 @@ class Command(BaseCommand):
             "-c",
             "--chunk-size",
             dest="chunk_size",
-            default=1000,
+            default=settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE,
+            type=int,
             help="Chunk size for batch import task",
         )
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3820 

#### What's this PR do?
Adds `type=int,` to the optional `chunk_size` argument specification and sets the default to the same as defined in settings.

#### How should this be manually tested?
Run any or all of the modied mgmt commands, with and without a `--chunk-size` parameter.  They should all start without errors (you don't need to wait for them to finish), assuming all the required .env settings are configured with the same values as on RC: 

```
XPRO_LEARNING_COURSE_ACCESS_KEY=
XPRO_LEARNING_COURSE_SECRET_ACCESS_KEY=
XPRO_LEARNING_COURSE_BUCKET_NAME=
XPRO_CATALOG_API_URL=https://xpro.mit.edu/api/programs/
XPRO_COURSES_API_URL=https://xpro.mit.edu/api/courses/

OCW_CONTENT_ACCESS_KEY=
OCW_CONTENT_SECRET_ACCESS_KEY=
OCW_CONTENT_BUCKET_NAME=
OCW_LEARNING_COURSE_BUCKET_NAME=

MITX_ONLINE_BASE_URL=https://mitxonline.mit.edu/
MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/courses/
MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/programs/
MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME=

EDX_API_URL=
EDX_API_CLIENT_ID=
EDX_API_CLIENT_SECRET=
EDX_API_ACCESS_TOKEN_URL=
EDX_LEARNING_COURSE_BUCKET_NAME=
```
