### PR TITLE
Remove signup options from the UI

### DIFF
--- a/frontends/open-discussions/package.json
+++ b/frontends/open-discussions/package.json
@@ -195,7 +195,7 @@
     "test": "./scripts/js_test.sh",
     "coverage": "COVERAGE=1 ./scripts/js_test.sh",
     "codecov": "CODECOV=1 ./scripts/js_test.sh",
-    "watch": "WATCH=1 ./scripts/js_test.sh",
+    "test-watch": "WATCH=1 ./scripts/js_test.sh",
     "typecheck": "flow check ./src",
     "fmt-fix": "LOG_LEVEL= prettier-eslint --eslint-path $INIT_CWD/node_modules/eslint --write --no-semi --ignore $PROJECT_CWD/'frontends/open-discussions/src/flow/**/*.js' $PROJECT_CWD/'frontends/open-discussions/src/**/*.js' $PROJECT_CWD/'frontends/open-discussions/scss/**/*.scss'",
     "fmt-check": "prettier-eslint --eslint-path $INIT_CWD/node_modules/eslint --list-different --no-semi --ignore $PROJECT_CWD/'frontends/open-discussions/src/flow/**/*.js' $PROJECT_CWD/'frontends/open-discussions/src/**/*.js' $PROJECT_CWD/'frontends/open-discussions/scss/**/*.scss'",

--- a/frontends/open-discussions/src/components/IntroCard.js
+++ b/frontends/open-discussions/src/components/IntroCard.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom"
 import Card from "./Card"
 
 import { userIsAnonymous } from "../lib/util"
