### PR TITLE
4225: Keycloak OIDC integration

### DIFF
--- a/app.json
+++ b/app.json
@@ -584,6 +584,30 @@
       "description": "SAML Identity Provider attribute for user email",
       "required": false
     },
+    "SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT": {
+      "description": "The base URI for OpenID Connect discovery, https://<OIDC_ENDPOINT>/ without .well-known/openid-configuration.",
+      "required": false
+    },
+    "SOCIAL_AUTH_OL_OIDC_KEY": {
+      "description": "The client ID provided by the OpenID Connect provider.",
+      "required": false
+    },
+    "SOCIAL_AUTH_OL_OIDC_SECRET": {
+      "description": "The client secret provided by the OpenID Connect provider.",
+      "required": false
+    },
+    "USERINFO_URL": {
+      "description": "Provder endpoint where client sends requests for identity claims.",
+      "required": false
+    },
+    "ACCESS_TOKEN_URL": {
+      "description": "Provider endpoint where client exchanges the authorization code for tokens.",
+      "required": false
+    },
+    "AUTHORIZATION_URL": {
+      "description": "Provider endpoint where the user is asked to authenticate.",
+      "required": false
+    },
     "SECRET_KEY": {
       "description": "Django secret key.",
       "generator": "secret"

--- a/authentication/backends/ol_open_id_connect.py
+++ b/authentication/backends/ol_open_id_connect.py
@@ -1,0 +1,10 @@
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+
+
+class OlOpenIdConnectAuth(OpenIdConnectAuth):
+    """
+    Custom wrapper class for adding additional functionality to the
+    OpenIdConnectAuth child class.
+    """
+
+    name = "ol-oidc"

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -381,11 +381,11 @@ SOCIAL_AUTH_PIPELINE = (
     # Update the user record with any changed info from the auth service.
     "social_core.pipeline.user.user_details",
     # Resolve outstanding channel invitations
-    # "authentication.pipeline.invite.resolve_outstanding_channel_invites",
+    "authentication.pipeline.invite.resolve_outstanding_channel_invites",
     # Create the moira list associations for the user if any.
     "authentication.pipeline.user.update_moira_lists",
     # update the user's managed channels
-    # "authentication.pipeline.user.update_managed_channel_memberships",
+    "authentication.pipeline.user.update_managed_channel_memberships",
 )
 SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT = get_string(
     name="SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT",

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -220,8 +220,86 @@ USE_L10N = True
 
 USE_TZ = True
 
-# social auth
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.8/howto/static-files/
+
+# Serve static files with dj-static
+STATIC_URL = "/static/"
+CLOUDFRONT_DIST = get_string("CLOUDFRONT_DIST", None)
+if CLOUDFRONT_DIST:
+    STATIC_URL = urljoin(
+        "https://{dist}.cloudfront.net".format(dist=CLOUDFRONT_DIST), STATIC_URL
+    )
+
+STATIC_ROOT = "staticfiles"
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+for name, path in [
+    ("open-discussions", os.path.join(BASE_DIR, "frontends/open-discussions/build")),
+    ("infinite-corridor", os.path.join(BASE_DIR, "frontends/infinite-corridor/build")),
+]:
+    if os.path.exists(path):
+        STATICFILES_DIRS.append((name, path))
+    else:
+        log.warning("Static file directory was missing: %s", path)
+
+# Important to define this so DEBUG works properly
+INTERNAL_IPS = (get_string("HOST_IP", "127.0.0.1"),)
+
+# Configure e-mail settings
+EMAIL_BACKEND = get_string(
+    "OPEN_DISCUSSIONS_EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_HOST = get_string("OPEN_DISCUSSIONS_EMAIL_HOST", "localhost")
+EMAIL_PORT = get_int("OPEN_DISCUSSIONS_EMAIL_PORT", 25)
+EMAIL_HOST_USER = get_string("OPEN_DISCUSSIONS_EMAIL_USER", "")
+EMAIL_HOST_PASSWORD = get_string("OPEN_DISCUSSIONS_EMAIL_PASSWORD", "")
+EMAIL_USE_TLS = get_bool("OPEN_DISCUSSIONS_EMAIL_TLS", False)
+EMAIL_SUPPORT = get_string("OPEN_DISCUSSIONS_SUPPORT_EMAIL", "support@example.com")
+DEFAULT_FROM_EMAIL = get_string("OPEN_DISCUSSIONS_FROM_EMAIL", "webmaster@localhost")
+
+MAILGUN_SENDER_DOMAIN = get_string("MAILGUN_SENDER_DOMAIN", None)
+if not MAILGUN_SENDER_DOMAIN:
+    raise ImproperlyConfigured("MAILGUN_SENDER_DOMAIN not set")
+MAILGUN_KEY = get_string("MAILGUN_KEY", None)
+if not MAILGUN_KEY:
+    raise ImproperlyConfigured("MAILGUN_KEY not set")
+MAILGUN_RECIPIENT_OVERRIDE = get_string("MAILGUN_RECIPIENT_OVERRIDE", None)
+MAILGUN_FROM_EMAIL = get_string("MAILGUN_FROM_EMAIL", "no-reply@example.com")
+MAILGUN_BCC_TO_EMAIL = get_string("MAILGUN_BCC_TO_EMAIL", None)
+
+ANYMAIL = {
+    "MAILGUN_API_KEY": MAILGUN_KEY,
+    "MAILGUN_SENDER_DOMAIN": MAILGUN_SENDER_DOMAIN,
+}
+
+# e-mail configurable admins
+ADMIN_EMAIL = get_string("OPEN_DISCUSSIONS_ADMIN_EMAIL", "")
+if ADMIN_EMAIL != "":
+    ADMINS = (("Admins", ADMIN_EMAIL),)
+else:
+    ADMINS = ()
+
+# Email Notifications config
+
+NOTIFICATION_EMAIL_BACKEND = get_string(
+    "OPEN_DISCUSSIONS_NOTIFICATION_EMAIL_BACKEND",
+    "anymail.backends.mailgun.EmailBackend",
+)
+# See https://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.rate_limit
+NOTIFICATION_ATTEMPT_RATE_LIMIT = get_string(
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_RATE_LIMIT", None  # default is no rate limit
+)
+
+NOTIFICATION_ATTEMPT_CHUNK_SIZE = get_int(
+    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_CHUNK_SIZE", 100
+)
+NOTIFICATION_SEND_CHUNK_SIZE = get_int(
+    "OPEN_DISCUSSIONS_NOTIFICATION_SEND_CHUNK_SIZE", 100
+)
+
+# Social Auth configurations - [START]
 AUTHENTICATION_BACKENDS = (
+    "authentication.backends.ol_open_id_connect.OlOpenIdConnectAuth",
     "authentication.backends.micromasters.MicroMastersAuth",
     "social_core.backends.email.EmailAuth",
     "social_core.backends.saml.SAMLAuth",
@@ -303,90 +381,41 @@ SOCIAL_AUTH_PIPELINE = (
     # Update the user record with any changed info from the auth service.
     "social_core.pipeline.user.user_details",
     # Resolve outstanding channel invitations
-    "authentication.pipeline.invite.resolve_outstanding_channel_invites",
+    # "authentication.pipeline.invite.resolve_outstanding_channel_invites",
     # Create the moira list associations for the user if any.
     "authentication.pipeline.user.update_moira_lists",
     # update the user's managed channels
-    "authentication.pipeline.user.update_managed_channel_memberships",
+    # "authentication.pipeline.user.update_managed_channel_memberships",
+)
+SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT = get_string(
+    name="SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT",
+    default=None,
 )
 
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
-
-# Serve static files with dj-static
-STATIC_URL = "/static/"
-CLOUDFRONT_DIST = get_string("CLOUDFRONT_DIST", None)
-if CLOUDFRONT_DIST:
-    STATIC_URL = urljoin(
-        "https://{dist}.cloudfront.net".format(dist=CLOUDFRONT_DIST), STATIC_URL
-    )
-
-STATIC_ROOT = "staticfiles"
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
-for name, path in [
-    ("open-discussions", os.path.join(BASE_DIR, "frontends/open-discussions/build")),
-    ("infinite-corridor", os.path.join(BASE_DIR, "frontends/infinite-corridor/build")),
-]:
-    if os.path.exists(path):
-        STATICFILES_DIRS.append((name, path))
-    else:
-        log.warning("Static file directory was missing: %s", path)
-
-# Important to define this so DEBUG works properly
-INTERNAL_IPS = (get_string("HOST_IP", "127.0.0.1"),)
-
-# Configure e-mail settings
-EMAIL_BACKEND = get_string(
-    "OPEN_DISCUSSIONS_EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
-)
-EMAIL_HOST = get_string("OPEN_DISCUSSIONS_EMAIL_HOST", "localhost")
-EMAIL_PORT = get_int("OPEN_DISCUSSIONS_EMAIL_PORT", 25)
-EMAIL_HOST_USER = get_string("OPEN_DISCUSSIONS_EMAIL_USER", "")
-EMAIL_HOST_PASSWORD = get_string("OPEN_DISCUSSIONS_EMAIL_PASSWORD", "")
-EMAIL_USE_TLS = get_bool("OPEN_DISCUSSIONS_EMAIL_TLS", False)
-EMAIL_SUPPORT = get_string("OPEN_DISCUSSIONS_SUPPORT_EMAIL", "support@example.com")
-DEFAULT_FROM_EMAIL = get_string("OPEN_DISCUSSIONS_FROM_EMAIL", "webmaster@localhost")
-
-MAILGUN_SENDER_DOMAIN = get_string("MAILGUN_SENDER_DOMAIN", None)
-if not MAILGUN_SENDER_DOMAIN:
-    raise ImproperlyConfigured("MAILGUN_SENDER_DOMAIN not set")
-MAILGUN_KEY = get_string("MAILGUN_KEY", None)
-if not MAILGUN_KEY:
-    raise ImproperlyConfigured("MAILGUN_KEY not set")
-MAILGUN_RECIPIENT_OVERRIDE = get_string("MAILGUN_RECIPIENT_OVERRIDE", None)
-MAILGUN_FROM_EMAIL = get_string("MAILGUN_FROM_EMAIL", "no-reply@example.com")
-MAILGUN_BCC_TO_EMAIL = get_string("MAILGUN_BCC_TO_EMAIL", None)
-
-ANYMAIL = {
-    "MAILGUN_API_KEY": MAILGUN_KEY,
-    "MAILGUN_SENDER_DOMAIN": MAILGUN_SENDER_DOMAIN,
-}
-
-# e-mail configurable admins
-ADMIN_EMAIL = get_string("OPEN_DISCUSSIONS_ADMIN_EMAIL", "")
-if ADMIN_EMAIL != "":
-    ADMINS = (("Admins", ADMIN_EMAIL),)
-else:
-    ADMINS = ()
-
-# Email Notifications config
-
-NOTIFICATION_EMAIL_BACKEND = get_string(
-    "OPEN_DISCUSSIONS_NOTIFICATION_EMAIL_BACKEND",
-    "anymail.backends.mailgun.EmailBackend",
-)
-# See https://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.rate_limit
-NOTIFICATION_ATTEMPT_RATE_LIMIT = get_string(
-    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_RATE_LIMIT", None  # default is no rate limit
+SOCIAL_AUTH_OL_OIDC_KEY = get_string(
+    name="SOCIAL_AUTH_OL_OIDC_KEY",
+    default="some available client id",
 )
 
-NOTIFICATION_ATTEMPT_CHUNK_SIZE = get_int(
-    "OPEN_DISCUSSIONS_NOTIFICATION_ATTEMPT_CHUNK_SIZE", 100
-)
-NOTIFICATION_SEND_CHUNK_SIZE = get_int(
-    "OPEN_DISCUSSIONS_NOTIFICATION_SEND_CHUNK_SIZE", 100
+SOCIAL_AUTH_OL_OIDC_SECRET = get_string(
+    name="SOCIAL_AUTH_OL_OIDC_SECRET",
+    default="some super secret key",
 )
 
+USERINFO_URL = get_string(
+    name="USERINFO_URL",
+    default=None,
+)
+
+ACCESS_TOKEN_URL = get_string(
+    name="ACCESS_TOKEN_URL",
+    default=None,
+)
+
+AUTHORIZATION_URL = get_string(
+    name="AUTHORIZATION_URL",
+    default=None,
+)
 # SAML settings
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = get_string(
     "SOCIAL_AUTH_SAML_SP_ENTITY_ID", SITE_BASE_URL
@@ -443,6 +472,8 @@ SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
     "wantAssertionsEncrypted": SOCIAL_AUTH_SAML_SECURITY_ENCRYPTED,
     "requestedAuthnContext": False,
 }
+
+# Social Auth configurations - [END]
 
 # embed.ly configuration
 EMBEDLY_KEY = get_string("EMBEDLY_KEY", None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1422,6 +1422,24 @@ offline = ["drf-spectacular-sidecar"]
 sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
+name = "ecdsa"
+version = "0.18.0"
+description = "ECDSA cryptographic signature library (pure python)"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
+    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
 name = "elastic-transport"
 version = "8.4.0"
 description = "Transport classes and utilities shared among Python Elastic client libraries"
@@ -1664,6 +1682,7 @@ files = [
     {file = "greenlet-2.0.2-cp27-cp27m-win32.whl", hash = "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74"},
     {file = "greenlet-2.0.2-cp27-cp27m-win_amd64.whl", hash = "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343"},
     {file = "greenlet-2.0.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
     {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
@@ -1672,6 +1691,7 @@ files = [
     {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
     {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
     {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
@@ -1701,6 +1721,7 @@ files = [
     {file = "greenlet-2.0.2-cp37-cp37m-win32.whl", hash = "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7"},
     {file = "greenlet-2.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3"},
     {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
@@ -1709,6 +1730,7 @@ files = [
     {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
     {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
     {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
     {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
@@ -2219,6 +2241,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -3167,6 +3199,27 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+
+[package.dependencies]
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
+
+[[package]]
 name = "python-rapidjson"
 version = "1.10"
 description = "Python wrapper around rapidjson"
@@ -3317,6 +3370,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -3324,8 +3378,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -3342,6 +3403,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -3349,6 +3411,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -3841,6 +3904,7 @@ cryptography = ">=1.4"
 defusedxml = ">=0.5.0rc1"
 oauthlib = ">=1.0.3"
 PyJWT = ">=2.0.0"
+python-jose = {version = ">=3.0.0", optional = true, markers = "extra == \"openidconnect\""}
 python3-openid = ">=3.0.10"
 requests = ">=2.9.1"
 requests-oauthlib = ">=0.6.1"
@@ -4366,4 +4430,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.4"
-content-hash = "1109846fcb345f3439a382ba10fd8ec3e219566c1cdc7f74f6f04cf325e24b7b"
+content-hash = "8fe4956fd037f0f1c71960e9cd6464fa547b15ac83c0ecb483ac9a342609966f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ urllib3 = "^1.25.10"
 uwsgi = "^2.0.21"
 wrapt = "^1.14.1"
 xbundle = "^0.3.1"
+social-auth-core = {extras = ["openidconnect"], version = "^4.4.2"}
 
 [tool.poetry.group.dev.dependencies]
 astroid = "^2.15.4"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4225

#### What's this PR do?
Adds OpenID Connect functionality to Open Discussions which allows for authenticating users via Keycloak.

#### How should this be manually tested?
You will need a Keycloak account configured for https://sso-qa.odl.mit.edu/realms/olapps .  You should be able to create your account by visiting https://sso-qa.odl.mit.edu/admin/olapps/console/#/ .

1. Add the following to your .env file
```
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=https://sso-qa.odl.mit.edu/realms/olapps
OIDC_ENDPOINT=https://sso-qa.odl.mit.edu/realms/olapps
SOCIAL_AUTH_OL_OIDC_KEY=ol-open-discussions-local
SOCIAL_AUTH_OL_OIDC_SECRET=<REQUEST_FROM_PR_AUTHOR>
AUTHORIZATION_URL=https://sso-qa.odl.mit.edu/realms/olapps/protocol/openid-connect/auth
ACCESS_TOKEN_URL=https://sso-qa.odl.mit.edu/realms/olapps/protocol/openid-connect/token
USERINFO_URL=https://sso-qa.odl.mit.edu/realms/olapps/protocol/openid-connect/userinfo
```
2. Using this PR's branch, visit: http://od.odl.local:8063/login/ol-oidc/
3. You should be redirected to a login page. Enter your Keycloak account credentials.
4. If your account credentials were correct, you should be redirected to the Open Discussions index page.

This can also be tested with the following scenario: 

1. You have an Open Discussions user record with the email apple123@fake.edu.  
2. You then visit http://od.odl.local:8063/login/ol-oidc/ and register a new Keycloak user with apple123@fake.edu.  
3. After confirming the email, you should be able to visit http://od.odl.local:8063/ and be logged in with an active session for apple123@fake.edu.  
4. If this user has Django admin in Open Discussion, you should also be able to access the Django Admin console.  
5. You should see two entries for the apple123@fake.edu user at http://od.odl.local:8063/admin/social_django/usersocialauth/ - one with a provider of "email" and the other with a provider of "ol-oidc".

## NOTE

1. If a user has a Keycloak account but no Open Discussions user record, they will be assigned a random username in Open Discussions.