### PR TITLE
Learn search results list dates are different than default drawer details dates

### DIFF
--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -1,4 +1,3 @@
-import moment from "moment"
 import React, { useCallback, useMemo } from "react"
 import Dotdotdot from "react-dotdotdot"
 import { toQueryString } from "ol-util"
@@ -18,8 +17,6 @@ import {
   resourceThumbnailSrc,
   CertificateIcon
 } from "../util"
-
-const DISPLAY_DATE_FORMAT = "MMMM D, YYYY"
 
 type CardVariant = "column" | "row" | "row-reverse"
 type OnActivateCard<R extends CardMinimalResource = CardMinimalResource> = (

--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -82,7 +82,7 @@ const LearningResourceCard = <R extends CardMinimalResource>({
     resource.certification && resource.certification.length > 0
   const startDate =
     hasCertificate && bestAvailableRun ?
-      moment(bestAvailableRun.best_start_date).format(DISPLAY_DATE_FORMAT) :
+      moment(bestAvailableRun.start_date).format(DISPLAY_DATE_FORMAT) :
       null
   const offerers = resource.offered_by ?? []
   const handleActivate = useCallback(

--- a/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCard.tsx
@@ -14,6 +14,7 @@ import { CardMinimalResource, EmbedlyConfig } from "../interfaces"
 import {
   findBestRun,
   getReadableResourceType,
+  getStartDate,
   resourceThumbnailSrc,
   CertificateIcon
 } from "../util"
@@ -82,7 +83,7 @@ const LearningResourceCard = <R extends CardMinimalResource>({
     resource.certification && resource.certification.length > 0
   const startDate =
     hasCertificate && bestAvailableRun ?
-      moment(bestAvailableRun.start_date).format(DISPLAY_DATE_FORMAT) :
+      getStartDate(resource.platform ?? "", bestAvailableRun) :
       null
   const offerers = resource.offered_by ?? []
   const handleActivate = useCallback(

--- a/frontends/ol-search-ui/src/util.tsx
+++ b/frontends/ol-search-ui/src/util.tsx
@@ -62,10 +62,10 @@ const resourceThumbnailSrc = (
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
 
 const runStartDate = (objectRun: LearningResourceRun): moment.Moment =>
-  moment(objectRun.best_start_date, DATE_FORMAT)
+  moment(objectRun.start_date, DATE_FORMAT)
 
 const runEndDate = (objectRun: LearningResourceRun): moment.Moment =>
-  moment(objectRun.best_end_date, DATE_FORMAT)
+  moment(objectRun.end_date, DATE_FORMAT)
 
 const compareRuns = (
   firstRun: LearningResourceRun,
@@ -75,7 +75,7 @@ const compareRuns = (
 const findBestRun = (
   runs: LearningResourceRun[]
 ): LearningResourceRun | undefined => {
-  const dated = runs.filter(run => run.best_start_date && run.best_end_date)
+  const dated = runs.filter(run => run.start_date && run.end_date)
 
   // Runs that are running right now
   const [bestCurrentRun] = dated.filter(

--- a/frontends/open-discussions/src/components/LearningResourceCard.js
+++ b/frontends/open-discussions/src/components/LearningResourceCard.js
@@ -10,13 +10,12 @@ import LoginTooltip from "./LoginTooltip"
 import LearningResourceIcon from "./LearningResourceIcon"
 
 import { setDialogData } from "../actions/ui"
-import { bestRun } from "../lib/learning_resources"
+import { bestRun, getStartDate } from "../lib/learning_resources"
 import { defaultResourceImageURL, embedlyThumbnail } from "../lib/url"
 import {
   CAROUSEL_IMG_WIDTH,
   CAROUSEL_IMG_HEIGHT,
   LR_TYPE_VIDEO,
-  DISPLAY_DATE_FORMAT,
   readableLearningResources
 } from "../lib/constants"
 import { SEARCH_GRID_UI, SEARCH_LIST_UI } from "../lib/search"
@@ -148,7 +147,7 @@ export function LearningResourceDisplay(props: Props) {
   const hasCertificate = object.certification && object.certification.length > 0
   const startDate =
     hasCertificate && bestAvailableRun
-      ? moment(bestAvailableRun.start_date).format(DISPLAY_DATE_FORMAT)
+      ? getStartDate(object, bestAvailableRun)
       : null
 
   const iconKeys =

--- a/frontends/open-discussions/src/components/LearningResourceCard.js
+++ b/frontends/open-discussions/src/components/LearningResourceCard.js
@@ -148,7 +148,7 @@ export function LearningResourceDisplay(props: Props) {
   const hasCertificate = object.certification && object.certification.length > 0
   const startDate =
     hasCertificate && bestAvailableRun
-      ? moment(bestAvailableRun.best_start_date).format(DISPLAY_DATE_FORMAT)
+      ? moment(bestAvailableRun.start_date).format(DISPLAY_DATE_FORMAT)
       : null
 
   const iconKeys =

--- a/frontends/open-discussions/src/components/LearningResourceCard.js
+++ b/frontends/open-discussions/src/components/LearningResourceCard.js
@@ -1,6 +1,5 @@
 // @flow
 /* global SETTINGS:false */
-import moment from "moment"
 import React, { useCallback } from "react"
 import Dotdotdot from "react-dotdotdot"
 import { useDispatch } from "react-redux"

--- a/frontends/open-discussions/src/components/LearningResourceCard_test.js
+++ b/frontends/open-discussions/src/components/LearningResourceCard_test.js
@@ -235,7 +235,7 @@ describe("LearningResourceCard", () => {
       .replace("calendar_today", "")
     assert.equal(
       startDate,
-      moment(bestRun(object.runs).best_start_date).format(DISPLAY_DATE_FORMAT)
+      moment(bestRun(object.runs).start_date).format(DISPLAY_DATE_FORMAT)
     )
   })
 

--- a/frontends/open-discussions/src/lib/learning_resources.js
+++ b/frontends/open-discussions/src/lib/learning_resources.js
@@ -37,10 +37,10 @@ export const availabilityLabel = (availability: ?string) => {
 }
 
 const runStartDate = (objectRun: LearningResourceRun): moment$Moment =>
-  moment(objectRun.best_start_date, DATE_FORMAT)
+  moment(objectRun.start_date, DATE_FORMAT)
 
 const runEndDate = (objectRun: LearningResourceRun): moment$Moment =>
-  moment(objectRun.best_end_date, DATE_FORMAT)
+  moment(objectRun.end_date, DATE_FORMAT)
 
 const compareRuns = (
   firstRun: LearningResourceRun,
@@ -48,7 +48,7 @@ const compareRuns = (
 ) => runStartDate(firstRun).diff(runStartDate(secondRun), "hours")
 
 export const bestRun = (runs: Array<LearningResourceRun>) => {
-  runs = runs.filter(run => run.best_start_date && run.best_end_date)
+  runs = runs.filter(run => run.start_date && run.end_date)
 
   // Runs that are running right now
   const currentRuns = runs.filter(
@@ -61,7 +61,7 @@ export const bestRun = (runs: Array<LearningResourceRun>) => {
   // The next future run
   const futureRuns = runs
     .filter(run => runStartDate(run).isAfter())
-    .sort(compareRuns)
+    .sort(compareRuns).reverse()
   if (!emptyOrNil(futureRuns)) {
     return futureRuns[0]
   }

--- a/frontends/open-discussions/src/lib/learning_resources.js
+++ b/frontends/open-discussions/src/lib/learning_resources.js
@@ -61,7 +61,7 @@ export const bestRun = (runs: Array<LearningResourceRun>) => {
   // The next future run
   const futureRuns = runs
     .filter(run => runStartDate(run).isAfter())
-    .sort(compareRuns).reverse()
+    .sort(compareRuns)
   if (!emptyOrNil(futureRuns)) {
     return futureRuns[0]
   }

--- a/frontends/open-discussions/src/lib/learning_resources_test.js
+++ b/frontends/open-discussions/src/lib/learning_resources_test.js
@@ -132,46 +132,46 @@ describe("Course utils", () => {
         }
 
         if (futureRunAvailable) {
-          futureRun.best_start_date = moment(currentDate)
+          futureRun.start_date = moment(currentDate)
             .add(5, "days")
             .format(DATE_FORMAT)
-          futureRun.best_end_date = moment(currentDate)
+          futureRun.end_date = moment(currentDate)
             .add(6, "days")
             .format(DATE_FORMAT)
           course.runs.push(futureRun)
 
           const otherFutureRun = makeRun()
-          otherFutureRun.best_start_date = moment(currentDate)
+          otherFutureRun.start_date = moment(currentDate)
             .add(15, "days")
             .format(DATE_FORMAT)
-          otherFutureRun.best_end_date = moment(currentDate)
+          otherFutureRun.end_date = moment(currentDate)
             .add(16, "days")
             .format(DATE_FORMAT)
           course.runs.push(otherFutureRun)
         }
 
         if (pastRunAvailable) {
-          pastRun.best_start_date = moment(currentDate)
+          pastRun.start_date = moment(currentDate)
             .subtract(5, "days")
             .format(DATE_FORMAT)
-          pastRun.best_end_date = moment(currentDate)
+          pastRun.end_date = moment(currentDate)
             .subtract(4, "days")
             .format(DATE_FORMAT)
           course.runs.push(pastRun)
 
           const otherPastRun = makeRun()
-          otherPastRun.best_start_date = moment(currentDate)
+          otherPastRun.start_date = moment(currentDate)
             .subtract(15, "days")
             .format(DATE_FORMAT)
-          otherPastRun.best_end_date = moment(currentDate)
+          otherPastRun.end_date = moment(currentDate)
             .subtract(14, "days")
             .format(DATE_FORMAT)
           course.runs.push(otherPastRun)
         }
 
         if (runWithNullStartDatesAvailable) {
-          nullRun.best_start_date = null
-          nullRun.best_end_date = null
+          nullRun.start_date = null
+          nullRun.end_date = null
           course.runs.push(nullRun)
         }
 

--- a/frontends/open-discussions/src/lib/learning_resources_test.js
+++ b/frontends/open-discussions/src/lib/learning_resources_test.js
@@ -122,10 +122,10 @@ describe("Course utils", () => {
         const nullRun = makeRun()
 
         if (currentRunAvailable) {
-          currentRun.best_start_date = moment(currentDate)
+          currentRun.start_date = moment(currentDate)
             .add(5, "days")
             .format(DATE_FORMAT)
-          currentRun.best_end_date = moment(currentDate)
+          currentRun.end_date = moment(currentDate)
             .subtract(5, "days")
             .format(DATE_FORMAT)
           course.runs.push(currentRun)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes [3842](https://github.com/mitodl/open-discussions/issues/3842)

#### What's this PR do?
Swaps both the ol-search-ui and open-discussions front end repos off using best_start_date and onto start_date as best_start_date is often enrollment date and a mismatch... and misnomer.

#### How should this be manually tested?
search for courses in open-discussions/learn/search and compare against the database to find preferably courses with mismatched best_start_date and start_date - I would recommend:

- 1 that is currently running with past dates
- 1 that is currently running with future dates
- 1 that is currently running only
- 1 that ran in the past without future dates
- 1 that ran in the past but has future dates
- 1 that runs in the future only

The selected "best run" should be the one expected which would be:

- Currently running (today's date is between the start and end dates)
- the next run (start date is after today's date, there is no current run)
- the last run that ran if neither of the previous exist.

The date on the search results should match the date in the drawer that opens when you click on the course
The dates in the date drop down (if there are multiple runs) should be in order. This can be hard to tell as sometimes there are wacky end dates. To fix this, I modified line 207 of expandedLearningResourceDisplay.js to `{getStartDate(object, run)} - {run.end_date}` so I could see this while testing.

#### Where should the reviewer start?
Start with the js changes as those are what is on learn/search and what is referenced in the ticket.

#### Any background context you want to provide?
You know that dog flying hte plane meme? That's me. I'm not certain that best_start_date doesn't have a purpose, only that that date causes the mismatch and because of inconsistencies with saved data vs what we display elsewhere. I also made the changes to both the js and ts versions since this would be incorrect in search-ui going forward if change isn't made there as well, although it should work the same in both.
