### PR TITLE
improve setMockResponse manual response resolution

### DIFF
--- a/frontends/infinite-corridor/src/example-request-mocks.test.ts
+++ b/frontends/infinite-corridor/src/example-request-mocks.test.ts
@@ -55,9 +55,11 @@ describe("request mocking", () => {
 
   test("Error codes reject", async () => {
     setMockResponse.post("/some-example", "Bad request", { code: 400 })
-    await expect(axios.post("/some-example", { a: 5 })).rejects.toEqual({
-      response: { data: "Bad request", status: 400 }
-    })
+    await expect(axios.post("/some-example", { a: 5 })).rejects.toEqual(
+      expect.objectContaining({
+        response: { data: "Bad request", status: 400 }
+      })
+    )
   })
 
   test("Errors if mock value is not set.", async () => {
@@ -73,5 +75,32 @@ describe("request mocking", () => {
     expect(consoleError).toHaveBeenCalledWith(
       "No response specified for post /some-example"
     )
+  })
+
+  test("Manually resolving a response", async () => {
+    let resolve: (value: number) => void = () => {
+      throw new Error("Not yet assigned")
+    }
+    const responseBody = new Promise(resolver => {
+      resolve = resolver
+    })
+
+    setMockResponse.get("/respond-when-i-say", responseBody)
+    const response = axios.get("/respond-when-i-say")
+    let responseStatus = "pending"
+    response.then(() => {
+      responseStatus = "resolved"
+    })
+
+    await Promise.resolve() // flush the event queue
+    expect(responseStatus).toBe("pending") // response is still pending
+    resolve(37)
+    expect(await response).toEqual(
+      expect.objectContaining({
+        data:   37,
+        status: 200
+      })
+    )
+    expect(responseStatus).toBe("resolved")
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
None directly; this PR fixes a test that broke when I started work on #3981 

#### What's this PR do?
This PR fixes how `setMockResponse` works with promises.

#### How should this be manually tested?
CI tests should pass.

#### Any background context you want to provide?
We often make mock API requests in our UI tests. We occasionally make assertions about the UI while the request is pending— the time between request & response. One such test is:

https://github.com/mitodl/open-discussions/blob/84e5ba5ed9af4552014a38de39e7670ff6ebab83/frontends/infinite-corridor/src/pages/user-lists/ItemsListing.test.tsx#L161

In these scenarios, we need to be able to set a mock response **and** control when the response resolves. 

While working on #3981, the aforementioned test broke. The reason turned out to be that in "manual resolution" scenarios, `setMockResponse` was responding too early. I do not entirely understand why the test is currently passing on master...