### PR TITLE
More improvements in memory usage for edx content archive processing

### DIFF
--- a/course_catalog/etl/edx_shared.py
+++ b/course_catalog/etl/edx_shared.py
@@ -16,7 +16,16 @@ log = logging.getLogger()
 
 
 def get_most_recent_course_archives(platform: str, s3_prefix: str = None) -> list[str]:
-    """Retrieve a list of S3 keys for the most recent edx course archives"""
+    """
+    Retrieve a list of S3 keys for the most recent edx course archives
+
+    Args:
+        platform(str): The edx platform
+        s3_prefix(str): The prefix for S3 object keys
+
+    Returns:
+        list of str: edx archive S3 keys
+    """
     bucket = get_learning_course_bucket(platform)
     if s3_prefix is None:
         s3_prefix = "courses"

--- a/course_catalog/etl/edx_shared.py
+++ b/course_catalog/etl/edx_shared.py
@@ -27,6 +27,9 @@ def get_most_recent_course_archives(platform: str, s3_prefix: str = None) -> lis
         list of str: edx archive S3 keys
     """
     bucket = get_learning_course_bucket(platform)
+    if not bucket:
+        log.warning("No S3 bucket for platform %s", platform)
+        return []
     if s3_prefix is None:
         s3_prefix = "courses"
     try:

--- a/course_catalog/etl/edx_shared_test.py
+++ b/course_catalog/etl/edx_shared_test.py
@@ -214,3 +214,20 @@ def test_get_most_recent_course_archives(
     )
     assert get_most_recent_course_archives(platform) == [f"2023{base_key}"]
     mock_get_bucket.assert_called_once_with(platform)
+
+
+@pytest.mark.parametrize("platform", [PlatformType.mitx.value, PlatformType.xpro.value])
+def test_get_most_recent_course_archives_empty(
+    mocker, mock_mitxonline_learning_bucket, platform
+):
+    """Empty list should be returned and a warning logged if no recent tar archives are found"""
+    bucket = mock_mitxonline_learning_bucket.bucket
+    mock_get_bucket = mocker.patch(
+        "course_catalog.etl.edx_shared.get_learning_course_bucket", return_value=bucket
+    )
+    mock_warning = mocker.patch("course_catalog.etl.edx_shared.log.warning")
+    assert get_most_recent_course_archives(platform) == []
+    mock_get_bucket.assert_called_once_with(platform)
+    mock_warning.assert_called_once_with(
+        "No %s exported courses found in S3 bucket %s", platform, bucket.name
+    )

--- a/course_catalog/etl/edx_shared_test.py
+++ b/course_catalog/etl/edx_shared_test.py
@@ -231,3 +231,13 @@ def test_get_most_recent_course_archives_empty(
     mock_warning.assert_called_once_with(
         "No %s exported courses found in S3 bucket %s", platform, bucket.name
     )
+
+
+@pytest.mark.parametrize("platform", [PlatformType.mitx.value, PlatformType.xpro.value])
+def test_get_most_recent_course_archives_no_bucket(settings, mocker, platform):
+    """Empty list should be returned and a warning logged if no bucket is found"""
+    settings.EDX_LEARNING_COURSE_BUCKET_NAME = None
+    settings.XPRO_LEARNING_COURSE_BUCKET_NAME = None
+    mock_warning = mocker.patch("course_catalog.etl.edx_shared.log.warning")
+    assert get_most_recent_course_archives(platform) == []
+    mock_warning.assert_called_once_with("No S3 bucket for platform %s", platform)

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -2,45 +2,44 @@
 import logging
 
 from django.conf import settings
-from django.db import transaction
-from django.db.models import OuterRef, Exists
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.db.models import Exists, OuterRef
 
-
-from course_catalog.constants import PrivacyLevel, ListType
+from course_catalog.constants import ListType, PrivacyLevel
 from course_catalog.etl.constants import (
+    CourseLoaderConfig,
     LearningResourceRunLoaderConfig,
     OfferedByLoaderConfig,
-    CourseLoaderConfig,
-    ProgramLoaderConfig,
+    PlaylistLoaderConfig,
     PodcastEpisodeLoaderConfig,
     PodcastLoaderConfig,
-    PlaylistLoaderConfig,
+    ProgramLoaderConfig,
     VideoLoaderConfig,
 )
+from course_catalog.etl.deduplication import get_most_relevant_run
 from course_catalog.etl.exceptions import ExtractException
 from course_catalog.models import (
+    ContentFile,
     Course,
     CourseInstructor,
     CoursePrice,
     CourseTopic,
-    LearningResourceRun,
     LearningResourceOfferor,
-    Program,
-    ProgramItem,
-    Video,
-    VideoChannel,
+    LearningResourceRun,
     Playlist,
     PlaylistVideo,
-    UserList,
-    UserListItem,
-    ContentFile,
     Podcast,
     PodcastEpisode,
+    Program,
+    ProgramItem,
+    UserList,
+    UserListItem,
+    Video,
+    VideoChannel,
 )
 from course_catalog.utils import load_course_blocklist, load_course_duplicates
-from course_catalog.etl.deduplication import get_most_relevant_run
 from search import task_helpers as search_task_helpers
 from search.constants import COURSE_TYPE
 
@@ -687,9 +686,9 @@ def load_content_files(course_run, content_files_data):
             for content_file in content_files_data
         ]
 
-        deleted_files = ContentFile.objects.filter(
-            run=course_run, published=True
-        ).exclude(pk__in=content_files_ids)
+        deleted_files = course_run.content_files.filter(published=True).exclude(
+            pk__in=content_files_ids
+        )
 
         deleted_files.update(published=False)
 

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -401,7 +401,15 @@ def transform_content_files(course_tarpath: str) -> Generator[dict, None, None]:
 
 
 def get_learning_course_bucket_name(platform: str) -> str:
-    """Get the name of the platform's edx content bucket"""
+    """
+    Get the name of the platform's edx content bucket
+
+    Args:
+        platform(str): The edx platform
+
+    Returns:
+        str: The name of the edx archive bucket for the platform
+    """
     bucket_names = {
         PlatformType.mitx.value: settings.EDX_LEARNING_COURSE_BUCKET_NAME,
         PlatformType.xpro.value: settings.XPRO_LEARNING_COURSE_BUCKET_NAME,

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -12,11 +12,13 @@ from functools import wraps
 from itertools import chain
 from subprocess import check_call
 from tempfile import TemporaryDirectory
+from typing import Generator
 
 import boto3
 import pytz
 import rapidjson
 import requests
+from boto.s3.bucket import Bucket
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from tika import parser as tika_parser
@@ -27,6 +29,7 @@ from course_catalog.constants import (
     CONTENT_TYPE_VERTICAL,
     OCW_DEPARTMENTS,
     VALID_TEXT_FILE_TYPES,
+    PlatformType,
 )
 from course_catalog.models import get_max_length
 
@@ -286,34 +289,46 @@ def get_text_from_element(element):
     return " ".join(content)
 
 
-def documents_from_olx(olx_path):  # pylint: disable=too-many-locals
+def get_xbundle_docs(olx_path: str) -> Generator[dict, None, None]:
+    """
+    Get vertical documents from an edx tar archive
+
+    Args:
+        olx_path(str): path to extracted edx tar archive
+
+    Yields:
+        tuple: A list of (bytes of content, metadata)
+    """
+    bundle = XBundle()
+    bundle.import_from_directory(olx_path)
+    for index, vertical in enumerate(bundle.course.findall(".//vertical")):
+        content = get_text_from_element(vertical)
+        yield (
+            content,
+            {
+                "key": f"vertical_{index + 1}",
+                "content_type": CONTENT_TYPE_VERTICAL,
+                "title": vertical.attrib.get("display_name") or "",
+                "mime_type": "application/xml",
+            },
+        )
+
+
+def documents_from_olx(
+    olx_path: str,
+) -> Generator[tuple, None, None]:  # pylint: disable=too-many-locals
     """
     Extract text from OLX directory
 
     Args:
         olx_path (str): The path to the directory with the OLX data
 
-    Returns:
-        list of tuple:
-            A list of (bytes of content, metadata)
+    Yields:
+        tuple: A list of (bytes of content, metadata)
     """
     try:
-        bundle = XBundle()
-        bundle.import_from_directory(olx_path)
-        for index, vertical in enumerate(bundle.course.findall(".//vertical")):
-            content = get_text_from_element(vertical)
-
-            yield (
-                (
-                    content,
-                    {
-                        "key": f"vertical_{index + 1}",
-                        "content_type": CONTENT_TYPE_VERTICAL,
-                        "title": vertical.attrib.get("display_name") or "",
-                        "mime_type": "application/xml",
-                    },
-                )
-            )
+        for vertical in get_xbundle_docs(olx_path):
+            yield vertical
     except Exception as err:
         log.exception("Could not read verticals from path %s", olx_path)
 
@@ -339,14 +354,16 @@ def documents_from_olx(olx_path):  # pylint: disable=too-many-locals
                 )
 
 
