### PR TITLE
2 New API filters for new open - offered_by and audience

### DIFF
--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,14 +1,13 @@
 """Course Catalog Filters"""
 import django_filters
+
 from course_catalog.models import Course
 
 
 class CourseFilter(django_filters.FilterSet):
     """Course filter"""
 
-    upcoming = django_filters.DateFilter(
-        field_name="start_date", lookup_expr="gt"
-    )
+    upcoming = django_filters.DateFilter(field_name="start_date", lookup_expr="gt")
 
     certificate = django_filters.Filter(
         field_name="certificates", lookup_expr="icontains"

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,0 +1,19 @@
+"""Course Catalog Filters"""
+import django_filters
+from course_catalog.models import Course
+
+
+class CourseFilter(django_filters.FilterSet):
+    """Course filter"""
+
+    upcoming = django_filters.DateFilter(
+        field_name="start_date", lookup_expr="gt"
+    )
+
+    certificate = django_filters.Filter(
+        field_name="certificates", lookup_expr="icontains"
+    )
+
+    class Meta:
+        model = Course
+        fields = ("upcoming", "platform", "program_type", "certificate")

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -9,10 +9,12 @@ class CourseFilter(django_filters.FilterSet):
 
     upcoming = django_filters.DateFilter(field_name="start_date", lookup_expr="gt")
 
-    certificate = django_filters.Filter(
+    certificates = django_filters.Filter(
         field_name="certificates", lookup_expr="icontains"
     )
 
+    # Need to update for audience
+
     class Meta:
         model = Course
-        fields = ["upcoming", "platform", "program_type", "certificate"]
+        fields = ["upcoming", "platform", "audience", "certificates"]

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,9 +1,8 @@
 """Course Catalog Filters for API"""
-from django_filters import AllValuesFilter, ChoiceFilter, FilterSet
+from django_filters import AllValuesFilter, Filter, FilterSet
 
 from course_catalog.models import (
     Course,
-    PlatformType,
     PROFESSIONAL_COURSE_PLATFORMS,
 )
 
@@ -11,14 +10,15 @@ from course_catalog.models import (
 class CourseFilter(FilterSet):
     """Course filter"""
 
-    audience = ChoiceFilter(method="filter_audience", choices=PlatformType)
+    audience = Filter(method="filter_audience", field_name="platform", lookup_expr="in")
     platform = AllValuesFilter()
 
     class Meta:
         model = Course
         fields = ["audience", "platform"]
 
-    def filter_audience(self, queryset, value):
+    def filter_audience(self, queryset, name, value):
+        """Audience filter for courses"""
         if value == "professional":
             queryset = queryset.filter(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
         else:

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -20,7 +20,9 @@ class CourseFilter(FilterSet):
         lookup_expr="in",
         choices=(("professional", "professional"), ("open", "open")),
     )
-    offered_by = ChoiceFilter(method="filter_offered_by", choices=OFFERED_BY_CHOICES, field_name="offered_by")
+    offered_by = ChoiceFilter(
+        method="filter_offered_by", choices=OFFERED_BY_CHOICES, field_name="offered_by"
+    )
 
     class Meta:
         model = Course

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,10 +1,13 @@
 """Course Catalog Filters for API"""
-from django_filters import AllValuesFilter, ChoiceFilter, FilterSet
+from django_filters import Filter, ChoiceFilter, FilterSet
 
+from course_catalog.constants import OfferedBy
 from course_catalog.models import (
     Course,
     PROFESSIONAL_COURSE_PLATFORMS,
 )
+
+OFFERED_BY_CHOICES = tuple([(ob.value, ob.value) for ob in OfferedBy])
 
 
 class CourseFilter(FilterSet):
@@ -17,11 +20,15 @@ class CourseFilter(FilterSet):
         lookup_expr="in",
         choices=(("professional", "professional"), ("open", "open")),
     )
-    offered_by = AllValuesFilter()
+    offered_by = ChoiceFilter(method="filter_offered_by", choices=OFFERED_BY_CHOICES, field_name="offered_by")
 
     class Meta:
         model = Course
         fields = ["audience", "offered_by"]
+
+    def filter_offered_by(self, queryset, _, value):
+        """OfferedBy Filter for courses"""
+        return queryset.filter(offered_by__name=value)
 
     def filter_audience(self, queryset, _, value):
         """Audience filter for courses"""

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -15,4 +15,4 @@ class CourseFilter(django_filters.FilterSet):
 
     class Meta:
         model = Course
-        fields = ("upcoming", "platform", "program_type", "certificate")
+        fields = ["upcoming", "platform", "program_type", "certificate"]

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,5 +1,5 @@
 """Course Catalog Filters for API"""
-from django_filters import CharFilter, DateTimeFilter, Filter, FilterSet
+from django_filters import AllValuesFilter, BooleanFilter, DateTimeFilter, Filter, FilterSet
 from django.db.models import Q
 
 from course_catalog.constants import PlatformType
@@ -11,8 +11,9 @@ class CourseFilter(FilterSet):
     """Course filter"""
 
     upcoming = DateTimeFilter(method="filter_upcoming")
-    professional_courses = CharFilter(method="filter_audience")
-    certificate = CharFilter(method="filter_certificate")
+    professional_courses = BooleanFilter(method="filter_audience")
+    certificate = BooleanFilter(method="filter_certificate")
+    platform = AllValuesFilter()
 
     class Meta:
         model = Course

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,20 +1,42 @@
-"""Course Catalog Filters"""
-import django_filters
+"""Course Catalog Filters for API"""
+from django_filters import CharFilter, DateTimeFilter, Filter, FilterSet
+from django.db.models import Q
 
-from course_catalog.models import Course
+from course_catalog.constants import PlatformType
+from course_catalog.models import Course, PROFESSIONAL_COURSE_PLATFORMS
+from open_discussions.utils import now_in_utc
 
 
-class CourseFilter(django_filters.FilterSet):
+class CourseFilter(FilterSet):
     """Course filter"""
-
-    upcoming = django_filters.DateFilter(field_name="start_date", lookup_expr="gt")
-
-    certificates = django_filters.Filter(
-        field_name="certificates", lookup_expr="icontains"
-    )
-
-    # Need to update for audience
+    upcoming = DateTimeFilter(method="filter_upcoming")
+    professional_courses = CharFilter(method="filter_audience")
+    certificate = CharFilter(method="filter_certificate")
 
     class Meta:
         model = Course
-        fields = ["upcoming", "platform", "audience", "certificates"]
+        fields = ["upcoming", "platform", "certificate", "professional_courses"]
+
+    def filter_upcoming(self, queryset, value):
+        if value:
+            queryset = queryset.filter(start_date__gte=now_in_utc)
+        else:
+            queryset = queryset.filter(start_date__lt=now_in_utc)
+        return queryset
+
+    def filter_audience(self, queryset, value):
+        if value:
+            queryset = queryset.filter(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
+        else:
+            queryset = queryset.filter(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
+        return queryset
+
+
+    def filter_certificate(self, queryset, value):
+        if value:
+            queryset = queryset.filter(Q(platform__in=PROFESSIONAL_COURSE_PLATFORMS) | Q(platform=
+                                                    PlatformType.mitx.value))
+        else:
+            queryset = queryset.filter(Q(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS) | ~Q(platform=
+                                                    PlatformType.mitx.value))
+        return queryset

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,5 +1,5 @@
 """Course Catalog Filters for API"""
-from django_filters import Filter, ChoiceFilter, FilterSet
+from django_filters import ChoiceFilter, FilterSet
 
 from course_catalog.constants import OfferedBy
 from course_catalog.models import (

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,5 +1,5 @@
 """Course Catalog Filters for API"""
-from django_filters import AllValuesFilter, Filter, FilterSet
+from django_filters import AllValuesFilter, ChoiceFilter, FilterSet
 
 from course_catalog.models import (
     Course,
@@ -10,7 +10,8 @@ from course_catalog.models import (
 class CourseFilter(FilterSet):
     """Course filter"""
 
-    audience = Filter(method="filter_audience", field_name="platform", lookup_expr="in")
+    audience = ChoiceFilter(method="filter_audience", field_name="platform", lookup_expr="in", choices=((
+        "professional", "professional"), ("open", "open")))
     platform = AllValuesFilter()
 
     class Meta:

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -10,8 +10,13 @@ from course_catalog.models import (
 class CourseFilter(FilterSet):
     """Course filter"""
 
-    audience = ChoiceFilter(method="filter_audience", field_name="platform", lookup_expr="in", choices=((
-        "professional", "professional"), ("open", "open")))
+    audience = ChoiceFilter(
+        label="Audience",
+        method="filter_audience",
+        field_name="platform",
+        lookup_expr="in",
+        choices=(("professional", "professional"), ("open", "open")),
+    )
     platform = AllValuesFilter()
 
     class Meta:

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -1,47 +1,26 @@
 """Course Catalog Filters for API"""
-from django_filters import AllValuesFilter, BooleanFilter, DateTimeFilter, Filter, FilterSet
-from django.db.models import Q
+from django_filters import AllValuesFilter, ChoiceFilter, FilterSet
 
-from course_catalog.constants import PlatformType
-from course_catalog.models import Course, PROFESSIONAL_COURSE_PLATFORMS
-from open_discussions.utils import now_in_utc
+from course_catalog.models import (
+    Course,
+    PlatformType,
+    PROFESSIONAL_COURSE_PLATFORMS,
+)
 
 
 class CourseFilter(FilterSet):
     """Course filter"""
 
-    upcoming = DateTimeFilter(method="filter_upcoming")
-    professional_courses = BooleanFilter(method="filter_audience")
-    certificate = BooleanFilter(method="filter_certificate")
+    audience = ChoiceFilter(method="filter_audience", choices=PlatformType)
     platform = AllValuesFilter()
 
     class Meta:
         model = Course
-        fields = ["upcoming", "platform", "certificate", "professional_courses"]
-
-    def filter_upcoming(self, queryset, value):
-        if value:
-            queryset = queryset.filter(start_date__gte=now_in_utc)
-        else:
-            queryset = queryset.filter(start_date__lt=now_in_utc)
-        return queryset
+        fields = ["audience", "platform"]
 
     def filter_audience(self, queryset, value):
-        if value:
+        if value == "professional":
             queryset = queryset.filter(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
         else:
             queryset = queryset.filter(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
-        return queryset
-
-    def filter_certificate(self, queryset, value):
-        if value:
-            queryset = queryset.filter(
-                Q(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
-                | Q(platform=PlatformType.mitx.value)
-            )
-        else:
-            queryset = queryset.filter(
-                Q(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
-                | ~Q(platform=PlatformType.mitx.value)
-            )
         return queryset

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -17,11 +17,11 @@ class CourseFilter(FilterSet):
         lookup_expr="in",
         choices=(("professional", "professional"), ("open", "open")),
     )
-    platform = AllValuesFilter()
+    offered_by = AllValuesFilter()
 
     class Meta:
         model = Course
-        fields = ["audience", "platform"]
+        fields = ["audience", "offered_by"]
 
     def filter_audience(self, queryset, _, value):
         """Audience filter for courses"""

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -9,6 +9,7 @@ from open_discussions.utils import now_in_utc
 
 class CourseFilter(FilterSet):
     """Course filter"""
+
     upcoming = DateTimeFilter(method="filter_upcoming")
     professional_courses = CharFilter(method="filter_audience")
     certificate = CharFilter(method="filter_certificate")
@@ -31,12 +32,15 @@ class CourseFilter(FilterSet):
             queryset = queryset.filter(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
         return queryset
 
-
     def filter_certificate(self, queryset, value):
         if value:
-            queryset = queryset.filter(Q(platform__in=PROFESSIONAL_COURSE_PLATFORMS) | Q(platform=
-                                                    PlatformType.mitx.value))
+            queryset = queryset.filter(
+                Q(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
+                | Q(platform=PlatformType.mitx.value)
+            )
         else:
-            queryset = queryset.filter(Q(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS) | ~Q(platform=
-                                                    PlatformType.mitx.value))
+            queryset = queryset.filter(
+                Q(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
+                | ~Q(platform=PlatformType.mitx.value)
+            )
         return queryset

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -22,5 +22,5 @@ class CourseFilter(FilterSet):
         if value == "professional":
             queryset = queryset.filter(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
         else:
-            queryset = queryset.filter(platform__not_in=PROFESSIONAL_COURSE_PLATFORMS)
+            queryset = queryset.exclude(platform__in=PROFESSIONAL_COURSE_PLATFORMS)
         return queryset

--- a/course_catalog/filters.py
+++ b/course_catalog/filters.py
@@ -17,7 +17,7 @@ class CourseFilter(FilterSet):
         model = Course
         fields = ["audience", "platform"]
 
-    def filter_audience(self, queryset, name, value):
+    def filter_audience(self, queryset, _, value):
         """Audience filter for courses"""
         if value == "professional":
             queryset = queryset.filter(platform__in=PROFESSIONAL_COURSE_PLATFORMS)

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -10,8 +10,8 @@ pytestmark = pytest.mark.django_db
 
 def test_course_filter_micromasters():
     """test that the platform filter works"""
-    mm_course = CourseFactory.create(platform = PlatformType.micromasters.value)
-    mitx_course = CourseFactory.create(platform = PlatformType.mitxonline.value)
+    mm_course = CourseFactory.create(platform=PlatformType.micromasters.value)
+    mitx_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
 
     query = CourseFilter({"platform": "micromasters"}).qs
 

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -19,7 +19,7 @@ def test_course_filter_upcoming():
     upcoming_course.start_date = now_in_utc + timedelta(days=1)
     not_upcoming_course.start_date = now_in_utc - timedelta(days=1)
 
-    query = CourseFilter({}).qs
+    query = CourseFilter({"upcoming": True}).qs
 
     assert upcoming_course in query
     assert not_upcoming_course not in query
@@ -33,7 +33,7 @@ def test_course_filter_micromasters():
     mm_course.platform = PlatformType.micromasters.value
     mitx_course.platform = PlatformType.mitxonline.value
 
-    query = CourseFilter(platform="micromasters").qs
+    query = CourseFilter({"platform": "micromasters"}).qs
 
     assert mm_course in query
     assert mitx_course not in query
@@ -53,7 +53,7 @@ def test_course_filter_certificate():
     cert_course.certificate = ["Certificate"]
     no_cert_course.certificate = []
 
-    query = CourseFilter(certificate="Certificate").qs
+    query = CourseFilter({"certificate": "Certificate"}).qs
 
     assert cert_course in query
     assert no_cert_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_course_filter_upcoming():
+    """Test that the upcoming course filter works"""
     upcoming_course = CourseFactory.create()
     not_upcoming_course = CourseFactory.create()
 
@@ -25,6 +26,7 @@ def test_course_filter_upcoming():
 
 
 def test_course_filter_micromasters():
+    """test that the platform filter works"""
     mm_course = CourseFactory.create(platform=PlatformType.micromasters.value)
     mitx_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
 
@@ -35,11 +37,13 @@ def test_course_filter_micromasters():
 
 
 def test_course_filter_professional():
+    """Test that the audience filter works"""
     # swapping this to audience, need a moment
     return
 
 
 def test_course_filter_certificate():
+    """Test that the certificate filter works"""
     cert_course = CourseFactory.create(certificates=["Certificate"])
     no_cert_course = CourseFactory.create(platform=[])
 
@@ -50,4 +54,5 @@ def test_course_filter_certificate():
 
 
 def test_course_filter_multi():
+    """Tests that filters can be combined"""
     return

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -19,7 +19,7 @@ def test_course_filter_upcoming():
     upcoming_course.start_date = now_in_utc + timedelta(days=1)
     not_upcoming_course.start_date = now_in_utc - timedelta(days=1)
 
-    query = CourseFilter().qs
+    query = CourseFilter({}).qs
 
     assert upcoming_course in query
     assert not_upcoming_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -1,0 +1,53 @@
+"""Tests for Course Catalog Filters"""
+import pytest
+from datetime import datetime, timedelta
+
+from course_catalog.constants import PlatformType
+from course_catalog.factories import CourseFactory
+from course_catalog.filters import CourseFilter
+
+from open_discussions.utils import now_in_utc
+
+pytestmark = pytest.mark.django_db
+
+
+def test_course_filter_upcoming():
+    upcoming_course = CourseFactory.create()
+    not_upcoming_course = CourseFactory.create()
+
+    upcoming_course.start_date = now_in_utc + timedelta(days=1)
+    not_upcoming_course.start_date = now_in_utc - timedelta(days=1)
+
+    query = CourseFilter().qs
+
+    assert upcoming_course in query
+    assert not_upcoming_course not in query
+
+
+def test_course_filter_micromasters():
+    mm_course = CourseFactory.create(platform=PlatformType.micromasters.value)
+    mitx_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
+
+    query = CourseFilter(platform="micromasters").qs
+
+    assert mm_course in query
+    assert mitx_course not in query
+
+
+def test_course_filter_professional():
+    # swapping this to audience, need a moment
+    return
+
+
+def test_course_filter_certificate():
+    cert_course = CourseFactory.create(certificates=["Certificate"])
+    no_cert_course = CourseFactory.create(platform=[])
+
+    query = CourseFilter(certificate="Certificate").qs
+
+    assert cert_course in query
+    assert no_cert_course not in query
+
+
+def test_course_filter_multi():
+    return

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -1,6 +1,6 @@
 """Tests for Course Catalog Filters"""
-import pytest
 from datetime import timedelta
+import pytest
 
 from course_catalog.constants import PlatformType
 from course_catalog.factories import CourseFactory

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -1,7 +1,7 @@
 """Tests for Course Catalog Filters"""
 import pytest
 
-from course_catalog.constants import PlatformType
+from course_catalog.constants import OfferedBy, PlatformType
 from course_catalog.factories import CourseFactory
 from course_catalog.filters import CourseFilter
 
@@ -9,11 +9,11 @@ pytestmark = pytest.mark.django_db
 
 
 def test_course_filter_micromasters():
-    """test that the platform filter works"""
-    mm_course = CourseFactory.create(platform=PlatformType.micromasters.value)
-    mitx_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
+    """test that the offered_by filter works"""
+    mm_course = CourseFactory.create(offered_by=OfferedBy.micromasters.value)
+    mitx_course = CourseFactory.create(offered_by=OfferedBy.mitxonline.value)
 
-    query = CourseFilter({"platform": "micromasters"}).qs
+    query = CourseFilter({"offered_by": "micromasters"}).qs
 
     assert mm_course in query
     assert mitx_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -1,6 +1,6 @@
 """Tests for Course Catalog Filters"""
 import pytest
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from course_catalog.constants import PlatformType
 from course_catalog.factories import CourseFactory
@@ -27,8 +27,11 @@ def test_course_filter_upcoming():
 
 def test_course_filter_micromasters():
     """test that the platform filter works"""
-    mm_course = CourseFactory.create(platform=PlatformType.micromasters.value)
-    mitx_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
+    mm_course = CourseFactory.create()
+    mitx_course = CourseFactory.create()
+
+    mm_course.platform = PlatformType.micromasters.value
+    mitx_course.platform = PlatformType.mitxonline.value
 
     query = CourseFilter(platform="micromasters").qs
 
@@ -44,8 +47,11 @@ def test_course_filter_professional():
 
 def test_course_filter_certificate():
     """Test that the certificate filter works"""
-    cert_course = CourseFactory.create(certificates=["Certificate"])
-    no_cert_course = CourseFactory.create(platform=[])
+    cert_course = CourseFactory.create()
+    no_cert_course = CourseFactory.create()
+
+    cert_course.certificate = ["Certificate"]
+    no_cert_course.certificate = []
 
     query = CourseFilter(certificate="Certificate").qs
 

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -1,37 +1,17 @@
 """Tests for Course Catalog Filters"""
-from datetime import timedelta
 import pytest
 
 from course_catalog.constants import PlatformType
 from course_catalog.factories import CourseFactory
 from course_catalog.filters import CourseFilter
 
-from open_discussions.utils import now_in_utc
-
 pytestmark = pytest.mark.django_db
-
-
-def test_course_filter_upcoming():
-    """Test that the upcoming course filter works"""
-    upcoming_course = CourseFactory.create()
-    not_upcoming_course = CourseFactory.create()
-
-    upcoming_course.start_date = now_in_utc + timedelta(days=1)
-    not_upcoming_course.start_date = now_in_utc - timedelta(days=1)
-
-    query = CourseFilter({"upcoming": True}).qs
-
-    assert upcoming_course in query
-    assert not_upcoming_course not in query
 
 
 def test_course_filter_micromasters():
     """test that the platform filter works"""
-    mm_course = CourseFactory.create()
-    mitx_course = CourseFactory.create()
-
-    mm_course.platform = PlatformType.micromasters.value
-    mitx_course.platform = PlatformType.mitxonline.value
+    mm_course = CourseFactory.create(platform = PlatformType.micromasters.value)
+    mitx_course = CourseFactory.create(platform = PlatformType.mitxonline.value)
 
     query = CourseFilter({"platform": "micromasters"}).qs
 
@@ -39,26 +19,32 @@ def test_course_filter_micromasters():
     assert mitx_course not in query
 
 
-def test_course_filter_professional():
+def test_course_filter_audience():
     """Test that the audience filter works"""
-    # swapping this to audience, need a moment
-    return
 
+    professional_course = CourseFactory.create(platform=PlatformType.xpro.value)
+    open_course = CourseFactory.create(platform=PlatformType.mitxonline.value)
 
-def test_course_filter_certificate():
-    """Test that the certificate filter works"""
-    cert_course = CourseFactory.create()
-    no_cert_course = CourseFactory.create()
+    query = CourseFilter({"audience": "professional"}).qs
 
-    cert_course.certificate = ["Certificate"]
-    no_cert_course.certificate = []
-
-    query = CourseFilter({"certificate": "Certificate"}).qs
-
-    assert cert_course in query
-    assert no_cert_course not in query
+    assert professional_course in query
+    assert open_course not in query
 
 
 def test_course_filter_multi():
     """Tests that filters can be combined"""
-    return
+    xpro_course = CourseFactory.create()
+    bootcamps_course = CourseFactory.create()
+    mitxonline_course = CourseFactory.create()
+
+    xpro_course.platform = PlatformType.xpro.value
+    bootcamps_course.platform = PlatformType.bootcamps.value
+    mitxonline_course.platform = PlatformType.mitxonline.value
+
+    query = CourseFilter(
+        {"audience": "professional", "platform": PlatformType.bootcamps.value}
+    ).qs
+
+    assert bootcamps_course in query
+    assert xpro_course not in query
+    assert mitxonline_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -19,7 +19,7 @@ def test_course_filter_micromasters():
     mm_course.offered_by.set([mm])
     mitx_course.offered_by.set([mitx])
 
-    query = CourseFilter({"offered_by": "Micromasters"}).qs
+    query = CourseFilter({"offered_by": OfferedBy.micromasters.value}).qs
 
     assert mm_course in query
     assert mitx_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -29,22 +29,3 @@ def test_course_filter_audience():
 
     assert professional_course in query
     assert open_course not in query
-
-
-def test_course_filter_multi():
-    """Tests that filters can be combined"""
-    xpro_course = CourseFactory.create()
-    bootcamps_course = CourseFactory.create()
-    mitxonline_course = CourseFactory.create()
-
-    xpro_course.platform = PlatformType.xpro.value
-    bootcamps_course.platform = PlatformType.bootcamps.value
-    mitxonline_course.platform = PlatformType.mitxonline.value
-
-    query = CourseFilter(
-        {"audience": "professional", "platform": PlatformType.bootcamps.value}
-    ).qs
-
-    assert bootcamps_course in query
-    assert xpro_course not in query
-    assert mitxonline_course not in query

--- a/course_catalog/filters_test.py
+++ b/course_catalog/filters_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from course_catalog.constants import OfferedBy, PlatformType
-from course_catalog.factories import CourseFactory
+from course_catalog.factories import CourseFactory, LearningResourceOfferorFactory
 from course_catalog.filters import CourseFilter
 
 pytestmark = pytest.mark.django_db
@@ -10,10 +10,16 @@ pytestmark = pytest.mark.django_db
 
 def test_course_filter_micromasters():
     """test that the offered_by filter works"""
-    mm_course = CourseFactory.create(offered_by=OfferedBy.micromasters.value)
-    mitx_course = CourseFactory.create(offered_by=OfferedBy.mitxonline.value)
+    mm = LearningResourceOfferorFactory.create(is_micromasters=True)
+    mitx = LearningResourceOfferorFactory.create(is_mitx=True)
 
-    query = CourseFilter({"offered_by": "micromasters"}).qs
+    mm_course = CourseFactory.create()
+    mitx_course = CourseFactory.create()
+
+    mm_course.offered_by.set([mm])
+    mitx_course.offered_by.set([mitx])
+
+    query = CourseFilter({"offered_by": "Micromasters"}).qs
 
     assert mm_course in query
     assert mitx_course not in query

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -198,7 +198,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):
         """
         Get upcoming courses
         """
-        kwargs = request.body
         page = self.paginate_queryset(
             self._get_base_queryset(runs__start_date__gt=timezone.now()).order_by(
                 "runs__start_date"

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -25,6 +25,7 @@ from authentication.decorators import blocked_ip_exempt
 from course_catalog.constants import PlatformType, PrivacyLevel, ResourceType
 from course_catalog.etl.podcast import generate_aggregate_podcast_rss
 from course_catalog.exceptions import WebhookException
+from course_catalog.filters import CourseFilter
 from course_catalog.models import (
     Course,
     CourseTopic,
@@ -145,6 +146,8 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):
     serializer_class = CourseSerializer
     pagination_class = DefaultPagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
+    filter_backends = [CourseFilter]
+    filterset_fields = ["upcoming", "platform", "program_type", "certificate"]
 
     def _get_base_queryset(self, *args, **kwargs):
         """Return the base queryset for all actions"""
@@ -194,6 +197,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):
         """
         Get upcoming courses
         """
+        kwargs = request.body
         page = self.paginate_queryset(
             self._get_base_queryset(runs__start_date__gt=timezone.now()).order_by(
                 "runs__start_date"

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -14,6 +14,7 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from django_filters import rest_framework as filters
 from rest_framework import status, viewsets
 from rest_framework.decorators import action, api_view
 from rest_framework.pagination import LimitOffsetPagination
@@ -146,8 +147,8 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):
     serializer_class = CourseSerializer
     pagination_class = DefaultPagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
-    filter_backends = [CourseFilter]
-    filterset_fields = ["upcoming", "platform", "program_type", "certificate"]
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = CourseFilter
 
     def _get_base_queryset(self, *args, **kwargs):
         """Return the base queryset for all actions"""

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -109,6 +109,7 @@ INSTALLED_APPS = (
     "guardian",
     "imagekit",
     "django_json_widget",
+    "django-filters"
     # Put our apps after this point
     "open_discussions",
     "authentication",

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -109,7 +109,7 @@ INSTALLED_APPS = (
     "guardian",
     "imagekit",
     "django_json_widget",
-    "django-filters"
+    "django_filters",
     # Put our apps after this point
     "open_discussions",
     "authentication",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
updates https://github.com/mitodl/open-discussions/issues/3868 

- one more PR will work out the last 2 filters:  certificates and upcoming/new/featured

#### What's this PR do?
This adds a filterset to courses, as a start, which will allow the use of django-filters on the `/api/v0/course/` endpoint using kwargs for:

- `offered_by` (to satisfy the need to filter by "micromasters" courses as in the original issue) - the available values of which can be found in the constants [here](https://github.com/mitodl/open-discussions/blob/bc117402290d48930b70fbadf0068b966f8d85dd/course_catalog/constants.py#L7).
- audience (to satisfy the need to filter by professional courses) - this adds a filter method to filter down platform by professional or open offerings which align with the `PROFESSIONAL_COURSE_PLATFORMS` found in our [models](https://github.com/mitodl/open-discussions/blob/bc117402290d48930b70fbadf0068b966f8d85dd/course_catalog/models.py#L28), which is how the property is calculated.

#### How should this be manually tested?
Using the backpopulate management commands, populate data for at least one professional platform and one open platform (I have xpro and mitxonline locally, but you can choose your own -more is better in this case as it will show better filtering). Suggested commands are here:
```
manage.py recreate_index --courses
manage.py backpopulate_mitxonline_data
manage.py backpopulate_mitxonline_files
manage.py backpopulate_xpro_data
manage.py backpopulate_xpro_files
```

With those in place, can use your browser to go to the following URLs and test that you have the correct data:
`http://od.odl.local:8063/api/v0/courses/` - Should show ALL courses imported
`http://od.odl.local:8063/api/v0/courses/?audience=professional` - Should show ONLY xpro courses and no mitxonline courses
`http://od.odl.local:8063/api/v0/courses/?platform=MITx` - should show ONLY mitx courses, and no xpro courses

You can also use the filters button in the web interface to change around filters.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
To be clear - the issue has 4 filters listed. This PR only covers 2 and does not cover the combination of those filters. Mostly this one is geared towards the simpler filters + a new method of using filters in our API - to allow for a little discussion/review around that before applying the two larger filters.
