### PR TITLE
Assign department to MITX Online, MITx, and OLL courses

### DIFF
--- a/course_catalog/etl/mitxonline.py
+++ b/course_catalog/etl/mitxonline.py
@@ -10,6 +10,7 @@ import requests
 from django.conf import settings
 
 from course_catalog.constants import OfferedBy, PlatformType
+from course_catalog.utils import extract_valid_department_from_id
 from course_catalog.etl.utils import transform_topics
 
 log = logging.getLogger(__name__)
@@ -130,6 +131,7 @@ def _transform_course(course):
     return {
         "course_id": course["readable_id"],
         "platform": PlatformType.mitxonline.value,
+        "department": extract_valid_department_from_id(course.get("key")),
         "title": course["title"],
         "offered_by": copy.deepcopy(OFFERED_BY),
         "topics": transform_topics(course.get("topics", [])),

--- a/course_catalog/etl/mitxonline.py
+++ b/course_catalog/etl/mitxonline.py
@@ -10,8 +10,7 @@ import requests
 from django.conf import settings
 
 from course_catalog.constants import OfferedBy, PlatformType
-from course_catalog.utils import extract_valid_department_from_id
-from course_catalog.etl.utils import transform_topics
+from course_catalog.etl.utils import transform_topics, extract_valid_department_from_id
 
 log = logging.getLogger(__name__)
 
@@ -131,7 +130,7 @@ def _transform_course(course):
     return {
         "course_id": course["readable_id"],
         "platform": PlatformType.mitxonline.value,
-        "department": extract_valid_department_from_id(course.get("key")),
+        "department": extract_valid_department_from_id(course["readable_id"]),
         "title": course["title"],
         "offered_by": copy.deepcopy(OFFERED_BY),
         "topics": transform_topics(course.get("topics", [])),

--- a/course_catalog/etl/mitxonline_test.py
+++ b/course_catalog/etl/mitxonline_test.py
@@ -11,7 +11,10 @@ import pytest
 from course_catalog.constants import PlatformType
 from course_catalog.etl import mitxonline
 from course_catalog.etl.mitxonline import _parse_datetime, parse_page_attribute
-from course_catalog.etl.utils import UCC_TOPIC_MAPPINGS
+from course_catalog.etl.utils import (
+    UCC_TOPIC_MAPPINGS,
+    extract_valid_department_from_id,
+)
 from open_discussions.test_utils import any_instance_of
 
 pytestmark = pytest.mark.django_db
@@ -135,6 +138,9 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                 {
                     "course_id": course_data["readable_id"],
                     "platform": PlatformType.mitxonline.value,
+                    "department": extract_valid_department_from_id(
+                        course_data["readable_id"]
+                    ),
                     "title": course_data["title"],
                     "image_src": parse_page_attribute(
                         course_data, "feature_image_src", is_url=True
@@ -219,6 +225,7 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
         {
             "course_id": course_data["readable_id"],
             "platform": PlatformType.mitxonline.value,
+            "department": extract_valid_department_from_id(course_data["readable_id"]),
             "title": course_data["title"],
             "image_src": parse_page_attribute(
                 course_data, "feature_image_src", is_url=True

--- a/course_catalog/etl/openedx.py
+++ b/course_catalog/etl/openedx.py
@@ -10,7 +10,8 @@ import requests
 from toolz import compose
 
 from course_catalog.etl.constants import COMMON_HEADERS
-from course_catalog.utils import get_year_and_semester, semester_year_to_date, extract_valid_department_from_id
+from course_catalog.utils import get_year_and_semester, semester_year_to_date
+from course_catalog.etl.utils import extract_valid_department_from_id
 
 OpenEdxConfiguration = namedtuple(
     "OpenEdxConfiguration",

--- a/course_catalog/etl/openedx.py
+++ b/course_catalog/etl/openedx.py
@@ -10,7 +10,7 @@ import requests
 from toolz import compose
 
 from course_catalog.etl.constants import COMMON_HEADERS
-from course_catalog.utils import get_year_and_semester, semester_year_to_date
+from course_catalog.utils import get_year_and_semester, semester_year_to_date, extract_valid_department_from_id
 
 OpenEdxConfiguration = namedtuple(
     "OpenEdxConfiguration",
@@ -235,6 +235,7 @@ def _transform_course(config, course):
     return {
         "course_id": course.get("key"),
         "title": course.get("title"),
+        "department": extract_valid_department_from_id(course.get("key")),
         "short_description": course.get("short_description"),
         "full_description": course.get("full_description"),
         "platform": config.platform,

--- a/course_catalog/etl/openedx_test.py
+++ b/course_catalog/etl/openedx_test.py
@@ -119,6 +119,7 @@ def test_transform_course(
     assert transformed_courses[0] == {
         "title": "The Analytics Edge",
         "course_id": "MITx+15.071x",
+        "department": ["15"],
         "short_description": "short_description",
         "full_description": "full description",
         "platform": openedx_config.platform,

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -26,6 +26,7 @@ from course_catalog.constants import (
     CONTENT_TYPE_FILE,
     CONTENT_TYPE_VERTICAL,
     VALID_TEXT_FILE_TYPES,
+    OCW_DEPARTMENTS,
 )
 from course_catalog.models import get_max_length
 
@@ -443,3 +444,20 @@ def transform_topics(topics):
             ]
         )
     ]
+
+
+def extract_valid_department_from_id(course_string):
+    """
+    Extracts a department from course data and returns
+
+    Args:
+        course_string (str): course name as string
+
+    Returns:
+        department (str): parsed department string
+    """
+    department_string = re.search("\+([^\.]*)\.", course_string)
+    if department_string:
+        dept_candidate = department_string.groups()[0]
+        return [dept_candidate] if dept_candidate in OCW_DEPARTMENTS.keys() else None
+    return None

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -15,6 +15,7 @@ from course_catalog.etl.utils import (
     documents_from_olx,
     extract_text_from_url,
     extract_text_metadata,
+    extract_valid_department_from_id,
     generate_unique_id,
     get_text_from_element,
     log_exceptions,
@@ -298,3 +299,14 @@ def test_documents_from_olx():
     assert formula2do[1]["key"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
     assert formula2do[1]["mime_type"] == "application/xml"
+
+
+def test_extract_valid_department_from_id():
+    """Test that correct department is extracted from ID"""
+    assert extract_valid_department_from_id("MITx+7.03.2x") == ["7"]
+    assert extract_valid_department_from_id("course-v1:MITxT+21A.819.2x") == ["21A"]
+    # Has a department not in the list and thus should not be entered
+    assert extract_valid_department_from_id("course-v1:MITxT+123.658.2x") is None
+    # Has no discernible department
+    assert extract_valid_department_from_id("MITx+CITE101x") is None
+    assert extract_valid_department_from_id("RanD0mStr1ng") is None

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -10,7 +10,7 @@ import requests
 import yaml
 from django.conf import settings
 
-from course_catalog.constants import OCW_DEPARTMENTS, PlatformType, semester_mapping
+from course_catalog.constants import PlatformType, semester_mapping
 from open_discussions.utils import generate_filepath
 
 log = logging.getLogger()
@@ -331,23 +331,3 @@ def parse_instructors(staff):
         instructors.append(instructor)
 
     return instructors
-
-
-def extract_valid_department_from_id(course_string):
-    """
-    Extracts a department from course data and returns
-
-    Args:
-        course_string (str): course name as string
-
-    Returns:
-        department (str): parsed department string
-    """
-    department_string = re.search("\+([^\.]*)\.", course_string)
-    if department_string:
-        dept_candidate = department_string.groups()[0]
-        return ([dept_candidate]
-                if dept_candidate in OCW_DEPARTMENTS.keys()
-                else None
-                )
-    return None

--- a/course_catalog/utils.py
+++ b/course_catalog/utils.py
@@ -10,7 +10,7 @@ import requests
 import yaml
 from django.conf import settings
 
-from course_catalog.constants import PlatformType, semester_mapping
+from course_catalog.constants import OCW_DEPARTMENTS, PlatformType, semester_mapping
 from open_discussions.utils import generate_filepath
 
 log = logging.getLogger()
@@ -331,3 +331,23 @@ def parse_instructors(staff):
         instructors.append(instructor)
 
     return instructors
+
+
+def extract_valid_department_from_id(course_string):
+    """
+    Extracts a department from course data and returns
+
+    Args:
+        course_string (str): course name as string
+
+    Returns:
+        department (str): parsed department string
+    """
+    department_string = re.search("\+([^\.]*)\.", course_string)
+    if department_string:
+        dept_candidate = department_string.groups()[0]
+        return ([dept_candidate]
+                if dept_candidate in OCW_DEPARTMENTS.keys()
+                else None
+                )
+    return None


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes #3827 

#### What's this PR do?
Adds a utility function taking the department number/identifier from the passed course id and assigning it to the `department` key in the course dict. 
The logic for this looks for the first instance of a `+` and the following `.`, takes the string between them, and compares it to the list of departments. If the string is there, that identifier is put in a list and passed back. If there is no matching string OR that matching string is not in the list of valid departments, 'None' is passed back.

#### How should this be manually tested?
I'll offer my process, but there is potentially(probably) a better way, but this let me walk through piece by piece.

1. I took the json from. `test_json.mitxonline_courses.json` and loaded it from file to a dict (basically replaced the loader function with a file open and json.loads, which returns the same result as the API call). 
2. I then ran that data through `transform_courses` which will run each of the courses in that list through the modified function `_transform_course`
3. Then ran `course_catalog.etl.loaders.load_courses` with the parameters `"mitxonline"` and the transformed data to success and verified that the new department identifiers saved.

