### PR TITLE
Run edx content file tasks weekly in a separate queue

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-04-27T20:25:55Z",
+  "generated_at": "2023-03-14T22:27:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -88,7 +88,7 @@
       {
         "hashed_secret": "6337548776a09dd16a40637eb96fe794f8d3eab0",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 14,
         "type": "Secret Keyword"
       }
     ],
@@ -106,19 +106,19 @@
         "type": "Base64 High Entropy String"
       }
     ],
-    "mail/templates/password_reset/body.html": [
-      {
-        "hashed_secret": "93f64017194ac1d984f80fc133f60bb9ec09215a",
-        "is_verified": false,
-        "line_number": 12,
-        "type": "Secret Keyword"
-      }
-    ],
     "frontends/open-discussions/src/reducers/auth.js": [
       {
         "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
         "is_verified": false,
         "line_number": 18,
+        "type": "Secret Keyword"
+      }
+    ],
+    "mail/templates/password_reset/body.html": [
+      {
+        "hashed_secret": "93f64017194ac1d984f80fc133f60bb9ec09215a",
+        "is_verified": false,
+        "line_number": 12,
         "type": "Secret Keyword"
       }
     ]

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default,edx_content --concurrency=1 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default,edx_content -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default,edx_content --concurrency=1 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default,edx_content -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app beat -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app beat -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bash scripts/heroku-release-phase.sh
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
-extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -B -l $OPEN_DISCUSSIONS_LOG_LEVEL
+extra_worker_2x: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,default --concurrency=2 -l $OPEN_DISCUSSIONS_LOG_LEVEL
 extra_worker_performance: bin/start-pgbouncer newrelic-admin run-program celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l $OPEN_DISCUSSIONS_LOG_LEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,9 +102,8 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions.celery:app beat -l --beat ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO} &
