### PR TITLE
Update cffi version, hopefully heroku will like this one better?

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ betamax_serializers
 boto3==1.26.143
 cairosvg
 celery==5.3.0
+cffi==1.15.1
 cryptography>=39.0.1
 dj-database-url==0.3.0
 dj-static==0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,8 +62,9 @@ certifi==2022.12.7
     #   opensearch-py
     #   requests
     #   sentry-sdk
-cffi==1.14.4
+cffi==1.15.1
     # via
+    #   -r requirements.in
     #   cairocffi
     #   cryptography
 charset-normalizer==3.1.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
Heroku couldn't build the prior version of `cffi` for some reason (even though github actions could), so updated it to the latest version.
`ERROR: Could not build wheels for cffi, which is required to install pyproject.toml-based projects`
https://dashboard.heroku.com/pipelines/96cae5ac-a78d-4487-98b4-e15bdec04e31

#### How should this be manually tested?
Tests should pass (but they already did before this)

