### PR TITLE
expose sentry env vars

### DIFF
--- a/infinite_example/views.py
+++ b/infinite_example/views.py
@@ -27,6 +27,9 @@ def index(request, **kwargs):  # pylint: disable=unused-argument
             and (is_admin_user(request) or is_staff_list_editor(request)),
         },
         "ckeditor_upload_url": settings.CKEDITOR_UPLOAD_URL,
+        "environment": settings.ENVIRONMENT,
+        "sentry_dsn": settings.SENTRY_DSN,
+        "release_version": settings.VERSION,
     }
 
     return render(request, "example.html", context=dict(js_settings=js_settings))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Followup to #4160

#### What's this PR do?
This PR adds the `SETTINGS` values to needed by #4160 

#### How should this be manually tested?
1. In your `.env` file, set `SENTRY_DSN=https://005a98ba45c3472dbb4c12405d814557@o48788.ingest.sentry.io/216201` *It's not secret*
2. Add something like `<button type="button" onClick={()=>{throw new Error('oh no')}}>Break the site</button>` into `frontends/infinite-corridor/src/components/Header.tsx`. *Or anyway; but the button is easy to find in the header*.
3. Click the button.
4. Visit https://mit-office-of-digital-learning.sentry.io/issues/?environment=dev&project=216201&query=is%3Aunresolved&referrer=issue-list&sort=date&statsPeriod=1h and look for your error. *That's this project, sorted by date, for dev environment*.
5. Remove SENTRY_DSN from your .env file so as not to send unnecessary stuff to sentry.
