### PR TITLE
Use single modal for "Add to list..." -> fix premature close

### DIFF
--- a/frontends/infinite-corridor/src/App.tsx
+++ b/frontends/infinite-corridor/src/App.tsx
@@ -17,6 +17,7 @@ import { QueryClientProvider, QueryClient } from "react-query"
 import Header from "./components/Header"
 import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles"
 import { muiTheme } from "./libs/mui"
+import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
 
 export const BASE_URL = "/infinite"
 
@@ -42,7 +43,9 @@ const AppProviders: React.FC<AppProps & { children: React.ReactNode }> = ({
     <MuiThemeProvider theme={muiTheme}>
       <QueryClientProvider client={queryClient}>
         <HelmetProvider>
-          <Router history={history}>{children}</Router>
+          <Router history={history}>
+            <NiceModalProvider>{children}</NiceModalProvider>
+          </Router>
         </HelmetProvider>
       </QueryClientProvider>
     </MuiThemeProvider>

--- a/frontends/infinite-corridor/src/components/LearningResourceCard.spec.tsx
+++ b/frontends/infinite-corridor/src/components/LearningResourceCard.spec.tsx
@@ -1,30 +1,23 @@
 import React from "react"
+import * as NiceModal from "@ebay/nice-modal-react"
 import {
   makeLearningResource,
   makeListItemMember,
   makeSearchResult
 } from "ol-search-ui/src/factories"
-import {
-  renderWithProviders,
-  user,
-  screen,
-  expectProps,
-  within
-} from "../test-utils"
+import { renderWithProviders, user, screen, within } from "../test-utils"
 import LearningResourceCard from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
 import AddToListDialog from "../pages/user-lists/AddToListDialog"
 
-jest.mock("../pages/user-lists/AddToListDialog", () => {
-  const actual = jest.requireActual("../pages/user-lists/AddToListDialog")
+jest.mock("@ebay/nice-modal-react", () => {
+  const actual = jest.requireActual("@ebay/nice-modal-react")
   return {
     __esModule: true,
     ...actual,
-    default:    jest.fn(() => <div>AddToListDialog</div>)
+    show:       jest.fn()
   }
 })
-
-const spyAddToListDialog = jest.mocked(AddToListDialog)
 
 type SetupOptions = {
   isAuthenticated?: boolean
@@ -126,16 +119,15 @@ describe("LearningResourceCard", () => {
   )
 
   test("Clicking 'add to list' button opens AddToListDialog", async () => {
+    const showModal = jest.mocked(NiceModal.show)
+
     const { resource } = setup({ isAuthenticated: true })
     const button = screen.getByRole("button", { name: "Add to list" })
-    expect(spyAddToListDialog).not.toHaveBeenCalled()
+
+    expect(showModal).not.toHaveBeenCalled()
     await user.click(button)
-    expectProps(spyAddToListDialog, {
-      resourceKey: expect.objectContaining({
-        id:          resource.id,
-        object_type: resource.object_type
-      }),
-      open: true
+    expect(showModal).toHaveBeenCalledWith(AddToListDialog, {
+      resourceKey: resource
     })
   })
 

--- a/frontends/infinite-corridor/src/components/LearningResourceCard.tsx
+++ b/frontends/infinite-corridor/src/components/LearningResourceCard.tsx
@@ -1,5 +1,6 @@
-import React from "react"
+import React, { useCallback } from "react"
 import classNames from "classnames"
+import * as NiceModal from "@ebay/nice-modal-react"
 import { LearningResourceCardTemplate } from "ol-search-ui"
 import type {
   LearningResourceCardTemplateProps,
@@ -11,9 +12,7 @@ import { imgConfigs } from "../util/constants"
 import IconButton from "@mui/material/IconButton"
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder"
 import BookmarkIcon from "@mui/icons-material/Bookmark"
-import AddToListDialog, {
-  useAddToListDialog
-} from "../pages/user-lists/AddToListDialog"
+import AddToListDialog from "../pages/user-lists/AddToListDialog"
 
 type TemplateProps = LearningResourceCardTemplateProps<
   LearningResource | LearningResourceSearchResult
@@ -31,7 +30,9 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   suppressImage
 }) => {
   const activateResource = useActivateResourceDrawer()
-  const addToList = useAddToListDialog()
+  const showAddToListDialog = useCallback(() => {
+    NiceModal.show(AddToListDialog, { resourceKey: resource })
+  }, [resource])
   const { user } = SETTINGS
   const isInList = (resource.lists?.length ?? 0) > 0 || resource.is_favorite
   return (
@@ -49,21 +50,13 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             <IconButton
               size="small"
               aria-label="Add to list"
-              onClick={() => addToList.open(resource)}
+              onClick={showAddToListDialog}
             >
               {isInList ? <BookmarkIcon /> : <BookmarkBorderIcon />}
             </IconButton>
           )
         }
       />
-      {addToList.ressourceKey && (
-        <AddToListDialog
-          resourceKey={addToList.ressourceKey}
-          onClose={addToList.close}
-          open={addToList.isOpen}
-          onExited={addToList.onExited}
-        />
-      )}
     </>
   )
 }

--- a/frontends/infinite-corridor/src/pages/user-lists/AddToListDialog.test.tsx
+++ b/frontends/infinite-corridor/src/pages/user-lists/AddToListDialog.test.tsx
@@ -8,13 +8,15 @@ import {
 import { UserList, LearningResource } from "ol-search-ui"
 import { assertNotNil } from "ol-util"
 
+import NiceModal from "@ebay/nice-modal-react"
 import AddToListDialog from "./AddToListDialog"
 import {
   expectProps,
   renderWithProviders,
   screen,
   user,
-  within
+  within,
+  act
 } from "../../test-utils"
 import {
   setMockResponse,
@@ -22,12 +24,13 @@ import {
 } from "../../test-utils/mockAxios"
 import { urls } from "../../api/learning-resources"
 import { CreateListDialog } from "./ManageListDialogs"
+import { waitForElementToBeRemoved } from "@testing-library/react"
 
 jest.mock("./ManageListDialogs", () => {
   const actual = jest.requireActual("./ManageListDialogs")
   return {
     ...actual,
-    CreateListDialog: jest.fn(() => <div role="dialog">Create new list</div>)
+    CreateListDialog: jest.fn(() => <div>Create new list</div>)
   }
 })
 
@@ -60,13 +63,14 @@ const setup = ({
   setMockResponse.get(urls.userList.listing(), paginatedLists)
 
   const onClose = jest.fn()
-  const view = renderWithProviders(
-    <AddToListDialog
-      onClose={onClose}
-      open={dialogOpen}
-      resourceKey={resource}
-    />
-  )
+  const view = renderWithProviders(null)
+
+  if (dialogOpen) {
+    act(() => {
+      NiceModal.show(AddToListDialog, { resourceKey: resource })
+    })
+  }
+
   return {
     view,
     onClose,
@@ -216,12 +220,28 @@ describe("AddToListDialog", () => {
     await user.click(button)
     expectProps(spyCreateListDialog, { open: true }, -1)
   })
-  test("Clicking close button calls onClose", async () => {
-    const { onClose } = setup()
-    const button = await screen.findByRole("button", { name: "Close" })
 
-    expect(onClose).toHaveBeenCalledTimes(0)
-    await user.click(button)
-    expect(onClose).toHaveBeenCalledTimes(1)
+  test("Opens and closes via NiceModal", async () => {
+    const { resource: resource1 } = setup()
+    const dialog1 = await screen.findByRole("dialog")
+    await within(dialog1).findByText(resource1.title, { exact: false })
+
+    // Close the dialog
+    act(() => {
+      NiceModal.hide(AddToListDialog)
+    })
+    await waitForElementToBeRemoved(dialog1)
+
+    // Open it with a new resource
+    const resource2 = makeCourse()
+    setMockResponse.get(
+      urls.resource.details(resource2.object_type, resource2.id),
+      resource2
+    )
+    act(() => {
+      NiceModal.show(AddToListDialog, { resourceKey: resource2 })
+    })
+    const dialog2 = await screen.findByRole("dialog")
+    await within(dialog2).findByText(resource2.title, { exact: false })
   })
 })

--- a/frontends/infinite-corridor/src/test-utils/index.tsx
+++ b/frontends/infinite-corridor/src/test-utils/index.tsx
@@ -94,7 +94,8 @@ export {
   prettyDOM,
   within,
   fireEvent,
-  waitFor
+  waitFor,
+  act
 } from "@testing-library/react"
 export { default as user } from "@testing-library/user-event"
 

--- a/frontends/infinite-corridor/src/test-utils/index.tsx
+++ b/frontends/infinite-corridor/src/test-utils/index.tsx
@@ -94,8 +94,7 @@ export {
   prettyDOM,
   within,
   fireEvent,
-  waitFor,
-  act
+  waitFor
 } from "@testing-library/react"
 export { default as user } from "@testing-library/user-event"
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "version": "0.0.0",
     "packageManager": "yarn@3.2.0",
     "dependencies": {
+        "@ebay/nice-modal-react": "^1.2.10",
         "@swc/core": "^1.3.32",
         "@swc/jest": "^0.2.21",
         "@testing-library/jest-dom": "^5.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,6 +2013,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ebay/nice-modal-react@npm:^1.2.10":
+  version: 1.2.10
+  resolution: "@ebay/nice-modal-react@npm:1.2.10"
+  peerDependencies:
+    react: ">16.8.0"
+    react-dom: ">16.8.0"
+  checksum: a66490807b2b77f825db10c15cc686680f81c5dfb82a6fd8c37550561e72a5e4ffd1ae1ec76bf1ec477df5acfddad5cdacf1a57ede91875b41e30f39c6b83491
+  languageName: node
+  linkType: hard
+
 "@emotion/babel-plugin@npm:^11.10.0":
   version: 11.10.0
   resolution: "@emotion/babel-plugin@npm:11.10.0"
@@ -16944,6 +16954,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "open-discussions-root@workspace:."
   dependencies:
+    "@ebay/nice-modal-react": ^1.2.10
     "@swc/core": ^1.3.32
     "@swc/jest": ^0.2.21
     "@testing-library/jest-dom": ^5.16.4


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3938 

#### What's this PR do?
This PR adds [`@ebay/nice-modal-react`](https://github.com/eBay/nice-modal-react) (see below) and uses it to manage the "Add to list" dialog. This fixes #3938 

#### How should this be manually tested?
1. Go to any list page http://od.odl.local:8063/infinite/lists/LIST_ID or favorites page `http://cac.od.odl.local:8063/infinite/lists/345` 
2. Click bookmark on any list item. Remove it from the current list. Modal should stay open. If you re-add it to the list, you should see it appear in the background (if your list is short enough).


#### Any background context you want to provide?

**tldr:** I am proposing to use a new library, [`@ebay/nice-modal-react`](https://github.com/eBay/nice-modal-react), to help manage modals, especially modals that can be opened from several places in the app. It's small, simple and has no dependencies. It seems reasonably maintained. 

**Problem::** Sometimes we want to open the same modal from many different places within the application. One example of this is the "Add to list" dialog that is openable from most resource cards on several pages. Two general ways to achieve this:

1. Have a single instance of the modal that reads from some global state. When we want to open the modal, update the associated global state. *The **"Learning Resource Drawer"** is handled this way, with the relevant global state in the URL bar. But it's not always natural to put the relevant info in the URL.*
3. Have many instances of the modal, co-located with where they are openable from, so that the parent component can pass the appropriate data. *This is how the **"Add to list" dialog** is currently handled. Every resource card has its own copy. (Only one ever exists in the DOM at a time, though).* 

A downside of (2) is if the modal causes its parent to unmount, then the modal will automatically close. Which might not be desirable. That's what happening in #3938.

I'd like to propose moving some of the modals (in particular, "Add to list...") to use global state managed by [`@ebay/nice-modal-react`](https://github.com/eBay/nice-modal-react).

Things I like about this library:
1. easy to have a single modal instance opened from several places
2. modal code is still isolated (We do declare a root `<NiceModal.Provider>` once, but declaring new modals does not need to change that root declaration at all, like you would have to if each modal were its own piece of redux)
4. Good typescript integration.
5. Modals manage their own visibility (including things like "don't unmount until after the transition ends", which is a small thing but easy to mess up). 
6. UI layer agnostic... can use with any modal UI (bootstrap, mui, ant design...) and comes with convenient helpers for those three popular libraries.

The flipside of (4) is that is that the library is more imperative than most react components. But I don't think that's bad... everything besides visibility is still declartive. 

See [their readme](https://github.com/eBay/nice-modal-react#nice-modal) or code in this PR for more. 

**Re global state:** In the new portions of Open we have generally avoided "global" state, state that can be read / updated by any components. Less global state => more encapsulation of components. But some things are global: the URL state is an obvious one, and controlling modal visibility seems reasonable to me, too.

#### Screenshots (if appropriate)

**Before:**

https://user-images.githubusercontent.com/9010790/233194711-8164b67c-3c5c-4c5d-9e48-f15d107dec12.mov

**After:**

https://user-images.githubusercontent.com/9010790/233195018-ec229340-95ae-4e45-9941-705910612cb1.mov

