### PR TITLE
Ab/fix aggregations

### DIFF
--- a/frontends/infinite-corridor/package.json
+++ b/frontends/infinite-corridor/package.json
@@ -13,7 +13,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@faker-js/faker": "^7.3.0",
-    "@mitodl/course-search-utils": "^2.2.0",
+    "@mitodl/course-search-utils": "^2.3.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.91",
     "@mui/material": "^5.9.0",

--- a/frontends/infinite-corridor/src/api/learning-resources/search.ts
+++ b/frontends/infinite-corridor/src/api/learning-resources/search.ts
@@ -36,6 +36,7 @@ const restrictFacetTypes = (allowedTypes: string[], facets?: Facets) => {
 
 type InfiniteSearchOptions = Omit<SearchQueryParams, "from"> & {
   allowedTypes?: string[]
+  aggregations?: string[]
 }
 
 const useInfiniteSearch = (params: InfiniteSearchOptions) => {

--- a/frontends/infinite-corridor/src/pages/SearchPage.test.tsx
+++ b/frontends/infinite-corridor/src/pages/SearchPage.test.tsx
@@ -102,7 +102,8 @@ describe("SearchPage", () => {
         text:         "",
         from:         0,
         activeFacets: expectedFacets,
-        size:         4
+        size:         4,
+        aggregations: ["certification", "type", "offered_by"]
       })
     )
 
@@ -113,7 +114,8 @@ describe("SearchPage", () => {
         text:         "",
         from:         4,
         activeFacets: expectedFacets,
-        size:         4
+        size:         4,
+        aggregations: ["certification", "type", "offered_by"]
       })
     )
   })
@@ -149,7 +151,8 @@ describe("SearchPage", () => {
       {
         from:         0,
         size:         4,
-        activeFacets: expectedFacets
+        activeFacets: expectedFacets,
+        aggregations: ["certification", "type", "offered_by"]
       },
       1
     )
@@ -167,7 +170,8 @@ describe("SearchPage", () => {
         activeFacets: {
           ...expectedFacets,
           offered_by: ["MITx"]
-        }
+        },
+        aggregations: ["certification", "type", "offered_by"]
       },
       2
     )
@@ -184,7 +188,8 @@ describe("SearchPage", () => {
         activeFacets: {
           ...expectedFacets,
           offered_by: ["MITx"]
-        }
+        },
+        aggregations: ["certification", "type", "offered_by"]
       },
       1
     )
@@ -208,7 +213,8 @@ describe("SearchPage", () => {
         size:         4,
         activeFacets: {
           ...expectedFacets
-        }
+        },
+        aggregations: ["certification", "type", "offered_by"]
       },
       2
     )
@@ -230,7 +236,8 @@ describe("SearchPage", () => {
         text:         "",
         from:         0,
         activeFacets: expectedFacets,
-        size:         4
+        size:         4,
+        aggregations: ["certification", "type", "offered_by"]
       })
     )
 
@@ -241,7 +248,8 @@ describe("SearchPage", () => {
         text:         "New Search Text",
         from:         0,
         activeFacets: expectedFacets,
-        size:         4
+        size:         4,
+        aggregations: ["certification", "type", "offered_by"]
       })
     )
   })

--- a/frontends/infinite-corridor/src/pages/SearchPage.tsx
+++ b/frontends/infinite-corridor/src/pages/SearchPage.tsx
@@ -24,6 +24,8 @@ const facetMap: FacetManifest = [
   ["offered_by", "Offered By"]
 ]
 
+const searchAggregationKeys = ["certification", "type", "offered_by"]
+
 const SearchPage: React.FC = () => {
   const isMd = useMuiBreakpoint("md")
 
@@ -34,7 +36,8 @@ const SearchPage: React.FC = () => {
     text,
     activeFacets,
     size:         pageSize,
-    allowedTypes: ALLOWED_TYPES
+    allowedTypes: ALLOWED_TYPES,
+    aggregations: searchAggregationKeys
   })
   useSyncUrlAndSearch(history, search)
 

--- a/frontends/ol-search-ui/package.json
+++ b/frontends/ol-search-ui/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@faker-js/faker": "^7.3.0",
-    "@mitodl/course-search-utils": "^2.2.0",
+    "@mitodl/course-search-utils": "^2.3.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.0",
     "lodash": "^4.17.21",

--- a/frontends/open-discussions/package.json
+++ b/frontends/open-discussions/package.json
@@ -29,7 +29,7 @@
     "@material/snackbar": "0.44.0",
     "@material/toolbar": "0.4.4",
     "@mitodl/ckeditor-custom-build": "0.0.4",
-    "@mitodl/course-search-utils": "^2.2.0",
+    "@mitodl/course-search-utils": "^2.3.0",
     "@mitodl/mdl-react-components": "0.0.3",
     "@reduxjs/toolkit": "1.4.0",
     "@sentry/browser": "5.5.0",

