### PR TITLE
4249: remove code from user migration script for importing credentials

### DIFF
--- a/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
+++ b/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
@@ -174,9 +174,9 @@ class Command(BaseCommand):
 
         keycloak_partial_import_url = f"{settings.KEYCLOAK_BASE_URL}/admin/realms/{settings.KEYCLOAK_REALM_NAME}/partialImport"
         unsynced_users_social_auth_query = Q()
-        if kwargs["filter-provider-name"] is not None:
+        if kwargs["filter_provider_name"] is not None:
             unsynced_users_social_auth_query &= Q(
-                social_auth__provider=kwargs["filter-provider-name"]
+                social_auth__provider=kwargs["filter_provider_name"]
             )
         unsynced_users = (
             User.objects.only("email")
@@ -187,16 +187,16 @@ class Command(BaseCommand):
             .prefetch_related("social_auth")
         )
         access_token = self._get_access_token(
-            kwargs["client_id"],
+            kwargs["client-id"],
             kwargs["username"],
             kwargs["password"],
-            kwargs["client_secret"],
+            kwargs["client-secret"],
         )
 
         unsynced_users_keycloak_payload_array = []
 
         # Process batches of the users who must be exported.
-        batch_size = kwargs["batch-size"]
+        batch_size = kwargs["batch_size"]
         for i in range(0, len(unsynced_users), batch_size):
             batch = unsynced_users[i : i + batch_size]
             for user in batch:

--- a/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
+++ b/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
@@ -18,17 +18,17 @@ class Command(BaseCommand):
     social-auth record for the "ol-oidc" provider.  The Keycloak user
     record is populated with the Django user's first_name, last_name, and email.
 
-    Optionally, the "--filter_provider_name" argument can be defined (string) when running this script.
+    Optionally, the "--filter-provider-name" argument can be defined (string) when running this script.
     If defined, Keycoak user records will be created only for Django user records which have no associated
     social-auth record for the "ol-oidc" provider, and have a social-auth record with a provider
     equal to the argument value.
 
-    Optionally, the "--keycloak_group_path" argument can be defined (string) when running this script
+    Optionally, the "--keycloak-group-path" argument can be defined (string) when running this script
     which will add all created Keycloak users to the Keycloak group path defined as the
-    argument value.  For example, "--keycloak_group_path=/imported/open-discussions/touchstone".
+    argument value.  For example, "--keycloak-group-path=/imported/open-discussions/touchstone".
     If the argument is defined, the Keycloak group path must exist prior to executing this script.
 
-    Optionally, the "--batch_size" argument can be defined (int) when running this script.
+    Optionally, the "--batch-size" argument can be defined (int) when running this script.
     The value of this argument controls how many Keycloak user records should be created
     with each API request made to Keycloak.  The default is 25.
 
