### PR TITLE
Rename department 21M from Music and Theater Arts to Music

### DIFF
--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -217,7 +217,7 @@ OCW_DEPARTMENTS = {
     },
     "21H": {"slug": "history", "name": "History"},
     "21L": {"slug": "literature", "name": "Literature"},
-    "21M": {"slug": "music-and-theater-arts", "name": "Music and Theater Arts"},
+    "21M": {"slug": "music", "name": "Music"},
     "22": {"slug": "nuclear-engineering", "name": "Nuclear Science and Engineering"},
     "24": {"slug": "linguistics-and-philosophy", "name": "Linguistics and Philosophy"},
     "CC": {"slug": "concourse", "name": "Concourse"},

--- a/course_catalog/constants.py
+++ b/course_catalog/constants.py
@@ -217,7 +217,7 @@ OCW_DEPARTMENTS = {
     },
     "21H": {"slug": "history", "name": "History"},
     "21L": {"slug": "literature", "name": "Literature"},
-    "21M": {"slug": "music-and-theater-arts", "name": "Music and Theater Arts"},
+    "21M": {"slug": "music", "name": "Music"},
     "21T": {"slug": "theater-arts", "name": "Theater Arts"},
     "22": {"slug": "nuclear-engineering", "name": "Nuclear Science and Engineering"},
     "24": {"slug": "linguistics-and-philosophy", "name": "Linguistics and Philosophy"},


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Renames department `21M` in `OCW_DEPARTMENTS` (`course_catalog/constants.py`):

- name: "Music and Theater Arts" → **Music**
- slug: `music-and-theater-arts` → `music`

### How can this be tested?
- Will be tested on RC
- Re-ingest/reindex an OCW course in department 21M — its `department_name` / `department_slug` and the search facet now show **Music** / `music`.
