### PR TITLE
More efficient download and processing of edx content archives

### DIFF
--- a/course_catalog/etl/edx_shared.py
+++ b/course_catalog/etl/edx_shared.py
@@ -12,7 +12,6 @@ from course_catalog.constants import PlatformType
 from course_catalog.etl.loaders import load_content_files
 from course_catalog.etl.utils import get_learning_course_bucket, transform_content_files
 from course_catalog.models import Course, LearningResourceRun
-from course_catalog.utils import get_s3_object_and_read
 
 log = logging.getLogger()
 
@@ -82,12 +81,10 @@ def sync_edx_course_files(
             log.info("No %s course runs matched tarfile %s", platform, course_tarfile)
             continue
         with TemporaryDirectory() as export_tempdir, TemporaryDirectory() as tar_tempdir:
-            tarbytes = get_s3_object_and_read(course_tarfile)
             course_tarpath = os.path.join(
                 export_tempdir, course_tarfile.key.split("/")[-1]
             )
-            with open(course_tarpath, "wb") as f:
-                f.write(tarbytes)
+            bucket.download_file(course_tarfile.key, course_tarpath)
             try:
                 check_call(["tar", "xf", course_tarpath], cwd=tar_tempdir)
             except CalledProcessError:

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -347,7 +347,8 @@ def transform_content_files(course_tarpath):
         course_tarpath (str): The path to the tarball which contains the OLX
     """
     content = []
-    with TemporaryDirectory() as inner_tempdir:
+    basedir = os.path.basename(course_tarpath).split(".")[0]
+    with TemporaryDirectory(prefix=basedir) as inner_tempdir:
         check_call(["tar", "xf", course_tarpath], cwd=inner_tempdir)
         olx_path = glob.glob(inner_tempdir + "/*")[0]
         for document, metadata in documents_from_olx(olx_path):

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -25,8 +25,8 @@ from xbundle import XBundle
 from course_catalog.constants import (
     CONTENT_TYPE_FILE,
     CONTENT_TYPE_VERTICAL,
-    VALID_TEXT_FILE_TYPES,
     OCW_DEPARTMENTS,
+    VALID_TEXT_FILE_TYPES,
 )
 from course_catalog.models import get_max_length
 
@@ -297,23 +297,25 @@ def documents_from_olx(olx_path):  # pylint: disable=too-many-locals
         list of tuple:
             A list of (bytes of content, metadata)
     """
-    documents = []
-    bundle = XBundle()
-    bundle.import_from_directory(olx_path)
-    for index, vertical in enumerate(bundle.course.findall(".//vertical")):
-        content = get_text_from_element(vertical)
+    try:
+        bundle = XBundle()
+        bundle.import_from_directory(olx_path)
+        for index, vertical in enumerate(bundle.course.findall(".//vertical")):
+            content = get_text_from_element(vertical)
 
-        documents.append(
-            (
-                content,
-                {
-                    "key": f"vertical_{index + 1}",
-                    "content_type": CONTENT_TYPE_VERTICAL,
-                    "title": vertical.attrib.get("display_name") or "",
-                    "mime_type": "application/xml",
-                },
+            yield (
+                (
+                    content,
+                    {
+                        "key": f"vertical_{index + 1}",
+                        "content_type": CONTENT_TYPE_VERTICAL,
+                        "title": vertical.attrib.get("display_name") or "",
+                        "mime_type": "application/xml",
+                    },
+                )
             )
-        )
+    except Exception as err:
+        log.exception(err)
 
     counter = _infinite_counter()
 
@@ -327,18 +329,14 @@ def documents_from_olx(olx_path):  # pylint: disable=too-many-locals
 
                 mimetype = mimetypes.types_map.get(extension_lower)
 
-                documents.append(
-                    (
-                        filebytes,
-                        {
-                            "key": f"document_{next(counter)}_{filename}",
-                            "content_type": CONTENT_TYPE_FILE,
-                            "mime_type": mimetype,
-                        },
-                    )
+                yield (
+                    filebytes,
+                    {
+                        "key": f"document_{next(counter)}_{filename}",
+                        "content_type": CONTENT_TYPE_FILE,
+                        "mime_type": mimetype,
+                    },
                 )
-
-    return documents
 
 
 def transform_content_files(course_tarpath):
@@ -366,7 +364,7 @@ def transform_content_files(course_tarpath):
 
             tika_content = tika_output.get("content") or ""
             tika_metadata = tika_output.get("metadata") or {}
-            content.append(
+            yield (
                 {
                     "content": tika_content.strip(),
                     "key": key,
@@ -382,7 +380,6 @@ def transform_content_files(course_tarpath):
                     "content_type": content_type,
                 }
             )
-    return content
 
 
 def get_learning_course_bucket(bucket_name):

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -315,7 +315,7 @@ def documents_from_olx(olx_path):  # pylint: disable=too-many-locals
                 )
             )
     except Exception as err:
-        log.exception(err)
+        log.exception("Could not read verticals from path %s", olx_path)
 
     counter = _infinite_counter()
 

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -239,9 +239,12 @@ def test_transform_content_files(mocker, has_metadata):
     script_dir = os.path.dirname(
         os.path.dirname(pathlib.Path(__file__).parent.absolute())
     )
-    content = transform_content_files(
-        os.path.join(script_dir, "test_json", "exported_courses_12345.tar.gz")
-    )
+    content = [
+        f
+        for f in transform_content_files(
+            os.path.join(script_dir, "test_json", "exported_courses_12345.tar.gz")
+        )
+    ]
     assert content == [
         {
             "content": tika_output["content"],
@@ -273,7 +276,7 @@ def test_documents_from_olx():
         check_call(["tar", "xf", "content-devops-0001.tar.gz"], cwd=temp)
 
         olx_path = os.path.join(temp, "content-devops-0001")
-        parsed_documents = documents_from_olx(olx_path)
+        parsed_documents = [doc for doc in documents_from_olx(olx_path)]
     assert len(parsed_documents) == 108
 
     expected_parsed_vertical = (

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 from subprocess import check_call
 from tempfile import TemporaryDirectory
+from unittest.mock import ANY
 
 import pytest
 import pytz
@@ -27,6 +28,26 @@ from course_catalog.etl.utils import (
 )
 
 pytestmark = pytest.mark.django_db
+
+
+def get_olx_test_docs():
+    """Get a list of edx docs from a sample archive file"""
+    script_dir = os.path.dirname(
+        os.path.dirname(pathlib.Path(__file__).parent.absolute())
+    )
+    with TemporaryDirectory() as temp:
+        check_call(
+            [
+                "tar",
+                "xf",
+                os.path.join(script_dir, "test_json", "exported_courses_12345.tar.gz"),
+            ],
+            cwd=temp,
+        )
+        check_call(["tar", "xf", "content-devops-0001.tar.gz"], cwd=temp)
+
+        olx_path = os.path.join(temp, "content-devops-0001")
+        return [doc for doc in documents_from_olx(olx_path)]
 
 
 @pytest.mark.parametrize("side_effect", ["One", Exception("error")])
@@ -264,19 +285,7 @@ def test_documents_from_olx():
     script_dir = os.path.dirname(
         os.path.dirname(pathlib.Path(__file__).parent.absolute())
     )
-    with TemporaryDirectory() as temp:
-        check_call(
-            [
-                "tar",
-                "xf",
-                os.path.join(script_dir, "test_json", "exported_courses_12345.tar.gz"),
-            ],
-            cwd=temp,
-        )
-        check_call(["tar", "xf", "content-devops-0001.tar.gz"], cwd=temp)
-
-        olx_path = os.path.join(temp, "content-devops-0001")
-        parsed_documents = [doc for doc in documents_from_olx(olx_path)]
+    parsed_documents = get_olx_test_docs()
     assert len(parsed_documents) == 108
 
     expected_parsed_vertical = (
@@ -302,6 +311,16 @@ def test_documents_from_olx():
     assert formula2do[1]["key"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
     assert formula2do[1]["mime_type"].endswith("/xml")
+
+
+def test_documents_from_olx_bad_vertical(mocker):
+    """An exception should be logged if verticals can't be read, other files should still be processed"""
+    mock_log = mocker.patch("course_catalog.etl.utils.log.exception")
+    mock_bundle = mocker.patch("course_catalog.etl.utils.XBundle")
+    mock_bundle.return_value.import_from_directory.side_effect = OSError()
+    parsed_documents = get_olx_test_docs()
+    mock_log.assert_called_once_with("Could not read verticals from path %s", ANY)
+    assert len(parsed_documents) == 92
 
 
 def test_extract_valid_department_from_id():

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -764,6 +764,8 @@ def start_recreate_index(self, indexes):
                             platform__in=(
                                 PlatformType.ocw.value,
                                 PlatformType.xpro.value,
+                                PlatformType.mitx.value,
+                                PlatformType.mitxonline.value,
                             )
                         )
                         .exclude(course_id__in=blocklisted_ids)

--- a/search/tasks_test.py
+++ b/search/tasks_test.py
@@ -456,8 +456,8 @@ def test_start_recreate_index(
         index_courses_mock.si.assert_any_call([courses[2].id, courses[3].id])
         index_courses_mock.si.assert_any_call([courses[4].id, courses[5].id])
 
-        # chunk size is 2 and there is only one course each for ocw and xpro
-        assert index_course_content_mock.si.call_count == 1
+        # chunk size is 2 and there is only one course each for ocw, xpro, and mitx
+        assert index_course_content_mock.si.call_count == 2
         index_course_content_mock.si.assert_any_call(
             [
                 *[
@@ -465,6 +465,15 @@ def test_start_recreate_index(
                     for course in courses
                     if course.platform == PlatformType.ocw.value
                 ],
+                *[
+                    course.id
+                    for course in courses
+                    if course.platform == PlatformType.mitx.value
+                ],
+            ]
+        )
+        index_course_content_mock.si.assert_any_call(
+            [
                 *[
                     course.id
                     for course in courses


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #3860

#### What's this PR do?
- Uses boto's `Bucket.download_file()` function to save edx archives to a temporary file, instead of reading the entire file into memory before saving to disk.
- Uses `yield` to return file content one by one instead of all at once in a single list
- Fixes the omission of mitx and mitxonline from file content index recreation
- Places a try-catch block around the parsing of "verticals" content via `XBundle`.  A handful of mitxonline tar archives raise an exception here due to "external entities" in an html file, that was preventing the rest of the archive from being processed.

#### How should this be manually tested?
- Set these to the same as production in your .env file:
```
MITX_ONLINE_BASE_URL
MITX_ONLINE_COURSES_API_URL
MITX_ONLINE_PROGRAMS_API_URL
MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME
```

- Delete any existing content files for mitxonline you might have, in a shell:
```python
from course_catalog.models import *
ContentFile.objects.filter(run__platform="mitxonline").delete()
```

- Run the following
```python
manage.py recreate_index --courses
manage.py backpopulate_mitxonline_data
manage.py backpopulate_mitxonline_files
```

- Go to http://localhost:8063/learn/search?q=%22tau%20prime%20and%20this%20curly%20tau%22 - there should be 1 course result

- Run `manage.py recreate_index --courses` again.  The above url should still return 1 result afterward.

