### PR TITLE
Add back in keycloak user attributes

### DIFF
--- a/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
+++ b/keycloak_user_export/management/commands/migrate_users_to_keycloak.py
@@ -160,6 +160,11 @@ class Command(BaseCommand):
             "enabled": True,
             "emailVerified": True,
             "email": user.email,
+            "totp": False,
+            "credentials": [],
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
+            "notBefore": 0,
             "realmRoles": [f"default-roles-{settings.KEYCLOAK_REALM_NAME}"],
             "groups": [keycloak_group_path] if keycloak_group_path else [],
             "attributes": {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/6385

#### What's this PR do?
This fixes a regression I created when I [removed these attributes in a previous PR](https://github.com/mitodl/open-discussions/pull/4370/files#diff-3c7da601b7ac6ddc426c2a3ca6a64796843e7e09259b9bd786462fa7190dfe5aL156-L163) that are declared as optional in the API and we were passing what I would've thought were defaults but apparently without these Keycloak ignores `emailVerified` and `groups`. No idea why. 

#### How should this be manually tested?
Run the migration command and pass `--keycloak-group-path`. The imported user(s) should be marked as email verified and be part of the group.