-      celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO} &
-      celery -A open_discussions.celery:app worker -Q edx_content -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO} &
+      celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,9 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -B -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
+      celery -A open_discussions.celery:app beat -l --beat ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO} &
+      celery -A open_discussions.celery:app worker -Q spam,digest_emails,default -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO} &
+      celery -A open_discussions.celery:app worker -Q edx_content -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/open_discussions/celery.py
+++ b/open_discussions/celery.py
@@ -25,6 +25,9 @@ app.conf.task_routes = {
     "course_catalog.tasks.import_all_xpro_files": {"queue": "edx_content"},
     "course_catalog.tasks.import_all_mitx_files": {"queue": "edx_content"},
     "course_catalog.tasks.import_all_mitxonline_files": {"queue": "edx_content"},
+    "search.tasks.index_course_content_files": {"queue": "edx_content"},
+    "search.tasks.index_run_content_files": {"queue": "edx_content"},
+    "search.tasks.delete_run_content_files": {"queue": "edx_content"},
     "notifications.tasks.send_frontpage_email_notification_batch": {
         "queue": "digest_emails"
     },

--- a/open_discussions/celery.py
+++ b/open_discussions/celery.py
@@ -20,6 +20,11 @@ app.conf.task_routes = {
     "channels.tasks.check_comment_for_spam": {"queue": "spam"},
     "channels.tasks.update_spam": {"queue": "spam"},
     "channels.tasks.retire_user": {"queue": "spam"},
+    "course_catalog.tasks.get_content_tasks": {"queue": "edx_content"},
+    "course_catalog.tasks.get_content_files": {"queue": "edx_content"},
+    "course_catalog.tasks.import_all_xpro_files": {"queue": "edx_content"},
+    "course_catalog.tasks.import_all_mitx_files": {"queue": "edx_content"},
+    "course_catalog.tasks.import_all_mitxonline_files": {"queue": "edx_content"},
     "notifications.tasks.send_frontpage_email_notification_batch": {
         "queue": "digest_emails"
     },

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -588,43 +588,43 @@ CELERY_BEAT_SCHEDULE = {
         "task": "notifications.tasks.send_weekly_frontpage_digests",
         "schedule": crontab(minute=0, hour=14, day_of_week=2),  # 10am EST on tuesdays
     },
-    "update_edx-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_mitx_data",
-        "schedule": crontab(minute=30, hour=13),  # 9:30am EST
-    },
-    "update-edx-files-every-1-days": {
-        "task": "course_catalog.tasks.import_all_mitx_files",
-        "schedule": crontab(minute=00, hour=14),  # 10:00 AM EST
-    },
     "update-micromasters-courses-every-1-days": {
         "task": "course_catalog.tasks.get_micromasters_data",
-        "schedule": crontab(minute=30, hour=16),  # 12:30pm EST
+        "schedule": crontab(minute=00, hour=15),  # 11:00am EST
+    },
+    "update_edx-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_mitx_data",
+        "schedule": crontab(minute=30, hour=15),  # 11:30am EST
+    },
+    "update-xpro-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_xpro_data",
+        "schedule": crontab(minute=30, hour=17),  # 1:30pm EST
+    },
+    "update-mitxonline-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_mitxonline_data",
+        "schedule": crontab(minute=30, hour=19),  # 3:30pm EST
+    },
+    "update-edx-files-every-1-weeks": {
+        "task": "course_catalog.tasks.import_all_mitx_files",
+        "schedule": crontab(minute=0, hour=16, day_of_week=1),  # 12:00 PM EST on Mondays
+    },
+    "update-xpro-files-every-1-weeks": {
+        "task": "course_catalog.tasks.import_all_xpro_files",
+        "schedule": crontab(minute=0, hour=16, day_of_week=2),  # 12:00 PM EST on Tuesdays
+    },
+    "update-mitxonline-files-every-1-weeks": {
+        "task": "course_catalog.tasks.import_all_mitxonline_files",
+        "schedule": crontab(minute=0,  hour=16, day_of_week=3),  # 12:00 PM EST on Wednesdays
+    },
+    "update-oll-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_oll_data",
+        "schedule": crontab(minute=30, hour=18),  # 2:30pm EST
     },
     "update-podcasts": {
         "task": "course_catalog.tasks.get_podcast_data",
         "schedule": get_int(
             "PODCAST_FETCH_SCHEDULE_SECONDS", 60 * 60 * 2
         ),  # default is every 2 hours
-    },
-    "update-xpro-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_xpro_data",
-        "schedule": crontab(minute=30, hour=17),  # 1:30pm EST
-    },
-    "update-xpro-files-every-1-days": {
-        "task": "course_catalog.tasks.import_all_xpro_files",
-        "schedule": crontab(minute=0, hour=18),  # 2:00pm EST
-    },
-    "update-mitxonline-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_mitxonline_data",
-        "schedule": crontab(minute=30, hour=19),  # 3:30pm EST
-    },
-    "update-mitxonline-files-every-1-days": {
-        "task": "course_catalog.tasks.import_all_mitxonline_files",
-        "schedule": crontab(minute=30, hour=20),  # 4:30pm EST
-    },
-    "update-oll-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_oll_data",
-        "schedule": crontab(minute=30, hour=18),  # 2:30pm EST
     },
     "update-prolearn-courses-every-1-days": {
         "task": "course_catalog.tasks.get_prolearn_data",

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -594,7 +594,9 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-edx-files-every-1-weeks": {
         "task": "course_catalog.tasks.import_all_mitx_files",
-        "schedule": crontab(minute=0, hour=16, day_of_week=1),  # 12:00 PM EST on Mondays
+        "schedule": crontab(
+            minute=0, hour=16, day_of_week=1
+        ),  # 12:00 PM EST on Mondays
     },
     "update-micromasters-courses-every-1-days": {
         "task": "course_catalog.tasks.get_micromasters_data",
@@ -606,17 +608,15 @@ CELERY_BEAT_SCHEDULE = {
             "PODCAST_FETCH_SCHEDULE_SECONDS", 60 * 60 * 2
         ),  # default is every 2 hours
     },
