### PR TITLE
Resolve Github Action Deprecation Warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,27 +104,14 @@ jobs:
   javascript-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up NodeJS
-        uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.15.1
+          node-version: '16.15.1'
+          cache: 'yarn'
 
       - name: Setup environment
         run: sudo apt-get install libelf1
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - 9200:9200
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: update apt
         run: sudo apt-get update -y
@@ -49,18 +49,13 @@ jobs:
       - name: Apt install
         run: cat Aptfile | sudo xargs apt-get install
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.9.13"
-
-      - id: cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/test_requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            **/test_requirements.txt
 
       - name: Install dependencies
         run: pip install -r requirements.txt -r test_requirements.txt


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4020 

#### What's this PR do?
This PR updates our github actions to resolve some [deprecation warnings](https://github.com/mitodl/open-discussions/actions/runs/5134607216) we have been getting.

#### How should this be manually tested?
- Observe that the tests are running and passing on CI, both JS and Python
- Observe that the cache is used... See the "pip install" and "yarn install" steps.

**NOTE:** The caches will only be used on the *second* run of github actions one this PR. From [About caching workflow dependencies](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#about-caching-workflow-dependencies):
> Workflow runs can restore caches created in either the current branch or the default branch (usually main)

Since the caching is different for this branch vs master, the first run of actions did not hit the cache. The second run of actions does hit the cache.

I expect that once this is part of the default branch, PRs will hit the new cache on their first run.
