### PR TITLE
Add sentry to new frontend pages

### DIFF
--- a/frontends/infinite-corridor/package.json
+++ b/frontends/infinite-corridor/package.json
@@ -14,6 +14,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.91",
     "@mui/material": "^5.9.0",
+    "@sentry/react": "^7.57.0",
     "@swc/core": "^1.3.32",
     "@tanstack/react-query": "^4.29.5",
     "@tanstack/react-query-devtools": "^4.29.6",

--- a/frontends/infinite-corridor/src/entry/root.tsx
+++ b/frontends/infinite-corridor/src/entry/root.tsx
@@ -4,6 +4,13 @@ import { createBrowserHistory } from "history"
 import { createQueryClient } from "../libs/react-query"
 import App from "../App"
 import invariant from "tiny-invariant"
+import * as Sentry from "@sentry/react"
+
+Sentry.init({
+  dsn:         SETTINGS.sentry_dsn,
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+})
 
 const container = document.getElementById("container")
 invariant(container, "Could not find container element")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,6 +4485,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/tracing@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry-internal/tracing@npm:7.57.0"
+  dependencies:
+    "@sentry/core": 7.57.0
+    "@sentry/types": 7.57.0
+    "@sentry/utils": 7.57.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: febb6ab6d8ef86e21d24d967a2183c3163d3bf016eadfe249a292af72b4636461b0d93d13d790d2c3bafd7c2c8209b2133b8371a2c974a732788f9524d998cb3
+  languageName: node
+  linkType: hard
+
 "@sentry/browser@npm:5.5.0":
   version: 5.5.0
   resolution: "@sentry/browser@npm:5.5.0"
@@ -4494,6 +4506,20 @@ __metadata:
     "@sentry/utils": 5.5.0
     tslib: ^1.9.3
   checksum: abe084cfe5f74712a673d30131e6f1eaf3938f442d2248d610816e950f8d046245e7da53a900a5a45481623b6bf0fd03153b67b8399b533f0551f40859734c7e
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/browser@npm:7.57.0"
+  dependencies:
+    "@sentry-internal/tracing": 7.57.0
+    "@sentry/core": 7.57.0
+    "@sentry/replay": 7.57.0
+    "@sentry/types": 7.57.0
+    "@sentry/utils": 7.57.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 836b0f5d2f0522c87275fdcc98ca4ed36daba469ccb83cf7dcf408cadefc8f014944d129448a0febac34259dda7d4215bfbe11a662dadf2dc5d7da22a255a5ab
   languageName: node
   linkType: hard
 
@@ -4507,6 +4533,17 @@ __metadata:
     "@sentry/utils": 5.5.0
     tslib: ^1.9.3
   checksum: ebf7191afae5cfc7b010826f2b9848655155cbf66c9d35c9ab315b85459835d718315216ba14110513c9eeb8555e5b5e25a72d292a5c51a6d4f6730256eb2ad1
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/core@npm:7.57.0"
+  dependencies:
+    "@sentry/types": 7.57.0
+    "@sentry/utils": 7.57.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 93f6c0934610b75c0ca49417f56bae63400e68fae4050dc099e4957ea3a660d79e12b614bf2df33841c3fbd6cf1341627fff4f313fd8a3ae215b1e909e5a987e
   languageName: node
   linkType: hard
 
