### PR TITLE
Account settings page should always display forgot password option (Keycloak enabled)

### DIFF
--- a/frontends/open-discussions/src/pages/AccountSettingsPage.js
+++ b/frontends/open-discussions/src/pages/AccountSettingsPage.js
@@ -50,11 +50,7 @@ class AccountSettingsPage extends React.Component<Props> {
       return (
         <div key={index} className="account-settings-row">
           <h5>MIT Open</h5>
-          {SETTINGS.FEATURES.KEYCLOAK_ENABLED ? (
-            <a href={PASSWORD_CHANGE_URL}>Change Password</a>
-          ) : (
-            <Link to={PASSWORD_CHANGE_URL}>Change Password</Link>
-          )}
+          <Link to={PASSWORD_CHANGE_URL}>Change Password</Link>
         </div>
       )
     case "micromasters":
@@ -92,11 +88,18 @@ class AccountSettingsPage extends React.Component<Props> {
               <span className="highlight"> {SETTINGS.user_full_name} </span>
               using:
             </label>
-            {R.compose(
-              R.addIndex(R.map)(this.renderSocialAuthLine),
-              // Show email auth before any other social auths
-              R.sortBy(auth => (auth.provider === "email" ? 0 : 1))
-            )(socialAuths)}
+            {SETTINGS.FEATURES.KEYCLOAK_ENABLED ? (
+              <div className="account-settings-row">
+                <h5>MIT Open</h5>
+                <a href={PASSWORD_CHANGE_URL}>Change Password</a>
+              </div>
+            ) : (
+              R.compose(
+                R.addIndex(R.map)(this.renderSocialAuthLine),
+                // Show email auth before any other social auths
+                R.sortBy(auth => (auth.provider === "email" ? 0 : 1))
+              )(socialAuths)
+            )}
           </Card>
         </div>
       </React.Fragment>

--- a/frontends/open-discussions/src/pages/AccountSettingsPage_test.js
+++ b/frontends/open-discussions/src/pages/AccountSettingsPage_test.js
@@ -55,4 +55,16 @@ describe("AccountSettingsPage", () => {
     assert.equal(rows.length, 2)
     assert.equal(rows.at(0).find("h5").text(), "MIT Open")
   })
+
+  it("renders change password when keycloak is active.", async () => {
+    SETTINGS.FEATURES.KEYCLOAK_ENABLED = true
+    helper.getSocialAuthTypesStub.returns(
+      Promise.resolve([{ provider: "ol-oidc" }, { provider: "email" }])
+    )
+    const wrapper = await renderPage()
+
+    const rows = wrapper.find(".account-settings-row")
+    assert.equal(rows.length, 2)
+    assert.equal(rows.at(0).find("h5").text(), "MIT Open")
+  })
 })

--- a/frontends/open-discussions/src/pages/AccountSettingsPage_test.js
+++ b/frontends/open-discussions/src/pages/AccountSettingsPage_test.js
@@ -64,7 +64,7 @@ describe("AccountSettingsPage", () => {
     const wrapper = await renderPage()
 
     const rows = wrapper.find(".account-settings-row")
-    assert.equal(rows.length, 2)
+    assert.equal(rows.length, 1)
     assert.equal(rows.at(0).find("h5").text(), "MIT Open")
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4236

#### What's this PR do?
When `FEATURE_KEYCLOAK_ENABLED=True` is set as an environment variable, and a user is logged in, the http://od.odl.local:8063/settings/account page should always display that the user is logged in via MIT Open along with a link to the change password page in Keycloak.

#### How should this be manually tested?

1. Define the required Keycloak environment variables: https://github.com/mitodl/open-discussions#keycloak-configuration
2. Log in to Open Discussions using your Keycloak account.
3. Navigate to http://od.odl.local:8063/settings/account and verify that the page matches the screenshots below.
4. Click the "Change password" link.  Verify that you are redirected to the Keycloak account settings - signing in page.

#### Screenshot
![Screenshot 2023-10-16 at 5 07 14 PM](https://github.com/mitodl/open-discussions/assets/8311573/7f2a07c9-8628-4f17-9577-0212c278caa1)

![Screenshot 2023-10-16 at 5 08 51 PM](https://github.com/mitodl/open-discussions/assets/8311573/25c717e3-8cf7-4ee4-bb0b-79a410e2d34a)


