### PR TITLE
Remove yarn postinstall script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Webpack build
+        run: yarn run build
+
       - name: Lints
         run: yarn run lint-check
 
@@ -144,9 +147,6 @@ jobs:
         env:
           CODECOV: true
           NODE_ENV: test
-
-      - name: Webpack build
-        run: yarn run build
 
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     ],
     "scripts": {
         "foreach-with-fallback": "yarn workspaces foreach --verbose --topological exec node ${PROJECT_CWD}/scripts/yarn-run-with-fallback.js $0 $1",
-        "postinstall": "yarn run build",
         "start-dev": "yarn run build && yarn workspaces foreach --verbose --parallel --jobs unlimited --interlaced exec node ${PROJECT_CWD}/scripts/yarn-run-with-fallback.js start-dev global:start-dev",
         "build": "run foreach-with-fallback build global:build",
         "clean": "run foreach-with-fallback clean global:clean",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing *Needs to be tested on Heroku*.
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Should help with #3691 

#### What's this PR do?

Post install is a script yarn runs automatically after install. I believe we do not need this and it is contributing to our overbuilding.
- We don't need it in dev because run-watch-dev.sh runs build.
- I believe we don't need it on Heroku because the buildpack runs "build" directly if found. (https://github.com/heroku/heroku-buildpack-nodejs/blob/5917461b195feea3b67571f39bfdcdf2c0e5c25d/lib/dependencies.sh#L108)

#### How should this be manually tested?
This really needs to be tested on Heroku. But you could check locally that:

1. `docker compose up` builds the app.

#### Any background context you want to provide?
On `docker compose up`, we build too often:
1. Once after `yarn install` if there have been changes since your last install
2. Twice with `run-watch-dev.sh`:
    1. Once at the start,
    2. then again when entering watch mode

This should eliminate (1). 2i is also undesirable, but not addressed here.

