### PR TITLE
Handle multiple prefixes in ocw webhook endpoint

### DIFF
--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -71,6 +71,7 @@ from open_discussions.permissions import (
     is_admin_user,
 )
 from open_discussions.settings import DRF_NESTED_PARENT_LOOKUP_PREFIX
+from open_discussions.utils import chunks
 from search.search_index_helpers import (
     deindex_course,
     deindex_staff_list,
@@ -540,13 +541,27 @@ class WebhookOCWNextView(APIView):
 
         version = content.get("version")
         prefix = content.get("prefix")
+        prefixes = content.get("prefixes", [prefix] if prefix else None)
         site_uid = content.get("site_uid")
         unpublished = content.get("unpublished", False)
+        status = 200
 
         if version == "live":
-            if prefix is not None:
-                # Index the course
-                get_ocw_next_courses.delay(url_paths=[prefix], force_overwrite=False)
+            if prefixes is not None:
+                # Index the course(s)
+                prefixes = (
+                    prefixes
+                    if isinstance(prefixes, list)
+                    else [prefix.strip() for prefix in prefixes.split(",")]
+                )
+                for url_paths in chunks(
+                    prefixes, chunk_size=settings.OCW_ITERATOR_CHUNK_SIZE
+                ):
+                    get_ocw_next_courses.delay(
+                        url_paths=url_paths,
+                        force_overwrite=False,
+                    )
+                message = f"OCW courses queued for indexing: {prefixes}"
             elif site_uid is not None and unpublished is True:
                 # Remove the course from the search index
                 course_run = LearningResourceRun.objects.filter(
@@ -557,8 +572,20 @@ class WebhookOCWNextView(APIView):
                     course.published = False
                     course.save()
                     deindex_course(course)
+                    message = f"OCW course {site_uid} queued for unpublishing"
+                else:
+                    message = (
+                        f"OCW course {site_uid} not found, so nothing to unpublish"
+                    )
+            else:
+                message = (
+                    f"Could not determine appropriate action from request: {content}"
+                )
+                status = 400
 
-        return Response({})
+        else:
+            message = "Not a live version, ignoring"
+        return Response(data={"message": message}, status=status)
 
 
 class PodcastViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):

--- a/course_catalog/views.py
+++ b/course_catalog/views.py
@@ -544,7 +544,7 @@ class WebhookOCWNextView(APIView):
         prefixes = content.get("prefixes", [prefix] if prefix else None)
         site_uid = content.get("site_uid")
         unpublished = content.get("unpublished", False)
-        status = 200
+        response_status = 200
 
         if version == "live":
             if prefixes is not None:
@@ -581,11 +581,11 @@ class WebhookOCWNextView(APIView):
                 message = (
                     f"Could not determine appropriate action from request: {content}"
                 )
-                status = 400
+                response_status = 400
 
         else:
             message = "Not a live version, ignoring"
-        return Response(data={"message": message}, status=status)
+        return Response(data={"message": message}, status=response_status)
 
 
 class PodcastViewSet(viewsets.ReadOnlyModelViewSet, FavoriteViewMixin):

--- a/course_catalog/views_test.py
+++ b/course_catalog/views_test.py
@@ -412,7 +412,7 @@ def test_ocw_webhook_endpoint_bad_key(settings, client):
         {"webhook_key": "fake_key", "version": "live"},
     ],
 )
-def test_ocw_webhook_endpoint(client, mocker, settings, data):
+def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
     """Test that the OCW webhook endpoint schedules a get_ocw_courses task"""
     settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = "fake_key"
     mock_get_ocw = mocker.patch(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/406 

#### What's this PR do?
Allows the OCW webhook to handle multiple sites at a time.  Produces more verbose/helpful output messages.

#### How should this be manually tested?
Set `OCW_NEXT_WEBHOOK_KEY=key` in your .env file

Try the following POST requests to `http://localhost:8063/api/v1/ocw_next_webhook/` , they should all work, kick off `get_ocw_next_courses` tasks, and return a helpful message in the response.

```
{
   "webhook_key": "key",
   "prefixes": 
    "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring-2007/, courses/18-657-mathematics-of-machine-learning-fall-2015/",
   "version": "live"
}
```


```
{
   "webhook_key": "key",
   "prefixes":  [
        "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring-2007/", 
        "courses/18-657-mathematics-of-machine-learning-fall-2015/"
    ],
   "version": "live"
}
```

```
{
   "webhook_key": "key",
   "prefix":  "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring/"
   "version": "live"
}

```


```
{
   "webhook_key": "key",
   "prefixes":  "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring/"
   "version": "live"
}
```