@@ -4532,10 +4569,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/react@npm:^7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/react@npm:7.57.0"
+  dependencies:
+    "@sentry/browser": 7.57.0
+    "@sentry/types": 7.57.0
+    "@sentry/utils": 7.57.0
+    hoist-non-react-statics: ^3.3.2
+    tslib: ^2.4.1 || ^1.9.3
+  peerDependencies:
+    react: 15.x || 16.x || 17.x || 18.x
+  checksum: 5ef32df35828dfe948dfc9fc1c2962d60e81088ad639589687dee43a840371b04074a4dd5748e7ed3fe65913b2979d9ac53804e828e2188c5bc80cf17b71ff23
+  languageName: node
+  linkType: hard
+
+"@sentry/replay@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/replay@npm:7.57.0"
+  dependencies:
+    "@sentry/core": 7.57.0
+    "@sentry/types": 7.57.0
+    "@sentry/utils": 7.57.0
+  checksum: b75b9dadbe0ef44eabaf7e16f76943841caf7e3c3e910314b139ed3a709a38d63e2dcb93e6983e46ab30c4dfa071cf0bb89b1ef08ccaa6295db72654d0bd6452
+  languageName: node
+  linkType: hard
+
 "@sentry/types@npm:5.5.0":
   version: 5.5.0
   resolution: "@sentry/types@npm:5.5.0"
   checksum: c75cf8983cefb73013d41063b31bcce534d2f886b0a77cb8fd32e6a2bdcfc5386ca97a585ca075956bb61877ab46c3cdbe1ec5029ee7003958eb336a31e064d9
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/types@npm:7.57.0"
+  checksum: 2836f35af0579fd1666d5871809143f3e138af63b102a3137ec0a72be5c24b7e59747e48e160cbdf0700f067a36d70915dbf14617ebf4c9a3990e9d37ceb74ae
   languageName: node
   linkType: hard
 
@@ -4546,6 +4616,16 @@ __metadata:
     "@sentry/types": 5.5.0
     tslib: ^1.9.3
   checksum: 177ec613d9b6d2dbeb6bd1c8c8a3c11e54105e9e6d8c25faa055b479a49052b96c9e4fcde2452becdea261992442a932ca2298176205c479cd109621ba2fb1ff
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.57.0":
+  version: 7.57.0
+  resolution: "@sentry/utils@npm:7.57.0"
+  dependencies:
+    "@sentry/types": 7.57.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 02031a74e83f49d9f1e8711f7242c740fd604e3dd0453ac1c666431c283609eeeb4113049049a6832ee7dac350503872e14c6454fda74874c48ba6e3b6e79863
   languageName: node
   linkType: hard
 
@@ -12420,7 +12500,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -12889,6 +12969,7 @@ __metadata:
     "@mui/icons-material": ^5.8.4
     "@mui/lab": ^5.0.0-alpha.91
     "@mui/material": ^5.9.0
+    "@sentry/react": ^7.57.0
     "@swc/core": ^1.3.32
     "@tanstack/react-query": ^4.29.5
     "@tanstack/react-query-devtools": ^4.29.6
@@ -22888,6 +22969,13 @@ __metadata:
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.1 || ^1.9.3":
+  version: 2.6.0
+  resolution: "tslib@npm:2.6.0"
+  checksum: c01066038f950016a18106ddeca4649b4d76caa76ec5a31e2a26e10586a59fceb4ee45e96719bf6c715648e7c14085a81fee5c62f7e9ebee68e77a5396e5538f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#4124 

#### What's this PR do?
This PR adds Sentry to new frontend pages.

#### How should this be manually tested?
1. In your `.env` file, set `SENTRY_DSN=https://005a98ba45c3472dbb4c12405d814557@o48788.ingest.sentry.io/216201` *It's not secret*
2. Add something like `<button type="button" onClick={()=>{throw new Error('oh no')}}>Break the site</button>` into `frontends/infinite-corridor/src/components/Header.tsx`. *Or anyway; but the button is easy to find in the header*.
3. Click the button.
4. Visit https://mit-office-of-digital-learning.sentry.io/issues/?environment=dev&project=216201&query=is%3Aunresolved&referrer=issue-list&sort=date&statsPeriod=1h and look for your error. *That's this project, sorted by date, for dev environment*.
5. Remove SENTRY_DSN from your .env file so as not to send unnecessary stuff to sentry.

**Note:** You may notice that the sentry page says it can't unminify the error code. I believe source maps will work once this is on rc/production... Sentry should read the source maps from `<JS filename>.map`, e.g., https://discussions-rc.odl.mit.edu/static/infinite-corridor/root-2f55e4ba52845f38.js.map ... But, it's not going to read those from your localhost!