### PR TITLE
Configure Renovate: Group CKEditor Updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "matchSourceUrls": ["https://github.com/ckeditor/ckeditor5"] 
     }
   ]
 }


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
Related to #4150 

#### What's this PR do?
This PR groups CKEditor updates together. CKEditor packages should, in general, be updated together. (See https://ckeditor.com/docs/ckeditor5/latest/updating/guides/updating-ckeditor-5.html) 

CKEditor is not included in Renovate's default monorepo list: https://docs.renovatebot.com/presets-monorepo/

#### How should this be manually tested?
Validate the configuration change: `npx --package renovate renovate-config-validator`
