### PR TITLE
Remove comment count from discussions

### DIFF
--- a/frontends/open-discussions/src/components/CompactPostDisplay.js
+++ b/frontends/open-discussions/src/components/CompactPostDisplay.js
@@ -99,7 +99,6 @@ export class CompactPostDisplay extends React.Component<Props> {
           <i className="material-icons chat_bubble_outline">
             chat_bubble_outline
           </i>
-          <span>{post.num_comments}</span>
         </Link>
         {userIsAnonymous() || useSearchPageUI ? null : (
           <i

--- a/frontends/open-discussions/src/components/CompactPostDisplay_test.js
+++ b/frontends/open-discussions/src/components/CompactPostDisplay_test.js
@@ -73,10 +73,8 @@ describe("CompactPostDisplay", () => {
     assert.ok(titleDisplay.exists())
     assert.deepEqual(titleDisplay.props().post, post)
 
-    assert.include(
-      wrapper.find(".comment-link").at(0).text(),
-      `${post.num_comments}`
-    )
+    const commentHref = wrapper.find(".comment-link")
+    assert.ok(commentHref.exists())
 
     const authoredBy = wrapper.find(".authored-by").text()
     assert(authoredBy.startsWith(post.author_name))

--- a/frontends/open-discussions/src/pages/PostPage.js
+++ b/frontends/open-discussions/src/pages/PostPage.js
@@ -22,10 +22,7 @@ import { CommentSortPicker } from "../components/Picker"
 import Dialog from "../components/Dialog"
 
 import { updateCommentSortParam, COMMENT_SORT_BEST } from "../lib/picker"
-import {
-  getPostDropdownMenuKey,
-  postMenuDropdownFuncs
-} from "../lib/posts"
+import { getPostDropdownMenuKey, postMenuDropdownFuncs } from "../lib/posts"
 import { actions } from "../actions"
 import { clearCommentError, replaceMoreComments } from "../actions/comment"
 import { setSnackbarMessage, showDialog, hideDialog } from "../actions/ui"

--- a/frontends/open-discussions/src/pages/PostPage.js
+++ b/frontends/open-discussions/src/pages/PostPage.js
@@ -23,7 +23,6 @@ import Dialog from "../components/Dialog"
 
 import { updateCommentSortParam, COMMENT_SORT_BEST } from "../lib/picker"
 import {
-  formatCommentsCount,
   getPostDropdownMenuKey,
   postMenuDropdownFuncs
 } from "../lib/posts"

--- a/frontends/open-discussions/src/pages/PostPage.js
+++ b/frontends/open-discussions/src/pages/PostPage.js
@@ -235,7 +235,7 @@ export class PostPage extends React.Component<PostPageProps> {
     if (post.num_comments > 0) {
       return (
         <div className="count-and-sort">
-          <div className="comments-count">{formatCommentsCount(post)}</div>
+          <div className="comments-count"></div>
           <CommentSortPicker
             updatePickerParam={updateCommentSortParam(this.props)}
             value={qs.parse(search).sort || COMMENT_SORT_BEST}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3824

#### What's this PR do?
This removes the comment count from post and front pages since the number is inaccurate due to spam removed and deleted comments

#### How should this be manually tested?
Open those pages and be sure the comment count is gone and the styling isn't completely broken.

#### Where should the reviewer start?
[local open](http://od.odl.local:8063/)

#### Any background context you want to provide?
The issue gives context - there is a fix, but it would likely cause load issues at scale. For now, we're removing the comment count until reddit is removed.
