### PR TITLE
4227: configure keycloak user migration plug in - REST API

### DIFF
--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,5 +1,5 @@
 """URL configurations for authentication"""
-from django.urls import re_path
+from django.urls import re_path, path
 from django.contrib.auth import views as auth_views
 
 from authentication.views import (
@@ -11,6 +11,7 @@ from authentication.views import (
     get_social_auth_types,
     login_complete,
     CustomDjoserAPIView,
+    get_user_details_for_keycloak,
 )
 
 
@@ -54,4 +55,9 @@ urlpatterns = [
     re_path(r"^api/v0/auths/$", get_social_auth_types, name="get-auth-types-api"),
     re_path(r"^login/complete$", login_complete, name="login-complete"),
     re_path(r"^logout/$", auth_views.LogoutView.as_view(), name="logout"),
+    path(
+        "api/v0/auth/<email>/",
+        get_user_details_for_keycloak,
+        name="get_user_details_for_keycloak",
+    ),
 ]

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -58,6 +58,6 @@ urlpatterns = [
     path(
         "api/v0/auth/<email>/",
         get_user_details_for_keycloak,
-        name="get_user_details_for_keycloak",
+        name="get-user-details-for-keycloak",
     ),
 ]

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
     re_path(r"^login/complete$", login_complete, name="login-complete"),
     re_path(r"^logout/$", auth_views.LogoutView.as_view(), name="logout"),
     path(
-        "api/v0/auth/<email>/",
+        "api/v0/auth/<email>",
         get_user_details_for_keycloak,
         name="get-user-details-for-keycloak",
     ),

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -266,8 +266,7 @@ def get_user_details_for_keycloak(request, email):
     if user:
         if request.method == "POST":
             body = json.loads(request.body)
-            password = body["password"]
-            if password and user[0].check_password(password):
+            if "password" in body and user[0].check_password(body["password"]):
                 return Response({}, status=status.HTTP_200_OK)
             else:
                 return Response({}, status=status.HTTP_403_FORBIDDEN)
@@ -278,6 +277,10 @@ def get_user_details_for_keycloak(request, email):
                 "lastName": user[0].last_name,
                 "enabled": True,
                 "emailVerified": True,
+                "attributes": {},
+                "roles": ["default-roles-olapps"],
+                "groups": [],
+                "requiredActions": [],
             }
             return Response(response, status=status.HTTP_200_OK)
     else:

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -36,6 +36,7 @@ from authentication.serializers import (
 from authentication.utils import load_drf_strategy
 from mail.api import render_email_templates, send_messages
 from open_discussions.authentication import BearerAuthentication
+from open_discussions.permissions import IsStaffPermission
 
 User = get_user_model()
 
@@ -242,7 +243,7 @@ class CustomDjoserAPIView(UserViewSet, ActionViewMixin):
 
 
 @api_view(["GET", "POST"])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticated, IsStaffPermission])
 @authentication_classes([BearerAuthentication])
 def get_user_details_for_keycloak(request, email):
     """

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -274,6 +274,7 @@ def get_user_details_for_keycloak(request, email):
         else:
             response = {
                 "email": user[0].email,
+                "username": user[0].email,
                 "firstName": user[0].first_name,
                 "lastName": user[0].last_name,
                 "enabled": True,

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,38 +1,37 @@
 """Authentication views"""
+import json
 from urllib.parse import quote
 
 import requests
+from anymail.message import AnymailMessage
 from django.conf import settings
-from django.core import mail as django_mail
 from django.contrib.auth import get_user_model, update_session_auth_hash
-from django.shortcuts import render, redirect
+from django.core import mail as django_mail
+from django.shortcuts import redirect, render
+from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
+from djoser.utils import ActionViewMixin
+from djoser.views import UserViewSet
+from rest_framework import status
+from rest_framework.decorators import (
+    action,
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_jwt.settings import api_settings
 from social_core.backends.email import EmailAuth
 from social_django.models import UserSocialAuth
 from social_django.utils import load_backend
-from profiles.models import Profile
-from rest_framework import status
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework.decorators import (
-    api_view,
-    permission_classes,
-    action,
-    authentication_classes,
-)
-from rest_framework.permissions import IsAuthenticated
-from rest_framework_jwt.settings import api_settings
-from anymail.message import AnymailMessage
-from djoser.views import UserViewSet
-from djoser.utils import ActionViewMixin
-from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
-import json
 
 from authentication.serializers import (
     LoginEmailSerializer,
     LoginPasswordSerializer,
-    RegisterEmailSerializer,
     RegisterConfirmSerializer,
     RegisterDetailsSerializer,
+    RegisterEmailSerializer,
 )
 from authentication.utils import load_drf_strategy
 from mail.api import render_email_templates, send_messages

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -245,8 +245,25 @@ class CustomDjoserAPIView(UserViewSet, ActionViewMixin):
 @permission_classes([IsAuthenticated])
 @authentication_classes([BearerAuthentication])
 def get_user_details_for_keycloak(request, email):
+    """
+    Endpoint for the Keycloak plug-in: https://github.com/daniel-frak/keycloak-user-migration.
+
+    Args:
+        email (string): The email of a user record in Open Discussions.
+
+    Returns:
+        Response: GET requests will respond with the user's first and last name,
+            and email address, along with some additional flags specific for
+            Keycloak.
+            POST requests will respond with a 200 status if the password,
+            contained in the body, matches the user's record.  If the
+            password does not match the user's record, a 403 response is
+            provided.
+            Both requests will respond with a 404 if no Open Discussion's user
+            has an email matching the email argument.
+    """
     user = User.objects.filter(email=email).all()
-    if user.exists:
+    if user:
         if request.method == "POST":
             body = json.loads(request.body)
             password = body["password"]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,13 +1,13 @@
 """Authentication views"""
 import json
 from urllib.parse import quote
-from django.http import Http404
 
 import requests
 from anymail.message import AnymailMessage
 from django.conf import settings
 from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.core import mail as django_mail
+from django.http import Http404
 from django.shortcuts import redirect, render
 from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 from djoser.utils import ActionViewMixin

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -788,6 +788,7 @@ def test_get_user_details_for_keycloak(client, user, admin_user):
         "roles": ["default-roles-olapps"],
         "groups": [],
         "requiredActions": [],
+        "username": user.username,
     }
 
 

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -788,7 +788,7 @@ def test_get_user_details_for_keycloak(client, user, admin_user):
         "roles": ["default-roles-olapps"],
         "groups": [],
         "requiredActions": [],
-        "username": user.username,
+        "username": user.email,
     }
 
 

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 import factory
 import pytest
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from social_core.backends.email import EmailAuth
 from social_core.backends.saml import SAMLAuth
 
@@ -769,3 +770,84 @@ def test_get_social_auth_types(client, user):
     client.force_login(user)
     resp = client.get(url)
     assert resp.json() == [{"provider": provider} for provider in social_auth_providers]
+
+
+def test_get_user_details_for_keycloak(client, user):
+    """Verify that get-user-details-for-keycloak returns a list expected attributes for the Keycloak plug-in."""
+    url = reverse("get-user-details-for-keycloak", kwargs={"email": user.email})
+    bearer_token = Token.objects.create(user=user)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    resp = client.get(url)
+    assert resp.json() == {
+        "email": user.email,
+        "firstName": user.first_name,
+        "lastName": user.last_name,
+        "enabled": True,
+        "emailVerified": True,
+        "attributes": {},
+        "roles": ["default-roles-olapps"],
+        "groups": [],
+        "requiredActions": [],
+    }
+
+
+def test_get_user_details_for_keycloak_requires_bearer_token(client, user):
+    """Verify that get-user-details-for-keycloak returns a list expected attributes for the Keycloak plug-in."""
+    url = reverse("get-user-details-for-keycloak", kwargs={"email": user.email})
+    response = client.get(url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_user_details_for_keycloak_user_not_found(client, user):
+    """Verify that get-user-details-for-keycloak returns a 404 if the user does not exist"""
+    url = reverse(
+        "get-user-details-for-keycloak",
+        kwargs={"email": "incorrect_user_email@email.com"},
+    )
+    bearer_token = Token.objects.create(user=user)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    response = client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_post_user_details_for_keycloak_user_not_found(client, user):
+    """Verify that get-user-details-for-keycloak returns a 404 if the user does not exist"""
+    url = reverse(
+        "get-user-details-for-keycloak",
+        kwargs={"email": "incorrect_user_email@email.com"},
+    )
+    bearer_token = Token.objects.create(user=user)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    response = client.post(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_post_user_details_for_keycloak_password_incorrect(mocker, client, user):
+    """Verify that get-user-details-for-keycloak returns a 403 if the POST contains an incorrect password"""
+    url = reverse("get-user-details-for-keycloak", kwargs={"email": user.email})
+    bearer_token = Token.objects.create(user=user)
+    # Mock that the password provided in the request does not match the Django user's.
+    mocker.patch("django.contrib.auth.models.User.check_password", return_value=False)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    response = client.post(url, data={"password": "incorrect_password"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_post_user_details_for_keycloak_password_missing(client, user):
+    """Verify that get-user-details-for-keycloak returns a 403 if the POST is missing the password json object"""
+    url = reverse("get-user-details-for-keycloak", kwargs={"email": user.email})
+    bearer_token = Token.objects.create(user=user)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    response = client.post(url, data={"pass": "incorrect_password"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_post_user_details_for_keycloak_(mocker, client, user):
+    """Verify that get-user-details-for-keycloak returns a 200 if the POST contains the correct password"""
+    url = reverse("get-user-details-for-keycloak", kwargs={"email": user.email})
+    bearer_token = Token.objects.create(user=user)
+    # Mock that the password provided in the request matches the Django user's.
+    mocker.patch("django.contrib.auth.models.User.check_password", return_value=True)
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + bearer_token.key)
+    response = client.post(url, data={"password": "correct_password"})
+    assert response.status_code == status.HTTP_200_OK

--- a/open_discussions/authentication.py
+++ b/open_discussions/authentication.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 import jwt
 from rest_framework.authentication import BaseAuthentication
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 
 
 User = get_user_model()
@@ -76,3 +77,14 @@ class StatelessTokenAuthentication(BaseAuthentication):
             return (user, None)
 
         return None
+
+class BearerAuthentication(TokenAuthentication):
+    '''
+    Simple token based authentication using utvsapitoken.
+
+    Clients should authenticate by passing the token key in the 'Authorization'
+    HTTP header, prepended with the string 'Bearer '.  For example:
+
+    Authorization: Bearer 956e252a-513c-48c5-92dd-bfddc364e812
+    '''
+    keyword = 'Bearer'

--- a/open_discussions/authentication.py
+++ b/open_discussions/authentication.py
@@ -1,12 +1,10 @@
 """Custom authentication for DRF"""
 import logging
 
-from django.contrib.auth import get_user_model
 import jwt
-from rest_framework.authentication import BaseAuthentication
+from django.contrib.auth import get_user_model
+from rest_framework.authentication import BaseAuthentication, TokenAuthentication
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
-from rest_framework.authentication import TokenAuthentication
-
 
 User = get_user_model()
 

--- a/open_discussions/authentication.py
+++ b/open_discussions/authentication.py
@@ -78,13 +78,15 @@ class StatelessTokenAuthentication(BaseAuthentication):
 
         return None
 
+
 class BearerAuthentication(TokenAuthentication):
-    '''
-    Simple token based authentication using utvsapitoken.
+    """
+    Token based authentication overriding the OOTB keyword.
 
     Clients should authenticate by passing the token key in the 'Authorization'
     HTTP header, prepended with the string 'Bearer '.  For example:
 
     Authorization: Bearer 956e252a-513c-48c5-92dd-bfddc364e812
