### PR TITLE
Fix the error printing for failed requests

### DIFF
--- a/authentication/management/commands/validate_user_emails.py
+++ b/authentication/management/commands/validate_user_emails.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
             )
         except requests.exceptions.HTTPError as exc:
             self.stderr.write(str(exc))
-            self.stderr.write(exc.response.json())
+            self.stderr.write(exc.response.text)
         except Exception as exc:
             self.stderr.write(str(exc))
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This fixes an issue with the error handling - `json()` was returning a `dict` which was throwing an error trying to print to stdout, `text` returns a plain string.

#### How should this be manually tested?
Set `MAILGUN_KEY` to a bad value and run `./manage.py validate_user_emails start`. You should see an error response like this printed:
```
401 Client Error: Unauthorized for url: https://api.mailgun.net/v4/address/validate/bulk/email-validation-1734013131-1
{"message":"Invalid private key"}
```

You may need to run `EmailValidation.objects.all().delete()` in a shell to reset validation state for your existing users.
