### PR TITLE
dont start extra tasks for index updates

### DIFF
--- a/channels/api_test.py
+++ b/channels/api_test.py
@@ -46,7 +46,7 @@ from channels.models import (
 )
 from channels.utils import DEFAULT_LISTING_PARAMS, ListingParams
 from channels.test_utils import assert_properties_eq
-from search import task_helpers as search_task_helpers
+from search import search_index_helpers
 from open_discussions.factories import UserFactory
 from notifications.models import NotificationSettings, NOTIFICATION_TYPE_MODERATOR
 from notifications.factories import NotificationSettingsFactory
@@ -180,7 +180,7 @@ def mock_client(mock_get_client):
 @pytest.fixture()
 def mock_upsert_profile(mocker):
     """Mock of upsert_profile function"""
-    return mocker.patch("channels.api.search_task_helpers.upsert_profile")
+    return mocker.patch("channels.api.search_index_helpers.upsert_profile")
 
 
 @pytest.fixture()
@@ -214,7 +214,7 @@ def test_apply_vote(
     Tests that the functions to apply an upvote/downvote behave appropriately given
     the voting request and the current state of upvotes/downvotes for the user.
     """
-    mocker.patch("search.task_helpers.update_indexed_score")
+    mocker.patch("search.search_index_helpers.update_indexed_score")
     mock_instance = mocker.Mock(likes=likes_value)
     vote_result = vote_func(mock_instance, request_data, allow_downvote=True)
     expected_vote_success = expected_instance_vote_func is not None
@@ -237,7 +237,7 @@ def test_vote_indexing(
     """Test that an upvote/downvote calls a function to update the index"""
     post = PostFactory.create(is_text=True)
     patched_vote_indexer = mocker.patch(
-        "channels.api.search_task_helpers.update_indexed_score"
+        "channels.api.search_index_helpers.update_indexed_score"
     )
     # Test upvote
     mock_reddit_obj = Mock()
@@ -431,7 +431,7 @@ def test_update_channel_type(mock_client, channel_type, indexing_decorator):
     )
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_channel_index
+        search_index_helpers.update_channel_index
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -448,7 +448,7 @@ def test_update_channel_setting(mock_client, channel_setting, indexing_decorator
     mock_client.subreddit.return_value.mod.update.assert_called_once_with(**kwargs)
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_channel_index
+        search_index_helpers.update_channel_index
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -726,7 +726,7 @@ def test_update_post_text(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_post_text
+        search_index_helpers.update_post_text
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -750,7 +750,7 @@ def test_update_post_article(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_post_text
+        search_index_helpers.update_post_text
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -798,7 +798,7 @@ def test_approve_post(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_post_removal_status
+        search_index_helpers.update_post_removal_status
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -813,7 +813,7 @@ def test_remove_post(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_post_removal_status
+        search_index_helpers.update_post_removal_status
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -833,7 +833,7 @@ def test_create_comment_on_post(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.index_new_comment
+        search_index_helpers.index_new_comment
         in indexing_decorator.mock_persist_func.original
     )
     assert Comment.objects.filter(
@@ -858,7 +858,7 @@ def test_create_comment_on_comment(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.index_new_comment
+        search_index_helpers.index_new_comment
         in indexing_decorator.mock_persist_func.original
     )
     assert Comment.objects.filter(
@@ -913,7 +913,7 @@ def test_delete_comment(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.set_comment_to_deleted
+        search_index_helpers.set_comment_to_deleted
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -928,7 +928,7 @@ def test_update_comment(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_comment_text
+        search_index_helpers.update_comment_text
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -943,7 +943,7 @@ def test_approve_comment(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_comment_removal_status
+        search_index_helpers.update_comment_removal_status
         in indexing_decorator.mock_persist_func.original
     )
 
@@ -958,7 +958,7 @@ def test_remove_comment(mock_client, indexing_decorator):
     # This API function should be wrapped with the indexing decorator and pass in a specific indexer function
     assert indexing_decorator.mock_persist_func.call_count == 1
     assert (
-        search_task_helpers.update_comment_removal_status
+        search_index_helpers.update_comment_removal_status
         in indexing_decorator.mock_persist_func.original
     )
 

--- a/channels/conftest.py
+++ b/channels/conftest.py
@@ -5,4 +5,4 @@ import pytest
 @pytest.fixture(autouse=True)
 def mock_search_tasks(mocker):
     """Patch the helpers so they don't fire celery tasks"""
-    return mocker.patch("channels.api.search_task_helpers")
+    return mocker.patch("channels.api.search_index_helpers")

--- a/channels/tasks.py
+++ b/channels/tasks.py
@@ -39,7 +39,7 @@ from mail import api as mail_api
 from open_discussions.celery import app
 from open_discussions.utils import chunks
 from search.exceptions import PopulateUserRolesException, RetryException
-from search import task_helpers
+from search import search_index_helpers
 from notifications.tasks import notify_moderators
 
 User = get_user_model()
@@ -623,5 +623,5 @@ def retire_user(user):
         user.save()
         user.social_auth.all().delete()
         user.received_invitations.all().delete()
-        task_helpers.deindex_profile(user)
+        search_index_helpers.deindex_profile(user)
         user.content_subscriptions.all().delete()

--- a/channels/tasks_test.py
+++ b/channels/tasks_test.py
@@ -571,6 +571,7 @@ def test_update_spam(
     mock_askimet_client = mocker.patch(
         "channels.tasks.create_akismet_client"
     ).return_value
+    mocker.patch("search.search_index_helpers.deindex_profile", autospec=True)
     tasks.update_spam.delay(
         spam=spam,
         comment_ids=[comment.id],

--- a/course_catalog/api.py
+++ b/course_catalog/api.py
@@ -32,7 +32,7 @@ from course_catalog.serializers import (
     OCWSerializer,
 )
 from course_catalog.utils import get_course_url, get_s3_object_and_read, safe_load_json
-from search.task_helpers import deindex_course, upsert_course
+from search.search_index_helpers import deindex_course, upsert_course
 
 log = logging.getLogger(__name__)
 

--- a/course_catalog/etl/loaders_test.py
+++ b/course_catalog/etl/loaders_test.py
@@ -95,24 +95,24 @@ def mock_tasks(mocker):
 def mock_upsert_tasks(mocker):
     """Mock out the upsert task helpers"""
     return SimpleNamespace(
-        upsert_course=mocker.patch("search.task_helpers.upsert_course"),
-        delete_course=mocker.patch("search.task_helpers.deindex_course"),
-        upsert_program=mocker.patch("search.task_helpers.upsert_program"),
-        delete_program=mocker.patch("search.task_helpers.deindex_program"),
-        upsert_video=mocker.patch("search.task_helpers.upsert_video"),
-        delete_video=mocker.patch("search.task_helpers.deindex_video"),
-        delete_user_list=mocker.patch("search.task_helpers.deindex_user_list"),
-        upsert_user_list=mocker.patch("search.task_helpers.upsert_user_list"),
-        upsert_podcast=mocker.patch("search.task_helpers.upsert_podcast"),
+        upsert_course=mocker.patch("search.search_index_helpers.upsert_course"),
+        delete_course=mocker.patch("search.search_index_helpers.deindex_course"),
+        upsert_program=mocker.patch("search.search_index_helpers.upsert_program"),
+        delete_program=mocker.patch("search.search_index_helpers.deindex_program"),
+        upsert_video=mocker.patch("search.search_index_helpers.upsert_video"),
+        delete_video=mocker.patch("search.search_index_helpers.deindex_video"),
+        delete_user_list=mocker.patch("search.search_index_helpers.deindex_user_list"),
+        upsert_user_list=mocker.patch("search.search_index_helpers.upsert_user_list"),
+        upsert_podcast=mocker.patch("search.search_index_helpers.upsert_podcast"),
         upsert_podcast_episode=mocker.patch(
-            "search.task_helpers.upsert_podcast_episode"
+            "search.search_index_helpers.upsert_podcast_episode"
         ),
-        delete_podcast=mocker.patch("search.task_helpers.deindex_podcast"),
+        delete_podcast=mocker.patch("search.search_index_helpers.deindex_podcast"),
         delete_podcast_episode=mocker.patch(
-            "search.task_helpers.deindex_podcast_episode"
+            "search.search_index_helpers.deindex_podcast_episode"
         ),
         index_run_content_files=mocker.patch(
-            "search.task_helpers.index_run_content_files"
+            "search.search_index_helpers.index_run_content_files"
         ),
     )
 
@@ -248,7 +248,7 @@ def test_load_course(  # pylint:disable=too-many-arguments
 ):
     """Test that load_course loads the course"""
     mock_delete_files = mocker.patch(
-        "course_catalog.etl.loaders.search_task_helpers.deindex_run_content_files"
+        "course_catalog.etl.loaders.search_index_helpers.deindex_run_content_files"
     )
     course = (
         CourseFactory.create(runs=None, published=is_published)
@@ -913,11 +913,11 @@ def test_load_content_files(mocker, is_published):
         autospec=True,
     )
     mock_bulk_index = mocker.patch(
-        "course_catalog.etl.loaders.search_task_helpers.index_run_content_files",
+        "course_catalog.etl.loaders.search_index_helpers.index_run_content_files",
         autospec=True,
     )
     mock_bulk_delete = mocker.patch(
-        "course_catalog.etl.loaders.search_task_helpers.deindex_run_content_files",
+        "course_catalog.etl.loaders.search_index_helpers.deindex_run_content_files",
         autospec=True,
     )
     load_content_files(course_run, content_data)

--- a/course_catalog/etl/youtube.py
+++ b/course_catalog/etl/youtube.py
@@ -20,7 +20,7 @@ from course_catalog.etl.exceptions import (
 )
 from course_catalog.models import Video
 from open_discussions.utils import now_in_utc
-from search.task_helpers import upsert_video
+from search.search_index_helpers import upsert_video
 
 
 CONFIG_FILE_REPO = "mitodl/open-video-data"

--- a/course_catalog/management/commands/backpopulate_edx_data.py
+++ b/course_catalog/management/commands/backpopulate_edx_data.py
@@ -5,7 +5,7 @@ from course_catalog.constants import PlatformType
 from course_catalog.models import Course
 from course_catalog.tasks import get_mitx_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_micromasters_data.py
+++ b/course_catalog/management/commands/backpopulate_micromasters_data.py
@@ -5,7 +5,7 @@ from course_catalog.constants import PlatformType
 from course_catalog.models import Program
 from course_catalog.tasks import get_micromasters_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_program
+from search.search_index_helpers import deindex_program
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_mitxonline_data.py
+++ b/course_catalog/management/commands/backpopulate_mitxonline_data.py
@@ -5,7 +5,7 @@ from course_catalog.constants import PlatformType
 from course_catalog.models import Course
 from course_catalog.tasks import get_mitxonline_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_ocw_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_data.py
@@ -7,7 +7,7 @@ from course_catalog.models import Course
 from course_catalog.tasks import get_ocw_data
 from open_discussions.constants import ISOFORMAT
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_ocw_next_data.py
+++ b/course_catalog/management/commands/backpopulate_ocw_next_data.py
@@ -6,7 +6,7 @@ from course_catalog.tasks import get_ocw_next_data
 from course_catalog.constants import PlatformType
 from open_discussions.constants import ISOFORMAT
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_ocw_topics.py
+++ b/course_catalog/management/commands/backpopulate_ocw_topics.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 from course_catalog.models import Course, CourseTopic
 from course_catalog.utils import get_ocw_topics
-from search.task_helpers import upsert_course
+from search.search_index_helpers import upsert_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_oll_data.py
+++ b/course_catalog/management/commands/backpopulate_oll_data.py
@@ -5,7 +5,7 @@ from course_catalog.constants import PlatformType
 from course_catalog.models import Course
 from course_catalog.tasks import get_oll_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_prolearn_data.py
+++ b/course_catalog/management/commands/backpopulate_prolearn_data.py
@@ -5,7 +5,7 @@ from course_catalog.etl.prolearn import PROLEARN_DEPARTMENT_MAPPING
 from course_catalog.models import Course, Program
 from course_catalog.tasks import get_prolearn_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course, deindex_program
+from search.search_index_helpers import deindex_course, deindex_program
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_xpro_data.py
+++ b/course_catalog/management/commands/backpopulate_xpro_data.py
@@ -5,7 +5,7 @@ from course_catalog.constants import PlatformType
 from course_catalog.models import Course
 from course_catalog.tasks import get_xpro_data
 from open_discussions.utils import now_in_utc
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/backpopulate_youtube_data.py
+++ b/course_catalog/management/commands/backpopulate_youtube_data.py
@@ -8,7 +8,7 @@ from course_catalog.models import Video
 from course_catalog.tasks import get_youtube_data, get_youtube_transcripts
 from open_discussions.utils import now_in_utc
 from open_discussions.constants import ISOFORMAT
-from search.task_helpers import deindex_video
+from search.search_index_helpers import deindex_video
 
 
 class Command(BaseCommand):

--- a/course_catalog/management/commands/delete_courses.py
+++ b/course_catalog/management/commands/delete_courses.py
@@ -4,7 +4,7 @@ import sys
 from django.core.management import BaseCommand
 
 from course_catalog.models import Course, Video
-from search.task_helpers import deindex_course, deindex_video
+from search.search_index_helpers import deindex_course, deindex_video
 
 
 class Command(BaseCommand):

--- a/course_catalog/migrations/0035_courses_to_runs.py
+++ b/course_catalog/migrations/0035_courses_to_runs.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models, transaction
 import django.db.models.deletion
 
-from search.task_helpers import deindex_course
+from search.search_index_helpers import deindex_course
 
 
 def delete_resources(apps, schema_editor):

--- a/course_catalog/migrations/0092_remove_instructor_dupes.py
+++ b/course_catalog/migrations/0092_remove_instructor_dupes.py
@@ -2,7 +2,7 @@
 from django.db import migrations, models, transaction
 from django.db.models import Count, Q
 
-from search.task_helpers import upsert_course
+from search.search_index_helpers import upsert_course
 
 
 def remove_dupes(apps, schema_editor):

--- a/course_catalog/serializers.py
+++ b/course_catalog/serializers.py
@@ -40,7 +40,7 @@ from course_catalog.models import (
 from moira_lists.moira_api import is_public_list_editor
 from open_discussions.serializers import WriteableSerializerMethodField
 from open_discussions.settings import DRF_NESTED_PARENT_LOOKUP_PREFIX
-from search.task_helpers import (
+from search.search_index_helpers import (
     deindex_staff_list,
     deindex_user_list,
     upsert_staff_list,

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -71,7 +71,7 @@ from open_discussions.permissions import (
     is_admin_user,
 )
 from open_discussions.settings import DRF_NESTED_PARENT_LOOKUP_PREFIX
-from search.task_helpers import (
+from search.search_index_helpers import (
     deindex_course,
     deindex_staff_list,
     deindex_user_list,

--- a/docs/how-to/learning_resources.md
+++ b/docs/how-to/learning_resources.md
@@ -31,7 +31,7 @@ and in tests for that code:
    - Add a new ES serializer
    - Create functions for bulk indexing of the new type
 
-- search.task_helpers
+- search.search_index_helpers
   - Add upsert and delete functions for the type
 
 - search.tasks

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -95,7 +95,7 @@ def session_indexing_decorator():
         return dummy_decorator_inner
 
     patched_decorator = patch(
-        "search.task_helpers.reddit_object_persist", dummy_decorator
+        "search.search_index_helpers.reddit_object_persist", dummy_decorator
     )
     patched_decorator.start()
     # Reload the modules that import and use the channels API. All methods decorated with
@@ -156,7 +156,7 @@ def mocked_celery(mocker):
 @pytest.fixture
 def mock_search_tasks(mocker):
     """Patch search tasks so they no-op"""
-    return mocker.patch("search.task_helpers")
+    return mocker.patch("search.search_index_helpers")
 
 
 @pytest.fixture

--- a/fixtures/reddit.py
+++ b/fixtures/reddit.py
@@ -88,8 +88,11 @@ def contributor_api(user):
 
 
 @pytest.fixture()
-def private_channel_and_contributor(private_channel, staff_api, user):
+def private_channel_and_contributor(private_channel, staff_api, user, mocker):
     """Fixture for a channel and a user who is a contributor"""
+
+    mocker.patch("search.search_index_helpers.upsert_profile", autospec=True)
+
     staff_api.add_contributor(user.username, private_channel.name)
     staff_api.add_subscriber(user.username, private_channel.name)
     return private_channel, user

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -10,7 +10,7 @@ from profiles.models import (
     SITE_TYPE_OPTIONS,
     PERSONAL_SITE_TYPE,
 )
-from search import task_helpers as search_task_helpers
+from search import search_index_helpers
 
 
 def ensure_profile(user, profile_data=None):
@@ -45,8 +45,8 @@ def after_profile_created_or_updated(profile):
         """
         Operations that should be run after the profile create or update is committed
         """
-        search_task_helpers.upsert_profile(profile.id)
-        search_task_helpers.update_author_posts_comments(profile.id)
+        search_index_helpers.upsert_profile(profile.id)
+        search_index_helpers.update_author_posts_comments(profile.id)
 
     # this will either get called when the outermost transaction commits or otherwise immediately
     # this avoids race conditions where the async tasks may not see the record or the updated values

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -52,7 +52,7 @@ def test_after_profile_created_or_updated(mocker, user):
     # you can't test transactions in tests because the test is wrapped in the transaction
     # so we mock it to mimic/test the behavior
     mock_transaction = mocker.patch("profiles.api.transaction")
-    mock_search_tasks = mocker.patch("profiles.api.search_task_helpers")
+    mock_search_tasks = mocker.patch("profiles.api.search_index_helpers")
 
     after_profile_created_or_updated(user.profile)
 

--- a/profiles/management/commands/retire_user.py
+++ b/profiles/management/commands/retire_user.py
@@ -2,7 +2,7 @@
 from django.core.management import BaseCommand
 from django.contrib.auth import get_user_model
 
-from search import task_helpers
+from search import search_index_helpers
 
 
 User = get_user_model()
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         )
         user.received_invitations.all().delete()
 
-        task_helpers.deindex_profile(user)
+        search_index_helpers.deindex_profile(user)
 
         self.stdout.write(
             "Deleting {} post/comment subscriptions".format(


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/4004

#### What's this PR do?
We had an issue where an ocw course was deleted and it took most of a day for the change to propagate to the search index.  Also for some of that time the course was already removed from the open database so it came up in /learn/search and /infinite/search but opened to a blank drawer. Not starting separate task for reindexing will improve the speed that things are indexed

#### How should this be manually tested?
Run some of the backpopulate_ tasks in course_catalog/management/ and verify that you don't see errors and the index is updating. 

Make a new post or comment in disscussions and verify that the new post is available in the  /search page
