### PR TITLE
fix resource type facet

### DIFF
--- a/frontends/infinite-corridor/package.json
+++ b/frontends/infinite-corridor/package.json
@@ -13,7 +13,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@faker-js/faker": "^7.3.0",
-    "@mitodl/course-search-utils": "2.1.0",
+    "@mitodl/course-search-utils": "^2.2.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.91",
     "@mui/material": "^5.9.0",

--- a/frontends/infinite-corridor/src/api/learning-resources/search.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/search.ts
@@ -43,7 +43,8 @@ const useInfiniteSearch = (params: InfiniteSearchOptions) => {
   const normalized: SearchQueryParams = allowedTypes ?
     {
       ...params,
-      activeFacets: restrictFacetTypes(allowedTypes, params.activeFacets)
+      activeFacets:  restrictFacetTypes(allowedTypes, params.activeFacets),
+      resourceTypes: allowedTypes
     } :
     params
   return useInfiniteQuery<SearchResponse>({

--- a/frontends/ol-search-ui/package.json
+++ b/frontends/ol-search-ui/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@faker-js/faker": "^7.3.0",
-    "@mitodl/course-search-utils": "2.1.0",
+    "@mitodl/course-search-utils": "^2.2.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.0",
     "lodash": "^4.17.21",

--- a/frontends/open-discussions/package.json
+++ b/frontends/open-discussions/package.json
@@ -29,7 +29,7 @@
     "@material/snackbar": "0.44.0",
     "@material/toolbar": "0.4.4",
     "@mitodl/ckeditor-custom-build": "0.0.4",
-    "@mitodl/course-search-utils": "2.1.0",
+    "@mitodl/course-search-utils": "^2.2.0",
     "@mitodl/mdl-react-components": "0.0.3",
     "@reduxjs/toolkit": "1.4.0",
     "@sentry/browser": "5.5.0",

--- a/frontends/open-discussions/src/lib/api/api.js
+++ b/frontends/open-discussions/src/lib/api/api.js
@@ -23,6 +23,7 @@ import type {
 } from "../../flow/discussionTypes"
 import type { NotificationSetting } from "../../flow/settingsTypes"
 import type { SearchParams } from "../../flow/searchTypes"
+
 import _ from "lodash"
 
 export function search(params: SearchParams): Promise<*> {
@@ -31,15 +32,13 @@ export function search(params: SearchParams): Promise<*> {
     "from",
     "size",
     "sort",
-    "channelName"
+    "channelName",
+    "resourceTypes"
   ])
 
   if (params["facets"]) {
-    searchParams["activeFacets"] = {
-      // $FlowFixMe
-      ...Object.fromEntries(params["facets"]),
-      type: params["type"]
-    }
+    // $FlowFixMe
+    searchParams["activeFacets"] = Object.fromEntries(params["facets"])
   }
 
   const body = buildSearchQuery(searchParams)

--- a/frontends/open-discussions/src/lib/api/api_test.js
+++ b/frontends/open-discussions/src/lib/api/api_test.js
@@ -297,8 +297,10 @@ describe("api", function() {
           .returns(body)
         const params = {
           text:   "text",
-          type:   "course",
-          facets: new Map([["offered_by", "OCW"]])
+          facets: new Map([
+            ["offered_by", "OCW"],
+            ["type", "course"]
+          ])
         }
         const standardizedParams = {
           text:         "text",

--- a/frontends/open-discussions/src/pages/CourseSearchPage.js
+++ b/frontends/open-discussions/src/pages/CourseSearchPage.js
@@ -36,6 +36,7 @@ import { useResponsive, useWidth } from "../hooks/util"
 import type { SortParam, LearningResourceResult } from "../flow/searchTypes"
 import type { Match } from "react-router"
 import type { CellWidth } from "../components/Grid"
+import { LR_TYPE_ALL } from "../lib/constants"
 
 export type CourseSearchParams = {
   type?: ?string | ?Array<string>,
@@ -152,12 +153,12 @@ export default function CourseSearchPage(props: Props) {
     async (text, searchFacets, from) => {
       await dispatch(
         actions.search.post({
-          channelName: null,
+          channelName:   null,
           text,
-          type:        searchFacets.type,
-          facets:      new Map(Object.entries(searchFacets)),
+          facets:        new Map(Object.entries(searchFacets)),
           from,
-          size:        SETTINGS.search_page_size
+          size:          SETTINGS.search_page_size,
+          resourceTypes: LR_TYPE_ALL
         })
       )
     },

--- a/frontends/open-discussions/src/pages/CourseSearchPage_test.js
+++ b/frontends/open-discussions/src/pages/CourseSearchPage_test.js
@@ -176,12 +176,12 @@ describe("CourseSearchPage", () => {
     wrapper.update()
     await wrapper.find("InfiniteScroll").prop("loadMore")()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: null,
-      from:        SETTINGS.search_page_size,
-      size:        SETTINGS.search_page_size,
-      text:        "",
-      type:        LR_TYPE_ALL,
-      facets:      new Map(
+      channelName:   null,
+      from:          SETTINGS.search_page_size,
+      size:          SETTINGS.search_page_size,
+      text:          "",
+      resourceTypes: LR_TYPE_ALL,
+      facets:        new Map(
         Object.entries({
           audience:            [],
           certification:       [],
@@ -212,12 +212,12 @@ describe("CourseSearchPage", () => {
 
     await render()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: null,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        LR_TYPE_ALL,
-      facets:      new Map(
+      channelName:   null,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: LR_TYPE_ALL,
+      facets:        new Map(
         Object.entries({
           audience:            [],
           certification:       [],
@@ -248,12 +248,12 @@ describe("CourseSearchPage", () => {
 
     await render()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: null,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        ["podcast", "podcastepisode"],
-      facets:      new Map(
+      channelName:   null,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: LR_TYPE_ALL,
+      facets:        new Map(
         Object.entries({
           audience:            [],
           certification:       [],
@@ -285,12 +285,12 @@ describe("CourseSearchPage", () => {
     SETTINGS.search_page_size = 5
     await render()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: null,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        ["userlist", "learningpath"],
-      facets:      new Map(
+      channelName:   null,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: LR_TYPE_ALL,
+      facets:        new Map(
         Object.entries({
           audience:            [],
           certification:       [],

--- a/frontends/open-discussions/src/pages/SearchPage.js
+++ b/frontends/open-discussions/src/pages/SearchPage.js
@@ -149,10 +149,17 @@ export class SearchPage extends React.Component<Props, State> {
       from = 0
     }
     this.setState({ from, error })
+
+    let resourceTypes = undefined
+
+    if (!R.isNil(type)) {
+      resourceTypes = [type]
+    }
+
     await runSearch({
       channelName,
       text,
-      type,
+      resourceTypes,
       from,
       size: SETTINGS.search_page_size
     })

--- a/frontends/open-discussions/src/pages/SearchPage_test.js
+++ b/frontends/open-discussions/src/pages/SearchPage_test.js
@@ -79,11 +79,11 @@ describe("SearchPage", () => {
     const { inner } = await renderPage()
 
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: channel.name,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        undefined
+      channelName:   channel.name,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: undefined
     })
     assert.deepEqual(
       inner.props().upvotedPosts.get(upvotedPost.id),
@@ -129,11 +129,11 @@ describe("SearchPage", () => {
     helper.searchStub.reset()
     await inner.find("InfiniteScroll").prop("loadMore")()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: channel.name,
-      from:        SETTINGS.search_page_size,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        undefined
+      channelName:   channel.name,
+      from:          SETTINGS.search_page_size,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: undefined
     })
     // from is 5, plus 5 is 10 which is == numHits so no more results
     wrapper.update()
@@ -263,22 +263,22 @@ describe("SearchPage", () => {
       }
     )
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: channel.name,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type
+      channelName:   channel.name,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: ["post"]
     })
   })
 
   it("has a default value for type, which is undefined", async () => {
     await renderPage()
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: channel.name,
-      from:        0,
-      size:        SETTINGS.search_page_size,
-      text:        "text",
-      type:        undefined
+      channelName:   channel.name,
+      from:          0,
+      size:          SETTINGS.search_page_size,
+      text:          "text",
+      resourceTypes: undefined
     })
   })
 
@@ -292,11 +292,11 @@ describe("SearchPage", () => {
       preventDefault: helper.sandbox.stub()
     })
     sinon.assert.calledWith(helper.searchStub, {
-      channelName: channel.name,
-      from:        0,
-      size:        SETTINGS.search_page_size,
+      channelName:   channel.name,
+      from:          0,
+      size:          SETTINGS.search_page_size,
       text,
-      type
+      resourceTypes: ["comment"]
     })
     assert.deepEqual(qs.parse(helper.currentLocation.search), { type, q: text })
     assert.deepEqual(inner.state(), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3944,9 +3944,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@mitodl/course-search-utils@npm:2.1.0"
+"@mitodl/course-search-utils@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mitodl/course-search-utils@npm:2.2.0"
   dependencies:
     bodybuilder: ^2.5.0
     history: ^4.9 || ^5.0.0
@@ -3954,7 +3954,7 @@ __metadata:
     ramda: ^0.27.1
   peerDependencies:
     react: ^16.13.1
-  checksum: ae553d7a6de03ce09aee7c99d7df6cb2bbb3853252a729f711aea785e2e48d9952a771fc7266e39c35d1d3ae9f836104259a8ef73e3620cddba2105d6f2bc7a4
+  checksum: aca74555fb31110cf6650e8130296c65d3b3e3a3ae031f744113682f704f232daf5ab666ffc067ad1a46c04a040651bdf415f99bef59e570b1cb18675e18154a
   languageName: node
   linkType: hard
 
@@ -12964,7 +12964,7 @@ __metadata:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
     "@faker-js/faker": ^7.3.0
-    "@mitodl/course-search-utils": 2.1.0
+    "@mitodl/course-search-utils": ^2.2.0
     "@mui/icons-material": ^5.8.4
     "@mui/lab": ^5.0.0-alpha.91
     "@mui/material": ^5.9.0
@@ -16833,7 +16833,7 @@ __metadata:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
     "@faker-js/faker": ^7.3.0
-    "@mitodl/course-search-utils": 2.1.0
+    "@mitodl/course-search-utils": ^2.2.0
     "@mui/icons-material": ^5.8.4
     "@mui/material": ^5.9.0
     lodash: ^4.17.21
@@ -17034,7 +17034,7 @@ __metadata:
     "@material/snackbar": 0.44.0
     "@material/toolbar": 0.4.4
     "@mitodl/ckeditor-custom-build": 0.0.4
-    "@mitodl/course-search-utils": 2.1.0
+    "@mitodl/course-search-utils": ^2.2.0
     "@mitodl/mdl-react-components": 0.0.3
     "@reduxjs/toolkit": 1.4.0
     "@sentry/browser": 5.5.0


### PR DESCRIPTION
This should be tested with https://github.com/mitodl/course-search-utils/pull/52

Once that PR is merges I will update this pr to point to course-search-utils on npm and not the branch

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3964

#### What's this PR do?
This pr updates course-search-utils so that both the selected types and the types that should be shown in the aggregation are passed to buildSearchQuery 

#### How should this be manually tested?
Run https://github.com/mitodl/open-discussions/pull/3987/files#diff-b95387fcdedc9cb7b3c27edce0e5e71aeecf6b46f42278b7e4c61f05c313796b verify that the resource type facet on both learn search and infinites search now work the same as other facets and you can select more than one resource type

Verify that open discussions channel search still works. The dropdown to select "profile" "comment" or "post" is broken on prod but should also work in that branch.

Point ocw_hugo_themes to open running this branch and run ocw search locally. Verify that it is also unaffected
