### PR TITLE
add podcast disclaimer

### DIFF
--- a/frontends/open-discussions/scss/podcasts.scss
+++ b/frontends/open-discussions/scss/podcasts.scss
@@ -83,7 +83,22 @@
 
   .podcast-footer {
     width: 100%;
-    border-top: 10px solid $course-blue;
+
+    .podcast-disclaimer-box {
+      background-color: $course-blue;
+      padding-top: 10px;
+      padding-bottom: 20px;
+    }
+
+    .podcast-disclaimer {
+      max-width: 900px;
+      color: white;
+      margin: auto;
+      padding: 16px;
+      @include breakpoint(mobile) {
+        font-size: 12px;
+      }
+    }
 
     .cells {
       display: flex;

--- a/frontends/open-discussions/src/components/PodcastFooter.js
+++ b/frontends/open-discussions/src/components/PodcastFooter.js
@@ -9,6 +9,15 @@ import { PODCAST_URL } from "../lib/url"
 export default function PodcastFooter() {
   return (
     <div className="podcast-footer">
+      <div className="podcast-disclaimer-box">
+        <div className="podcast-disclaimer">
+          <strong>Disclaimer</strong> - The views, thoughts, and opinions
+          expressed in the programs listed above are the speaker’s own and do
+          not necessarily represent the views, thoughts, and opinions of the
+          Massachusetts Institute of Technology. The material and information
+          presented here is for general information purposes only.
+        </div>
+      </div>
       <div className="cells">
         <div className="cell logo-legal">
           <a


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/3986

#### What's this PR do?
Adds a disclaimer saying that the views expressed in podcasts do not necessarily represent the view of MIT

#### How should this be manually tested?
Go to http://localhost:8063/podcasts/
Verify that the disclaimer is visible and looks good

#### Screenshots (if appropriate)
Desktop
<img width="1710" alt="Screenshot 2024-04-23 at 3 29 07 PM" src="https://github.com/mitodl/open-discussions/assets/1934992/93ecf4f3-96fc-4a1e-aa7c-6893efa77e6e">

Mobile
<img width="378" alt="Screenshot 2024-04-23 at 3 40 40 PM" src="https://github.com/mitodl/open-discussions/assets/1934992/b3b9a304-b886-4fb0-bea6-31053986f8ff">
