### PR TITLE
Only validate active user emails

### DIFF
--- a/authentication/management/commands/validate_user_emails.py
+++ b/authentication/management/commands/validate_user_emails.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
                     user=OuterRef("pk"), email=OuterRef("email")
                 )
             )
-        ).filter(has_email_validations=False)
+        ).filter(is_active=True, has_email_validations=False)
 
         try:
             email_validation_api.start_user_email_validation(


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
The command was validating inactive accounts, all of which didn't have an email address to validate since we scrubbed spammer accoutns, so we should just skip those accounts because it can be a lot to process.

#### How should this be manually tested?
Disable a `User` Account, remove any `EmailValidation` records for them, and then verify no new `EmailValidation` record is created for them when you run `./manage.py. validate_user_emails start`
