### PR TITLE
Switch poetry over to using virtualenvs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.4 as base
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
@@ -8,39 +8,55 @@ WORKDIR /tmp
 COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
-RUN apt-get update && apt-get install libpq-dev postgresql-client -y
 
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 
-# Add, and run as, non-root user.
-RUN mkdir /src
-RUN adduser --disabled-password --gecos "" mitodl
-RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
-
 # Poetry env configuration
 ENV  \
   # poetry:
-  POETRY_VERSION=1.5.1 \
+  POETRY_VERSION=1.8.2 \
   POETRY_VIRTUALENVS_CREATE=false \
-  POETRY_CACHE_DIR='/tmp/cache/poetry'
+  POETRY_CACHE_DIR='/tmp/cache/poetry' \
+  POETRY_HOME='/home/mitodl/.local' \
+  VIRTUAL_ENV="/opt/venv"
 
+ENV PATH="$VIRTUAL_ENV/bin:$POETRY_HOME/bin:$PATH"
+
+# Add, and run as, non-root user.
+RUN mkdir /app
+RUN adduser --disabled-password --gecos "" mitodl
+RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
+RUN mkdir "${VIRTUAL_ENV}" && chown -R mitodl:mitodl "${VIRTUAL_ENV}"
+
+
+USER mitodl
 # Install poetry
-RUN pip install "poetry==$POETRY_VERSION"
+RUN pipx install "poetry==$POETRY_VERSION"
 
 # Install project packages
-COPY pyproject.toml /src
-COPY poetry.lock /src
-WORKDIR /src
+WORKDIR /app
+COPY pyproject.toml poetry.lock /app
+RUN python3 -m venv "$VIRTUAL_ENV"
 RUN poetry install
 
-# Add project
-COPY . /src
-WORKDIR /src
-RUN chown -R mitodl:mitodl /src
-
+USER root
 RUN apt-get clean && apt-get purge
+
+
+# Set pip cache folder, as it is breaking pip when it is on a shared volume
+ENV XDG_CACHE_HOME /tmp/.cache
+
+# Add project
+COPY . /app
+
+FROM base as django
+
 USER mitodl
+
+# django-server target
+# =======================================
+FROM django as django-server
 
 EXPOSE 8063
 ENV PORT 8063

--- a/apt.txt
+++ b/apt.txt
@@ -1,9 +1,12 @@
 # Core requirements
-git
 curl
+git
+libffi-dev
 libjpeg-dev
-zlib1g-dev
+libpq-dev
+libxmlsec1-dev
 net-tools
 pkg-config
-libffi-dev
-libxmlsec1-dev
+postgresql-client
+pipx
+zlib1g-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: django-server
     environment:
       << : *py-environment
       PORT: 8061
@@ -83,6 +84,8 @@ services:
     tty: true
     ports:
       - "8061:8061"
+    volumes:
+      - .:/app
     links:
       - db
       - opensearch-node1
@@ -111,6 +114,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: django
     environment: *py-environment
     env_file: .env
     command: >
@@ -122,6 +126,8 @@ services:
       - db
       - opensearch-node1
       - redis
+    volumes:
+      - .:/app
     extra_hosts: *default-extra-hosts
 
   tika:


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR switches poetry over to installing project dependencies via virtualenv, which avoids a build error that was happening:
<details><summary>Stacktrace</summary>

```
9.668   ChefBuildError
9.668
9.668   Backend subprocess exited when trying to invoke get_requires_for_build_wheel
9.668
9.668   Traceback (most recent call last):
9.668     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
9.668       main()
9.668     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
9.668       json_out['return_val'] = hook(**hook_input['kwargs'])
9.668                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
9.668     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 112, in get_requires_for_build_wheel
9.668       backend = _build_backend()
9.668                 ^^^^^^^^^^^^^^^^
9.668     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 74, in _build_backend
9.668       ep = os.environ['PEP517_BUILD_BACKEND']
9.668            ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
9.668     File "<frozen os>", line 679, in __getitem__
9.668   KeyError: 'PEP517_BUILD_BACKEND'
9.668
9.668
9.668   at /usr/local/lib/python3.11/site-packages/poetry/installation/chef.py:147 in _prepare
9.673       143│
9.673       144│                 error = ChefBuildError("\n\n".join(message_parts))
9.673       145│
9.673       146│             if error is not None:
9.673     → 147│                 raise error from None
9.673       148│
9.673       149│             return path
9.673       150│
9.673       151│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
9.674
9.674 Note: This error originates from the build backend, and is likely not a problem with poetry but with docopt (0.6.2) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "docopt (==0.6.2)"'.
9.674
9.865
9.865   ChefBuildError
9.865
9.866   Backend subprocess exited when trying to invoke get_requires_for_build_wheel
9.866
9.866   Traceback (most recent call last):
9.866     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
9.866       main()
9.866     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
9.866       json_out['return_val'] = hook(**hook_input['kwargs'])
9.866                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
9.866     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 112, in get_requires_for_build_wheel
9.866       backend = _build_backend()
9.866                 ^^^^^^^^^^^^^^^^
9.866     File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 74, in _build_backend
9.866       ep = os.environ['PEP517_BUILD_BACKEND']
9.866            ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
9.866     File "<frozen os>", line 679, in __getitem__
9.866   KeyError: 'PEP517_BUILD_BACKEND'
9.866
9.866
9.866   at /usr/local/lib/python3.11/site-packages/poetry/installation/chef.py:147 in _prepare
9.872       143│
9.872       144│                 error = ChefBuildError("\n\n".join(message_parts))
9.872       145│
9.872       146│             if error is not None:
9.872     → 147│                 raise error from None
9.872       148│
9.872       149│             return path
9.872       150│
9.872       151│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
9.872
9.872 Note: This error originates from the build backend, and is likely not a problem with poetry but with pyrepl (0.9.0) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "pyrepl (==0.9.0)"'.
9.872
------
failed to solve: process "/bin/sh -c poetry install" did not complete successfully: exit code: 1
```
</details>

#### How should this be manually tested?
Running `docker compose build` should pass for you