### PR TITLE
Move the transformation inside _transform_search_results_suggest

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -371,6 +371,7 @@ def _transform_search_results_suggest(search_result):
     """
 
     es_suggest = search_result.pop("suggest", {})
+    search_result["hits"]["total"] = _transform_search_result_total_es7(search_result)
     if (
         search_result.get("hits", {}).get("total", 0)
         <= settings.ELASTICSEARCH_MAX_SUGGEST_HITS
@@ -499,7 +500,6 @@ def transform_results(search_result, user, department_filters):
                     user, object_type, object_id
                 )
 
-    search_result["hits"]["total"] = _transform_search_result_total_es7(search_result)
     search_result = _transform_search_results_suggest(search_result)
 
     if len(department_filters) > 0:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #3999 

#### What's this PR do?
This PR moves the transformation for es6/7 compatibility inside the `_transform_search_results_suggest` function.  The only place it was called prior was right before it and the conditional that breaks is inside that function.

#### How should this be manually tested?
Check `http://od.odl.local:8063/learn/search` or a `post` to the endpoint.
