### PR TITLE
fix renovate configuration typo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "matchFields": [
+      "matchFiles": [
         "frontends/open-discussions/package.json"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4050

#### What's this PR do?
This fixes a typo introduced in #4034 

#### How should this be manually tested?
Check that this branch passes with renovate validation with `npx --package renovate renovate-config-validator`:
```
# this will error:
git checkout master
git pull
npx --package renovate renovate-config-validator
# this will pass happily
git checkout cc/fix-renovate
npx --package renovate renovate-config-validator
```
