### PR TITLE
Add department 21T (Theater Arts)

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -218,6 +218,7 @@ OCW_DEPARTMENTS = {
     "21H": {"slug": "history", "name": "History"},
     "21L": {"slug": "literature", "name": "Literature"},
     "21M": {"slug": "music-and-theater-arts", "name": "Music and Theater Arts"},
+    "21T": {"slug": "theater-arts", "name": "Theater Arts"},
     "22": {"slug": "nuclear-engineering", "name": "Nuclear Science and Engineering"},
     "24": {"slug": "linguistics-and-philosophy", "name": "Linguistics and Philosophy"},
     "CC": {"slug": "concourse", "name": "Concourse"},


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Adds `21T` to `OCW_DEPARTMENTS` in `course_catalog/constants.py`:

- name: `Theater Arts`
- slug: `theater-arts`

Department name/slug and the department search facet are derived from this map, so 21T courses would otherwise show a blank department and be absent from the facet.

### How can this be tested?
- Will be tested on RC.
- Ingest an OCW course whose `department_number` is `21T`. Its `department_name` / `department_slug` resolve to **Theater Arts** / `theater-arts`, and it appears under the Theater Arts department facet in search.