### PR TITLE
Fix error with xmlsec library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4375

#### What's this PR do?

It looks like previous github action runs ran on ubuntu 22.04 which worked. `ubuntu-latest` now points to `ubuntu-24.04`, but this isn't reflected in https://github.com/actions/runner-images/?tab=readme-ov-file#available-images, so I'm not really sure what's going on there, something is possibly botched.

I tried multiple attempts at trying to get the most recent xmlsec/lxml versions to work but none of them did. This is blocking us so I'm simply going to pin to `ubuntu-22.04` as a short term solution.

#### How should this be manually tested?

- The first commit in this branch illustrates the failure.
- The code changes fix this and the tests should pass.