--- a/frontends/open-discussions/src/lib/api/api.js
+++ b/frontends/open-discussions/src/lib/api/api.js
@@ -33,7 +33,8 @@ export function search(params: SearchParams): Promise<*> {
     "size",
     "sort",
     "channelName",
-    "resourceTypes"
+    "resourceTypes",
+    "aggregations"
   ])
 
   if (params["facets"]) {

--- a/frontends/open-discussions/src/pages/CourseSearchPage.js
+++ b/frontends/open-discussions/src/pages/CourseSearchPage.js
@@ -37,6 +37,13 @@ import type { SortParam, LearningResourceResult } from "../flow/searchTypes"
 import type { Match } from "react-router"
 import type { CellWidth } from "../components/Grid"
 import { LR_TYPE_ALL } from "../lib/constants"
+const aggregations = [
+  "audience",
+  "certification",
+  "type",
+  "topics",
+  "offered_by"
+]
 
 export type CourseSearchParams = {
   type?: ?string | ?Array<string>,
@@ -158,7 +165,8 @@ export default function CourseSearchPage(props: Props) {
           facets:        new Map(Object.entries(searchFacets)),
           from,
           size:          SETTINGS.search_page_size,
-          resourceTypes: LR_TYPE_ALL
+          resourceTypes: LR_TYPE_ALL,
+          aggregations
         })
       )
     },

--- a/frontends/open-discussions/src/pages/CourseSearchPage_test.js
+++ b/frontends/open-discussions/src/pages/CourseSearchPage_test.js
@@ -193,7 +193,14 @@ describe("CourseSearchPage", () => {
           course_feature_tags: [],
           resource_type:       []
         })
-      )
+      ),
+      aggregations: [
+        "audience",
+        "certification",
+        "type",
+        "topics",
+        "offered_by"
+      ]
     })
     wrapper.update()
     // from is 5, plus 5 is 10 which is == numHits so no more results
@@ -229,7 +236,14 @@ describe("CourseSearchPage", () => {
           course_feature_tags: [],
           resource_type:       []
         })
-      )
+      ),
+      aggregations: [
+        "audience",
+        "certification",
+        "type",
+        "topics",
+        "offered_by"
+      ]
     })
   })
 
@@ -265,7 +279,14 @@ describe("CourseSearchPage", () => {
           course_feature_tags: [],
           resource_type:       []
         })
-      )
+      ),
+      aggregations: [
+        "audience",
+        "certification",
+        "type",
+        "topics",
+        "offered_by"
+      ]
     })
   })
 
@@ -302,7 +323,14 @@ describe("CourseSearchPage", () => {
           course_feature_tags: [],
           resource_type:       []
         })
-      )
+      ),
+      aggregations: [
+        "audience",
+        "certification",
+        "type",
+        "topics",
+        "offered_by"
+      ]
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3944,9 +3944,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@mitodl/course-search-utils@npm:2.2.0"
+"@mitodl/course-search-utils@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@mitodl/course-search-utils@npm:2.3.0"
   dependencies:
     bodybuilder: ^2.5.0
     history: ^4.9 || ^5.0.0
@@ -3954,7 +3954,7 @@ __metadata:
     ramda: ^0.27.1
   peerDependencies:
     react: ^16.13.1
-  checksum: aca74555fb31110cf6650e8130296c65d3b3e3a3ae031f744113682f704f232daf5ab666ffc067ad1a46c04a040651bdf415f99bef59e570b1cb18675e18154a
+  checksum: 9a4ec0c8cf27dfc10b83c131d0debb2e95a4f9ab8b179c19a0d5759f3777640336252ed692087fba0814331cf85f58334f2fa39562ff608cd76643aed4de4dc3
   languageName: node
   linkType: hard
 
@@ -12974,7 +12974,7 @@ __metadata:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
     "@faker-js/faker": ^7.3.0
-    "@mitodl/course-search-utils": ^2.2.0
+    "@mitodl/course-search-utils": ^2.3.0
     "@mui/icons-material": ^5.8.4
     "@mui/lab": ^5.0.0-alpha.91
     "@mui/material": ^5.9.0
@@ -16803,7 +16803,7 @@ __metadata:
     "@emotion/react": ^11.9.3
     "@emotion/styled": ^11.9.3
     "@faker-js/faker": ^7.3.0
-    "@mitodl/course-search-utils": ^2.2.0
+    "@mitodl/course-search-utils": ^2.3.0
     "@mui/icons-material": ^5.8.4
     "@mui/material": ^5.9.0
     lodash: ^4.17.21
@@ -17004,7 +17004,7 @@ __metadata:
     "@material/snackbar": 0.44.0
     "@material/toolbar": 0.4.4
     "@mitodl/ckeditor-custom-build": 0.0.4
-    "@mitodl/course-search-utils": ^2.2.0
+    "@mitodl/course-search-utils": ^2.3.0
     "@mitodl/mdl-react-components": 0.0.3
     "@reduxjs/toolkit": 1.4.0
     "@sentry/browser": 5.5.0


### PR DESCRIPTION
#### What are the relevant tickets?
closes https://github.com/mitodl/course-search-utils/issues/53

#### What's this PR do?
This pr updates the query generation code to no longer perform all aggregations for all queries. Instead each UI should pass a list of aggregations that need to be performed to properly display the facets and resource counts by facet.

This  currently points to the version of course-search-utils from https://github.com/mitodl/course-search-utils/pull/55/.  I will update the code to point to npm once that pr is released.

#### How should this be manually tested?
Test with https://github.com/mitodl/course-search-utils/pull/55
and https://github.com/mitodl/ocw-hugo-themes/pull/1154

Run the code in this branch. Verify that the search ui at  /search, /learn/search, /infinite/search and /infinite/demo all work normally
