### PR TITLE
Make learning path items drag resortable

### DIFF
--- a/frontends/infinite-corridor/src/api/learning-resources/hooks.test.tsx
+++ b/frontends/infinite-corridor/src/api/learning-resources/hooks.test.tsx
@@ -13,14 +13,12 @@ import {
   useDeleteFromUserListItems,
   useDeleteUserList,
   useResource,
-  useUserListItems,
   useUserListsListing,
-  useFavoritesListing,
   useFavorite,
   useUnfavorite
 } from "./hooks"
 import { setMockResponse } from "../../test-utils/mockAxios"
-import { urls } from "./urls"
+import { urls, keys } from "./urls"
 import { useInfiniteSearch } from "./search"
 
 function* makeCounter() {
@@ -49,7 +47,13 @@ const setup = () => {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )
 
-  return { wrapper }
+  const spies = {
+    queryClient: {
+      invalidateQueries: jest.spyOn(queryClient, "invalidateQueries")
+    }
+  }
+
+  return { wrapper, spies }
 }
 
 test("useResource rejects with invalid resource type", async () => {
@@ -131,84 +135,50 @@ test("useDeleteUserList invalidates all resource queries", async () => {
 })
 
 test("useAddToUserListItems invalidates userlist details and listing", async () => {
-  /**
-   * This test will use a hook wrapping several react-query useQuery calls
-   * and a react-query mutation call (`useAddToUserListItems`).
-   *
-   * Then, we'll add a list item via `useAddToUserListItems` and check
-   * that dependent queries are refetched (their cache should be invalided by
-   * the mutation). We'll also check that some other queries are unaffected
-   **/
+  const { wrapper, spies } = setup()
 
-  const { wrapper } = setup()
-
-  const targetListData = factories.makeUserList()
-  const otherListData = factories.makeUserList()
-  const addedResourceData = factories.makeCourse()
+  const list = factories.makeUserList()
+  const resource = factories.makeCourse()
   const modifiedAddedResource = {
-    ...addedResourceData,
-    lists: addedResourceData.lists.concat({} as ListItemMember)
+    ...resource,
+    lists: resource.lists.concat({} as ListItemMember)
   }
 
-  const useTestHook = () => {
-    const addItem = useAddToUserListItems()
-    const addedResource = useResource(
-      addedResourceData.object_type,
-      addedResourceData.id
-    )
-    const targetList = useResource(LRT.Userlist, targetListData.id)
-    const otherList = useResource(LRT.Userlist, otherListData.id)
-    const listing = useUserListsListing()
-    const targetItems = useUserListItems(targetListData.id)
-    return {
-      addedResource,
-      addItem,
-      targetList,
-      otherList,
-      listing,
-      targetItems
-    }
-  }
-
-  const { result, waitFor } = renderHook(() => useTestHook(), { wrapper })
-  await waitFor(
-    () =>
-      result.current.targetList.isSuccess &&
-      result.current.otherList.isSuccess &&
-      result.current.listing.isSuccess &&
-      result.current.targetItems.isSuccess &&
-      result.current.addedResource.isSuccess
+  const { result: resourceResult } = renderHook(
+    () => useResource(resource.object_type, resource.id),
+    { wrapper }
   )
+  const { result: addResult } = renderHook(() => useAddToUserListItems(), {
+    wrapper
+  })
 
-  setMockResponse.post(urls.userList.itemAdd(targetListData.id), {
+  setMockResponse.post(urls.userList.itemAdd(list.id), {
     content_data: modifiedAddedResource
   })
 
-  const before = result.current
   await act(async () => {
-    await result.current.addItem.mutateAsync({
-      userListId: targetListData.id,
+    await addResult.current.mutateAsync({
+      userListId: list.id,
       payload:    {
-        object_id:    addedResourceData.id,
-        content_type: addedResourceData.object_type
+        object_id:    resource.id,
+        content_type: resource.object_type
       }
     })
   })
-  const after = result.current
 
-  // Non-target list refetched
-  expect(before.otherList.data).toEqual(after.otherList.data)
-  // Listing is refetched (list item counts have changed)
-  expect(before.listing.data).not.toEqual(after.listing.data)
-  // target list has been refetched
-  expect(before.targetList.data).not.toEqual(after.targetList.data)
-  // target list items are refetched
-  expect(before.targetItems.data).not.toEqual(after.targetItems.data)
+  // The list we modified was invalidated
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.userList.id(list.id).all
+  })
+  // The list listing was invalided.
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.userList.listing.all
+  })
+  // Nothing else invalidated
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledTimes(2)
 
-  // The resource we added has changed ...
-  expect(after.addedResource.data).not.toEqual(before.addedResource.data)
-  // ... and comes from POST response
-  expect(after.addedResource.data).toEqual(modifiedAddedResource)
+  // The POST response result updated resource data
+  expect(resourceResult.current.data).toEqual(modifiedAddedResource)
 })
 
 test("useAddToUserListItems patches search results", async () => {
@@ -295,152 +265,110 @@ test("useDeleteFromUserListItems patches search results", async () => {
 })
 
 test("useDeleteFromUserListItems invalidates appropriate queries", async () => {
-  /**
-   * This test will use a hook wrapping several react-query useQuery calls
-   * and a react-query mutation call (`useDeleteFromUserListItems`).
-   *
-   * Then, we'll delete a list item via `useDeleteFromUserListItems` and check
-   * that dependent queries are refetched (their cache should be invalided by
-   * the mutation). We'll also check that some other queries are unaffected
-   **/
-  const { wrapper } = setup()
+  const { wrapper, spies } = setup()
 
-  const affectedListData = factories.makeUserList()
-  const unaffectedListData = factories.makeUserList()
-  const itemToDeleteData = factories.makeListItemMember({
+  const userlist = factories.makeUserList()
+  const itemToDelete = factories.makeListItemMember({
     content_type: LRT.Course, // should match affectedResourceData
-    list_id:      affectedListData.id
+    list_id:      userlist.id
   })
 
-  const affectedResourceData = factories.makeCourse({
-    lists: [itemToDeleteData]
+  const resource = factories.makeCourse({
+    id:    itemToDelete.object_id,
+    lists: [itemToDelete]
   })
-  setMockResponse.get(
-    urls.resource.details(
-      itemToDeleteData.content_type,
-      itemToDeleteData.object_id
-    ),
-    affectedResourceData
-  )
-  const modifiedResource = { ...affectedResourceData, lists: [] }
+  const resourceUrl = urls.resource.details(resource.object_type, resource.id)
+  setMockResponse.get(resourceUrl, resource)
 
-  const useTestHook = () => {
-    const deleteItem = useDeleteFromUserListItems()
-    const affectedResource = useResource(
-      itemToDeleteData.content_type,
-      itemToDeleteData.object_id
-    )
-    const affectedList = useResource(LRT.Userlist, affectedListData.id)
-    const unaffectedList = useResource(LRT.Userlist, unaffectedListData.id)
-    const listing = useUserListsListing()
-    const affectedListItems = useUserListItems(affectedListData.id)
-    return {
-      affectedResource,
-      deleteItem,
-      affectedList,
-      unaffectedList,
-      listing,
-      affectedListItems
-    }
-  }
+  const { result } = renderHook(() => useDeleteFromUserListItems(), { wrapper })
 
-  const { result, waitFor } = renderHook(() => useTestHook(), { wrapper })
-  await waitFor(
-    () =>
-      result.current.affectedList.isSuccess &&
-      result.current.unaffectedList.isSuccess &&
-      result.current.listing.isSuccess &&
-      result.current.affectedListItems.isSuccess &&
-      result.current.affectedResource.isSuccess
-  )
+  await act(async () => result.current.mutateAsync(itemToDelete))
 
-  setMockResponse.get(
-    urls.resource.details(
-      itemToDeleteData.content_type,
-      itemToDeleteData.object_id
-    ),
-    modifiedResource
-  )
-  const before = result.current
-  await act(async () => {
-    await result.current.deleteItem.mutateAsync(itemToDeleteData)
+  // Check the invalidations
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledTimes(3)
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.userList.id(userlist.id).all
   })
-  const after = result.current
-
-  expect(before.affectedResource.data).not.toEqual(after.affectedResource.data)
-  expect(before.affectedList.data).not.toEqual(after.affectedList.data)
-  expect(before.listing.data).not.toEqual(after.listing.data)
-  expect(before.affectedListItems.data).not.toEqual(
-    after.affectedListItems.data
-  )
-
-  expect(before.unaffectedList.data).toEqual(after.unaffectedList.data)
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.userList.listing.all
+  })
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.resource(resource.object_type).id(resource.id).details
+  })
 })
 
-test.each([
-  {
-    hook:        useFavorite,
-    wasFavorite: false
-  },
-  {
-    hook:        useUnfavorite,
-    wasFavorite: true
-  }
-])(
-  "$hook.name invalidates appropriate queries",
-  async ({ hook, wasFavorite }) => {
-    const { wrapper } = setup()
-    const targetResourceData = factories.makeCourse({
-      is_favorite: wasFavorite
-    })
-    const otherResourceData = factories.makeCourse()
+test("useDeleteFromUserListItems optimistically updates resource data", async () => {
+  const { wrapper } = setup()
 
-    const targetResourceUrl = urls.resource.details(
-      targetResourceData.object_type,
-      targetResourceData.id
-    )
-    setMockResponse.get(targetResourceUrl, targetResourceData)
+  const userlist = factories.makeUserList()
+  const itemToDelete = factories.makeListItemMember({
+    content_type: LRT.Course, // should match affectedResourceData
+    list_id:      userlist.id
+  })
 
-    const useTestHook = () => {
-      const favoritesListing = useFavoritesListing()
-      const mutation = hook()
-      const targetResource = useResource(
-        targetResourceData.object_type,
-        targetResourceData.id
-      )
-      const otherResource = useResource(
-        otherResourceData.object_type,
-        otherResourceData.id
-      )
-      return { mutation, targetResource, favoritesListing, otherResource }
-    }
-    const { result, waitFor } = renderHook(() => useTestHook(), { wrapper })
-    await waitFor(
-      () =>
-        result.current.targetResource.isSuccess &&
-        result.current.favoritesListing.isSuccess &&
-        result.current.otherResource.isSuccess
-    )
+  const resource = factories.makeCourse({
+    id:    itemToDelete.object_id,
+    lists: [itemToDelete]
+  })
+  const resourceUrl = urls.resource.details(resource.object_type, resource.id)
+  setMockResponse.get(resourceUrl, resource)
+  const modifiedResource = { ...resource, lists: [] }
 
-    const before = result.current
-    setMockResponse.get(targetResourceUrl, {
-      ...targetResourceData,
-      is_favorite: !wasFavorite
-    })
-    await act(async () => {
-      await result.current.mutation.mutateAsync(targetResourceData)
-    })
-    const after = result.current
+  const { result: resourceQuery } = renderHook(
+    () => useResource(resource.object_type, resource.id),
+    { wrapper }
+  )
+  const { result, waitFor } = renderHook(() => useDeleteFromUserListItems(), {
+    wrapper
+  })
 
-    // These two are invalidated
-    expect(before.targetResource.data).not.toEqual(after.targetResource.data)
-    expect(before.favoritesListing.data).not.toEqual(
-      after.favoritesListing.data
-    )
-    // this is not
-    expect(before.otherResource.data).toEqual(after.otherResource.data)
-  }
-)
+  await waitFor(() => resourceQuery.current.isFetched)
+
+  act(() => {
+    result.current.mutateAsync(itemToDelete)
+  })
+
+  // Check the optimistic update
+  await waitFor(() => {
+    expect(resourceQuery.current.data).toEqual(modifiedResource)
+  })
+})
+
+test("useFavorite invalidates appropriate queries", async () => {
+  const { wrapper, spies } = setup()
+  const resource = factories.makeCourse({ is_favorite: false })
+
+  const { result } = renderHook(() => useFavorite(), { wrapper })
+
+  await act(async () => {
+    await result.current.mutateAsync(resource)
+  })
+
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.resource(resource.object_type).id(resource.id).details
+  })
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.favorites.all
+  })
+})
+
+test("useUnfavorite invalidates appropriate queries", async () => {
+  const { wrapper, spies } = setup()
+  const resource = factories.makeCourse({ is_favorite: true })
+
+  const { result } = renderHook(() => useUnfavorite(), { wrapper })
+
+  await act(async () => {
+    await result.current.mutateAsync(resource)
+  })
+
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.resource(resource.object_type).id(resource.id).details
+  })
+  expect(spies.queryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: keys.favorites.all
+  })
+})
 
 test.each([
   {
@@ -483,4 +411,12 @@ test.each([
   await waitFor(() => {
     expect(result.current.search.data?.pages).toEqual([expected])
   })
+})
+
+test("useFavoritesListing pagination", () => {
+  // TODO
+})
+
+test("useItemListing pagination", () => {
+  // TODO
 })

--- a/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
@@ -407,21 +407,21 @@ const useMoveUserListItem = () => {
 }
 
 export {
-  useResource,                     // details
-  useUserListItems,                // items listing
-  useUserList,                     // details
-  useUserListsListing,             // listing
-  useFavoritesListing,             // items listing
+  useResource, // details
+  useUserListItems, // items listing
+  useUserList, // details
+  useUserListsListing, // listing
+  useFavoritesListing, // items listing
   useTopics,
-  useCreateUserList,               // mutation
-  useUpdateUserList,               // mutation
-  useDeleteUserList,              // mutation
-  useAddToUserListItems,          // mutation
-  useDeleteFromUserListItems,   // mutation
-  useFavorite,                    // mutation
-  useUnfavorite,                 // mutation
-  useUpcomingCourses,           // listing
-  usePopularContent,          // listing
-  useNewVideos,              // listing
-  useMoveUserListItem         // mutation
+  useCreateUserList, // mutation
+  useUpdateUserList, // mutation
+  useDeleteUserList, // mutation
+  useAddToUserListItems, // mutation
+  useDeleteFromUserListItems, // mutation
+  useFavorite, // mutation
+  useUnfavorite, // mutation
+  useUpcomingCourses, // listing
+  usePopularContent, // listing
+  useNewVideos, // listing
+  useMoveUserListItem // mutation
 }

--- a/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
@@ -407,21 +407,21 @@ const useMoveUserListItem = () => {
 }
 
 export {
-  useResource,
-  useUserListItems,
-  useUserList,
-  useUserListsListing,
-  useFavoritesListing,
+  useResource,                     // details
+  useUserListItems,                // items listing
+  useUserList,                     // details
+  useUserListsListing,             // listing
+  useFavoritesListing,             // items listing
   useTopics,
-  useCreateUserList,
-  useUpdateUserList,
-  useDeleteUserList,
-  useAddToUserListItems,
-  useDeleteFromUserListItems,
-  useFavorite,
-  useUnfavorite,
-  useUpcomingCourses,
-  usePopularContent,
-  useNewVideos,
-  useMoveUserListItem
+  useCreateUserList,               // mutation
+  useUpdateUserList,               // mutation
+  useDeleteUserList,              // mutation
+  useAddToUserListItems,          // mutation
+  useDeleteFromUserListItems,   // mutation
+  useFavorite,                    // mutation
+  useUnfavorite,                 // mutation
+  useUpcomingCourses,           // listing
+  usePopularContent,          // listing
+  useNewVideos,              // listing
+  useMoveUserListItem         // mutation
 }

--- a/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/hooks.ts
@@ -42,6 +42,9 @@ const useUserListsListing = (options?: UserListOptions) => {
   )
 }
 
+/**
+ * Note: this is an InfiniteQuery, so the data is an array of pages.
+ */
 const useUserListItems = (
   listId: number,
   options: Omit<PaginationSearchParams, "offset"> &
@@ -340,6 +343,17 @@ const moveUserListItem = async ({ item, newPosition }: MoveItemPayload) => {
   const body = { position: newPosition }
   await axios.patch(url, body)
 }
+
+/**
+ * Mutation for moving a list item to a new position.
+ *
+ * The `mutationFn` requires both the old and new
+ *   - the new item `position` (item positions come from the API)
+ *   - both the old and new indices within UI array.
+ *
+ * We use the indices to update the UI immediately, and the positions to make
+ * the API call.
+ */
 const useMoveUserListItem = () => {
   const queryClient = useQueryClient()
   return useMutation({
@@ -373,7 +387,8 @@ const useMoveUserListItem = () => {
        * But the API calls are based on list items' `position` property, not
        * their index within the list.
        *
-       * The position properties are still out-of-date, so re-fetch the list.
+       * The position properties are incorrect after our reordering, so re-fetch
+       * the list.
        *
        * Since the listing is an InfiniteQuery, this invalidates all pages,
        * which could be slow if several pages are showing. In practice, usually

--- a/frontends/infinite-corridor/src/api/learning-resources/urls.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/urls.ts
@@ -232,13 +232,8 @@ const keys = {
   topics: [baseKey, "topics"],
 
   favorites: {
-    all:      resourceKeys(TYPE_FAVORITES).all,
-    infinite: <T extends Omit<PaginationSearchParams, "offset">>(opts?: T) => [
-      ...resourceKeys(TYPE_FAVORITES).all,
-      "items",
-      "infinite",
-      opts
-    ]
+    all:     resourceKeys(TYPE_FAVORITES).all,
+    listing: resourceKeys(TYPE_FAVORITES).listing
   },
 
   search: {

--- a/frontends/infinite-corridor/src/api/learning-resources/urls.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/urls.ts
@@ -210,15 +210,19 @@ const keys = {
   all:      [baseKey],
   resource: resourceKeys,
   userList: {
-    all: () => resourceKeys(LRT.Userlist).all,
-    id:  (id: number) => ({
-      ...resourceKeys(LRT.Userlist).id(id),
-      itemsListing: (options?: PaginationSearchParams) => [
-        ...keys.userList.id(id).all,
-        "items",
-        options
-      ]
-    }),
+    all: resourceKeys(LRT.Userlist).all,
+    id:  (id: number) => {
+      const forId = resourceKeys(LRT.Userlist).id(id)
+      return {
+        ...forId,
+        itemsListing: {
+          all:      [...forId.all, "items"],
+          infinite: <T extends Omit<PaginationSearchParams, "offset">>(
+            opts?: T
+          ) => [...forId.all, "items", "infinite", opts]
+        }
+      }
+    },
     listing: {
       all:  resourceKeys(LRT.Userlist).listing.all,
       page: (opts?: UserListOptions) =>
@@ -228,8 +232,13 @@ const keys = {
   topics: [baseKey, "topics"],
 
   favorites: {
-    all:     resourceKeys(TYPE_FAVORITES).all,
-    listing: resourceKeys(TYPE_FAVORITES).listing
+    all:      resourceKeys(TYPE_FAVORITES).all,
+    infinite: <T extends Omit<PaginationSearchParams, "offset">>(opts?: T) => [
+      ...resourceKeys(TYPE_FAVORITES).all,
+      "items",
+      "infinite",
+      opts
+    ]
   },
 
   search: {

--- a/frontends/infinite-corridor/src/components/LearningResourceCard.tsx
+++ b/frontends/infinite-corridor/src/components/LearningResourceCard.tsx
@@ -20,13 +20,15 @@ type TemplateProps = LearningResourceCardTemplateProps<
 >
 type LearningResourceCardProps = Pick<
   TemplateProps,
-  "variant" | "resource" | "className"
+  "variant" | "resource" | "className" | "sortable" | "suppressImage"
 >
 
 const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   resource,
   variant,
-  className
+  className,
+  sortable,
+  suppressImage
 }) => {
   const activateResource = useActivateResourceDrawer()
   const addToList = useAddToListDialog()
@@ -36,6 +38,8 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
     <>
       <LearningResourceCardTemplate
         variant={variant}
+        sortable={sortable}
+        suppressImage={suppressImage}
         className={classNames("ic-resource-card", className)}
         resource={resource}
         imgConfig={imgConfigs[variant]}

--- a/frontends/infinite-corridor/src/entry/root.tsx
+++ b/frontends/infinite-corridor/src/entry/root.tsx
@@ -12,5 +12,3 @@ ReactDOM.render(
   <App queryClient={queryClient} history={browserHistory} />,
   container
 )
-
-window.queryClient = queryClient

--- a/frontends/infinite-corridor/src/entry/root.tsx
+++ b/frontends/infinite-corridor/src/entry/root.tsx
@@ -12,3 +12,5 @@ ReactDOM.render(
   <App queryClient={queryClient} history={browserHistory} />,
   container
 )
+
+window.queryClient = queryClient

--- a/frontends/infinite-corridor/src/pages/HomePage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/HomePage.test.tsx
@@ -49,7 +49,7 @@ describe("HomePage", () => {
   })
 
   it("renders a resource carusel with upcoming courses", async () => {
-    const coursesResult = lrFactory.makeCoursesPaginated(4)
+    const coursesResult = lrFactory.makeCoursesPaginated({ count: 4 })
 
     setMockResponse.post("search/", { hits: { hits: [], total: 0 } })
 
@@ -80,7 +80,7 @@ describe("HomePage", () => {
   })
 
   it("renders a resource carusel with new videos", async () => {
-    const videosResult = lrFactory.makeVideosPaginated(4)
+    const videosResult = lrFactory.makeVideosPaginated({ count: 4 })
 
     setMockResponse.post("search/", { hits: { hits: [], total: 0 } })
 
@@ -111,7 +111,7 @@ describe("HomePage", () => {
   })
 
   it("renders a resource carusel with popular learning resources", async () => {
-    const popularResult = lrFactory.makeLearningResourcesPaginated(4)
+    const popularResult = lrFactory.makeLearningResourcesPaginated({ count: 4 })
 
     setMockResponse.post("search/", { hits: { hits: [], total: 0 } })
 

--- a/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.test.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/EditFieldBasicForm.test.tsx
@@ -15,7 +15,7 @@ describe("EditFieldBasicForm", () => {
   let field: FieldChannel, publicLists: PaginatedResult<UserList>
 
   beforeEach(() => {
-    publicLists = resourceFactory.makeUserListsPaginated(5)
+    publicLists = resourceFactory.makeUserListsPaginated({ count: 5 })
     setMockResponse.get(
       lrUrls.userList.listing({
         public: true
@@ -29,19 +29,19 @@ describe("EditFieldBasicForm", () => {
     })
     setMockResponse.get(
       lrUrls.userList.itemsListing(publicLists.results[0].id),
-      resourceFactory.makeUserListItemsPaginated(2)
+      resourceFactory.makeUserListItemsPaginated({ count: 2 })
     )
     setMockResponse.get(
       lrUrls.userList.itemsListing(publicLists.results[1].id),
-      resourceFactory.makeUserListItemsPaginated(2)
+      resourceFactory.makeUserListItemsPaginated({ count: 2 })
     )
     setMockResponse.get(
       lrUrls.userList.itemsListing(publicLists.results[2].id),
-      resourceFactory.makeUserListItemsPaginated(2)
+      resourceFactory.makeUserListItemsPaginated({ count: 2 })
     )
     setMockResponse.get(
       lrUrls.userList.itemsListing(publicLists.results[4].id),
-      resourceFactory.makeUserListItemsPaginated(2)
+      resourceFactory.makeUserListItemsPaginated({ count: 2 })
     )
     setMockResponse.get(urls.fieldDetails(field.name), field)
     setMockResponse.get(

--- a/frontends/infinite-corridor/src/pages/field-details/FieldPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/FieldPage.test.tsx
@@ -64,9 +64,9 @@ const setupApis = (fieldPatch?: Partial<FieldChannel>) => {
   const list1 = factory.makeFieldUserList()
   const list2 = factory.makeFieldUserList()
   const list3 = factory.makeFieldUserList()
-  const items1 = lrFactory.makeUserListItemsPaginated(4)
-  const items2 = lrFactory.makeUserListItemsPaginated(2)
-  const items3 = lrFactory.makeUserListItemsPaginated(2)
+  const items1 = lrFactory.makeUserListItemsPaginated({ count: 4 })
+  const items2 = lrFactory.makeUserListItemsPaginated({ count: 2 })
+  const items3 = lrFactory.makeUserListItemsPaginated({ count: 2 })
 
   const field = factory.makeField({
     featured_list: list1,

--- a/frontends/infinite-corridor/src/pages/field-details/FieldPage.tsx
+++ b/frontends/infinite-corridor/src/pages/field-details/FieldPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react"
+import React, { useCallback, useMemo } from "react"
 import { useParams, useLocation, useHistory } from "react-router"
 import Tab from "@mui/material/Tab"
 import TabContext from "@mui/lab/TabContext"
@@ -32,7 +32,10 @@ interface FieldListProps {
 
 const FieldList: React.FC<FieldListProps> = ({ list }) => {
   const itemsQuery = useUserListItems(list.id)
-  const items = itemsQuery.data?.results.map(r => r.content_data) ?? []
+  const items = useMemo(() => {
+    const pages = itemsQuery.data?.pages ?? []
+    return pages.flatMap(p => p.results.map(r => r.content_data)) ?? []
+  }, [itemsQuery.data?.pages])
   return (
     <section>
       <h3>{list.title}</h3>
@@ -49,7 +52,10 @@ const FieldList: React.FC<FieldListProps> = ({ list }) => {
 
 const FieldCarousel: React.FC<FieldListProps> = ({ list }) => {
   const itemsQuery = useUserListItems(list.id)
-  const items = itemsQuery.data?.results.map(r => r.content_data) ?? []
+  const items = useMemo(() => {
+    const pages = itemsQuery.data?.pages ?? []
+    return pages.flatMap(p => p.results.map(r => r.content_data)) ?? []
+  }, [itemsQuery.data?.pages])
   const isSm = useMuiBreakpoint("sm")
   const isLg = useMuiBreakpoint("lg")
   const pageSize = isLg ? 3 : isSm ? 2 : 1

--- a/frontends/infinite-corridor/src/pages/user-lists/AddToListDialog.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/AddToListDialog.test.tsx
@@ -44,7 +44,7 @@ const setup = ({
   dialogOpen = true
 }: Partial<SetupOptions> = {}) => {
   const resource = makeCourse({ is_favorite: isFavorite })
-  const paginatedLists = makeUserListsPaginated(3)
+  const paginatedLists = makeUserListsPaginated({ count: 3 })
   const lists = paginatedLists.results
 
   inLists.forEach(index => {

--- a/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.test.tsx
@@ -44,7 +44,7 @@ describe("FavoritesPage", () => {
     const { favorites } = setup()
     expectProps(spyItemsListing, {
       isLoading:    true,
-      data:         undefined,
+      items:        undefined,
       emptyMessage: "You don't have any favorites yet."
     })
 
@@ -53,7 +53,7 @@ describe("FavoritesPage", () => {
         spyItemsListing,
         {
           isLoading:    false,
-          data:         favorites,
+          items:        favorites.results,
           emptyMessage: "You don't have any favorites yet."
         },
         -1

--- a/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.test.tsx
@@ -25,10 +25,9 @@ describe("FavoritesPage", () => {
   /**
    * Set up the mock API responses for lists page.
    */
-  const setup = (itemsCount?: number) => {
-    const favorites = factories.makeFavorites(
-      itemsCount ?? faker.datatype.number({ min: 2, max: 5 })
-    )
+  const setup = () => {
+    const count = faker.datatype.number({ min: 2, max: 5 })
+    const favorites = factories.makeFavorites({ count })
     setMockResponse.get(lrUrls.favorite.listing(), favorites)
 
     const { history } = renderTestApp({ url: `/lists/favorites` })

--- a/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { BannerPage } from "ol-util"
 import { GridColumn, GridContainer } from "../../components/layout"
 import { useFavoritesListing } from "../../api/learning-resources"
@@ -7,6 +7,11 @@ import UserListItems from "./ItemsListing"
 
 const FavoritesPage: React.FC = () => {
   const favoritesQuery = useFavoritesListing()
+
+  const items = useMemo(() => {
+    const pages = favoritesQuery.data?.pages
+    return pages?.flatMap(p => p.results.map(r => r))
+  }, [favoritesQuery.data])
 
   return (
     <BannerPage
@@ -20,7 +25,7 @@ const FavoritesPage: React.FC = () => {
             <h1 className="ic-list-header">My Favorites</h1>
             <UserListItems
               isLoading={favoritesQuery.isLoading}
-              data={favoritesQuery.data}
+              items={items}
               emptyMessage="You don't have any favorites yet."
             />
           </GridColumn>

--- a/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/FavoritesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React from "react"
 import { BannerPage } from "ol-util"
 import { GridColumn, GridContainer } from "../../components/layout"
 import { useFavoritesListing } from "../../api/learning-resources"
@@ -8,10 +8,7 @@ import UserListItems from "./ItemsListing"
 const FavoritesPage: React.FC = () => {
   const favoritesQuery = useFavoritesListing()
 
-  const items = useMemo(() => {
-    const pages = favoritesQuery.data?.pages
-    return pages?.flatMap(p => p.results.map(r => r))
-  }, [favoritesQuery.data])
+  const items = favoritesQuery.data?.results
 
   return (
     <BannerPage

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { faker } from "@faker-js/faker"
-import { SortableList, SortableItem, assertNotNil } from "ol-util"
+import { SortableList, SortableItem } from "ol-util"
 import LearningResourceCard from "../../components/LearningResourceCard"
 import * as factories from "ol-search-ui/src/factories"
 import {
@@ -15,6 +15,7 @@ import UserListItems, { UserListItemsProps } from "./ItemsListing"
 import { allowConsoleErrors } from "ol-util/src/test-utils"
 import axios from "../../libs/axios"
 import { urls } from "../../api/learning-resources"
+import invariant from "tiny-invariant"
 
 jest.mock("ol-util", () => {
   const actual = jest.requireActual("ol-util")
@@ -112,13 +113,13 @@ describe("Sorting ItemListing", () => {
     const allProps = { ...defaultProps, ...props }
     const { history } = renderWithProviders(<UserListItems {...allProps} />)
 
-    const { cancelSort } = spySortableList.mock.lastCall[0]
-    assertNotNil(cancelSort)
+    const { cancelDrop } = spySortableList.mock.lastCall[0]
+    invariant(cancelDrop)
 
     const simulateDrag = (from: number, to: number) => {
       const active = items[from]
       const over = items[to]
-      cancelSort({
+      cancelDrop({
         activeIndex: from,
         overIndex:   to,
         active:      {

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
@@ -1,23 +1,43 @@
 import React from "react"
 import { faker } from "@faker-js/faker"
+import { SortableList, assertNotNil } from "ol-util"
 import LearningResourceCard from "../../components/LearningResourceCard"
 import * as factories from "ol-search-ui/src/factories"
-import { screen, expectProps, renderWithProviders } from "../../test-utils"
+import {
+  screen,
+  expectProps,
+  renderWithProviders,
+  setMockResponse,
+  waitFor
+} from "../../test-utils"
 import UserListItems, { UserListItemsProps } from "./ItemsListing"
+import { allowConsoleErrors } from "ol-util/src/test-utils"
+import axios from "../../libs/axios"
+import { urls } from "../../api/learning-resources"
+
+jest.mock("ol-util", () => {
+  const actual = jest.requireActual("ol-util")
+  return {
+    __esModule:   true,
+    ...actual,
+    SortableList: jest.fn(actual.SortableList)
+  }
+})
 
 const spyLearningResourceCard = jest.mocked(LearningResourceCard)
-
-const setup = (props: Partial<UserListItemsProps>) => {
-  const defaultProps: UserListItemsProps = {
-    isLoading:    true,
-    emptyMessage: "Empty message"
-  }
-  const allProps = { ...defaultProps, ...props }
-  const { history } = renderWithProviders(<UserListItems {...allProps} />)
-  return { history }
-}
+const spySortableList = jest.mocked(SortableList)
 
 describe("ItemsListing", () => {
+  const setup = (props: Partial<UserListItemsProps>) => {
+    const defaultProps: UserListItemsProps = {
+      isLoading:    true,
+      emptyMessage: "Empty message"
+    }
+    const allProps = { ...defaultProps, ...props }
+    const { history } = renderWithProviders(<UserListItems {...allProps} />)
+    return { history }
+  }
+
   test("Shows loading message while loading", () => {
     setup({ isLoading: true })
     screen.getByLabelText("Loading")
@@ -30,7 +50,7 @@ describe("ItemsListing", () => {
     "Shows empty message when there are no items",
     ({ count, hasEmptyMessage }) => {
       const emptyMessage = faker.lorem.sentence()
-      const items = factories.makeUserListItemsPaginated(count).results
+      const items = factories.makeUserListItemsPaginated({ count }).results
       setup({ isLoading: false, emptyMessage, items })
       const emptyMessageElement = screen.queryByText(emptyMessage)
       expect(!!emptyMessageElement).toBe(hasEmptyMessage)
@@ -38,7 +58,7 @@ describe("ItemsListing", () => {
   )
 
   test("Shows a list of LearningResourceCards", () => {
-    const items = factories.makeUserListItemsPaginated(3).results
+    const items = factories.makeUserListItemsPaginated({ count: 3 }).results
     setup({ isLoading: false, items })
     const titles = items.map(item => item.content_data.title)
     const headings = screen.getAllByRole("heading", {
@@ -47,6 +67,89 @@ describe("ItemsListing", () => {
     expect(headings.map(h => h.textContent)).toEqual(titles)
     items.forEach(item => {
       expectProps(spyLearningResourceCard, { resource: item.content_data })
+    })
+  })
+
+  test("Shows a list of sortable LearningResourceCards when sortable=true", () => {
+    const items = factories.makeUserListItemsPaginated({ count: 3 }).results
+    setup({ isLoading: false, items, id: 1, sortable: true })
+    const titles = items.map(item => item.content_data.title)
+    const headings = screen.getAllByRole("heading", {
+      name: value => titles.includes(value)
+    })
+    expect(headings.map(h => h.textContent)).toEqual(titles)
+    items.forEach(item => {
+      expectProps(spyLearningResourceCard, {
+        resource: item.content_data,
+        sortable: true
+      })
+    })
+  })
+
+  test("Throws error if passed 'sortable' without a list id", () => {
+    allowConsoleErrors()
+    const items = factories.makeUserListItemsPaginated({ count: 3 }).results
+    expect(() => {
+      setup({ isLoading: false, items, sortable: true })
+    }).toThrow("Sortable list must have an id")
+  })
+})
+
+describe("Sorting ItemListing", () => {
+  const setup = (props: Partial<UserListItemsProps> = {}) => {
+    const items = factories.makeUserListItemsPaginated({ count: 5 }).results
+    const listId = faker.datatype.number()
+    const defaultProps: UserListItemsProps = {
+      id:           listId,
+      items:        items,
+      isLoading:    false,
+      sortable:     true,
+      emptyMessage: "Empty message"
+    }
+    const allProps = { ...defaultProps, ...props }
+    const { history } = renderWithProviders(<UserListItems {...allProps} />)
+
+    const { cancelSort } = spySortableList.mock.lastCall[0]
+    assertNotNil(cancelSort)
+
+    const simulateDrag = (from: number, to: number) => {
+      const active = items[from]
+      const over = items[to]
+      cancelSort({
+        activeIndex: from,
+        overIndex:   to,
+        active:      {
+          data: {
+            // @ts-expect-error not fully simulated
+            current: active
+          }
+        },
+        over: {
+          data: {
+            // @ts-expect-error not fully simulated
+            current: over
+          }
+        }
+      })
+    }
+
+    return { history, simulateDrag, items, listId }
+  }
+
+  test("Dragging an item to a new position calls API correctly", async () => {
+    const { simulateDrag, items, listId } = setup()
+    const [from, to] = [1, 3]
+    const active = items[from]
+    const over = items[to]
+    const patchUrl = urls.userList.itemDetails(listId, active.id)
+    setMockResponse.patch(patchUrl)
+
+    simulateDrag(from, to)
+
+    expect(axios.patch).toHaveBeenCalledTimes(0)
+    await waitFor(() => expect(axios.patch).toHaveBeenCalled())
+    expect(axios.patch).toHaveBeenCalledWith(patchUrl, {
+      position: over.position
     })
   })
 })

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx
@@ -20,7 +20,7 @@ const setup = (props: Partial<UserListItemsProps>) => {
 describe("ItemsListing", () => {
   test("Shows loading message while loading", () => {
     setup({ isLoading: true })
-    screen.getByText("Loading...")
+    screen.getByLabelText("Loading")
   })
 
   test.each([
@@ -30,24 +30,23 @@ describe("ItemsListing", () => {
     "Shows empty message when there are no items",
     ({ count, hasEmptyMessage }) => {
       const emptyMessage = faker.lorem.sentence()
-      const data = factories.makeUserListItemsPaginated(count)
-      setup({ isLoading: false, emptyMessage, data })
+      const items = factories.makeUserListItemsPaginated(count).results
+      setup({ isLoading: false, emptyMessage, items })
       const emptyMessageElement = screen.queryByText(emptyMessage)
       expect(!!emptyMessageElement).toBe(hasEmptyMessage)
     }
   )
 
   test("Shows a list of LearningResourceCards", () => {
-    const data = factories.makeUserListItemsPaginated(3)
-    const items = data.results.map(result => result.content_data)
-    setup({ isLoading: false, data })
-    const titles = items.map(item => item.title)
+    const items = factories.makeUserListItemsPaginated(3).results
+    setup({ isLoading: false, items })
+    const titles = items.map(item => item.content_data.title)
     const headings = screen.getAllByRole("heading", {
       name: value => titles.includes(value)
     })
     expect(headings.map(h => h.textContent)).toEqual(titles)
-    items.forEach(resource => {
-      expectProps(spyLearningResourceCard, { resource })
+    items.forEach(item => {
+      expectProps(spyLearningResourceCard, { resource: item.content_data })
     })
   })
 })

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
@@ -1,39 +1,101 @@
-import React from "react"
-import type { PaginatedUserListItems } from "ol-search-ui"
+import React, { useCallback } from "react"
+import type { PaginatedUserListItems, UserListItem } from "ol-search-ui"
 import LearningResourceCard from "../../components/LearningResourceCard"
+import {
+  SortableItem,
+  SortableList,
+  RenderActive,
+  LoadingSpinner
+} from "ol-util"
 
 type UserListItemsProps = {
   isLoading: boolean
   data?: PaginatedUserListItems
   emptyMessage: string
+  sortable?: boolean
+}
+
+const UserListItemsViewOnly: React.FC<{
+  items: UserListItem[]
+}> = ({ items }) => {
+  return (
+    <ul className="ic-card-row-list">
+      {items.map(item => {
+        return (
+          <li key={item.id}>
+            <LearningResourceCard
+              variant="row-reverse"
+              resource={item.content_data}
+            />
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+const UserListItemsSortable: React.FC<{
+  items: UserListItem[]
+}> = ({ items }) => {
+  const renderDragging: RenderActive = useCallback(active => {
+    const item = active.data.current as UserListItem
+    return (
+      <LearningResourceCard
+        className="ic-dragging"
+        sortable
+        suppressImage
+        variant="row-reverse"
+        resource={item.content_data}
+      />
+    )
+  }, [])
+  return (
+    <ul className="ic-card-row-list">
+      <SortableList
+        itemIds={items.map(item => item.id)}
+        onSortEnd={event => console.log(event)}
+        renderActive={renderDragging}
+      >
+        {items.map(item => {
+          return (
+            <SortableItem Component="li" key={item.id} id={item.id} data={item}>
+              {handleProps => {
+                return (
+                  <div {...handleProps}>
+                    <LearningResourceCard
+                      sortable
+                      suppressImage
+                      variant="row-reverse"
+                      resource={item.content_data}
+                    />
+                  </div>
+                )
+              }}
+            </SortableItem>
+          )
+        })}
+      </SortableList>
+    </ul>
+  )
 }
 
 const UserListItems: React.FC<UserListItemsProps> = ({
   isLoading,
   data,
-  emptyMessage
+  emptyMessage,
+  sortable = false
 }) => {
+  const items = data?.results
   return (
     <>
-      {isLoading && <p>Loading...</p>}
-      {data &&
-        (data.results.length === 0 ? (
+      {isLoading && <LoadingSpinner loading />}
+      {items &&
+        (items.length === 0 ? (
           <p className="empty-message">{emptyMessage}</p>
+        ) : sortable ? (
+          <UserListItemsSortable items={items} />
         ) : (
-          <ul className="ic-card-row-list">
-            {data.results.map(list => {
-              return (
-                <li key={list.id}>
-                  <LearningResourceCard
-                    sortable
-                    suppressImage
-                    variant="row-reverse"
-                    resource={list.content_data}
-                  />
-                </li>
-              )
-            })}
-          </ul>
+          <UserListItemsViewOnly items={items} />
         ))}
     </>
   )

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
@@ -25,6 +25,8 @@ const UserListItems: React.FC<UserListItemsProps> = ({
               return (
                 <li key={list.id}>
                   <LearningResourceCard
+                    sortable
+                    suppressImage
                     variant="row-reverse"
                     resource={list.content_data}
                   />

--- a/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react"
+import classNames from "classnames"
 import type { UserListItem } from "ol-search-ui"
 import LearningResourceCard from "../../components/LearningResourceCard"
 import {
@@ -13,7 +14,8 @@ import { useMoveUserListItem } from "../../api/learning-resources"
 type UserListItemsProps = {
   id?: number
   items?: UserListItem[]
-  isLoading: boolean
+  isLoading?: boolean
+  isRefetching?: boolean
   emptyMessage: string
   sortable?: boolean
 }
@@ -40,7 +42,8 @@ const UserListItemsViewOnly: React.FC<{
 const UserListItemsSortable: React.FC<{
   listId: number
   items: UserListItem[]
-}> = ({ items, listId }) => {
+  isRefetching?: boolean
+}> = ({ items, listId, isRefetching }) => {
   const move = useMoveUserListItem()
   const renderDragging: RenderActive = useCallback(active => {
     const item = active.data.current as UserListItem
@@ -75,8 +78,15 @@ const UserListItemsSortable: React.FC<{
     },
     [move, listId]
   )
+  const disabled = isRefetching || move.isLoading
+  console.log("move isLoading", move.isLoading)
+  console.log("isRefetching", isRefetching)
   return (
-    <ul className="ic-card-row-list">
+    <ul
+      className={classNames("ic-card-row-list", {
+        "sorting-disabled": disabled
+      })}
+    >
       <SortableList
         itemIds={items.map(item => item.id)}
         cancelSort={cancelSort}
@@ -84,7 +94,13 @@ const UserListItemsSortable: React.FC<{
       >
         {items.map(item => {
           return (
-            <SortableItem Component="li" key={item.id} id={item.id} data={item}>
+            <SortableItem
+              Component="li"
+              key={item.id}
+              id={item.id}
+              data={item}
+              disabled={disabled}
+            >
               {handleProps => {
                 return (
                   <div {...handleProps}>
@@ -109,6 +125,7 @@ const UserListItems: React.FC<UserListItemsProps> = ({
   id,
   items,
   isLoading,
+  isRefetching,
   emptyMessage,
   sortable = false
 }) => {
@@ -120,7 +137,11 @@ const UserListItems: React.FC<UserListItemsProps> = ({
         (items.length === 0 ? (
           <p className="empty-message">{emptyMessage}</p>
         ) : sortable && id ? (
-          <UserListItemsSortable listId={id} items={items} />
+          <UserListItemsSortable
+            listId={id}
+            items={items}
+            isRefetching={isRefetching}
+          />
         ) : (
           <UserListItemsViewOnly items={items} />
         ))}

--- a/frontends/infinite-corridor/src/pages/user-lists/ManageListDialogs.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/ManageListDialogs.test.tsx
@@ -61,7 +61,7 @@ describe("Creation", () => {
       user: { is_public_list_editor: true, is_authenticated: true }
     }
   ) => {
-    const topics = factories.makeTopicsPaginated(5)
+    const topics = factories.makeTopicsPaginated({ count: 5 })
     setMockResponse.get(lrUrls.topics.listing, topics)
     const onClose = jest.fn()
     renderWithProviders(
@@ -219,7 +219,7 @@ describe("Editing", () => {
     resourceOverrides: Partial<UserList> = {},
     topicsCount = 1
   ) => {
-    const topics = factories.makeTopicsPaginated(5)
+    const topics = factories.makeTopicsPaginated({ count: 5 })
     setMockResponse.get(lrUrls.topics.listing, topics)
     const resource = factories.makeUserList({
       ...resourceOverrides,

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.test.tsx
@@ -100,7 +100,7 @@ describe("UserListDetailsPage", () => {
     const { paginatedItems } = setup()
     expectProps(spyItemsListing, {
       isLoading:    true,
-      data:         undefined,
+      items:        undefined,
       emptyMessage: "There are no items in this list yet."
     })
 
@@ -109,7 +109,7 @@ describe("UserListDetailsPage", () => {
         spyItemsListing,
         {
           isLoading:    false,
-          data:         paginatedItems,
+          items:        paginatedItems.results,
           emptyMessage: "There are no items in this list yet."
         },
         -1

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.tsx
@@ -94,6 +94,7 @@ const UserListsDetailsPage: React.FC = () => {
               id={id}
               items={items}
               isLoading={itemsQuery.isLoading}
+              isRefetching={itemsQuery.isFetching}
               sortable={isSorting}
               emptyMessage="There are no items in this list yet."
             />

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListDetailsPage.tsx
@@ -22,9 +22,11 @@ const UserListsDetailsPage: React.FC = () => {
   const itemsQuery = useUserListItems(id)
   const editing = useEditingDialog()
   const [isSorting, toggleIsSorting] = useToggle(false)
-  const canSort = userListQuery.data?.list_type === LRT.LearningPath
 
+  const itemCount = userListQuery.data?.item_count
   const canEdit = userListQuery.data?.author === SETTINGS.user.id
+  const canSort =
+    canEdit && itemCount && userListQuery.data?.object_type === LRT.LearningPath
   const description = userListQuery.data?.short_description
   const count = userListQuery.data?.item_count
 

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.test.tsx
@@ -45,8 +45,8 @@ describe("UserListsListingPage", () => {
     favoritesCount = faker.datatype.number({ min: 2, max: 5 }),
     listsCount = faker.datatype.number({ min: 2, max: 5 })
   } = {}) => {
-    const favorites = factories.makeFavorites(favoritesCount)
-    const userLists = factories.makeUserListsPaginated(listsCount)
+    const favorites = factories.makeFavorites({ count: favoritesCount })
+    const userLists = factories.makeUserListsPaginated({ count: listsCount })
     const topics = [
       ...userLists.results,
       ...favorites.results.map(fav => fav.content_data)

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.tsx
@@ -106,7 +106,7 @@ const UserListsListingPage: React.FC = () => {
   const userListsQuery = useUserListsListing()
   const favoritesQuery = useFavoritesListing()
   const favorites = favoritesQuery.data ?
-    makeFavorites(favoritesQuery.data.count) :
+    makeFavorites(favoritesQuery.data.pages[0].count) :
     null
 
   const history = useHistory()

--- a/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/UserListsListingPage.tsx
@@ -106,7 +106,7 @@ const UserListsListingPage: React.FC = () => {
   const userListsQuery = useUserListsListing()
   const favoritesQuery = useFavoritesListing()
   const favorites = favoritesQuery.data ?
-    makeFavorites(favoritesQuery.data.pages[0].count) :
+    makeFavorites(favoritesQuery.data.count) :
     null
 
   const history = useHistory()

--- a/frontends/infinite-corridor/src/scss/combined.scss
+++ b/frontends/infinite-corridor/src/scss/combined.scss
@@ -13,6 +13,7 @@
 @use "widgets";
 @use "layout";
 @use "ol-util/assets/loading_spinner";
+@use "ol-util/assets/sortable";
 @use "demopage";
 
 html {

--- a/frontends/infinite-corridor/src/scss/userlists.scss
+++ b/frontends/infinite-corridor/src/scss/userlists.scss
@@ -64,3 +64,7 @@
     padding-bottom: 0;
   }
 }
+
+.sorting-disabled {
+  opacity: 0.5;
+}

--- a/frontends/infinite-corridor/src/test-utils/index.tsx
+++ b/frontends/infinite-corridor/src/test-utils/index.tsx
@@ -29,7 +29,7 @@ const renderTestApp = (options: Partial<TestAppOptions> = {}) => {
   const history = createMemoryHistory({ initialEntries: [`${BASE_URL}${url}`] })
   const queryClient = createQueryClient()
   render(<App queryClient={queryClient} history={history} />)
-  return { history }
+  return { history, queryClient }
 }
 
 /**

--- a/frontends/infinite-corridor/src/test-utils/index.tsx
+++ b/frontends/infinite-corridor/src/test-utils/index.tsx
@@ -89,6 +89,7 @@ export { renderTestApp, renderWithProviders, expectProps }
 // Conveniences
 export { setMockResponse }
 export {
+  act,
   screen,
   prettyDOM,
   within,

--- a/frontends/ol-forms/package.json
+++ b/frontends/ol-forms/package.json
@@ -7,8 +7,8 @@
     "styled-components": "5"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.0.5",
-    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.0",
     "formik": "^2.2.9",
     "lodash": "^4.17.21",

--- a/frontends/ol-search-ui/assets/learning-resource-card.scss
+++ b/frontends/ol-search-ui/assets/learning-resource-card.scss
@@ -27,6 +27,14 @@ $small-font-size: 0.75em !default;
   flex-direction: row-reverse;
 }
 
+.ol-lrc-row-reverse .ol-lrc-image {
+  margin-left: 16px;
+}
+
+.ol-lrc-row .ol-lrc-image {
+  margin-right: 16px;
+}
+
 .ol-lrc-content .clickable-title {
   border: none;
   background-color: white;
@@ -41,7 +49,7 @@ $small-font-size: 0.75em !default;
   cursor: pointer;
 }
 
-.ol-lrc-content.MuiCardContent-root {
+.ol-lrc-details {
   /*
   Make content flexbox so that we can control which child fills remaining space.
   */
@@ -105,6 +113,20 @@ $small-font-size: 0.75em !default;
 .ol-lrc-title {
   font-weight: $bold-weight;
   margin:0;
+}
+
+.ol-lrc-drag-handle {
+  display: flex;
+  align-items: center;
+  font-size: 40px;
+  align-self: stretch;
+  color: $light-text;
+  border-right: 1px solid $light-text;
+  margin-right: 16px;
+}
+
+.MuiCardContent-root.ol-lrc-sortable {
+  padding-left: 4px;
 }
 
 .ol-lrc-footer-row {

--- a/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.test.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.test.tsx
@@ -4,6 +4,7 @@ import { assertInstanceOf } from "ol-util"
 import LearningResourceCardTemplate from "./LearningResourceCardTemplate"
 import { makeCourse, makeImgConfig, makeUserList } from "../factories"
 import { resourceThumbnailSrc } from "../util"
+import { allowConsoleErrors } from "ol-util/src/test-utils"
 
 describe("LearningResourceCard", () => {
   it("renders title and cover image", () => {
@@ -124,7 +125,7 @@ describe("LearningResourceCard", () => {
   it.each([
     { sortable: true, shows: "Shows" },
     { sortable: false, shows: "Does not show" }
-  ])("$shows a drag handle when sortable is $sortable", ({sortable}) => {
+  ])("$shows a drag handle when sortable is $sortable", ({ sortable }) => {
     const resource = makeCourse()
     const imgConfig = makeImgConfig()
     render(
@@ -139,18 +140,23 @@ describe("LearningResourceCard", () => {
     expect(!!screen.queryByTestId("DragIndicatorIcon")).toBe(sortable)
   })
 
-  it.each([
-    { svariant: "row" },
-    { variant: "column" },
-  ])("Throws error if sortable & unsupported variant", () => {
-    const resource = makeCourse()
-    const imgConfig = makeImgConfig()
-    expect(() => render(
-      <LearningResourceCardTemplate
-        variant="row-reverse"
-        resource={resource}
-        imgConfig={imgConfig}
-        sortable={true}
-      />)).toThrow(/only supported for variant='row-reverse'/)
-  })
+  it.each([{ variant: "row" }, { variant: "column" }] as const)(
+    "Throws error if sortable & unsupported variant",
+    ({ variant }) => {
+      const resource = makeCourse()
+      const imgConfig = makeImgConfig()
+      const shouldThrow = () => {
+        render(
+          <LearningResourceCardTemplate
+            variant={variant}
+            resource={resource}
+            imgConfig={imgConfig}
+            sortable={true}
+          />
+        )
+      }
+      allowConsoleErrors()
+      expect(shouldThrow).toThrow(/only supported for variant='row-reverse'/)
+    }
+  )
 })

--- a/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.test.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.test.tsx
@@ -120,4 +120,37 @@ describe("LearningResourceCard", () => {
     )
     expect(screen.queryByText("item", { exact: false })).toBe(null)
   })
+
+  it.each([
+    { sortable: true, shows: "Shows" },
+    { sortable: false, shows: "Does not show" }
+  ])("$shows a drag handle when sortable is $sortable", ({sortable}) => {
+    const resource = makeCourse()
+    const imgConfig = makeImgConfig()
+    render(
+      <LearningResourceCardTemplate
+        variant="row-reverse"
+        resource={resource}
+        imgConfig={imgConfig}
+        sortable={sortable}
+      />
+    )
+
+    expect(!!screen.queryByTestId("DragIndicatorIcon")).toBe(sortable)
+  })
+
+  it.each([
+    { svariant: "row" },
+    { variant: "column" },
+  ])("Throws error if sortable & unsupported variant", () => {
+    const resource = makeCourse()
+    const imgConfig = makeImgConfig()
+    expect(() => render(
+      <LearningResourceCardTemplate
+        variant="row-reverse"
+        resource={resource}
+        imgConfig={imgConfig}
+        sortable={true}
+      />)).toThrow(/only supported for variant='row-reverse'/)
+  })
 })

--- a/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.tsx
+++ b/frontends/ol-search-ui/src/components/LearningResourceCardTemplate.tsx
@@ -8,7 +8,7 @@ import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import Chip from "@mui/material/Chip"
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday"
-import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator"
 
 import CardMedia from "@mui/material/CardMedia"
 import {
@@ -132,7 +132,10 @@ const LRCImage: React.FC<LRCImageProps> = ({
   variant
 }) => {
   if (suppressImage) return null
-  const dims = variant === 'column' ? { height: imgConfig.height } : {width: imgConfig.width, height: imgConfig.height}
+  const dims =
+    variant === "column" ?
+      { height: imgConfig.height } :
+      { width: imgConfig.width, height: imgConfig.height }
   return (
     <CardMedia
       component="img"
@@ -175,31 +178,34 @@ const LearningResourceCardTemplate = <R extends CardMinimalResource>({
     [resource, onActivate]
   )
 
-  invariant(!sortable || variant === "row-reverse", "sortable only supported for variant='row-reverse'")
+  invariant(
+    !sortable || variant === "row-reverse",
+    "sortable only supported for variant='row-reverse'"
+  )
 
   return (
-    <Card
-      className={classNames(className, "ol-lrc-root")}
-    >
-      {variant === 'column' ?
+    <Card className={classNames(className, "ol-lrc-root")}>
+      {variant === "column" ? (
         <LRCImage
           variant={variant}
           suppressImage={suppressImage}
           resource={resource}
           imgConfig={imgConfig}
-        /> : null }
-      <CardContent className={classNames("ol-lrc-content", variantClasses[variant], {
-        "ol-lrc-sortable": sortable
-      })}>
-        {
-          variant !== 'column' ?
-            <LRCImage
-              variant={variant}
-              suppressImage={suppressImage}
-              resource={resource}
-              imgConfig={imgConfig}
-            /> : null
-        }
+        />
+      ) : null}
+      <CardContent
+        className={classNames("ol-lrc-content", variantClasses[variant], {
+          "ol-lrc-sortable": sortable
+        })}
+      >
+        {variant !== "column" ? (
+          <LRCImage
+            variant={variant}
+            suppressImage={suppressImage}
+            resource={resource}
+            imgConfig={imgConfig}
+          />
+        ) : null}
         <div className="ol-lrc-details">
           <div className="ol-lrc-type-row">
             <span className="ol-lrc-type">
@@ -218,8 +224,8 @@ const LearningResourceCardTemplate = <R extends CardMinimalResource>({
               {resource.title}
             </Dotdotdot>
           )}
-          {
-            sortable ? null : <>
+          {sortable ? null : (
+            <>
               <CardBody resource={resource} />
               <div className="ol-lrc-fill-space-content-end">
                 <div className="ol-lrc-footer-row">
@@ -230,13 +236,13 @@ const LearningResourceCardTemplate = <R extends CardMinimalResource>({
                 </div>
               </div>
             </>
-          }
+          )}
         </div>
-        { sortable ?
+        {sortable ? (
           <div className="ol-lrc-drag-handle">
             <DragIndicatorIcon fontSize="inherit" />
-          </div> :
-          null }
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   )

--- a/frontends/ol-util/assets/sortable.scss
+++ b/frontends/ol-util/assets/sortable.scss
@@ -1,0 +1,8 @@
+.ol-draggable {
+  cursor: grab;
+}
+
+
+.ol-dragging, .ol-dragging * {
+  cursor: grabbing;
+}

--- a/frontends/ol-util/package.json
+++ b/frontends/ol-util/package.json
@@ -8,8 +8,8 @@
     "styled-components": "5"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.0.5",
-    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.0",
     "@faker-js/faker": "^7.3.0",
     "classnames": "^2.3.1",

--- a/frontends/ol-util/src/components/SortableList.test.tsx
+++ b/frontends/ol-util/src/components/SortableList.test.tsx
@@ -60,7 +60,7 @@ const setupTest = (itemIds: string[]) => {
   const spyDndContext = jest.mocked(DndContext)
   const spies = {
     renderActive: jest.fn((a: Active) => <div>Active Item {a.id}</div>),
-    onSortEnd:    jest.fn(),
+    onSortEnd:    jest.fn()
   }
   render(
     <SortableList
@@ -136,35 +136,40 @@ describe("SortableList", () => {
       itemIds:   ["A", "B", "C", "D"],
       afterIds:  ["B", "A", "C", "D"],
       dragIndex: 1,
-      dropIndex: 0
+      dropIndex: 0,
+      targetId:  "B"
     },
     {
       itemIds:   ["A", "B", "C", "D"],
       afterIds:  ["A", "B", "C", "D"],
       dragIndex: 1,
-      dropIndex: 1
+      dropIndex: 1,
+      targetId:  "B"
     },
     {
       itemIds:   ["A", "B", "C", "D"],
       afterIds:  ["A", "C", "B", "D"],
       dragIndex: 1,
-      dropIndex: 2
+      dropIndex: 2,
+      targetId:  "B"
     },
     {
       itemIds:   ["A", "B", "C", "D"],
       afterIds:  ["A", "C", "D", "B"],
       dragIndex: 1,
-      dropIndex: 3
+      dropIndex: 3,
+      targetId:  "B"
     },
     {
       itemIds:   ["A", "B", "C", "D"],
       afterIds:  ["C", "A", "B", "D"],
       dragIndex: 2,
-      dropIndex: 0
+      dropIndex: 0,
+      targetId:  "C"
     }
   ])(
     "it emits the correct onSortEnd events ($dragIndex --> $dropIndex, $afterIds)",
-    ({ itemIds, afterIds, dragIndex, dropIndex }) => {
+    ({ itemIds, afterIds, dragIndex, dropIndex, targetId }) => {
       const { spies, dnd, dndEvents } = setupTest(itemIds)
 
       const startEvent = dndEvents.start(dragIndex)
@@ -173,28 +178,33 @@ describe("SortableList", () => {
       act(() => dnd.onDragEnd(endEvent))
       expect(spies.onSortEnd).toHaveBeenCalledTimes(1)
       expect(spies.onSortEnd).toHaveBeenCalledWith({
-        itemIds: afterIds
+        itemIds:  afterIds,
+        oldIndex: dragIndex,
+        newIndex: dropIndex,
+        targetId
       })
     }
   )
 })
 
 describe("SortableItem", () => {
-  it.each([
-    { tag: "div" },
-    { tag: "li" },
-  ] as const)("Renders the specified tag", ({tag}) => {
-    const view = render(<SortableItem Component={tag} id="1" />)
+  it.each([{ tag: "div" }, { tag: "li" }] as const)(
+    "Renders the specified tag",
+    ({ tag }) => {
+      const view = render(<SortableItem Component={tag} id="1" />)
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const el = view.container.firstChild as HTMLElement
-    expect(el.tagName).toBe(tag.toUpperCase())
-  })
+      // eslint-disable-next-line testing-library/no-node-access
+      const el = view.container.firstChild as HTMLElement
+      expect(el.tagName).toBe(tag.toUpperCase())
+    }
+  )
 
   it("Renders child with class ol-draggable", () => {
-    render(<SortableItem Component="div" id="1" >
-      {props=> <div {...props} data-testid="sortable-child"  /> }
-    </SortableItem>)
+    render(
+      <SortableItem Component="div" id="1">
+        {props => <div {...props} data-testid="sortable-child" />}
+      </SortableItem>
+    )
 
     expect(screen.getByTestId("sortable-child")).toHaveClass("ol-draggable")
   })

--- a/frontends/ol-util/src/components/SortableList.test.tsx
+++ b/frontends/ol-util/src/components/SortableList.test.tsx
@@ -61,13 +61,13 @@ const setupTest = (itemIds: string[]) => {
   const spies = {
     renderActive: jest.fn((a: Active) => <div>Active Item {a.id}</div>),
     onSortEnd:    jest.fn(),
-    cancelSort:   jest.fn(() => false)
+    cancelDrop:   jest.fn(() => false)
   }
   render(
     <SortableList
       renderActive={spies.renderActive}
       onSortEnd={spies.onSortEnd}
-      cancelSort={spies.cancelSort}
+      cancelDrop={spies.cancelDrop}
       itemIds={itemIds}
     />
   )
@@ -180,8 +180,8 @@ describe("SortableList", () => {
         active:      endEvent.active
       })
 
-      expect(spies.cancelSort).toHaveBeenCalledTimes(1)
-      expect(spies.cancelSort).toHaveBeenCalledWith({
+      expect(spies.cancelDrop).toHaveBeenCalledTimes(1)
+      expect(spies.cancelDrop).toHaveBeenCalledWith({
         itemIds:     afterIds,
         activeIndex: dragIndex,
         overIndex:   dropIndex,

--- a/frontends/ol-util/src/components/SortableList.test.tsx
+++ b/frontends/ol-util/src/components/SortableList.test.tsx
@@ -8,7 +8,7 @@ import type {
   UniqueIdentifier as Id
 } from "@dnd-kit/core"
 import type { SortableData } from "@dnd-kit/sortable"
-import SortableList from "./SortableList"
+import SortableList, { SortableItem } from "./SortableList"
 
 jest.mock("@dnd-kit/core", () => {
   const actual = jest.requireActual("@dnd-kit/core")
@@ -22,14 +22,6 @@ jest.mock("@dnd-kit/core", () => {
      * Since dnd-kit is non-functional in JSDom, let's always render the children.
      */
     DragOverlay: ({ children }) => <div>{children}</div>
-  }
-})
-
-jest.mock("./SortableList", () => {
-  const actual = jest.requireActual("./SortableList")
-  return {
-    __esModule: true,
-    default:    jest.fn(actual.default)
   }
 })
 
@@ -69,7 +61,6 @@ const setupTest = (itemIds: string[]) => {
   const spies = {
     renderActive: jest.fn((a: Active) => <div>Active Item {a.id}</div>),
     onSortEnd:    jest.fn(),
-    SortableList: jest.mocked(SortableList)
   }
   render(
     <SortableList
@@ -186,4 +177,25 @@ describe("SortableList", () => {
       })
     }
   )
+})
+
+describe("SortableItem", () => {
+  it.each([
+    { tag: "div" },
+    { tag: "li" },
+  ] as const)("Renders the specified tag", ({tag}) => {
+    const view = render(<SortableItem Component={tag} id="1" />)
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const el = view.container.firstChild as HTMLElement
+    expect(el.tagName).toBe(tag.toUpperCase())
+  })
+
+  it("Renders child with class ol-draggable", () => {
+    render(<SortableItem Component="div" id="1" >
+      {props=> <div {...props} data-testid="sortable-child"  /> }
+    </SortableItem>)
+
+    expect(screen.getByTestId("sortable-child")).toHaveClass("ol-draggable")
+  })
 })

--- a/frontends/ol-util/src/components/SortableList.tsx
+++ b/frontends/ol-util/src/components/SortableList.tsx
@@ -86,7 +86,7 @@ type SortEndEvent<I extends UniqueIdentifier = UniqueIdentifier> = {
 type OnSortEnd<I extends UniqueIdentifier = UniqueIdentifier> = (
   event: SortEndEvent<I>
 ) => void
-type CancelSort<I extends UniqueIdentifier = UniqueIdentifier> = (
+type CancelDrop<I extends UniqueIdentifier = UniqueIdentifier> = (
   event: SortEndEvent<I>
 ) => boolean | Promise<boolean>
 
@@ -114,7 +114,7 @@ interface SortableListProps<I extends UniqueIdentifier = UniqueIdentifier> {
   itemIds: I[]
   onSortEnd?: OnSortEnd<I>
   renderActive: RenderActive
-  cancelSort?: CancelSort<I>
+  cancelDrop?: CancelDrop<I>
 }
 const dropAnimationConfig: DropAnimation = {
   sideEffects: defaultDropAnimationSideEffects({
@@ -170,7 +170,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
   itemIds,
   renderActive,
   onSortEnd,
-  cancelSort
+  cancelDrop
 }: SortableListProps<I>): React.ReactElement => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -204,9 +204,9 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
       setActive(null)
       const event = makeSortEndEvent<I>(e)
       if (!event) return true
-      return cancelSort?.(event) ?? false
+      return cancelDrop?.(event) ?? false
     },
-    [cancelSort]
+    [cancelDrop]
   )
 
   return (
@@ -233,7 +233,7 @@ export type {
   RenderActive,
   SortEndEvent,
   OnSortEnd,
-  CancelSort,
+  CancelDrop,
   SortableItemProps,
   SortableListProps
 }

--- a/frontends/ol-util/src/components/SortableList.tsx
+++ b/frontends/ol-util/src/components/SortableList.tsx
@@ -25,7 +25,8 @@ import { CSS } from "@dnd-kit/utilities"
 type SortableItemProps<I extends UniqueIdentifier = UniqueIdentifier> = {
   id: I
   children?: (props: HandleProps) => React.ReactNode
-  data?: Data
+  data?: Data,
+  Component?: React.ElementType
 }
 type HandleProps = React.HTMLAttributes<HTMLElement> & {
   ref: (el: HTMLElement | null) => void
@@ -53,15 +54,18 @@ const SortableItem = <I extends UniqueIdentifier = UniqueIdentifier>(
   const handleProps: HandleProps = useMemo(
     () => ({
       ...listeners,
-      ref: setActivatorNodeRef
+      ref:       setActivatorNodeRef,
+      className: "ol-draggable"
     }),
     [setActivatorNodeRef, listeners]
   )
 
+  const { Component = "div" } = props
+
   return (
-    <div ref={setNodeRef} style={style} {...attributes}>
+    <Component ref={setNodeRef} style={style} {...attributes}>
       {props.children && props.children(handleProps)}
-    </div>
+    </Component>
   )
 }
 
@@ -132,7 +136,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
   children,
   itemIds,
   renderActive,
-  onSortEnd
+  onSortEnd,
 }: SortableListProps<I>): React.ReactElement => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -176,7 +180,9 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
         {children}
       </SortableContext>
       <DragOverlay dropAnimation={dropAnimationConfig}>
-        {active && renderActive(active)}
+        <div className="ol-dragging">
+          {active && renderActive(active)}
+        </div>
       </DragOverlay>
     </DndContext>
   )

--- a/frontends/ol-util/src/components/SortableList.tsx
+++ b/frontends/ol-util/src/components/SortableList.tsx
@@ -25,7 +25,7 @@ import { CSS } from "@dnd-kit/utilities"
 type SortableItemProps<I extends UniqueIdentifier = UniqueIdentifier> = {
   id: I
   children?: (props: HandleProps) => React.ReactNode
-  data?: Data,
+  data?: Data
   Component?: React.ElementType
 }
 type HandleProps = React.HTMLAttributes<HTMLElement> & {
@@ -75,6 +75,12 @@ type SortEndEvent<I extends UniqueIdentifier = UniqueIdentifier> = {
    * The item order post-sort
    */
   itemIds: I[]
+  /**
+   * The id of the item that was moved.
+   */
+  targetId: I
+  oldIndex: number
+  newIndex: number
 }
 
 interface SortableListProps<I extends UniqueIdentifier = UniqueIdentifier> {
@@ -136,7 +142,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
   children,
   itemIds,
   renderActive,
-  onSortEnd,
+  onSortEnd
 }: SortableListProps<I>): React.ReactElement => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -164,7 +170,12 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
       const { items: oldItems, index: from } = active.data.current.sortable
       const { index: to } = over.data.current.sortable
       const newItems = arrayMove(oldItems, from, to) as I[]
-      onSortEnd({ itemIds: newItems })
+      onSortEnd({
+        itemIds:  newItems,
+        targetId: newItems[to],
+        oldIndex: from,
+        newIndex: to
+      })
     },
     [onSortEnd]
   )
@@ -180,9 +191,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
         {children}
       </SortableContext>
       <DragOverlay dropAnimation={dropAnimationConfig}>
-        <div className="ol-dragging">
-          {active && renderActive(active)}
-        </div>
+        <div className="ol-dragging">{active && renderActive(active)}</div>
       </DragOverlay>
     </DndContext>
   )

--- a/frontends/ol-util/src/components/SortableList.tsx
+++ b/frontends/ol-util/src/components/SortableList.tsx
@@ -29,6 +29,7 @@ type SortableItemProps<I extends UniqueIdentifier = UniqueIdentifier> = {
   children?: (props: HandleProps) => React.ReactNode
   data?: Data
   Component?: React.ElementType
+  disabled?: boolean
 }
 type HandleProps = React.HTMLAttributes<HTMLElement> & {
   ref: (el: HTMLElement | null) => void
@@ -47,7 +48,7 @@ const SortableItem = <I extends UniqueIdentifier = UniqueIdentifier>(
     transition,
     isDragging,
     setActivatorNodeRef
-  } = useSortable({ id: props.id, data: props.data })
+  } = useSortable({ id: props.id, data: props.data, disabled: props.disabled })
   const style = {
     transform: CSS.Translate.toString(transform),
     transition,
@@ -57,9 +58,9 @@ const SortableItem = <I extends UniqueIdentifier = UniqueIdentifier>(
     () => ({
       ...listeners,
       ref:       setActivatorNodeRef,
-      className: "ol-draggable"
+      className: !props.disabled ? "ol-draggable" : undefined
     }),
-    [setActivatorNodeRef, listeners]
+    [setActivatorNodeRef, listeners, props.disabled]
   )
 
   const { Component = "div" } = props

--- a/frontends/ol-util/src/components/SortableList.tsx
+++ b/frontends/ol-util/src/components/SortableList.tsx
@@ -199,7 +199,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
     [onSortEnd]
   )
 
-  const cancelDrop = useCallback(
+  const handleCancelDrop = useCallback(
     (e: CancelDropArguments) => {
       setActive(null)
       const event = makeSortEndEvent<I>(e)
@@ -215,7 +215,7 @@ const SortableList = <I extends UniqueIdentifier = UniqueIdentifier>({
       onDragStart={handleDragStart}
       onDragMove={handleDragStart}
       onDragEnd={handleDragEnd}
-      cancelDrop={cancelDrop}
+      cancelDrop={handleCancelDrop}
     >
       <SortableContext strategy={verticalListSortingStrategy} items={itemIds}>
         {children}

--- a/frontends/ol-util/src/components/index.ts
+++ b/frontends/ol-util/src/components/index.ts
@@ -21,7 +21,7 @@ export type {
   RenderActive,
   SortEndEvent,
   OnSortEnd,
-  CancelSort,
+  CancelDrop,
   SortableItemProps,
   SortableListProps
 } from "./SortableList"

--- a/frontends/ol-util/src/components/index.ts
+++ b/frontends/ol-util/src/components/index.ts
@@ -12,10 +12,16 @@ export { default as MITLogoLink } from "./MITLogoLink"
 export { default as TitledCarousel } from "./TitledCarousel"
 export type { TitledCarouselProps } from "./TitledCarousel"
 
-export { default as SortableList, SortableItem } from "./SortableList"
+export {
+  default as SortableList,
+  SortableItem,
+  arrayMove
+} from "./SortableList"
 export type {
   RenderActive,
   SortEndEvent,
+  OnSortEnd,
+  CancelSort,
   SortableItemProps,
   SortableListProps
 } from "./SortableList"

--- a/frontends/ol-util/src/factories.ts
+++ b/frontends/ol-util/src/factories.ts
@@ -7,7 +7,7 @@ type Factory<T, U = never> = (overrides?: Partial<T>, options?: U) => T
 const makePaginatedFactory =
   <T>(makeResult: Factory<T>) =>
     (
-      count: number,
+      { count, pageSize }: { count: number; pageSize?: number },
       {
         previous = null,
         next = null
@@ -16,7 +16,7 @@ const makePaginatedFactory =
       previous?: string | null
     } = {}
     ): PaginatedResult<T> => {
-      const results = times(count, () => makeResult())
+      const results = times(pageSize ?? count, () => makeResult())
       return {
         results,
         count,

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "stylelint": "^15.2.0",
         "stylelint-config-standard-scss": "^7.0.1",
         "swc-loader": "^0.2.3",
+        "tiny-invariant": "^1.3.1",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.1",
         "typescript": "^4.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16977,6 +16977,7 @@ __metadata:
     stylelint: ^15.2.0
     stylelint-config-standard-scss: ^7.0.1
     swc-loader: ^0.2.3
+    tiny-invariant: ^1.3.1
     ts-jest: ^28.0.5
     ts-node: ^10.8.1
     typescript: ^4.9.5
@@ -22309,6 +22310,13 @@ __metadata:
   version: 1.2.0
   resolution: "tiny-invariant@npm:1.2.0"
   checksum: e09a718a7c4a499ba592cdac61f015d87427a0867ca07f50c11fd9b623f90cdba18937b515d4a5e4f43dac92370498d7bdaee0d0e7a377a61095e02c4a92eade
+  languageName: node
+  linkType: hard
+
+"tiny-invariant@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "tiny-invariant@npm:1.3.1"
+  checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,30 +1964,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dnd-kit/core@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "@dnd-kit/core@npm:6.0.5"
+"@dnd-kit/core@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "@dnd-kit/core@npm:6.0.8"
   dependencies:
     "@dnd-kit/accessibility": ^3.0.0
-    "@dnd-kit/utilities": ^3.2.0
+    "@dnd-kit/utilities": ^3.2.1
     tslib: ^2.0.0
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 09061e741bea9d2ba3987d01bb760c354fe29ca27996e74da3774e68c4783cf09ad21087703b5ffb036d3c2f86d16bea3c9f24466c2f266c8698f1e76c29d386
+  checksum: abe48ff7395f84fd8c15e6c8b13da4df153dc1f1076096d783acd0c25539516c77e4854ea59be6621dde55739cb0df1d62924ad069df3267fe05ad90ef729b2f
   languageName: node
   linkType: hard
 
-"@dnd-kit/sortable@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "@dnd-kit/sortable@npm:7.0.1"
+"@dnd-kit/sortable@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@dnd-kit/sortable@npm:7.0.2"
   dependencies:
     "@dnd-kit/utilities": ^3.2.0
     tslib: ^2.0.0
   peerDependencies:
-    "@dnd-kit/core": ^6.0.4
+    "@dnd-kit/core": ^6.0.7
     react: ">=16.8.0"
-  checksum: b8b5ae504d57d6afb847c3ac8a865a3623c5915f4f0dd767017a17e6d1d36e144b74f6f90a17c07d5f8ddc83395a2db8bb90c420f017aee15bd88538b6f3f226
+  checksum: 4ce705aceb15766a0deefe25a9d95a87e9413c3fb9088ea3eb0962e57f844895000117fcec7c0944a0d4ae4e1e889cfa69e3d3778164d4d23115fb1edb218283
   languageName: node
   linkType: hard
 
@@ -1999,6 +1999,17 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: 575e554992c5ff26622854b889b6288580f308e1125620a4aae55d0a113d47f05fdb7c6e2023ce51c58d5a206091fc1deac868222dd5f9c35c80c3e2f99db9af
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@dnd-kit/utilities@npm:3.2.1"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 038fd5cc1328bf4c9dca17cd48046e5a687bbf9d904c7197f851aab869ab52d9dee2734b2e255256fd6158245acd00063a23deed962c7673c0fadfbf061f04ca
   languageName: node
   linkType: hard
 
@@ -16791,8 +16802,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ol-forms@workspace:frontends/ol-forms"
   dependencies:
-    "@dnd-kit/core": ^6.0.5
-    "@dnd-kit/sortable": ^7.0.1
+    "@dnd-kit/core": ^6.0.8
+    "@dnd-kit/sortable": ^7.0.2
     "@dnd-kit/utilities": ^3.2.0
     formik: ^2.2.9
     lodash: ^4.17.21
@@ -16828,8 +16839,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ol-util@workspace:frontends/ol-util"
   dependencies:
-    "@dnd-kit/core": ^6.0.5
-    "@dnd-kit/sortable": ^7.0.1
+    "@dnd-kit/core": ^6.0.8
+    "@dnd-kit/sortable": ^7.0.2
     "@dnd-kit/utilities": ^3.2.0
     "@faker-js/faker": ^7.3.0
     classnames: ^2.3.1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3912 

#### What's this PR do?
This PR makes learning paths drag re-sortable at `infinite/lists/<learning path id>`.

#### How should this be manually tested?
1. Visit http://od.odl.local:8063/infinite/lists
2. Create and populate some userlists / learning paths if you haven't already. *Populate them via the bookmark icon on search results page, http://.od.odl.local:8063/infinite/search*. Make sure you have at least one learning path and at least one userlist.
3. From http://od.odl.local:8063/infinite/lists, visit the details page for a userlist *not a learning path*. It should not have a "Reorder" button.
4. Now visit a learning path page. It should have a "Reorder" button. Try reordering things:
     - drag items up/down within the list ... the order should be correct after you drag, and also after you reload the page.
     - If you like, try reproducing bug #3944. It should be repredocable on `/learn` but not on `/infinite`. 
5. Visit a public learning path as an anonymous user in private browser window. You should not be able to Reorder.

#### Screenshots (if appropriate)

**Desktop:**

https://user-images.githubusercontent.com/9010790/233116127-74a3f4b2-16ef-4aa1-be89-ab396f415820.mov

**Mobile:**
<img width="462" alt="Screenshot 2023-04-19 at 11 04 58 AM" src="https://user-images.githubusercontent.com/9010790/233118446-8e9299c9-3899-4dc9-a463-ff786a9c39eb.png">

