### PR TITLE
make ocw file descriptions the way they were previously

### DIFF
--- a/course_catalog/etl/ocw_next.py
+++ b/course_catalog/etl/ocw_next.py
@@ -256,7 +256,7 @@ def transform_resource(
                 )
 
     resource_data = {
-        "description": resource_data.get("content"),
+        "description": resource_data.get("description"),
         "file_type": file_type,
         "content_type": content_type,
         "url": "../" + s3_path,

--- a/course_catalog/etl/ocw_next_test.py
+++ b/course_catalog/etl/ocw_next_test.py
@@ -61,7 +61,7 @@ def test_transform_ocw_next_content_files(settings, mocker):
     assert content_data[2] == {
         "content": "TEXT",
         "content_type": "pdf",
-        "description": "This resource contains problem set 1",
+        "description": "Description of problem set 1",
         "file_type": "application/pdf",
         "key": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
         "learning_resource_types": [
@@ -77,7 +77,7 @@ def test_transform_ocw_next_content_files(settings, mocker):
     assert content_data[3] == {
         "content": "TEXT",
         "content_type": "video",
-        "description": "Video Description",
+        "description": "Description of the video",
         "file_type": "video/mp4",
         "key": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
         "learning_resource_types": ["Competition Videos"],

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/data.json
@@ -2,6 +2,7 @@
   "audience": ["Learners"],
   "body": "",
   "content": "This resource contains problem set 1",
+  "description": "Description of problem set 1",
   "content_type": "resource",
   "draft": false,
   "file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/0902956aa08f67a954b28efdcbaaa472_MIT6_262S11_assn%2001.pdf",

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/data.json
@@ -3,6 +3,7 @@
   "body": "",
   "content": "Video Description",
   "content_type": "resource",
+  "description": "Description of the video",
   "draft": false,
   "file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/gdrive_uploads/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26/94force.mp4",
   "file_type": "video/mp4",


### PR DESCRIPTION
### What are the relevant tickets?
None 

### Description (What does it do?)
https://github.com/mitodl/open-discussions/pull/4445 updated the the ocw etl to use the new format for data.json files. As part of that i replaced the description field with the contents of the content field which had more detailed resource descriptions and is more frequently non-empty. This is what we plan to use for learn. Unfortunately this does not work for ocw search because 1) the content has embedded html which ocw does not display correctly and 2) long descriptions do not look good with the small cards in the ocw resource search.  

For example these are the updated search cards for 2-003sc-engineering-dynamics-fall-2011 
https://live-qa.ocw.mit.edu/search/?q=Lecture%2021%3A%20Vibration%20Isolation&type=resourcefile

And this is what it looks like on prod:
https://ocw.mit.edu/search/?q=Lecture%2021%3A%20Vibration%20Isolation&r=Lecture%20Videos&type=resourcefile

This undoes that change and uses the original description field which is populated in both the old and new data format. 


### Screenshots (if appropriate):
Set aws credentials to the values from either learn or discussions rc 
Set OCW_NEXT_LIVE_BUCKET=ocw-content-live-qa

Run `docker-compose run web ./manage.py backpopulate_ocw_next_data --course-name 2-003sc-engineering-dynamics-fall-2011  --overwrite`

From the shell run
```
from course_catalog.models import *
ContentFile.objects.filter(title="Lecture 21: Vibration Isolation").last().description
```
should be ''
```
ContentFile.objects.filter(title="Recitation 9 Notes: Generalized Forces with Double Pendulum Example").last().description
```
should be

`This file contains information regarding recitation 9 notes: generalized forces with double pendulum example.'

Any other 2.003SC ContentFIle should have the description that is on prod currently - you can find the files at 
https://ocw.mit.edu/search/?q=2.003SC&type=resourcefile (or search the prod discussions database)