### PR TITLE
Upgrade Elasticsearch to 6.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "6379"
 
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2
     environment:
       - network.host=0.0.0.0
       - http.cors.enabled=true

--- a/requirements.in
+++ b/requirements.in
@@ -29,8 +29,8 @@ djangorestframework==3.11.2
 djangorestframework-jwt==1.11.0
 drf-extensions==0.5.0
 djoser==2.0.3
-elasticsearch-dsl==6.1.0
-elasticsearch==6.3.0
+elasticsearch-dsl>=6.0.0,<7.0.0
+elasticsearch==6.8.2
 factory_boy
 faker
 feedparser>=6.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,7 +173,7 @@ drf-extensions==0.5.0
     # via -r requirements.in
 drf-spectacular==0.26.1
     # via -r requirements.in
-elasticsearch==6.3.0
+elasticsearch==6.8.2
     # via
     #   -r requirements.in
     #   django-server-status


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Updates https://github.com/mitodl/open-discussions/issues/3494

#### What's this PR do?
This PR upgrades our local client and service to 6.8.2 in preparation for the upgrade to ES 7.

#### How should this be manually tested?
Run test suite and go through to use the course catalog and post endpoints to search using postman or tool of your choice. 
Rerun indices using the management commands (I would backpopulate data & files and then recreate indices for at least one of our sets of data). 
Make sure `/learn/search` and post pages (when posts exist) work.

#### Background info
Prod service is already 6.8
