### PR TITLE
fix flaky test: use standard date format for cards

### DIFF
--- a/frontends/open-discussions/src/components/LearningResourceCard_test.js
+++ b/frontends/open-discussions/src/components/LearningResourceCard_test.js
@@ -12,6 +12,7 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 
 import { bestRun } from "../lib/learning_resources"
 import {
+  makePlatform,
   makeCourse,
   makeLearningResource,
   makeUserList
@@ -24,7 +25,8 @@ import {
   OPEN_CONTENT,
   PROFESSIONAL,
   CERTIFICATE,
-  DISPLAY_DATE_FORMAT
+  DISPLAY_DATE_FORMAT,
+  platforms
 } from "../lib/constants"
 import {
   COURSE_SEARCH_URL,
@@ -228,6 +230,8 @@ describe("LearningResourceCard", () => {
   it(`should render a start date if there is a certificate`, async () => {
     const object = makeLearningResource(LR_TYPE_COURSE)
     object.certification = [CERTIFICATE]
+    // OCW courses format dates differently, so exclude them here.
+    object.platform = makePlatform({ exclude: [platforms.OCW] })
     const { wrapper } = await render({ object })
     const startDate = wrapper
       .find(".start-date")

--- a/frontends/open-discussions/src/factories/learning_resources.js
+++ b/frontends/open-discussions/src/factories/learning_resources.js
@@ -253,3 +253,10 @@ export const makeRandomResource = () =>
 export const makePopularContentResponse = (count: number = 10) => {
   return R.times(makeRandomResource, count)
 }
+
+export const makePlatform = ({
+  exclude = []
+}: { exclude?: string[] } = {}): string => {
+  const include = Object.values(platforms).filter(p => !exclude.includes(p))
+  return casual.random_element(include)
+}

--- a/frontends/open-discussions/src/lib/constants.js
+++ b/frontends/open-discussions/src/lib/constants.js
@@ -128,7 +128,7 @@ export const readableLearningResources = {
 }
 
 export const DATE_FORMAT = "YYYY-MM-DD[T]HH:mm:ss[Z]"
-export const DISPLAY_DATE_FORMAT = "MMMM D, YYYY"
+export const DISPLAY_DATE_FORMAT = "MMMM DD, YYYY"
 
 export const PHONE = "PHONE"
 export const TABLET = "TABLET"

--- a/frontends/open-discussions/src/lib/learning_resources.js
+++ b/frontends/open-discussions/src/lib/learning_resources.js
@@ -12,7 +12,8 @@ import {
   LR_TYPE_LEARNINGPATH,
   LR_TYPE_PROGRAM,
   LR_TYPE_COURSE,
-  platforms
+  platforms,
+  DISPLAY_DATE_FORMAT
 } from "./constants"
 
 import { capitalize, emptyOrNil, formatPrice } from "./util"
@@ -116,9 +117,9 @@ export const getStartDate = (
   if (object.platform === platforms.OCW) {
     return `${capitalize(objectRun.semester || "")} ${objectRun.year || ""}`
   } else if (objectRun.start_date) {
-    return moment(objectRun.start_date).format("MMMM DD, YYYY")
+    return moment(objectRun.start_date).format(DISPLAY_DATE_FORMAT)
   } else if (objectRun.best_start_date) {
-    return moment(objectRun.best_start_date).format("MMMM DD, YYYY")
+    return moment(objectRun.best_start_date).format(DISPLAY_DATE_FORMAT)
   }
   return "Ongoing"
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3863 

#### What's this PR do?
~This PR changes the date format on learning resource cards to the same format we use most places—`MMMM D, YYYY`. Previously, the format had `DD` so single-digit days would display as `04`, etc. See screenshots.~

This PR updates the `DISPLAY_DATE_FORMAT` constant. **We were previously using this constant only in tests.** Now we use it also as the format for generating dates. 

#### How should this be manually tested?
View a learning resource card on `/learn` that has a date. It should look the same as it did before.