-import { REGISTER_URL, newPostURL, MIT_LOGO_URL } from "../lib/url"
+import { newPostURL, MIT_LOGO_URL } from "../lib/url"
 
 export default function IntroCard() {
   return (

--- a/frontends/open-discussions/src/components/IntroCard.js
+++ b/frontends/open-discussions/src/components/IntroCard.js
@@ -22,14 +22,11 @@ export default function IntroCard() {
           </p>
         </div>
         <div className="action-col">
-          {userIsAnonymous() ? null :
-            (<Link
-              className="link-button"
-              to={newPostURL()}
-            >
+          {userIsAnonymous() ? null : (
+            <Link className="link-button" to={newPostURL()}>
               "Create a post"
-            </Link>)
-          }
+            </Link>
+          )}
         </div>
       </div>
     </Card>

--- a/frontends/open-discussions/src/components/IntroCard.js
+++ b/frontends/open-discussions/src/components/IntroCard.js
@@ -22,12 +22,14 @@ export default function IntroCard() {
           </p>
         </div>
         <div className="action-col">
-          <Link
-            className="link-button"
-            to={userIsAnonymous() ? REGISTER_URL : newPostURL()}
-          >
-            {userIsAnonymous() ? "Become a member" : "Create a post"}
-          </Link>
+          {userIsAnonymous() ? null :
+            (<Link
+              className="link-button"
+              to={newPostURL()}
+            >
+              "Create a post"
+            </Link>)
+          }
         </div>
       </div>
     </Card>

--- a/frontends/open-discussions/src/components/IntroCard_test.js
+++ b/frontends/open-discussions/src/components/IntroCard_test.js
@@ -6,7 +6,7 @@ import { shallow } from "enzyme"
 
 import IntroCard from "./IntroCard"
 
-import { REGISTER_URL, newPostURL } from "../lib/url"
+import { newPostURL } from "../lib/url"
 import * as utilLib from "../lib/util"
 
 describe("IntroCard", () => {

--- a/frontends/open-discussions/src/components/IntroCard_test.js
+++ b/frontends/open-discussions/src/components/IntroCard_test.js
@@ -23,15 +23,19 @@ describe("IntroCard", () => {
   })
 
   //
-  ;[
-    [true, REGISTER_URL, "Become a member"],
-    [false, newPostURL(), "Create a post"]
-  ].forEach(([isAnon, url, text]) => {
-    it(`should return the right stuff when anon == ${String(isAnon)}`, () => {
-      isAnonStub.returns(isAnon)
-      const link = render().find(".link-button")
-      assert.equal(link.prop("to"), url)
-      assert.equal(link.text(), text)
-    })
+  it(`should return the the create a post link when anon == false`, () => {
+    const url = newPostURL()
+    const text = '"Create a post"'
+    isAnonStub.returns(false)
+    const link = render().find(".link-button")
+    assert.equal(link.prop("to"), url)
+    assert.equal(link.text(), text)
+  })
+  it(`should not return a link when anon == true`, () => {
+    isAnonStub.returns(true)
+    const link = render().find(".link-button")
+    assert.equal(link.length, 0)
+    const text = render().find("Become a member")
+    assert.equal(text.length, 0)
   })
 })

--- a/frontends/open-discussions/src/components/LoginTooltip.js
+++ b/frontends/open-discussions/src/components/LoginTooltip.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 import Tooltip from "rc-tooltip"
 
 import { userIsAnonymous } from "../lib/util"
-import { LOGIN_URL, REGISTER_URL } from "../lib/url"
+import { LOGIN_URL } from "../lib/url"
 
 import type { Location } from "react-router-dom"
 

--- a/frontends/open-discussions/src/components/LoginTooltip.js
+++ b/frontends/open-discussions/src/components/LoginTooltip.js
@@ -25,14 +25,6 @@ export const LoginTooltipContent = () => (
         >
           Log In
         </Link>
-        <Link
-          className="link-button red"
-          to={(location: Location) =>
-            `${REGISTER_URL}?next=${encodeURIComponent(location.pathname)}`
-          }
-        >
-          Sign Up
-        </Link>
       </div>
     </div>
   </div>

--- a/frontends/open-discussions/src/components/LoginTooltip_test.js
+++ b/frontends/open-discussions/src/components/LoginTooltip_test.js
@@ -27,13 +27,10 @@ describe("LoginTooltip", () => {
     const pathname = "/next/url"
     const wrapper = renderLoginTooltipHelper()
     const links = wrapper.find(Link)
+    assert.equal(links.length, 1)
     assert.equal(
       links.at(0).prop("to")({ pathname }),
       `/login/?next=${encodeURIComponent(pathname)}`
-    )
-    assert.equal(
-      links.at(1).prop("to")({ pathname }),
-      `/signup/?next=${encodeURIComponent(pathname)}`
     )
   })
 })

--- a/frontends/open-discussions/src/components/UserMenu.js
+++ b/frontends/open-discussions/src/components/UserMenu.js
@@ -62,9 +62,6 @@ export const LoggedOutMenu = (props: DropdownMenuProps) => (
     <li>
       <Link to={LOGIN_URL}>Log In</Link>
     </li>
-    <li>
-      <Link to={REGISTER_URL}>Sign Up</Link>
-    </li>
   </DropdownMenu>
 )
 

--- a/frontends/open-discussions/src/components/UserMenu.js
+++ b/frontends/open-discussions/src/components/UserMenu.js
@@ -13,8 +13,7 @@ import {
   profileURL,
   userListIndexURL,
   SETTINGS_URL,
-  LOGIN_URL,
-  REGISTER_URL
+  LOGIN_URL
 } from "../lib/url"
 import { PHONE } from "../lib/constants"
 

--- a/frontends/open-discussions/src/components/UserMenu_test.js
+++ b/frontends/open-discussions/src/components/UserMenu_test.js
@@ -102,22 +102,21 @@ describe("UserMenu", () => {
     assert.isTrue(wrapper.find(LoggedInMenu).exists())
   })
 
-  it("should not contain logged-out user links when profile is null", () => {
+  it("should contain logged-out user links when profile is null", () => {
     const wrapper = renderUserMenu({ showUserMenu: true, profile: null })
-    assert.isFalse(wrapper.find(REGISTER_URL).exists())
+    assert.isTrue(wrapper.find(LoggedOutMenu).exists())
   })
 
   describe("menu items", () => {
     const menuProps = { closeMenu: () => {} }
 
-    it("should include login and sign up links for logged-out users", () => {
+    it("should include login links only for logged-out users", () => {
       const wrapper = shallow(<LoggedOutMenu {...menuProps} />)
       const links = wrapper.find(Link)
+      assert.equal(links.length, 1)
       const firstLinkProps = links.at(0).props()
       assert.equal(firstLinkProps.to, LOGIN_URL)
       assert.equal(firstLinkProps.children, "Log In")
-      assert.isFalse(wrapper.find(REGISTER_URL).exists())
-      assert.isFalse(wrapper.find("Sign Up").exists())
     })
 
     it("should include settings link if non-null profile is provided", () => {

--- a/frontends/open-discussions/src/components/UserMenu_test.js
+++ b/frontends/open-discussions/src/components/UserMenu_test.js
@@ -102,9 +102,9 @@ describe("UserMenu", () => {
     assert.isTrue(wrapper.find(LoggedInMenu).exists())
   })
 
-  it("should contain logged-out user links when profile is null", () => {
+  it("should not contain logged-out user links when profile is null", () => {
     const wrapper = renderUserMenu({ showUserMenu: true, profile: null })
-    assert.isTrue(wrapper.find(LoggedOutMenu).exists())
+    assert.isFalse(wrapper.find(REGISTER_URL).exists())
   })
 
   describe("menu items", () => {
@@ -116,9 +116,8 @@ describe("UserMenu", () => {
       const firstLinkProps = links.at(0).props()
       assert.equal(firstLinkProps.to, LOGIN_URL)
       assert.equal(firstLinkProps.children, "Log In")
-      const secondLinkProps = links.at(1).props()
-      assert.equal(secondLinkProps.to, REGISTER_URL)
-      assert.equal(secondLinkProps.children, "Sign Up")
+      assert.isFalse(wrapper.find(REGISTER_URL).exists())
+      assert.isFalse(wrapper.find("Sign Up").exists())
     })
 
     it("should include settings link if non-null profile is provided", () => {

--- a/frontends/open-discussions/src/components/UserMenu_test.js
+++ b/frontends/open-discussions/src/components/UserMenu_test.js
@@ -9,7 +9,7 @@ import { Link } from "react-router-dom"
 import UserMenu, { LoggedInMenu, LoggedOutMenu } from "./UserMenu"
 import { DropDownArrow, DropUpArrow } from "./Arrow"
 
-import { profileURL, SETTINGS_URL, LOGIN_URL, REGISTER_URL } from "../lib/url"
+import { profileURL, SETTINGS_URL, LOGIN_URL } from "../lib/url"
 import * as utilFuncs from "../lib/util"
 import { defaultProfileImageUrl } from "../lib/util"
 import { configureShallowRenderer, shouldIf } from "../lib/test_utils"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3781 

#### What's this PR do?
This PR removes the signup options from the user flow in Open Discussions to mitigate spam.

#### How should this be manually tested?
As a logged out user, make sure that you can not find a signup link. Should still be able to go to /signup by typing it in or clicking a link. Also, make sure the UI still looks ok.

#### Screenshots (if appropriate)


![Screenshot 2023-07-26 090336](https://github.com/mitodl/open-discussions/assets/7756053/fa6ba246-4617-463c-a095-3072355d0239)
![Screenshot 2023-07-26 090332](https://github.com/mitodl/open-discussions/assets/7756053/fe60baa5-f977-4fde-b924-492ff5f7bafb)
![Screenshot 2023-07-26 090338](https://github.com/mitodl/open-discussions/assets/7756053/1652625a-83ab-4f3c-99fc-acdc10592659)
