### PR TITLE
fix ocw etl

### DIFF
--- a/app.json
+++ b/app.json
@@ -494,10 +494,6 @@
       "description": "bucket for ocw-next courses data",
       "required": false
     },
-    "OCW_NEXT_AWS_STORAGE_BUCKET_NAME": {
-      "description": "bucket for ocw-next storage data",
-      "required": false
-    },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {
       "value": "50"
     },

--- a/course_catalog/etl/ocw_next.py
+++ b/course_catalog/etl/ocw_next.py
@@ -1,4 +1,5 @@
 """OCW Next Resource ETL"""
+
 import logging
 import mimetypes
 from os.path import splitext
@@ -49,9 +50,14 @@ def transform_ocw_next_content_files(s3_resource, course_prefix, force_overwrite
         if obj.key.endswith("data.json"):
             try:
                 resource_json = safe_load_json(get_s3_object_and_read(obj), obj.key)
-                transformed_resource = transform_resource(
-                    obj.key, resource_json, s3_resource, force_overwrite
-                )
+                if resource_json.get("resourcetype"):
+                    transformed_resource = transform_resource(
+                        obj.key, resource_json, s3_resource, force_overwrite
+                    )
+                else:
+                    transformed_resource = transform_resource_legacy(
+                        obj.key, resource_json, s3_resource, force_overwrite
+                    )
                 if transformed_resource:
                     yield transformed_resource
 
@@ -81,10 +87,11 @@ def transform_page(s3_key, page_data):
         "content": page_data.get("content"),
         "key": s3_path,
         "published": True,
+        "description": page_data.get("description"),
     }
 
 
