### PR TITLE
Add OCW SP department

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -257,6 +257,7 @@ OCW_DEPARTMENTS = {
         "name": "Athletics, Physical Education and Recreation",
     },
     "RES": {"slug": "supplemental-resources", "name": "Supplemental Resources"},
+    "SP": {"slug": "special-programs", "name": "Special Programs"},
     "STS": {
         "slug": "science-technology-and-society",
         "name": "Science, Technology, and Society",


### PR DESCRIPTION
#### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/3793.

#### What's this PR do?
This PR adds a new  SP (Special Programs) constant to OCW departments, allowing for users to search by that department.

#### How should this be manually tested?
This will primarily be tested on RC; it adds a new constant value for an additional OCW department and does not impact functionality in any other way.
