### PR TITLE
Remove discontinued codecov package

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 astroid==2.11.6
 black==22.6.0
 bpython
-codecov
 ddt
 django-debug-toolbar
 ipdb


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR removes `codecov` pypi package, since it no longer exists https://pypi.org/project/codecov/.

Codecov is changing its github integration; the python package no longer exists. Our action works for now, but we probably need to update to the App at some point. (https://about.codecov.io/blog/codecov-is-updating-its-github-integration/?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=mitodl)

#### How should this be manually tested?
Check that CI passed and Codecov made a comment 📣

