### PR TITLE
Do not display "English" as default language on resources

### DIFF
--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.test.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.test.tsx
@@ -134,15 +134,33 @@ describe("ExpandedLearningResourceDisplay", () => {
   it.each([
     { languageCode: "en-us", language: "English" },
     { languageCode: "fr", language: "French" },
-    { languageCode: "zh-CN", language: "Chinese" },
-    { languageCode: null, language: "English" },
-    { languageCode: "", language: "English" }
-  ])("should render the course language", ({ languageCode, language }) => {
-    const run = makeRun({ language: languageCode })
-    const resource = makeCourse({ runs: [run] })
-    renderLearningResourceDetails({ resource })
-    screen.getByText(language)
-  })
+    { languageCode: "zh-CN", language: "Chinese" }
+  ])(
+    "should render Language: <LanguageName> if course language is specified",
+    ({ languageCode, language }) => {
+      const run = makeRun({ language: languageCode })
+      const resource = makeCourse({ runs: [run] })
+      renderLearningResourceDetails({ resource })
+      const dd = getByTerm(document.body, "Language:")
+      expect(dd.textContent).toBe(language)
+    }
+  )
+
+  it.each([
+    { languageCode: "en", shouldRender: true },
+    { languageCode: null, shouldRender: false },
+    { languageCode: "", shouldRender: false }
+  ])(
+    "Renders language info if and only if specified",
+    ({ languageCode, shouldRender }) => {
+      const run = makeRun({ language: languageCode })
+      const resource = makeCourse({ runs: [run] })
+      renderLearningResourceDetails({ resource })
+      expect(queryByTerm(document.body, "Language:") !== null).toBe(
+        shouldRender
+      )
+    }
+  )
 
   it("formats and renders the cost", () => {
     const run = makeRun({ prices: [{ price: 25.5, mode: "" }] })

--- a/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
+++ b/frontends/ol-search-ui/src/components/ExpandedLearningResourceDisplay.tsx
@@ -217,8 +217,8 @@ const getInfoRows = (
     },
     {
       label:   "Language",
-      include: true,
-      value:   languageName(run?.language ?? "en")
+      include: !!languageName(run?.language),
+      value:   languageName(run?.language)
     }
   ]
 

--- a/frontends/ol-search-ui/src/util.test.ts
+++ b/frontends/ol-search-ui/src/util.test.ts
@@ -1,0 +1,34 @@
+import { languageName } from "./util"
+
+describe("languageName", () => {
+  it("Returns english name for 2-digit ISO-639-1 code", () => {
+    expect(languageName("en")).toBe("English")
+    expect(languageName("fi")).toBe("Finnish")
+    expect(languageName("zh")).toBe("Chinese")
+  })
+
+  it("allows case-insensitive input", () => {
+    expect(languageName("EN")).toBe("English")
+    expect(languageName("eN")).toBe("English")
+    expect(languageName("En")).toBe("English")
+    expect(languageName("ZH")).toBe("Chinese")
+    expect(languageName("zH")).toBe("Chinese")
+  })
+
+  it("Ignores trailing country codes", () => {
+    expect(languageName("en-DE")).toBe("English")
+    expect(languageName("fi-US")).toBe("Finnish")
+    expect(languageName("zh-US")).toBe("Chinese")
+  })
+
+  it("Returns null if input is null or undefined", () => {
+    expect(languageName(undefined)).toBe(null)
+    expect(languageName(null)).toBe(null)
+  })
+
+  it("Returns null if input is not a 2-digit ISO-639-1 code", () => {
+    expect(languageName("zz")).toBe(null)
+    expect(languageName("")).toBe(null)
+    expect(languageName("eng")).toBe(null)
+  })
+})

--- a/frontends/ol-search-ui/src/util.tsx
+++ b/frontends/ol-search-ui/src/util.tsx
@@ -8,7 +8,7 @@ import {
 } from "./interfaces"
 import React, { useState, useEffect } from "react"
 import { capitalize, emptyOrNil } from "ol-util"
-import LocaleCode from "locale-code"
+import ISO6391 from "iso-639-1"
 import Decimal from "decimal.js-light"
 
 export const getImageSrc = (
@@ -200,10 +200,20 @@ export const getInstructorName = (instructor: CourseInstructor) => {
   return ""
 }
 
-export const languageName = (langCode: string | null): string =>
-  LocaleCode.getLanguageName(
-    `${langCode ? langCode.split("-")[0].toLowerCase() : "en"}-US`
-  )
+/**
+ * Given a 2-digit [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes),
+ * return the language name in English.
+ *
+ * If code is invalid or null, return null.
+ *
+ * Tolerates codes with a region code, e.g. "en-US".
+ */
+export const languageName = (langCode?: string | null): string | null => {
+  if (!langCode) return null
+  const code = langCode.split("-")[0].toLowerCase()
+  const name = ISO6391.getName(code)
+  return name === "" ? null : name
+}
 
 const formatPrice = (price: number | null | undefined): string => {
   if (price === null || price === undefined) {

--- a/frontends/open-discussions/src/components/ExpandedLearningResourceDisplay.js
+++ b/frontends/open-discussions/src/components/ExpandedLearningResourceDisplay.js
@@ -325,11 +325,12 @@ export default function ExpandedLearningResourceDisplay(props: Props) {
                 )
                 : null}
               {isCoursewareResource(object.object_type)
-                ? lrInfoRow(
-                  "language",
-                  "Language:",
-                  languageName(selectedRun ? selectedRun.language : "en")
-                )
+                ? languageName(selectedRun?.language) &&
+                  lrInfoRow(
+                    "language",
+                    "Language:",
+                    languageName(selectedRun?.language)
+                  )
                 : null}
               {object.object_type === LR_TYPE_VIDEO ? (
                 <React.Fragment>

--- a/frontends/open-discussions/src/components/ExpandedLearningResourceDisplay_test.js
+++ b/frontends/open-discussions/src/components/ExpandedLearningResourceDisplay_test.js
@@ -450,9 +450,7 @@ describe("ExpandedLearningResourceDisplay", () => {
   ;[
     ["en-us", "English"],
     ["fr", "French"],
-    ["zh-CN", "Chinese"],
-    [null, "English"],
-    ["", "English"]
+    ["zh-CN", "Chinese"]
   ].forEach(([langCode, langName]) => {
     it(`should display the correct language name for ${String(
       langCode
@@ -465,6 +463,17 @@ describe("ExpandedLearningResourceDisplay", () => {
         wrapper.find(".language").closest(".info-row").find(".value").text(),
         langName
       )
+    })
+  })
+  ;["not-a-language", null, ""].forEach(langCode => {
+    it(`Does not display a language for langCode=${String(
+      langCode
+    )}`, async () => {
+      // $FlowFixMe: course run won't be null here
+      bestRun(course.runs).language = langCode
+      // $FlowFixMe: course run won't be null here
+      const { wrapper } = await render({}, { runId: bestRun(course.runs).id })
+      assert.equal(wrapper.find(".language").isEmpty(), true)
     })
   })
 
@@ -657,10 +666,6 @@ describe("ExpandedLearningResourceDisplay", () => {
     const { wrapper } = await render()
     assert.isNotOk(wrapper.find(".bar_chart").at(0).exists())
     assert.isNotOk(wrapper.find(".school").at(1).exists())
-    assert.equal(
-      wrapper.find(".language").closest(".info-row").find(".value").text(),
-      "English"
-    )
   })
 
   //

--- a/frontends/open-discussions/src/lib/util.js
+++ b/frontends/open-discussions/src/lib/util.js
@@ -137,10 +137,13 @@ export const isValidUrl = (url: string): boolean =>
 export const toArray = (obj: any) =>
   Array.isArray(obj) ? obj : obj ? [obj] : undefined
 
-export const languageName = (langCode: ?string): string =>
-  LocaleCode.getLanguageName(
-    `${langCode ? langCode.split("-")[0].toLowerCase() : "en"}-US`
+export const languageName = (langCode: ?string): string | null => {
+  if (!langCode) return null
+  const lang = LocaleCode.getLanguageName(
+    `${langCode.split("-")[0].toLowerCase()}-US`
   )
+  return lang ? lang : null
+}
 
 export const flatZip = R.compose(R.flatten, R.zip)
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "eslint-plugin-testing-library": "^5.5.1",
         "exec-sh": "^0.4.0",
         "html-entities": "^2.3.3",
+        "iso-639-1": "^2.1.15",
         "jest": "^28.1.1",
         "jest-environment-jsdom": "^28.1.1",
         "jest-extended": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13709,7 +13709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iso-639-1@npm:^2.0.0":
+"iso-639-1@npm:^2.0.0, iso-639-1@npm:^2.1.15":
   version: 2.1.15
   resolution: "iso-639-1@npm:2.1.15"
   checksum: a201530819d33e9ce077b02c786d67b35be5d823be27b5aacc18d880e580e559e39ec5055f8e2abcdc210f46618a643bf3c74e6fe6e8255fe62059682750e595
@@ -16971,6 +16971,7 @@ __metadata:
     eslint-plugin-testing-library: ^5.5.1
     exec-sh: ^0.4.0
     html-entities: ^2.3.3
+    iso-639-1: ^2.1.15
     jest: ^28.1.1
     jest-environment-jsdom: ^28.1.1
     jest-extended: ^3.0.1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3957 *A course clearly in spanish displaying "English" as its language, because the course did not specify a language and "English" was our default.*

#### What's this PR do?
This PR changes our Learning Resource displays (card, drawer) to not show "English" as the default course language. If a run has no language specified, then no language row is displayed in course info section.

#### How should this be manually tested?
1. **no language specified**:  At http://od.odl.local:8063/infinite or http://od.odl.local:8063/infinite/search, click on a card title. Most resources have no language specified, so clicking any of them should be fine.
    - In network tab, check the API response for the resource details. In "runs"  property, check that no language is specified.
    - Check that no language is displayed in the learning resource drawer
2. **Language is displayed if exists on resource runs:** Only `mitx` resources have languages defined, and most of the time it's English.
    - Find some MITx courses that have language specified (see below), and check that it displays correctly in the learning resource drawer. 

To find MITx course that have a language specified, you can run `docker compose run --rm web ./manage.py shell` and then run
```python
from course_catalog.models import LearningResourceRun

languages = ["tr", "ko", "en-us", "es-es", None]
base_url = "http://cac.od.odl.local:8063/infinite"
for lang in languages:
    try:
        filter_kwrags = {
            "language": lang,
        } if lang is not None else { "language__isnull": True }
        course = next(
            run for run in
            LearningResourceRun.objects.filter(platform='mitx', **filter_kwrags, published=True)
            if getattr(run.content_object, "published")
        ).content_object
        print(f"{lang} course:")
        print(f"{base_url}?resource_id={course.id}&resource_type=course")
    except StopIteration:
        print(f"Could not find a published course with language {lang}")
        continue
```

Which should print you the URL of some resources with non-null langauges.

#### Screenshots (if appropriate)

<img width="400" alt="Screenshot 2023-04-25 at 4 38 31 PM" src="https://user-images.githubusercontent.com/9010790/234398500-ee901331-a173-4cf2-84a3-864dbc264450.png">
<img width="400" alt="Screenshot 2023-04-25 at 4 38 19 PM" src="https://user-images.githubusercontent.com/9010790/234398494-c8f42dec-cf65-46d2-becc-d9c0e82cd6a7.png">
