### PR TITLE
Modify date parsing to be less rigid

### DIFF
--- a/course_catalog/etl/mitxonline.py
+++ b/course_catalog/etl/mitxonline.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import re
 from datetime import datetime
+from dateutil.parser import parse
 from urllib.parse import urljoin
 
 import pytz
@@ -14,8 +15,6 @@ from course_catalog.etl.utils import transform_topics, extract_valid_department_
 
 log = logging.getLogger(__name__)
 
-
-MITX_ONLINE_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 EXCLUDE_REGEX = r"PROCTORED EXAM"
 
@@ -33,7 +32,7 @@ def _parse_datetime(value):
         datetime: the parsed datetime
     """
     return (
-        datetime.strptime(value, MITX_ONLINE_DATETIME_FORMAT).replace(tzinfo=pytz.utc)
+        parse(value).replace(tzinfo=pytz.utc)
         if value
         else None
     )

--- a/course_catalog/etl/mitxonline.py
+++ b/course_catalog/etl/mitxonline.py
@@ -31,11 +31,7 @@ def _parse_datetime(value):
     Returns:
         datetime: the parsed datetime
     """
-    return (
-        parse(value).replace(tzinfo=pytz.utc)
-        if value
-        else None
-    )
+    return parse(value).replace(tzinfo=pytz.utc) if value else None
 
 
 def parse_page_attribute(mitx_json, attribute, is_url=False, is_list=False):

--- a/course_catalog/etl/openedx.py
+++ b/course_catalog/etl/openedx.py
@@ -2,7 +2,7 @@
 ETL extract and transformations for openedx
 """
 from collections import namedtuple
-from datetime import datetime
+from dateutil.parser import parse
 import logging
 
 import pytz
@@ -88,7 +88,7 @@ def _parse_openedx_datetime(datetime_str):
     Returns:
         str: the parsed datetime
     """
-    return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ").astimezone(pytz.utc)
+    return parse(datetime_str).astimezone(pytz.utc)
 
 
 def _get_course_marketing_url(config, course):

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -27,11 +27,7 @@ def _parse_datetime(value):
     Returns:
         datetime: the parsed datetime
     """
-    return (
-        parse(value).replace(tzinfo=pytz.utc)
-        if value
-        else None
-    )
+    return parse(value).replace(tzinfo=pytz.utc) if value else None
 
 
 def extract_programs():

--- a/course_catalog/etl/xpro.py
+++ b/course_catalog/etl/xpro.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 from datetime import datetime
+from dateutil.parser import parse
 
 import pytz
 import requests
@@ -12,8 +13,6 @@ from course_catalog.etl.utils import transform_topics
 
 log = logging.getLogger(__name__)
 
-
-XPRO_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 OFFERED_BY = [{"name": OfferedBy.xpro.value}]
 
@@ -29,7 +28,7 @@ def _parse_datetime(value):
         datetime: the parsed datetime
     """
     return (
-        datetime.strptime(value, XPRO_DATETIME_FORMAT).replace(tzinfo=pytz.utc)
+        parse(value).replace(tzinfo=pytz.utc)
         if value
         else None
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3915

#### What's this PR do?
Changes over from strptime to dateutil.parse to make the dates that we're grabbing from external sources less rigid in case of another change

#### How should this be manually tested?
run backpopulate management commands

#### Where should the reviewer start?
Run them once before to see them fail. I will mention that edx commands are currently disallowed due to API error from us testing it being broken.

If you have existing data, make sure you don't see any doubling of courses or runs.

#### Any background context you want to provide?
found while reviewing https://github.com/mitodl/open-discussions/pull/3899/files