-    '''
-    keyword = 'Bearer'
+    """
+
+    keyword = "Bearer"

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -103,7 +103,7 @@ INSTALLED_APPS = (
     "social_django",
     "server_status",
     "rest_framework",
-    'rest_framework.authtoken',
+    "rest_framework.authtoken",
     "corsheaders",
     "webpack_loader",
     "anymail",
@@ -725,7 +725,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
         "open_discussions.authentication.IgnoreExpiredJwtAuthentication",
-        'open_discussions.authentication.BearerAuthentication',
+        "open_discussions.authentication.BearerAuthentication",
     ),
     "EXCEPTION_HANDLER": "open_discussions.exceptions.api_exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -103,6 +103,7 @@ INSTALLED_APPS = (
     "social_django",
     "server_status",
     "rest_framework",
+    'rest_framework.authtoken',
     "corsheaders",
     "webpack_loader",
     "anymail",
@@ -724,6 +725,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
         "open_discussions.authentication.IgnoreExpiredJwtAuthentication",
+        'open_discussions.authentication.BearerAuthentication',
     ),
     "EXCEPTION_HANDLER": "open_discussions.exceptions.api_exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4227

#### What's this PR do?
Adds a REST API endpoint (`http://od.odl.local:8063/api/v0/auth/<email>/` which can receive the GET and POST calls expected from the Keycloak plug-in described here: https://github.com/daniel-frak/keycloak-user-migration#prerequisites---rest-endpoints-in-the-legacy-system

Adds an override to `TokenAuthentication` in order to allow for the `Authorization` header to use "Bearer <YOUR_TOKEN_KEY>" instead of the OOTB "Token <YOUR_TOKEN_KEY>".

This has been tested with the plugin using the instructions provided here: https://github.com/daniel-frak/keycloak-user-migration#launching-and-configuring-the-example

#### How should this be manually tested?

1. Using this branch, run ./manage.py migrate in order to add the Auth Token models.
2. Create a token for your staff user by going to http://od.odl.local:8063/admin/authtoken/tokenproxy/ and clicking "ADD TOKEN" in the top right.
3. I completed the following steps using the Postman application.
4. This new endpoint requires authorization for a user with staff permissions in Django.  This is done by adding a bearer token header to your request that is formatted like similar to `Authorization: Bearer 956e252a-513c-48c5-92dd-bfddc364e812` but adding your token.
5. When making a GET request, such as (http://od.odl.local:8063/api/v0/auth/collinp%40mit.edu/), you should expect the following response:
```
{
    "email": "collinp@mit.edu",
    "firstName": "Collin",
    "lastName": "Preston",
    "enabled": true,
    "emailVerified": true,
    "attributes": {},
    "roles": [
        "default-roles-olapps"
    ],
    "groups": [],
    "requiredActions": []
}
```
6. When making a POST request, you will need to have the body of:
```
{
  "password": "your_users_password"
}
```
7. If `your_users_password` matches your Django user's password, then you should expect a 200 response.
