### PR TITLE
Redirect open.mit.edu/podcasts to learn.mit.edu/podcasts

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -27,6 +27,10 @@ server {
         try_files /static/images/favicon.ico /favicon.ico;
     }
 
+    location /podcasts {
+        return 301 https://learn.mit.edu/podcasts;
+    }
+
     location / {
         include uwsgi_params;
         uwsgi_pass web:8061;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -79,6 +79,10 @@ http {
             return 204;
         }
 
+        location /podcasts {
+            return 301 https://learn.mit.edu/podcasts;
+        }
+
         location / {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;


### PR DESCRIPTION
## Summary
- Per mitodl/hq#12912, the Learn podcasts page replaces the one on open.mit.edu.
- Adds an nginx-level 301 redirect for `/podcasts` (and any subpath) to `https://learn.mit.edu/podcasts`, in both the Heroku (`config/nginx.conf.erb`) and local dev (`config/nginx.conf`) configs.
- Follows the existing vanity-redirect pattern already in this file (`lemelsonx.mit.edu`, `themove.mit.edu`).
- Confirmed `https://open.mit.edu/podcasts/` currently serves no `<link rel="canonical">` tag, and `https://learn.mit.edu/podcasts` returns 200, so no cleanup is needed before the redirect goes live.

## Test plan
- [ ] Deploy to Heroku review app / staging and confirm `https://open.mit.edu/podcasts/` and `https://open.mit.edu/podcasts/anything` both 301 to `https://learn.mit.edu/podcasts`.
- [ ] Confirm other routes (`/`, `/c/...`, static assets) are unaffected.

Closes mitodl/hq#12912