-def transform_resource(
+def transform_resource_legacy(
     s3_key, resource_data, s3_resource, force_overwrite
 ):  # pylint:disable=too-many-locals,too-many-branches
     """Transforms the data from data.json for a resource into content_file data
@@ -128,18 +135,13 @@ def transform_resource(
         file_s3_path = "courses" + file_s3_path.split("courses")[1]
 
     ext_lower = splitext(file_s3_path)[-1].lower()
-    mime_type = mimetypes.types_map.get(file_s3_path)
+    mime_type = mimetypes.types_map.get(ext_lower)
     content_json = None
 
     if ext_lower in VALID_TEXT_FILE_TYPES:
-        try:
-            s3_obj = s3_resource.Object(
-                settings.OCW_NEXT_AWS_STORAGE_BUCKET_NAME, unquote(file_s3_path)
-            ).get()
-        except ClientError:
-            s3_obj = s3_resource.Object(
-                settings.OCW_NEXT_LIVE_BUCKET, unquote(file_s3_path)
-            ).get()
+        s3_obj = s3_resource.Object(
+            settings.OCW_NEXT_LIVE_BUCKET, unquote(file_s3_path)
+        ).get()
 
         course_file_obj = ContentFile.objects.filter(key=s3_path).first()
 
@@ -165,6 +167,99 @@ def transform_resource(
         "file_type": file_type,
         "content_type": content_type,
         "url": "../" + urlparse(s3_path).path.lstrip("/"),
+        "title": title,
+        "content_title": title,
+        "key": s3_path,
+        "learning_resource_types": resource_data.get("learning_resource_types"),
+        "published": True,
+    }
+
+    if content_json:
+        resource_data["content"] = content_json.get("content")
+
+    if image_src:
+        resource_data["image_src"] = image_src
+
+    return resource_data
+
+
+def transform_resource(
+    s3_key, resource_data, s3_resource, force_overwrite
+):  # pylint:disable=too-many-locals,too-many-branches
+    """Transforms the data from data.json for a resource into content_file data
+
+    Args:
+        s3_key (str):S3 path for the data.json file for the page
+        resource_data (dict): JSON data from the data.json file for the page
+        s3_resource (str): The S3 resource
+        force_overwrite (bool): Overwrite document text if true
+
+
+    Returns:
+        dict: transformed content file data
+
+    """
+    s3_path = s3_key.split("data.json")[0]
+    s3_path = urlparse(s3_path).path.lstrip("/")
+
+    file_type = resource_data.get("file_type")
+    video_files = resource_data.get("video_files", {})
+    if resource_data.get("resourcetype") == "Video":
+        content_type = CONTENT_TYPE_VIDEO
+    else:
+        content_type = get_content_type(file_type)
+
+    if content_type == "video":
+        file_s3_path = video_files.get("video_transcript_file")
+        image_src = video_files.get("video_thumbnail_file")
+    else:
+        file_s3_path = resource_data.get("file")
+        image_src = None
+
+    if not file_s3_path:
+        return None
+
+    title = resource_data.get("title")
+
+    if title in {"3play caption file", "3play pdf file"}:
+        return None
+
+    if not file_s3_path.startswith("courses"):
+        file_s3_path = "courses" + file_s3_path.split("courses")[1]
+
+    ext_lower = splitext(file_s3_path)[-1].lower()
+    mime_type = mimetypes.types_map.get(ext_lower)
+    content_json = None
+
+    if ext_lower in VALID_TEXT_FILE_TYPES:
+        s3_obj = s3_resource.Object(
+            settings.OCW_NEXT_LIVE_BUCKET, unquote(file_s3_path)
+        ).get()
+
+        course_file_obj = ContentFile.objects.filter(key=s3_path).first()
+
+        needs_text_update = (
+            force_overwrite
+            or course_file_obj is None
+            or (
+                s3_obj is not None
+                and s3_obj["LastModified"] >= course_file_obj.updated_on
+            )
+        )
+
+        if needs_text_update:
+            s3_body = s3_obj["Body"].read() if s3_obj else None
+            if s3_body:
+                content_json = extract_text_metadata(
+                    s3_body,
+                    other_headers={"Content-Type": mime_type} if mime_type else {},
+                )
+
+    resource_data = {
+        "description": resource_data.get("content"),
+        "file_type": file_type,
+        "content_type": content_type,
+        "url": "../" + s3_path,
         "title": title,
         "content_title": title,
         "key": s3_path,

--- a/course_catalog/etl/ocw_next_test.py
+++ b/course_catalog/etl/ocw_next_test.py
@@ -1,4 +1,5 @@
 """Next OCW ETL tests"""
+
 from datetime import datetime
 
 import boto3
@@ -42,6 +43,7 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "published": True,
         "title": "Pages",
         "content_title": "Pages",
+        "description": None,
         "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
     }
 
@@ -52,6 +54,7 @@ def test_transform_ocw_next_content_files(settings, mocker):
         "published": True,
         "title": "Syllabus",
         "content_title": "Syllabus",
+        "description": "Description of Syllabus",
         "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
     }
 

--- a/open_discussions/settings_course_etl.py
+++ b/open_discussions/settings_course_etl.py
@@ -19,7 +19,6 @@ OCW_CONTENT_BUCKET_NAME = get_string("OCW_CONTENT_BUCKET_NAME", None)
 
 # s3 Buckets for OCW Next imports
 OCW_NEXT_LIVE_BUCKET = get_string("OCW_NEXT_LIVE_BUCKET", None)
-OCW_NEXT_AWS_STORAGE_BUCKET_NAME = get_string("OCW_NEXT_AWS_STORAGE_BUCKET_NAME", None)
 
 # S3 Bucket info for exporting OCW Plone media files
 OCW_LEARNING_COURSE_BUCKET_NAME = get_string("OCW_LEARNING_COURSE_BUCKET_NAME", None)

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/data.json
@@ -1,6 +1,12 @@
-
 {
-  "title":"Syllabus",
-  "content":"Course Meeting Times Lecture"
+  "audience": [],
+  "content": "Course Meeting Times Lecture",
+  "content_type": "page",
+  "description": "Description of Syllabus",
+  "draft": false,
+  "iscjklanguage": false,
+  "learning_resource_types": [],
+  "level": [],
+  "title": "Syllabus",
+  "uid": "414408f8-e288-491a-8416-269f011da428"
 }
-

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/data.json
@@ -1,8 +1,46 @@
-{  
-  "description": "This resource contains problem set 1",
+{
+  "audience": ["Learners"],
+  "body": "",
+  "content": "This resource contains problem set 1",
+  "content_type": "resource",
+  "draft": false,
   "file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/0902956aa08f67a954b28efdcbaaa472_MIT6_262S11_assn%2001.pdf",
-  "learning_resource_types": ["Activity Assignments","Activity Assignments with Examples"],
-  "resource_type": "Document",
   "file_type": "application/pdf",
-  "title":  "Resource Title"
+  "gdrive_url": "",
+  "image_metadata": {
+    "caption": "",
+    "credit": "",
+    "image-alt": ""
+  },
+  "iscjklanguage": false,
+  "learning_resource_types": [
+    "Activity Assignments",
+    "Activity Assignments with Examples"
+  ],
+  "level": ["Undergraduate"],
+  "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "resourcetype": "Document",
+  "title": "Resource Title",
+  "uid": "42a52ff4-42ea-429c-936a-c75dfdc21d8f",
+  "video_files": {
+    "archive_url": "",
+    "video_captions_file": "",
+    "video_captions_resource": {
+      "content": "",
+      "website": "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006"
+    },
+    "video_thumbnail_file": "",
+    "video_transcript_file": "",
+    "video_transcript_resource": {
+      "content": "",
+      "website": "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006"
+    }
+  },
+  "video_metadata": {
+    "source": "",
+    "video_speakers": "",
+    "video_tags": "",
+    "youtube_description": "",
+    "youtube_id": ""
+  }
 }

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
@@ -1,12 +1,37 @@
 {
-  "description": "Video Description",
+  "audience": ["Learners"],
+  "body": "",
+  "content": "Video Description",
+  "content_type": "resource",
+  "draft": false,
   "file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/gdrive_uploads/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26/94force.mp4",
-  "learning_resource_types": ["Competition Videos"],
-  "resource_type": "Video",
   "file_type": "video/mp4",
-  "youtube_key":  "vKer2U5W5-s",
-  "captions_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript_webvtt",
-  "transcript_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript.pdf",
-  "thumbnail_file": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
-  "archive_url": null
+  "gdrive_url": "",
+  "image_metadata": {
+    "caption": "",
+    "credit": "",
+    "image-alt": ""
+  },
+  "iscjklanguage": false,
+  "learning_resource_types": ["Competition Videos"],
+  "level": ["Undergraduate"],
+  "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "resourcetype": "Video",
+  "title": null,
+  "uid": "42a52ff4-42ea-429c-936a-c75dfdc21d8f",
+  "video_files": {
+    "archive_url": "",
+    "video_captions_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript_webvtt",
+    "video_captions_resource": "",
+    "video_thumbnail_file": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
+    "video_transcript_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript.pdf",
+    "video_transcript_resource": ""
+  },
+  "video_metadata": {
+    "source": "",
+    "video_speakers": "",
+    "video_tags": "",
+    "youtube_description": "",
+    "youtube_id": "vKer2U5W5-s"
+  }
 }


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/mit-learn/pull/3202

### Description (What does it do?)
https://github.com/mitodl/ocw-hugo-themes/pull/1780 updates ocw-hugo-themes to include the full ocw-studio metadata for pages and resources. In order for all new metadata that is added to ocw to be immediately available for learn the data.json files in the ocw s3 bucket will have the contentfile metadata in the original format that ocw uses. This pr updates open-discussions to be able to use the new data format. For now the code supports data in either format. A followup pr will delete transform_contentfile_legacy.

### How can this be tested?
Set 

AWS_SECRET_ACCESS_KEY= value from open rc
AWS_ACCESS_KEY_ID=value from open rc
OCW_NEXT_LIVE_BUCKET=ocw-content-live-production

Run 
`docker-compose run web ./manage.py backpopulate_ocw_next_data --course-name 9-35-perception-spring-2024 --overwrite`

From the shell run

```
from course_catalog.models import *
 ContentFile.objects.filter(content_type='file').last().__dict__
 ContentFile.objects.filter(content_type='video').last().__dict__
 ContentFile.objects.filter(content_type='page').last().__dict__
```

check that you get files from 9-35-perception-spring-2024 and copy the output to a file

Set 

AWS_SECRET_ACCESS_KEY= ask me for the value
AWS_ACCESS_KEY_ID=ask me for the value
OCW_NEXT_LIVE_BUCKET=abeglovatest

Run 
`docker-compose run web ./manage.py backpopulate_ocw_next_data --course-name 9-35-perception-spring-2024 --overwrite`
again

From the shell find the objects you found previously. They should have the same data except the video object (and maybe the file object depending on the one you get) will have "description" set