### PR TITLE
Fix profile bulk indexing

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -345,7 +345,7 @@ def index_items(documents, object_type, update_only, **kwargs):
     for chunk in chunks(
         documents, chunk_size=settings.ELASTICSEARCH_INDEXING_CHUNK_SIZE
     ):
-        documents_size = len(json.dumps(chunk))
+        documents_size = len(json.dumps(chunk, default=str))
         # Keep chunking the chunks until either the size is acceptable or there's nothing left to chunk
         if documents_size > settings.ELASTICSEARCH_MAX_REQUEST_SIZE:
             if len(chunk) == 1:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/3949

#### What's this PR do?
When calculating the length of a document for indexing, uses the `default=str` kwarg to force anything that can't be serialized into a string (like datetime objects) - this happens for some profiles who are channel members.

#### How should this be manually tested?
- Tests should pass
- If you remove the `default=str` option added to `json.dumps()` in this PR, the new test will fail.
- If you have users who are members of a discussion channel (requires reddit), running `manage.py recreate_index --profiles` should work on this branch (and fail on master).
