### PR TITLE
Remove RES constant from OCW departments

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -256,7 +256,6 @@ OCW_DEPARTMENTS = {
         "slug": "athletics-physical-education-and-recreation",
         "name": "Athletics, Physical Education and Recreation",
     },
-    "RES": {"slug": "supplemental-resources", "name": "Supplemental Resources"},
     "SP": {"slug": "special-programs", "name": "Special Programs"},
     "STS": {
         "slug": "science-technology-and-society",


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4855

#### What's this PR do?
This PR removes a RES (Supplemental Resources) constant from OCW departments.

#### How should this be manually tested?
This will be tested at RC. 