-def transform_content_files(course_tarpath):
+def transform_content_files(course_tarpath: str) -> Generator[dict, None, None]:
     """
     Pass content to tika, then return a JSON document with the transformed content inside it
 
     Args:
         course_tarpath (str): The path to the tarball which contains the OLX
+
+    Yields:
+        dict: content from file
     """
-    content = []
     basedir = os.path.basename(course_tarpath).split(".")[0]
     with TemporaryDirectory(prefix=basedir) as inner_tempdir:
         check_call(["tar", "xf", course_tarpath], cwd=inner_tempdir)
@@ -383,19 +400,34 @@ def transform_content_files(course_tarpath):
             )
 
 
-def get_learning_course_bucket(bucket_name):
+def get_learning_course_bucket_name(platform: str) -> str:
+    """Get the name of the platform's edx content bucket"""
+    bucket_names = {
+        PlatformType.mitx.value: settings.EDX_LEARNING_COURSE_BUCKET_NAME,
+        PlatformType.xpro.value: settings.XPRO_LEARNING_COURSE_BUCKET_NAME,
+        PlatformType.mitxonline.value: settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME,
+    }
+    return bucket_names.get(platform)
+
+
+def get_learning_course_bucket(platform: str) -> Bucket:
     """
-    Get the learning course S3 Bucket holding content file data
+    Get the platform's learning course S3 Bucket holding content file data
+
+    Args:
+        platform(str): The platform value
 
     Returns:
         boto3.Bucket: the OCW S3 Bucket or None
     """
