### PR TITLE
For edx platforms, do not handle content files as part of course ETL

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -46,6 +46,17 @@ class PlatformType(Enum):
     ctl = "ctl"
 
 
+EDX_PLATFORMS = [
+    platform.value
+    for platform in (
+        PlatformType.mitx,
+        PlatformType.mitxonline,
+        PlatformType.xpro,
+        PlatformType.oll,
+    )
+]
+
+
 class ResourceType(Enum):
     """
     Enum for resource types (for OCW and MitX)

--- a/course_catalog/etl/loaders.py
+++ b/course_catalog/etl/loaders.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 
-from course_catalog.constants import PrivacyLevel, UserListType
+from course_catalog.constants import PrivacyLevel, UserListType, EDX_PLATFORMS
 from course_catalog.etl.constants import (
     CourseLoaderConfig,
     LearningResourceRunLoaderConfig,
@@ -167,7 +167,9 @@ def load_run(learning_resource, run_data, *, config=LearningResourceRunLoaderCon
         load_offered_bys(
             learning_resource_run, offered_bys_data, config=config.offered_by
         )
-        load_content_files(learning_resource_run, content_files)
+        if platform not in EDX_PLATFORMS:
+            # edx content files should be handled separately
+            load_content_files(learning_resource_run, content_files)
 
     return learning_resource_run
 

--- a/course_catalog/etl/utils.py
+++ b/course_catalog/etl/utils.py
@@ -386,6 +386,7 @@ def transform_content_files(course_tarpath: str) -> Generator[dict, None, None]:
                 {
                     "content": tika_content.strip(),
                     "key": key,
+                    "published": True,
                     "content_title": (
                         metadata.get("title") or tika_metadata.get("title") or ""
                     )[: get_max_length("content_title")],

--- a/course_catalog/etl/utils_test.py
+++ b/course_catalog/etl/utils_test.py
@@ -279,6 +279,7 @@ def test_transform_content_files(mocker, has_metadata):
             "content_title": metadata["title"] if has_metadata else "",
             "content_language": metadata["language"] if has_metadata else "",
             "content_type": content_type,
+            "published": True,
         }
     ]
     extract_mock.assert_called_once_with(document, other_headers={})
@@ -339,7 +340,7 @@ def test_extract_valid_department_from_id():
 @pytest.mark.parametrize("platform", [PlatformType.mitx.value, PlatformType.xpro.value])
 def test_get_learning_course_bucket(
     aws_settings, mock_mitx_learning_bucket, mock_xpro_learning_bucket, platform
-):
+):  # pylint: disable=unused-argument
     """The correct bucket should be returned by the function"""
     assert get_learning_course_bucket(platform).name == (
         aws_settings.EDX_LEARNING_COURSE_BUCKET_NAME


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/3927

#### What's this PR do?
Omits `ContentFile` handling (`load_content_files`) from the common `load_run` ETL function for edx courses, because that should be handled in a separate task.

#### How should this be manually tested?
Copy values for RC `MITX_ONLINE_*` settings into your .env

If you don't already have mitxonline courses/runs:
  - Run `manage.py backpopulate_mitxonline_data`

If you don't already have  mitxonline published `ContentFiles`:
  - Run `manage.py  backpopulate_mitxonline_files`

Once you do have published mitxonline courses, runs, and `ContentFiles`:
  - Run `manage.py  backpopulate_mitxonline_data` again
  
You should still have published ContentFiles (`ContentFile.objects.filter(run__platform="mitxonline", published=True)`)
