### PR TITLE
Draft - Upgrade ES version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,8 +29,8 @@ djangorestframework==3.11.2
 djangorestframework-jwt==1.11.0
 drf-extensions==0.5.0
 djoser==2.0.3
-elasticsearch-dsl==6.1.0
-elasticsearch==6.3.0
+elasticsearch-dsl>=6.0.0,<7.0.0
+elasticsearch==6.8.2
 factory_boy
 faker
 feedparser>=6.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,7 +173,7 @@ drf-extensions==0.5.0
     # via -r requirements.in
 drf-spectacular==0.26.1
     # via -r requirements.in
-elasticsearch==6.3.0
+elasticsearch==6.8.2
     # via
     #   -r requirements.in
     #   django-server-status


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
updates https://github.com/mitodl/open-discussions/issues/3494

#### What's this PR do?
This PR upgrades our ElasticSearch version from a lower 6.X version to 6.8 which is the first step in the recommended migration path, to ensure our indices and code behave moving over to 7.1 and OpenSearch.

#### How should this be manually tested?
Pull branch, build docker, launch and test that you can use /search/learn, tests pass, and things work as expected (Indexes exist)

#### Where should the reviewer start?
Build the image. Make sure it's usable.

#### Any background context you want to provide?
This branch is the first branch and will serve as the main branch for the OS PRs to merge into - for now it's showing that we can upgrade our 6.X to 6.8 

Since the "preferred" upgrade path in all of the documentation for the service is to 6.8, then 7.1 and then OpenSearch, I've modified the plan (as briefly noted on the issue) to follow a similar plan of incremental changes for the client.  While we may not take that approach in our own service upgrade, I am working off this branch going forward to allow for a lower level look at the changes to find the pain points in smaller PRs.  Once all of the changes have been vetted, we will have this branch to move forward from.