-    s3 = boto3.resource(
-        "s3",
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-    )
-    return s3.Bucket(bucket_name)
+    bucket_name = get_learning_course_bucket_name(platform)
+    if bucket_name:
+        s3 = boto3.resource(
+            "s3",
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        )
+        return s3.Bucket(bucket_name)
 
 
 def _load_ucc_topic_mappings():

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -156,7 +156,6 @@ def transform_programs(programs):
                     or _parse_datetime(program["start_date"]),
                     "best_end_date": _parse_datetime(program["end_date"]),
                     "offered_by": copy.deepcopy(OFFERED_BY),
-                    "title": program["title"],
                     "short_description": program["description"],
                     "instructors": [
                         {"full_name": instructor["name"]}

--- a/course_catalog/etl/xpro_test.py
+++ b/course_catalog/etl/xpro_test.py
@@ -116,7 +116,6 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
                         {"full_name": instructor["name"]}
                         for instructor in program_data.get("instructors", [])
                     ],
-                    "title": program_data["title"],
                     "short_description": program_data["description"],
                     "offered_by": xpro.OFFERED_BY,
                     "raw_json": program_data,

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -277,7 +277,7 @@ def get_content_files(
     if not (
         settings.AWS_ACCESS_KEY_ID
         and settings.AWS_SECRET_ACCESS_KEY
-        and get_learning_course_bucket_name(platform)
+        and get_learning_course_bucket_name(platform) is not None
     ):
         log.warning("Required settings missing for %s files", platform)
         return

--- a/course_catalog/tasks.py
+++ b/course_catalog/tasks.py
@@ -21,7 +21,11 @@ from course_catalog.api import (
 )
 from course_catalog.constants import PlatformType
 from course_catalog.etl import enrollments, pipelines, youtube
-from course_catalog.etl.edx_shared import sync_edx_course_files
+from course_catalog.etl.edx_shared import (
+    get_most_recent_course_archives,
+    sync_edx_course_files,
+)
+from course_catalog.etl.utils import get_learning_course_bucket_name
 from course_catalog.models import Course
 from course_catalog.utils import load_course_blocklist
 from open_discussions.celery import app
@@ -66,7 +70,7 @@ def get_ocw_courses(
 
 
 def get_content_tasks(
-    bucket_name: str, platform: str, chunk_size: int = None, s3_prefix: str = None
+    platform: str, chunk_size: int = None, s3_prefix: str = None
 ) -> List[Task]:
     """
     Return a list of grouped celery tasks for indexing edx content
@@ -75,14 +79,15 @@ def get_content_tasks(
         chunk_size = settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE
 
     blocklisted_ids = load_course_blocklist()
+    archive_keys = get_most_recent_course_archives(platform, s3_prefix=s3_prefix)
     return celery.group(
         [
-            get_content_files.si(ids, bucket_name, platform, s3_prefix=s3_prefix)
+            get_content_files.si(ids, platform, archive_keys, s3_prefix=s3_prefix)
             for ids in chunks(
                 Course.objects.filter(published=True)
                 .filter(platform=platform)
                 .exclude(course_id__in=blocklisted_ids)
-                .order_by("id")
+                .order_by("-id")
                 .values_list("id", flat=True),
                 chunk_size=chunk_size,
             )
@@ -264,17 +269,19 @@ def import_all_ocw_files(self, chunk_size):
 
 @app.task
 def get_content_files(
-    ids: List[int], bucket_name: str, platform: str, s3_prefix: str = None
+    ids: List[int], platform: str, keys: List[str], s3_prefix: str = None
 ):
     """
     Task to sync edX course content files with database
     """
     if not (
-        bucket_name and settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY
+        settings.AWS_ACCESS_KEY_ID
+        and settings.AWS_SECRET_ACCESS_KEY
+        and get_learning_course_bucket_name(platform)
     ):
         log.warning("Required settings missing for %s files", platform)
         return
-    sync_edx_course_files(bucket_name, platform, ids, s3_prefix)
+    sync_edx_course_files(platform, ids, keys, s3_prefix=s3_prefix)
 
 
 @app.task(bind=True)
@@ -283,7 +290,6 @@ def import_all_xpro_files(self, chunk_size=None):
 
     raise self.replace(
         get_content_tasks(
-            settings.XPRO_LEARNING_COURSE_BUCKET_NAME,
             PlatformType.xpro.value,
             chunk_size,
         )
@@ -295,7 +301,6 @@ def import_all_mitxonline_files(self, chunk_size=None):
     """Ingest MITx Online files from an S3 bucket"""
     raise self.replace(
         get_content_tasks(
-            settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME,
             PlatformType.mitxonline.value,
             chunk_size,
         )
@@ -307,7 +312,6 @@ def import_all_mitx_files(self, chunk_size=None):
     """Ingest MITx files from an S3 bucket"""
     raise self.replace(
         get_content_tasks(
-            settings.EDX_LEARNING_COURSE_BUCKET_NAME,
             PlatformType.mitx.value,
             chunk_size,
             s3_prefix=settings.EDX_LEARNING_COURSE_BUCKET_PREFIX,

--- a/course_catalog/tasks_test.py
+++ b/course_catalog/tasks_test.py
@@ -508,7 +508,22 @@ def test_get_content_tasks(settings, mocker, mocked_celery, mock_mitx_learning_b
     )
 
 
-def test_get_test_get_content_tasks_missing_settings(mocker, settings):
+def test_get_content_files(mocker, mock_mitx_learning_bucket):
+    """Test that get_content_files calls sync_edx_course_files with expected parameters"""
+    mock_sync_edx_course_files = mocker.patch(
+        "course_catalog.tasks.sync_edx_course_files"
+    )
+    mocker.patch(
+        "course_catalog.tasks.get_learning_course_bucket_name",
+        return_value=mock_mitx_learning_bucket.bucket.name,
+    )
+    get_content_files([1, 2], "mitx", ["foo.tar.gz"])
+    mock_sync_edx_course_files.assert_called_once_with(
+        "mitx", [1, 2], ["foo.tar.gz"], s3_prefix=None
+    )
+
+
+def test_get_content_files_missing_settings(mocker, settings):
     """Test that get_content_files does nothing without required settings"""
     mock_sync_edx_course_files = mocker.patch(
         "course_catalog.tasks.sync_edx_course_files"

--- a/fixtures/aws.py
+++ b/fixtures/aws.py
@@ -25,7 +25,7 @@ def mock_s3_fixture():
 def aws_settings(settings):
     """Default AWS test settings"""
     settings.AWS_ACCESS_KEY_ID = "aws_id"
-    settings.AWS_SECRET_ACCESS_KEY = "aws_secret"
+    settings.AWS_SECRET_ACCESS_KEY = "aws_secret"  # pragma: allowlist secret`
     return settings
 
 
@@ -57,6 +57,15 @@ def xpro_aws_settings(aws_settings):
     """Default xPRO test settings"""
     aws_settings.XPRO_LEARNING_COURSE_BUCKET_NAME = (
         "test-xpro-bucket"  # impossible bucket name
+    )
+    return aws_settings
+
+
+@pytest.fixture(autouse=True)
+def mitx_aws_settings(aws_settings):
+    """Default MITx Online test settings"""
+    aws_settings.EDX_LEARNING_COURSE_BUCKET_NAME = (
+        "test-mitx-bucket"  # impossible bucket name
     )
     return aws_settings
 
@@ -97,4 +106,18 @@ def mock_mitxonline_learning_bucket(
     bucket = s3.create_bucket(
         Bucket=mitxonline_aws_settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME
     )
+    yield SimpleNamespace(s3=s3, bucket=bucket)
+
+
+@pytest.fixture(autouse=True)
+def mock_mitx_learning_bucket(
+    mitx_aws_settings, mock_s3_fixture
+):  # pylint: disable=unused-argument
+    """Mock OCW learning bucket"""
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=mitx_aws_settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=mitx_aws_settings.AWS_SECRET_ACCESS_KEY,
+    )
+    bucket = s3.create_bucket(Bucket=mitx_aws_settings.EDX_LEARNING_COURSE_BUCKET_NAME)
     yield SimpleNamespace(s3=s3, bucket=bucket)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Related to #3860 

#### What's this PR do?
Make some modest improvements to memory usage for edx content processing tasks (max docker memory usage is reduced by about 200 MB).

#### How should this be manually tested?
Run any or all the following.  If you monitor memory with docker stats, the celery memory usage should rarely go above 1 GB.  Not sure if that is enough to prevent dyno restarts on heroku though, that will need to be tested there.

```
manage.py backpopulate_mitxonline_files  # run backpopulate_mitxonline_data first to import courses if necessary
manage.py backpopulate_xpro_files  # run backpopulate_xpro_data first to import courses if necessary
manage.py backpopulate_edx_files  # run backpopulate_edx_data first to import courses if necessary
```