@@ -69,29 +69,29 @@ class Command(BaseCommand):
             help="Password of a Keycloak realm admin user.",
         )
         parser.add_argument(
-            "client_id",
+            "client-id",
             help="Client ID for the Keycloak Admin-CLI client.",
         )
         parser.add_argument(
-            "client_secret",
+            "client-secret",
             help="Client secret for the Keycloak Admin-CLI client.",
         )
         parser.add_argument(
-            "--batch_size",
+            "--batch-size",
             nargs="?",
             default=25,
             type=int,
             help="(Optional) How many users to export to Keycloak at a time.",
         )
         parser.add_argument(
-            "--keycloak_group_path",
+            "--keycloak-group-path",
             nargs="?",
             default="",
             type=str,
             help="(Optional) The Keycloak group's path users should will added to.",
         )
         parser.add_argument(
-            "--filter_provider_name",
+            "--filter-provider-name",
             nargs="?",
             default=None,
             type=str,
@@ -174,9 +174,9 @@ class Command(BaseCommand):
 
         keycloak_partial_import_url = f"{settings.KEYCLOAK_BASE_URL}/admin/realms/{settings.KEYCLOAK_REALM_NAME}/partialImport"
         unsynced_users_social_auth_query = Q()
-        if kwargs["filter_provider_name"] is not None:
+        if kwargs["filter-provider-name"] is not None:
             unsynced_users_social_auth_query &= Q(
-                social_auth__provider=kwargs["filter_provider_name"]
+                social_auth__provider=kwargs["filter-provider-name"]
             )
         unsynced_users = (
             User.objects.only("email")
@@ -186,10 +186,6 @@ class Command(BaseCommand):
             .select_related("userexporttokeycloak")
             .prefetch_related("social_auth")
         )
-        if kwargs["filter_provider_name"] is not None:
-            unsynced_users = unsynced_users.filter(
-                social_auth__provider=kwargs["filter_provider_name"]
-            )
         access_token = self._get_access_token(
             kwargs["client_id"],
             kwargs["username"],
@@ -200,7 +196,7 @@ class Command(BaseCommand):
         unsynced_users_keycloak_payload_array = []
 
         # Process batches of the users who must be exported.
-        batch_size = kwargs["batch_size"]
+        batch_size = kwargs["batch-size"]
         for i in range(0, len(unsynced_users), batch_size):
             batch = unsynced_users[i : i + batch_size]
             for user in batch:
@@ -226,10 +222,10 @@ class Command(BaseCommand):
             # If Keycloak responds with a 401, refresh the access_token and retry once.
             if response.status_code == 401:
                 access_token = self._get_access_token(
-                    kwargs["client_id"],
+                    kwargs["client-id"],
                     kwargs["username"],
                     kwargs["password"],
-                    kwargs["client_secret"],
+                    kwargs["client-secret"],
                 )
                 headers = {
                     "Content-Type": "application/json",

--- a/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
+++ b/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
             A new access_token (string) for the administrator user for use with the Keycloak admin-cli client.
         """
         url = f"{settings.KEYCLOAK_BASE_URL}/realms/{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/token"
-        payload = f"{urlencode({'client_id': client_id})}&{urlencode({'username': username})}&{urlencode({'password': password})}&grant_type=password&{urlencode({'client_secret': client_secret})}&{urlencode({'scope': 'email openid'})}"
+        payload = f"{urlencode(dict(client_id=client_id, username=username, password=password, grant_type='password', client_secret=client_secret, scope='email openid'))}"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
         response = requests.request("POST", url, headers=headers, data=payload)

--- a/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
+++ b/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
@@ -18,10 +18,10 @@ class Command(BaseCommand):
     social-auth record for the "ol-oidc" provider.  The Keycloak user
     record is populated with the Django user's first_name, last_name, and email.
 
-    Optionally, the "--filter_provider_name" argument can be defined (string) when running this script
-    which will only create Keycloak user records for Django user records which have no associated
-    social-auth record for the "ol-oidc" provider and must have a social-auth record
-    for a provider matching the value of the supplied argument.
+    Optionally, the "--filter_provider_name" argument can be defined (string) when running this script.
+    If defined, Keycoak user records will be created only for Django user records which have no associated
+    social-auth record for the "ol-oidc" provider, and have a social-auth record with a provider
+    equal to the argument value.
 
     Optionally, the "--keycloak_group_path" argument can be defined (string) when running this script
     which will add all created Keycloak users to the Keycloak group path defined as the
@@ -88,14 +88,14 @@ class Command(BaseCommand):
             nargs="?",
             default="",
             type=str,
-            help="(Optional) The Keycloak group's path users should be added to.",
+            help="(Optional) The Keycloak group's path users should will added to.",
         )
         parser.add_argument(
             "--filter_provider_name",
             nargs="?",
             default=None,
             type=str,
-            help="(Optional) Only import users with a specified social auth provider.",
+            help="(Optional) Only create Keycloak users for Django user records associated with a specific social-auth provider.",
         )
 
     def _get_access_token(
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             client_secret (str): The client secret associated with Keycloak's admin-cli client.
 
         Returns:
-            A new access_token for the administrator user for use with the Keycloak admin-cli client.
+            A new access_token (string) for the administrator user for use with the Keycloak admin-cli client.
         """
         url = f"{settings.KEYCLOAK_BASE_URL}/realms/{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/token"
         payload = f"{urlencode({'client_id': client_id})}&{urlencode({'username': username})}&{urlencode({'password': password})}&grant_type=password&{urlencode({'client_secret': client_secret})}&{urlencode({'scope': 'email openid'})}"
@@ -127,6 +127,7 @@ class Command(BaseCommand):
 
         Args:
             user (models.User): A Django User model record.
+            keycloak_group_path (str): The Keycloak group path which newly created users should be added to.
 
         Returns:
             dict: user representation for use with the Keycloak partialImport Admin REST API endpoint.


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4250 & https://github.com/mitodl/open-discussions/issues/4249.

#### What's this PR do?

Updates the Keycloak user migration script:
1. Removes functionality for migrating the user's password.
2. Adds functionality to specify a Keycloak group that any migrated users will be added to.
3. Adds functionality to only migrated Django user records with an specified associated social-auth provider, and no associated social-auth record for the "ol-apps" provider.

Updates Keycloak user migration script documentation: https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit?pli=1#heading=h.ds1pmqw8dg34

#### How should this be manually tested?
The following scenarios should be repeatable.
1. All Django user records without an associated social-auth record for the "ol-apps" provider have a Keycloak account created when the script is run without the `filter_provider_name` argument.
2. All Django user records without an associated social-auth record for the "ol-apps" provider but must have an associated social-auth record for the "email" provider have a Keycloak account created when the script is run with the `--filter_provider_name=email` argument.  Any users without a social-auth record should not be created.
3. All Django user records without an associated social-auth record for the "ol-apps" provider have a Keycloak account created and are added to the Keycloak group "/test/test-child" when the script is run without the `filter_provider_name` argument and with `--keycloak_group_path=/test/test-child`.
4. Any user created in Keycloak via the script should not have any credential.

#### Where should the reviewer start?
Documentation.

#### Any background context you want to provide?
https://docs.google.com/spreadsheets/d/1gOCQLNk1hBMutYoZVZ0Qa3SWb6LHRO9sepXCxy7X2q4/edit#gid=1942862761
