### PR TITLE
Update docker-compose entrypoint for tika to point to the correct version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,6 @@ services:
 
   tika:
     image: apache/tika:1.28
-    entrypoint: java -jar tika-server-1.28.jar -h 0.0.0.0 -spawnChild
     ports:
       - "9998:9998"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
 
   tika:
     image: apache/tika:1.28
-    entrypoint: java -jar tika-server-1.23.jar -h 0.0.0.0 -spawnChild
+    entrypoint: java -jar tika-server-1.28.jar -h 0.0.0.0 -spawnChild
     ports:
       - "9998:9998"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #4155

#### What's this PR do?
Updates the tika entrypoint to the correct jar version in docker-compose.yml

#### How should this be manually tested?
- Run `docker-compose up`, check the log for tika entries, you should not see any errors about the tika jar file not being found
- Run `docker-compose run --rm web python manage.py backpopulate_mitxonline_files` (assuming you have previously run `backpopulate_mitxonline_data` and have appropriate `MITXONLINE_` settings in your .env) - tika should parse the content without errors.


#### Any background context you want to provide?
Bad renovate, bad

