### PR TITLE
remove signup link from login page

### DIFF
--- a/frontends/open-discussions/src/pages/auth/LoginPage.js
+++ b/frontends/open-discussions/src/pages/auth/LoginPage.js
@@ -3,8 +3,6 @@
 import React from "react"
 import { connect } from "react-redux"
 import R from "ramda"
-import { Link } from "react-router-dom"
-import qs from "query-string"
 
 import Card from "../../components/Card"
 import MetaTags from "../../components/MetaTags"
@@ -17,7 +15,7 @@ import { setAuthUserDetail } from "../../actions/ui"
 import { processAuthResponse } from "../../lib/auth"
 import { configureForm, getAuthResponseFieldErrors } from "../../lib/forms"
 import { formatTitle } from "../../lib/title"
-import { REGISTER_URL, getNextParam } from "../../lib/url"
+import { getNextParam } from "../../lib/url"
 import { validateEmailForm as validateForm } from "../../lib/validation"
 import { mergeAndInjectProps } from "../../lib/redux_props"
 import { FLOW_LOGIN, isProcessing } from "../../reducers/auth"
@@ -49,12 +47,6 @@ export class LoginPage extends React.Component<LoginPageProps> {
 
             {renderForm()}
             <ExternalLogins next={next} />
-            <div className="alternate-auth-link">
-              Not a member?{" "}
-              <Link to={`${REGISTER_URL}?${qs.stringify({ next })}`}>
-                Sign up
-              </Link>
-            </div>
           </Card>
         </div>
       </div>

--- a/frontends/open-discussions/src/pages/auth/LoginPage_test.js
+++ b/frontends/open-discussions/src/pages/auth/LoginPage_test.js
@@ -95,12 +95,12 @@ describe("LoginPage", () => {
     assert.ok(link.exists())
   })
 
-  it("should contain a link to the signup page", async () => {
+  it("should not contain a link to the signup page", async () => {
     const { inner } = await renderPage()
     const link = inner
       .find("Link")
       .findWhere(c => c.prop("to") === `${REGISTER_URL}?next=%2F`)
-    assert.ok(link.exists())
+    assert.ok(!link.exists())
   })
 
   it("form onSubmit prop calls api correctly", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#3781; a followup to #4196  

#### What's this PR do?
Removes signup link from login page.

#### How should this be manually tested?
1. Visit `/login`. There should be no link to the signup page.

#### Screenshots
<img width="457" alt="Screenshot 2023-07-27 at 2 54 39 PM" src="https://github.com/mitodl/open-discussions/assets/9010790/be9e1bde-c0e2-48c6-a635-6e16ce5d8a7d">

