### PR TITLE
Set concurrency=4 (2x CPU) for the celery extra_worker_performance dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
 worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=4 -l $OPEN_DISCUSSIONS_LOG_LEVEL


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Related to #3860 

#### What's this PR do?
Increases concurrency for the `extra_worker_performance` celery worker from the default (2, == # CPU's) to 4, because there seems to be a backlog building on RC after switching to this dyno type.

#### How should this be manually tested?
Once it is on RC, the celery redis queue size should start going down more quickly.

```python
import os
import redis
from urllib.parse import urlparse
url = urlparse(os.environ.get("REDISCLOUD_URL"))
r = redis.Redis(host=url.hostname, port=url.port, password=url.password)
r.llen("default")
```

