### PR TITLE
re-alphabetize open-discussions/package.json

### DIFF
--- a/frontends/open-discussions/package.json
+++ b/frontends/open-discussions/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@babel/core": "7.18.5",
+    "@babel/eslint-parser": "7.11.0",
     "@babel/plugin-proposal-class-properties": "7.17.12",
     "@babel/plugin-transform-react-constant-elements": "7.17.12",
     "@babel/plugin-transform-react-inline-elements": "7.16.7",
@@ -53,7 +54,6 @@
     "array-move": "2.2.2",
     "assert": "2.0.0",
     "autoprefixer": "9.7.4",
-    "@babel/eslint-parser": "7.11.0",
     "babel-loader": "8.1.0",
     "babel-plugin-istanbul": "4.1.6",
     "blueimp-canvas-to-blob": "3.14.0",


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This PR re-alphabetizes `frontends/open-discussions/package.json`.

**Question:** Why is this necessary?
**Answer:** Currently, whenever `docker compose up` or install JS dependencies, you'll notice an edit to `frontends/open-discussions/package.json` even though you didn't touch it.

**Question:** Why did this happen?
**Answer:** Renovate quirk:

1. Whenever you `yarn install` (e.g., on docker compose up) or `yarn add <package-name>`, yarn alphabetizes the package.sjon file.
2. Recently, renovate replaced dependency `babel-eslint` with `@babel/eslint-parser` (the newer version is a package scoped to babel org).
3. I'm not entirely sure how renovate goes about editing files, but it did not re-alphabetize the package.json dependencies. 

#### How should this be manually tested?

As long as CI passes, don't bother.