### PR TITLE
Add more valid text file types

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -122,20 +122,29 @@ OFFERED_BY_MAPPINGS = {
 semester_mapping = {"1T": "spring", "2T": "summer", "3T": "fall"}
 
 VALID_TEXT_FILE_TYPES = [
-    ".pdf",
-    ".htm",
-    ".html",
-    ".txt",
+    ".csv",
     ".doc",
     ".docx",
-    ".xls",
-    ".xlsx",
+    ".htm",
+    ".html",
+    ".json",
+    ".m",
+    ".mat",
+    ".md",
+    ".pdf",
     ".ppt",
     ".pptx",
-    ".xml",
-    ".json",
-    ".rtf",
     ".ps",
+    ".py",
+    ".r",
+    ".rtf",
+    ".sjson",
+    ".srt",
+    ".txt",
+    ".vtt",
+    ".xls",
+    ".xlsx",
+    ".xml",
 ]
 
 

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -274,7 +274,7 @@ def test_documents_from_olx():
 
         olx_path = os.path.join(temp, "content-devops-0001")
         parsed_documents = documents_from_olx(olx_path)
-    assert len(parsed_documents) == 106
+    assert len(parsed_documents) == 108
 
     expected_parsed_vertical = (
         "\n    Where all of the tests are defined  Jasmine tests: HTML module edition \n"
@@ -298,7 +298,7 @@ def test_documents_from_olx():
     assert formula2do[0] == b'<html filename="formula2do" display_name="To do list"/>\n'
     assert formula2do[1]["key"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
-    assert formula2do[1]["mime_type"] == "application/xml"
+    assert formula2do[1]["mime_type"].endswith("/xml")
 
 
 def test_extract_valid_department_from_id():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3840

#### What's this PR do?
Adds additional file types that should be sent to tika for text extraction

#### How should this be manually tested?
-Set the following to the same values as RC in your .env file (along with AWS creds):
```
MITX_ONLINE_BASE_URL
MITX_ONLINE_COURSES_API_URL
MITX_ONLINE_PROGRAMS_API_URL
MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME
```

- Run the following command:
```
manage.py recreate_index --all   # if you don't already have a search index
manage.py backpopulate_mitxonline_data
```

- Run the following in a shell:
```
from course_catalog.etl.edx_shared import sync_edx_course_files
from django.conf import settings
from course_catalog.models import Course
course_id = Course.objects.get(course_id="course-v1:MITxT+10.50.CH02x").id
sync_edx_course_files(settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME, "mitxonline", [course_id])
```

Go to http://localhost:8063/learn/search?q=%22which%20is%20valid%20for%20Stokes%20flows%22 - there should be 1 course result