### PR TITLE
Revert "Set concurrency=4 (2x CPU) for the extra_worker_performance d…

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
 worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=4 -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL


### PR DESCRIPTION
This reverts the modified concurrency value, which apparently is ignored if it's greater than the # of CPU's.

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Related to #3889 , #3860 

#### What's this PR do?
Reverts the previous commit

#### How should this be manually tested?
Should not see any change on RC

