### PR TITLE
Delete orphaned indices after a failed reindex

### DIFF
--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -748,6 +748,25 @@ def switch_indices(backing_index, object_type):
     )
 
 
+def delete_orphaned_indices():
+    """
+    Delete any indices without aliases and any reindexing aliases
+    """
+    conn = get_conn()
+    indices = conn.indices.get_alias(index="*")
+    for index in indices:
+        aliases = indices[index]["aliases"]
+        keys = [alias for alias in aliases]
+        for alias in aliases:
+            if "reindexing" in alias:
+                log.info(f"Deleting alias {alias} for index {index}")
+                conn.indices.delete_alias(name=alias, index=index)
+                keys.remove(alias)
+        if not keys:
+            log.info(f"Deleting index {index}")
+            conn.indices.delete(index)
+
+
 def es_iterate_all_documents(index, query, pagesize=250):
     """
     Helper to iterate all values from an index

--- a/search/indexing_api.py
+++ b/search/indexing_api.py
@@ -759,11 +759,11 @@ def delete_orphaned_indices():
         keys = [alias for alias in aliases]
         for alias in aliases:
             if "reindexing" in alias:
-                log.info(f"Deleting alias {alias} for index {index}")
+                log.info("Deleting alias %s for index %s", alias, index)
                 conn.indices.delete_alias(name=alias, index=index)
                 keys.remove(alias)
         if not keys:
-            log.info(f"Deleting index {index}")
+            log.info("Deleting index %s", index)
             conn.indices.delete(index)
 
 

--- a/search/tasks.py
+++ b/search/tasks.py
@@ -46,7 +46,6 @@ from search.constants import (
     VIDEO_TYPE,
 )
 from search.exceptions import ReindexException, RetryException
-from search.indexing_api import delete_orphaned_indices
 from search.serializers import (
     OSContentFileSerializer,
     OSCourseSerializer,
@@ -1288,7 +1287,7 @@ def finish_recreate_index(results, backing_indices):
     errors = merge_strings(results)
     if errors:
         try:
-            delete_orphaned_indices()
+            api.delete_orphaned_indices()
         except RequestError as ex:
             raise RetryException(str(ex))
         raise ReindexException(f"Errors occurred during recreate_index: {errors}")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #3978 

#### What's this PR do?
- Retries switching indices if any request errors occur while doing so (typically because the indices are being snapshotted)
- Deleted orphaned indices & aliases if the reindex fails

#### How should this be manually tested?
- On the master branch, modify `search.tasks.index_programs` to always raise an exception:
```python
    try:
        raise Exception("oops")
    except (RetryException, Ignore):
        ...same as before
    except:
        ...same as before
```

- Run `manage.py recreate_index --programs` 4 or 5 times.  It should fail each time.
- In a shell, run the following, there should be multiple indices for `program` returned, one with a reindexing alias.
```python
from search.indexing_api import *
get_conn().indices.get_alias(index="*")
```
- Switch to this branch and redo all the above (but you only have to run `recreate_index --programs` once).  This time there should only be one index for `program`, and it should have two aliases:
```
 'discussions_local_program_<uuid>': {'aliases': {'discussions_local_all_default': {},
   'discussions_local_program_default': {}}},
```   
