### PR TITLE
OpenSeach Local Service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # Set min and max JVM heap sizes to at least 50% of system RAM
       - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
@@ -60,7 +60,6 @@ services:
       - opensearch-data1:/usr/share/opensearch/data
     ports:
       - 9100:9200
-      - 9600:9600 # required for Performance Analyzer
 
   nginx:
     image: nginx:1.9.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-environment:
   OPEN_DISCUSSIONS_REDDIT_CLIENT_ID: od_client_id
   OPEN_DISCUSSIONS_REDDIT_SECRET: od_client_secret
   OPEN_DISCUSSIONS_FEATURES_DEFAULT: 'True'
-  OPENSEARCH_URL: elastic:9200
+  OPENSEARCH_URL: opensearch-node1:9200
   CELERY_TASK_ALWAYS_EAGER: 'False'
   CELERY_BROKER_URL: redis://redis:6379/4
   CELERY_RESULT_BACKEND: redis://redis:6379/4
@@ -38,16 +38,29 @@ services:
     ports:
       - "6379"
 
-  elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+  opensearch-node1:
+    image: opensearchproject/opensearch:1.0.0
+    container_name: opensearch-node1
     environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
       - network.host=0.0.0.0
       - http.cors.enabled=true
       - http.cors.allow-origin=*
       - http.max_content_length=10mb
       - rest.action.multi.allow_explicit_index=false
+      - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data
     ports:
       - 9101:9200
 
@@ -73,7 +86,7 @@ services:
       - "8061:8061"
     links:
       - db
-      - elastic
+      - opensearch-node1
       - redis
       - watch
     extra_hosts: *default-extra-hosts
@@ -116,3 +129,6 @@ services:
     entrypoint: java -jar tika-server-1.23.jar -h 0.0.0.0 -spawnChild
     ports:
       - "9998:9998"
+
+volumes:
+  opensearch-data1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,13 +39,13 @@ services:
       - "6379"
 
   opensearch-node1:
-    image: opensearchproject/opensearch:1.0.0
+    image: opensearchproject/opensearch:1.3.9
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
       - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
@@ -59,7 +59,8 @@ services:
     volumes:
       - opensearch-data1:/usr/share/opensearch/data
     ports:
-      - 9101:9200
+      - 9100:9200
+      - 9600:9600 # required for Performance Analyzer
 
   nginx:
     image: nginx:1.9.5
@@ -118,8 +119,8 @@ services:
       celery -A open_discussions.celery:app worker -Q spam,digest_emails,edx_content,default -l ${OPEN_DISCUSSIONS_LOG_LEVEL:-INFO}'
     links:
       - db
-      - redis
       - opensearch-node1
+      - redis
     extra_hosts: *default-extra-hosts
 
   tika:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,14 +44,11 @@ services:
     environment:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
-      - network.host=0.0.0.0
-      - http.cors.enabled=true
-      - http.cors.allow-origin=*
-      - http.max_content_length=10mb
-      - rest.action.multi.allow_explicit_index=false
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
-      - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
+      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
+      - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
     ulimits:
       memlock:
         soft: -1
@@ -122,6 +119,7 @@ services:
     links:
       - db
       - redis
+      - opensearch-node1
     extra_hosts: *default-extra-hosts
 
   tika:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
updates https://github.com/mitodl/open-discussions/issues/3494

#### What's this PR do?
This PR changes the local docker-compose and ci files to use OpenSearch rather than Elasticsearch to match production once Mike updates the service on prod.

#### How should this be manually tested?
Pull local, `docker compose build` - this will not be a migration or upgrade to your current container, but rather will build a new one. Once that is done, make sure you can populate and index data and files.

You CAN do a local export and import to protect your data if you would like to preserve it, but this is not necessary to test. 

#### Any background context you want to provide?
This is the last (local) step in the migration off of Elasticsearch. 
