### PR TITLE
Fix podcast images

### DIFF
--- a/frontends/open-discussions/.sass-lint.yml
+++ b/frontends/open-discussions/.sass-lint.yml
@@ -12,7 +12,12 @@ rules:
   no-debug: 1
   no-important: 0
   no-empty-rulesets: 2
-  no-misspelled-properties: 2
+  no-misspelled-properties:
+    # sass-lint's built-in property list predates aspect-ratio
+    - 2
+    -
+      extra-properties:
+        - aspect-ratio
   no-mergeable-selectors: 2
   no-trailing-whitespace: 2
   trailing-semicolon: 2

--- a/frontends/open-discussions/scss/learning-resource-drawer.scss
+++ b/frontends/open-discussions/scss/learning-resource-drawer.scss
@@ -14,6 +14,8 @@
       display: block;
       margin: auto;
       width: 100%;
+      aspect-ratio: 440 / 239;
+      object-fit: cover;
     }
   }
 

--- a/frontends/open-discussions/scss/podcasts.scss
+++ b/frontends/open-discussions/scss/podcasts.scss
@@ -240,7 +240,8 @@
         border-radius: 5px;
         max-width: 125px;
         min-width: 125px;
-        max-height: 79px;
+        height: 77px;
+        object-fit: cover;
         overflow: hidden;
       }
     }
@@ -267,7 +268,8 @@
     .cover-img {
       img {
         width: 100%;
-        min-height: 170px;
+        height: 170px;
+        object-fit: cover;
         border-radius: 5px 5px 0 0;
       }
     }

--- a/frontends/open-discussions/src/lib/url.js
+++ b/frontends/open-discussions/src/lib/url.js
@@ -63,25 +63,27 @@ export const defaultResourceImageURL = () =>
   ).toString()
 
 // When the embedly key is unset (the embedly subscription was cancelled) we
-// serve the raw, unoptimized image instead of routing through embedly.
+// serve the raw, unoptimized image instead of routing through embedly. Fall
+// back to the blank thumbnail when there is no url, matching embedly's old
+// errorurl behavior so we never render a broken image.
 export const embedlyThumbnail = (
   key: string,
   url: string,
   height: number,
   width: number
 ) =>
-  key
+  key && url
     ? `https://i.embed.ly/1/display/crop/?key=${key}&url=${encodeURIComponent(
-        url
-      )}&height=${height}&width=${width}&grow=true&animate=false&errorurl=${blankThumbnailUrl()}`
-    : url
+      url
+    )}&height=${height}&width=${width}&grow=true&animate=false&errorurl=${blankThumbnailUrl()}`
+    : url || blankThumbnailUrl()
 
 export const embedlyResizeImage = (key: string, url: string, height: number) =>
-  key
+  key && url
     ? `https://i.embed.ly/1/display/resize/?key=${key}&url=${encodeURIComponent(
-        url
-      )}&height=${height}&grow=false&animate=false&errorurl=${blankThumbnailUrl()}`
-    : url
+      url
+    )}&height=${height}&grow=false&animate=false&errorurl=${blankThumbnailUrl()}`
+    : url || blankThumbnailUrl()
 
 export const absolutizeURL = (url: string) =>
   new URL(url, window.location.origin).toString()

--- a/frontends/open-discussions/src/lib/url.js
+++ b/frontends/open-discussions/src/lib/url.js
@@ -62,20 +62,26 @@ export const defaultResourceImageURL = () =>
     window.location.origin
   ).toString()
 
+// When the embedly key is unset (the embedly subscription was cancelled) we
+// serve the raw, unoptimized image instead of routing through embedly.
 export const embedlyThumbnail = (
   key: string,
   url: string,
   height: number,
   width: number
 ) =>
-  `https://i.embed.ly/1/display/crop/?key=${key}&url=${encodeURIComponent(
-    url
-  )}&height=${height}&width=${width}&grow=true&animate=false&errorurl=${blankThumbnailUrl()}`
+  key
+    ? `https://i.embed.ly/1/display/crop/?key=${key}&url=${encodeURIComponent(
+        url
+      )}&height=${height}&width=${width}&grow=true&animate=false&errorurl=${blankThumbnailUrl()}`
+    : url
 
 export const embedlyResizeImage = (key: string, url: string, height: number) =>
-  `https://i.embed.ly/1/display/resize/?key=${key}&url=${encodeURIComponent(
-    url
-  )}&height=${height}&grow=false&animate=false&errorurl=${blankThumbnailUrl()}`
+  key
+    ? `https://i.embed.ly/1/display/resize/?key=${key}&url=${encodeURIComponent(
+        url
+      )}&height=${height}&grow=false&animate=false&errorurl=${blankThumbnailUrl()}`
+    : url
 
 export const absolutizeURL = (url: string) =>
   new URL(url, window.location.origin).toString()

--- a/frontends/open-discussions/src/lib/url_test.js
+++ b/frontends/open-discussions/src/lib/url_test.js
@@ -252,6 +252,11 @@ describe("url helper functions", () => {
       const url = "http://www.fake.url/fake.html"
       assert.equal(embedlyThumbnail("", url, 100, 200), url)
     })
+
+    it("should return the blank thumbnail when the url is falsy", () => {
+      assert.equal(embedlyThumbnail("", "", 100, 200), blankThumbnailUrl())
+      assert.equal(embedlyThumbnail("key", "", 100, 200), blankThumbnailUrl())
+    })
   })
 
   describe("embedlyResizeImage", () => {

--- a/frontends/open-discussions/src/lib/url_test.js
+++ b/frontends/open-discussions/src/lib/url_test.js
@@ -247,6 +247,11 @@ describe("url helper functions", () => {
       assert.ok(embedlyUrl.includes(`animate=false`))
       assert.ok(embedlyUrl.includes(`url=${encodeURIComponent(url)}`))
     })
+
+    it("should return the raw url when the key is unset", () => {
+      const url = "http://www.fake.url/fake.html"
+      assert.equal(embedlyThumbnail("", url, 100, 200), url)
+    })
   })
 
   describe("embedlyResizeImage", () => {
@@ -259,6 +264,11 @@ describe("url helper functions", () => {
       assert.ok(embedlyUrl.includes(`key=${key}`))
       assert.ok(embedlyUrl.includes(`animate=false`))
       assert.ok(embedlyUrl.includes(`url=${encodeURIComponent(url)}`))
+    })
+
+    it("should return the raw url when the key is unset", () => {
+      const url = "http://www.fake.url/fake.jpg"
+      assert.equal(embedlyResizeImage("", url, 512), url)
     })
   })
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes the images on the podcast page 

### Screenshots (if appropriate):
<img width="1607" height="902" alt="Screenshot 2026-07-01 at 3 47 07 PM" src="https://github.com/user-attachments/assets/4f15e134-507e-4e08-86a8-e029841762ef" />
<img width="439" height="731" alt="Screenshot 2026-07-01 at 3 47 26 PM" src="https://github.com/user-attachments/assets/7d9e2cc9-42b9-47b0-ad35-9d9f461f2292" />


### How can this be tested?
View `/podcasts` after having run `./manage.py backpopulate_podcast_data`