-    "update_edx-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_mitx_data",
-        "schedule": crontab(minute=30, hour=15),  # 11:30am EST
-    },
     "update-xpro-courses-every-1-days": {
         "task": "course_catalog.tasks.get_xpro_data",
         "schedule": crontab(minute=30, hour=17),  # 1:30pm EST
     },
     "update-xpro-files-every-1-weeks": {
         "task": "course_catalog.tasks.import_all_xpro_files",
-        "schedule": crontab(minute=0, hour=16, day_of_week=2),  # 12:00 PM EST on Tuesdays
+        "schedule": crontab(
+            minute=0, hour=16, day_of_week=2
+        ),  # 12:00 PM EST on Tuesdays
     },
     "update-mitxonline-courses-every-1-days": {
         "task": "course_catalog.tasks.get_mitxonline_data",
@@ -624,7 +624,9 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-mitxonline-files-every-1-weeks": {
         "task": "course_catalog.tasks.import_all_mitxonline_files",
-        "schedule": crontab(minute=0,  hour=16, day_of_week=3),  # 12:00 PM EST on Wednesdays
+        "schedule": crontab(
+            minute=0, hour=16, day_of_week=3
+        ),  # 12:00 PM EST on Wednesdays
     },
     "update-oll-courses-every-1-days": {
         "task": "course_catalog.tasks.get_oll_data",

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -588,9 +588,23 @@ CELERY_BEAT_SCHEDULE = {
         "task": "notifications.tasks.send_weekly_frontpage_digests",
         "schedule": crontab(minute=0, hour=14, day_of_week=2),  # 10am EST on tuesdays
     },
+    "update_edx-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_mitx_data",
+        "schedule": crontab(minute=30, hour=15),  # 11:30am EST
+    },
+    "update-edx-files-every-1-weeks": {
+        "task": "course_catalog.tasks.import_all_mitx_files",
+        "schedule": crontab(minute=0, hour=16, day_of_week=1),  # 12:00 PM EST on Mondays
+    },
     "update-micromasters-courses-every-1-days": {
         "task": "course_catalog.tasks.get_micromasters_data",
         "schedule": crontab(minute=00, hour=15),  # 11:00am EST
+    },
+    "update-podcasts": {
+        "task": "course_catalog.tasks.get_podcast_data",
+        "schedule": get_int(
+            "PODCAST_FETCH_SCHEDULE_SECONDS", 60 * 60 * 2
+        ),  # default is every 2 hours
     },
     "update_edx-courses-every-1-days": {
         "task": "course_catalog.tasks.get_mitx_data",
@@ -600,17 +614,13 @@ CELERY_BEAT_SCHEDULE = {
         "task": "course_catalog.tasks.get_xpro_data",
         "schedule": crontab(minute=30, hour=17),  # 1:30pm EST
     },
-    "update-mitxonline-courses-every-1-days": {
-        "task": "course_catalog.tasks.get_mitxonline_data",
-        "schedule": crontab(minute=30, hour=19),  # 3:30pm EST
-    },
-    "update-edx-files-every-1-weeks": {
-        "task": "course_catalog.tasks.import_all_mitx_files",
-        "schedule": crontab(minute=0, hour=16, day_of_week=1),  # 12:00 PM EST on Mondays
-    },
     "update-xpro-files-every-1-weeks": {
         "task": "course_catalog.tasks.import_all_xpro_files",
         "schedule": crontab(minute=0, hour=16, day_of_week=2),  # 12:00 PM EST on Tuesdays
+    },
+    "update-mitxonline-courses-every-1-days": {
+        "task": "course_catalog.tasks.get_mitxonline_data",
+        "schedule": crontab(minute=30, hour=19),  # 3:30pm EST
     },
     "update-mitxonline-files-every-1-weeks": {
         "task": "course_catalog.tasks.import_all_mitxonline_files",
@@ -619,12 +629,6 @@ CELERY_BEAT_SCHEDULE = {
     "update-oll-courses-every-1-days": {
         "task": "course_catalog.tasks.get_oll_data",
         "schedule": crontab(minute=30, hour=18),  # 2:30pm EST
-    },
-    "update-podcasts": {
-        "task": "course_catalog.tasks.get_podcast_data",
-        "schedule": get_int(
-            "PODCAST_FETCH_SCHEDULE_SECONDS", 60 * 60 * 2
-        ),  # default is every 2 hours
     },
     "update-prolearn-courses-every-1-days": {
         "task": "course_catalog.tasks.get_prolearn_data",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #3860 

#### What's this PR do?
Reduces the celery schedule of edx contenfile ingestion tasks from daily to weekly, and runs them in a separate queue, which is only processed by the performance worker or 2x workers.

#### How should this be manually tested?
Run the following, it should complete successfully:
```
manage.py backpopulate_edx_files
```

#### Any background context you want to provide?
Edx course archives are saved to S3 every day with distinct daily keys, even if nothing changes.  Ideally, only courses with new/updated content should be archived to S3, and then subsequently processed by open-discussions.  For now, this PR reduces the frequency of those processing tasks.
