### PR TITLE
fix(sentry): cap request bodies at 1KB and scrub Postgres DETAIL rows

### DIFF
--- a/open_discussions/sentry.py
+++ b/open_discussions/sentry.py
@@ -1,5 +1,7 @@
 """Sentry setup and configuration"""
 
+import re
+
 import sentry_sdk
 from celery.exceptions import WorkerLostError
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -16,8 +18,11 @@ SHUTDOWN_ERRORS = (WorkerLostError, SystemExit)
 # value, where no SDK privacy setting reaches it: send_default_pii governs
 # user/cookie/header capture and max_request_body_size governs request bodies,
 # and neither touches exception text.
-PG_DETAIL_MARKER = "\nDETAIL:"
-PG_DETAIL_REPLACEMENT = "\nDETAIL:  [scrubbed]"
+#
+# The newline is matched both raw and as a literal backslash-n: the SDK repr()s
+# frame locals and non-string logging params during serialization, so there the
+# DETAIL line arrives as "...constraint\\nDETAIL: ..." inside a repr string.
+PG_DETAIL_RE = re.compile(r"(\n|\\n)DETAIL:.*", re.DOTALL)
 
 
 def scrub_pg_detail(text):
@@ -26,10 +31,9 @@ def scrub_pg_detail(text):
     Keeps the primary message, which is what identifies the failure, and drops
     the row echo plus any HINT/CONTEXT Postgres appends after it.
     """
-    index = text.find(PG_DETAIL_MARKER)
-    if index == -1:
-        return text
-    return text[:index] + PG_DETAIL_REPLACEMENT
+    return PG_DETAIL_RE.sub(
+        lambda match: match.group(1) + "DETAIL:  [scrubbed]", text, count=1
+    )
 
 
 def scrub_pg_details(event):
@@ -37,15 +41,15 @@ def scrub_pg_details(event):
 
     The row echo reaches Sentry through more fields than the exception value:
     LoggingIntegration puts the log message in a breadcrumb
-    (integrations/logging.py:311), logger.error("...: %s", exc) puts it in
-    logentry.params (:274), and captured stack-frame locals carry it in
-    frame vars because include_local_variables defaults to True
-    (consts.py:1028, utils.py:616).  Walking the whole event covers those
-    without enumerating them, and does not go stale when the SDK adds another.
+    (BreadcrumbHandler._breadcrumb_from_record), logger.error("...: %s", exc)
+    puts it in logentry.params (EventHandler._emit), and captured stack-frame
+    locals carry it in frame vars because include_local_variables defaults to
+    True (serialize_frame).  Walking the whole event covers those without
+    enumerating them, and does not go stale when the SDK adds another.
 
-    Safe to walk naively because client._prepare_event serializes the event
-    before calling before_send (client.py:650 vs :658), so every leaf here is
-    already a JSON primitive -- no live exception objects to coerce.
+    Safe to walk naively because Client._prepare_event serializes the event
+    before calling before_send, so every leaf here is already a JSON
+    primitive -- no live exception objects to coerce.
     """
     return _scrub_node(event)
 
@@ -61,8 +65,6 @@ def _scrub_node(node):
     if isinstance(node, list):
         node[:] = [_scrub_node(item) for item in node]
         return node
-    if isinstance(node, tuple):
-        return tuple(_scrub_node(item) for item in node)
     return node
 
 
@@ -101,11 +103,12 @@ def init_sentry(*, dsn, environment, version, log_level):
         release=version,
         before_send=before_send,
         # Request bodies are NOT gated on send_default_pii: the SDK sets
-        # request.data unconditionally (sentry_sdk/integrations/_wsgi_common.py
-        # :123) and this is the only control (:61).  Left unset it defaults to
-        # "medium", i.e. 10,000-byte bodies -- enrollment, checkout, profile and
-        # SCIM payloads.  Set explicitly so the choice is findable here rather
-        # than in a dependency's defaults.
+        # request.data unconditionally (RequestExtractor.extract_into_event)
+        # and this is the only control (request_body_within_bounds).  Left
+        # unset it defaults to "medium", i.e. 10,000-byte bodies -- profile
+        # edits, user lists and widget lists posted to the DRF APIs.  Set
+        # explicitly so the choice is findable here rather than in a
+        # dependency's defaults.
         max_request_body_size="small",
         integrations=[
             DjangoIntegration(),

--- a/open_discussions/sentry.py
+++ b/open_discussions/sentry.py
@@ -33,26 +33,37 @@ def scrub_pg_detail(text):
 
 
 def scrub_pg_details(event):
-    """Apply scrub_pg_detail everywhere an error string lands on the event.
+    """Truncate Postgres DETAIL lines everywhere in a Sentry event.
 
-    Covers exception values, the logentry message/formatted pair, and the legacy
-    top-level message, so the scrub holds whether the event arrived as an
-    uncaught exception or via logger.exception.
+    The row echo reaches Sentry through more fields than the exception value:
+    LoggingIntegration puts the log message in a breadcrumb
+    (integrations/logging.py:311), logger.error("...: %s", exc) puts it in
+    logentry.params (:274), and captured stack-frame locals carry it in
+    frame vars because include_local_variables defaults to True
+    (consts.py:1028, utils.py:616).  Walking the whole event covers those
+    without enumerating them, and does not go stale when the SDK adds another.
+
+    Safe to walk naively because client._prepare_event serializes the event
+    before calling before_send (client.py:650 vs :658), so every leaf here is
+    already a JSON primitive -- no live exception objects to coerce.
     """
-    for entry in (event.get("exception") or {}).get("values") or []:
-        value = entry.get("value")
-        if isinstance(value, str):
-            entry["value"] = scrub_pg_detail(value)
-    logentry = event.get("logentry")
-    if isinstance(logentry, dict):
-        for key in ("formatted", "message"):
-            value = logentry.get(key)
-            if isinstance(value, str):
-                logentry[key] = scrub_pg_detail(value)
-    top_message = event.get("message")
-    if isinstance(top_message, str):
-        event["message"] = scrub_pg_detail(top_message)
-    return event
+    return _scrub_node(event)
+
+
+def _scrub_node(node):
+    """Recurse through the serialized event, rewriting strings in place."""
+    if isinstance(node, str):
+        return scrub_pg_detail(node)
+    if isinstance(node, dict):
+        for key, value in node.items():
+            node[key] = _scrub_node(value)
+        return node
+    if isinstance(node, list):
+        node[:] = [_scrub_node(item) for item in node]
+        return node
+    if isinstance(node, tuple):
+        return tuple(_scrub_node(item) for item in node)
+    return node
 
 
 def before_send(event, hint):

--- a/open_discussions/sentry.py
+++ b/open_discussions/sentry.py
@@ -1,4 +1,5 @@
 """Sentry setup and configuration"""
+
 import sentry_sdk
 from celery.exceptions import WorkerLostError
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -7,6 +8,51 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 # these errors occur when a shutdown is happening (usually caused by a SIGTERM)
 SHUTDOWN_ERRORS = (WorkerLostError, SystemExit)
+
+
+# Postgres appends a DETAIL line to constraint violations that echoes the whole
+# offending row -- on a users table that is the learner's name, email and
+# external UUID.  psycopg puts it in str(exc), so it ships inside the exception
+# value, where no SDK privacy setting reaches it: send_default_pii governs
+# user/cookie/header capture and max_request_body_size governs request bodies,
+# and neither touches exception text.
+PG_DETAIL_MARKER = "\nDETAIL:"
+PG_DETAIL_REPLACEMENT = "\nDETAIL:  [scrubbed]"
+
+
+def scrub_pg_detail(text):
+    """Truncate a Postgres error string at its DETAIL line.
+
+    Keeps the primary message, which is what identifies the failure, and drops
+    the row echo plus any HINT/CONTEXT Postgres appends after it.
+    """
+    index = text.find(PG_DETAIL_MARKER)
+    if index == -1:
+        return text
+    return text[:index] + PG_DETAIL_REPLACEMENT
+
+
+def scrub_pg_details(event):
+    """Apply scrub_pg_detail everywhere an error string lands on the event.
+
+    Covers exception values, the logentry message/formatted pair, and the legacy
+    top-level message, so the scrub holds whether the event arrived as an
+    uncaught exception or via logger.exception.
+    """
+    for entry in (event.get("exception") or {}).get("values") or []:
+        value = entry.get("value")
+        if isinstance(value, str):
+            entry["value"] = scrub_pg_detail(value)
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        for key in ("formatted", "message"):
+            value = logentry.get(key)
+            if isinstance(value, str):
+                logentry[key] = scrub_pg_detail(value)
+    top_message = event.get("message")
+    if isinstance(top_message, str):
+        event["message"] = scrub_pg_detail(top_message)
+    return event
 
 
 def before_send(event, hint):
@@ -25,7 +71,7 @@ def before_send(event, hint):
         if isinstance(exc_value, SHUTDOWN_ERRORS):
             # so we don't want to report expected shutdown errors to sentry
             return None
-    return event
+    return scrub_pg_details(event)
 
 
 def init_sentry(*, dsn, environment, version, log_level):
@@ -43,6 +89,13 @@ def init_sentry(*, dsn, environment, version, log_level):
         environment=environment,
         release=version,
         before_send=before_send,
+        # Request bodies are NOT gated on send_default_pii: the SDK sets
+        # request.data unconditionally (sentry_sdk/integrations/_wsgi_common.py
+        # :123) and this is the only control (:61).  Left unset it defaults to
+        # "medium", i.e. 10,000-byte bodies -- enrollment, checkout, profile and
+        # SCIM payloads.  Set explicitly so the choice is findable here rather
+        # than in a dependency's defaults.
+        max_request_body_size="small",
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),

--- a/open_discussions/sentry_test.py
+++ b/open_discussions/sentry_test.py
@@ -60,3 +60,72 @@ def test_before_send_scrubs_the_event():
     """The scrub is wired into the before_send hook, not just callable."""
     event = {"exception": {"values": [{"value": PG_INTEGRITY_ERROR}]}}
     assert "learner@example.invalid" not in repr(before_send(event, {}))
+
+
+def test_scrubs_breadcrumb_messages():
+    """LoggingIntegration records the log message as a breadcrumb."""
+    event = {
+        "breadcrumbs": {
+            "values": [
+                {
+                    "type": "log",
+                    "category": "django_scim.views",
+                    "message": PG_INTEGRITY_ERROR,
+                }
+            ]
+        }
+    }
+    scrub_pg_details(event)
+    assert "learner@example.invalid" not in repr(event)
+
+
+def test_scrubs_logentry_params():
+    """logger.error("...: %s", exc) puts the exception in logentry.params."""
+    event = {
+        "logentry": {
+            "message": "Unable to complete SCIM call: %s",
+            "formatted": "Unable to complete SCIM call: " + PG_INTEGRITY_ERROR,
+            "params": [PG_INTEGRITY_ERROR],
+        }
+    }
+    scrub_pg_details(event)
+    assert "learner@example.invalid" not in repr(event)
+
+
+def test_scrubs_captured_frame_locals():
+    """include_local_variables defaults to True, so frame vars carry it too."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "value": "boom",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "save",
+                                "vars": {"exc": PG_INTEGRITY_ERROR, "retries": 3},
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    scrub_pg_details(event)
+    assert "learner@example.invalid" not in repr(event)
+    frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert frame["vars"]["retries"] == 3
+
+
+def test_walk_preserves_non_string_leaves():
+    """The walk must not coerce timestamps, ints or None into strings."""
+    event = {
+        "timestamp": 1757345533.179,
+        "level": "error",
+        "extra": {"count": 42, "missing": None, "flag": True},
+        "message": PG_INTEGRITY_ERROR,
+    }
+    scrub_pg_details(event)
+    assert event["timestamp"] == 1757345533.179
+    assert event["extra"] == {"count": 42, "missing": None, "flag": True}
+    assert "learner@example.invalid" not in event["message"]

--- a/open_discussions/sentry_test.py
+++ b/open_discussions/sentry_test.py
@@ -1,5 +1,14 @@
 """Tests for Sentry event scrubbing."""
 
+# pylint: disable=redefined-outer-name
+import json
+import logging
+
+import pytest
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.transport import Transport
+
 from open_discussions.sentry import (
     before_send,
     scrub_pg_detail,
@@ -19,12 +28,49 @@ PG_PRIMARY_MESSAGE = (
 )
 
 
+class FakeTransport(Transport):
+    """Collect outgoing events instead of sending them."""
+
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def capture_envelope(self, envelope):
+        self.events.extend(
+            item.payload.json for item in envelope.items if item.type == "event"
+        )
+
+
+@pytest.fixture
+def sentry_transport():
+    """Initialize the real SDK with before_send, and detach it afterwards."""
+    transport = FakeTransport()
+    sentry_sdk.init(  # pylint:disable=abstract-class-instantiated
+        dsn="https://k@o0.ingest.sentry.io/0",
+        transport=transport,
+        before_send=before_send,
+        default_integrations=False,
+        integrations=[
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR)
+        ],
+    )
+    yield transport
+    sentry_sdk.get_global_scope().set_client(None)
+
+
 def test_detail_line_is_truncated():
     """The row echo goes; the primary error that names the failure stays."""
     scrubbed = scrub_pg_detail(PG_INTEGRITY_ERROR)
     assert scrubbed.startswith(PG_PRIMARY_MESSAGE)
     assert "learner@example.invalid" not in scrubbed
     assert "12d7dfc5-6f84-46db-9383-2d7079434173" not in scrubbed
+
+
+def test_escaped_detail_line_is_truncated():
+    """repr() turns the newline into a literal backslash-n; that form goes too."""
+    scrubbed = scrub_pg_detail(repr(Exception(PG_INTEGRITY_ERROR)))
+    assert PG_PRIMARY_MESSAGE in scrubbed
+    assert "learner@example.invalid" not in scrubbed
 
 
 def test_message_without_detail_is_unchanged():
@@ -80,12 +126,12 @@ def test_scrubs_breadcrumb_messages():
 
 
 def test_scrubs_logentry_params():
-    """logger.error("...: %s", exc) puts the exception in logentry.params."""
+    """logger.error("...: %s", exc) puts the repr'd exception in logentry.params."""
     event = {
         "logentry": {
             "message": "Unable to complete SCIM call: %s",
             "formatted": "Unable to complete SCIM call: " + PG_INTEGRITY_ERROR,
-            "params": [PG_INTEGRITY_ERROR],
+            "params": [repr(Exception(PG_INTEGRITY_ERROR))],
         }
     }
     scrub_pg_details(event)
@@ -93,7 +139,7 @@ def test_scrubs_logentry_params():
 
 
 def test_scrubs_captured_frame_locals():
-    """include_local_variables defaults to True, so frame vars carry it too."""
+    """include_local_variables defaults to True, so repr'd frame vars carry it."""
     event = {
         "exception": {
             "values": [
@@ -103,7 +149,10 @@ def test_scrubs_captured_frame_locals():
                         "frames": [
                             {
                                 "function": "save",
-                                "vars": {"exc": PG_INTEGRITY_ERROR, "retries": 3},
+                                "vars": {
+                                    "exc": repr(Exception(PG_INTEGRITY_ERROR)),
+                                    "retries": 3,
+                                },
                             }
                         ]
                     },
@@ -129,3 +178,22 @@ def test_walk_preserves_non_string_leaves():
     assert event["timestamp"] == 1757345533.179
     assert event["extra"] == {"count": 42, "missing": None, "flag": True}
     assert "learner@example.invalid" not in event["message"]
+
+
+def test_real_sdk_scrubs_params_and_local_variables(sentry_transport):
+    """Go through the real SDK, which repr()s params and locals before before_send."""
+
+    def save():
+        exc = Exception(PG_INTEGRITY_ERROR)
+        raise exc
+
+    try:
+        save()
+    except Exception as e:  # pylint:disable=broad-except
+        logging.getLogger("x").error("Unable to save: %s", e)
+        sentry_sdk.capture_exception(e)
+    sentry_sdk.flush()
+
+    assert len(sentry_transport.events) == 2
+    for event in sentry_transport.events:
+        assert "learner@example.invalid" not in json.dumps(event)

--- a/open_discussions/sentry_test.py
+++ b/open_discussions/sentry_test.py
@@ -1,0 +1,62 @@
+"""Tests for Sentry event scrubbing."""
+
+from open_discussions.sentry import (
+    before_send,
+    scrub_pg_detail,
+    scrub_pg_details,
+)
+
+# A real MITXONLINE-6PK exception value, with the learner identifiers replaced.
+PG_INTEGRITY_ERROR = (
+    'null value in column "name" of relation "users_user" violates not-null '
+    "constraint\n"
+    "DETAIL:  Failing row contains (1863408, , 2026-08-07 18:38:14.503726+00, f, "
+    "learner@example.invalid, learner@example.invalid, null, f, t, "
+    "12d7dfc5-6f84-46db-9383-2d7079434173, 1863408, learner@example.invalid, f)."
+)
+PG_PRIMARY_MESSAGE = (
+    'null value in column "name" of relation "users_user" violates not-null constraint'
+)
+
+
+def test_detail_line_is_truncated():
+    """The row echo goes; the primary error that names the failure stays."""
+    scrubbed = scrub_pg_detail(PG_INTEGRITY_ERROR)
+    assert scrubbed.startswith(PG_PRIMARY_MESSAGE)
+    assert "learner@example.invalid" not in scrubbed
+    assert "12d7dfc5-6f84-46db-9383-2d7079434173" not in scrubbed
+
+
+def test_message_without_detail_is_unchanged():
+    """A message with no DETAIL line passes through untouched."""
+    message = "connection to server failed"
+    assert scrub_pg_detail(message) == message
+
+
+def test_hint_and_context_after_detail_are_dropped():
+    """HINT and CONTEXT follow DETAIL and can quote row data too."""
+    text = "boom\nDETAIL:  row data\nHINT:  try again\nCONTEXT:  SQL statement"
+    scrubbed = scrub_pg_detail(text)
+    assert "row data" not in scrubbed
+    assert "try again" not in scrubbed
+    assert "SQL statement" not in scrubbed
+
+
+def test_scrubs_exception_values_logentry_and_message():
+    """Every place the SDK can put an error string is covered."""
+    event = {
+        "exception": {"values": [{"value": PG_INTEGRITY_ERROR}]},
+        "logentry": {
+            "message": PG_INTEGRITY_ERROR,
+            "formatted": PG_INTEGRITY_ERROR,
+        },
+        "message": PG_INTEGRITY_ERROR,
+    }
+    scrub_pg_details(event)
+    assert "learner@example.invalid" not in repr(event)
+
+
+def test_before_send_scrubs_the_event():
+    """The scrub is wired into the before_send hook, not just callable."""
+    event = {"exception": {"values": [{"value": PG_INTEGRITY_ERROR}]}}
+    assert "learner@example.invalid" not in repr(before_send(event, {}))


### PR DESCRIPTION
## This repo

This app never passed `max_request_body_size`, so it has been on the SDK default of `"medium"` — 10KB bodies — by omission rather than by decision. Sets it to `"small"` explicitly at the `sentry_sdk.init` call site, so the choice is findable there rather than in a dependency's defaults, and adds the Postgres `DETAIL:` scrub to the existing `before_send`.

Production runs Django under WSGI (uwsgi), so the Content-Length caveat below doesn't apply.

## What

Two independent ways learner data reaches Sentry, neither of them governed by `send_default_pii`. Part of a ten-repo change on branch `tmacey/sentry-scrub-request-bodies`.

### 1. HTTP request bodies are captured with no PII gate

`request_info["data"]` is set unconditionally in `RequestExtractor.extract_into_event`. The only control is `max_request_body_size`, checked by `request_body_within_bounds`:

| value | effect |
| --- | --- |
| `never` | no bodies |
| `small` | bodies <= 1,000 bytes |
| `medium` | bodies <= 10,000 bytes — **the SDK default** |
| `always` | no limit |

Verified against sentry-sdk source: `request_body_within_bounds` does the bounds check, `RequestExtractor.extract_into_event` sets the body unconditionally, and `"medium"` is the `max_request_body_size` default. The repos in this change pin 1.9.0 to 2.68.0, and the behaviour is the same across them.

The bound is checked against the declared `Content-Length`, and a missing or malformed header counts as 0. Under WSGI, Django then reads 0 bytes, so nothing gets past it. Under ASGI, Django takes `CONTENT_LENGTH` from the header and reads the whole body, so on learn-ai and mit-learn a chunked request with no `Content-Length` is captured in full. The Starlette integration (ol-analytics-api) attaches no body when the header is absent.

Which endpoints that actually means, measured in Sentry over the 30 days to 2026-09-08 (`dataset=errors`, `http.method:[POST,PUT,PATCH]`, grouped by transaction):

| transaction | project | events |
| --- | --- | --- |
| `PATCH /scim/v2/Users/{uuid}` | mitxonline | 17,610 |
| `POST /api/v1/webhooks/content_files/` | mit-learn | 5,039 |
| `POST /api/v1/enrollments/` | mitxonline | 1,436 |
| `POST .../xblock/{usage_id}/handler/{handler}/` | openedx-mitxpro | 553 |
| `POST /cms/pages/{page_id}/edit/` | micromasters | 273 |
| `POST /api/profile/details/` | mitxonline | 132 |
| `POST /api/checkout/result/` | mitxonline | 65 |
| `POST /api/checkout/redeem_discount/` | mitxonline | 46 |

Enrollment, checkout, profile edits, SCIM user attributes, and xblock handler submissions — governed by a knob nobody set.

### 2. Postgres `DETAIL:` lines leak rows through the exception text

A constraint violation carries a `DETAIL:  Failing row contains (...)` line reproducing the whole offending row, and psycopg puts it in `str(exc)`. It therefore ships inside the *exception value*, where no SDK privacy option reaches it — `send_default_pii` governs user/cookie/header capture and `max_request_body_size` governs bodies; neither touches exception text.

Measured on [MITXONLINE-6PK](https://mit-office-of-digital-learning.sentry.io/issues/MITXONLINE-6PK): a SCIM `PATCH` `IntegrityError` on `users_user` whose `DETAIL` line reproduces a learner email address three times per event. First seen 2026-05-27, **46,764 occurrences**, last seen 2026-09-08 — still firing.

`before_send` now walks the whole serialized event and truncates any string at its `DETAIL:` line, whether the newline arrives raw or as a literal `\n` (the SDK `repr()`s frame locals and non-string log params before `before_send` runs). It keeps the primary error that names the failure and drops the row echo plus any `HINT`/`CONTEXT` after it.

## Testing

Unit tests next to the module use a real MITXONLINE-6PK exception value with the learner identifiers replaced. They assert the primary message survives, the email and external UUID do not, and `HINT`/`CONTEXT` are dropped, for both the raw `DETAIL:` line and the repr'd form the SDK produces for frame locals and log params. One test goes through a real SDK client, with this module's `before_send` and a fake transport, and checks that no outgoing event carries the email. Against the pre-review module, 4 of the tests fail, that one included.

## Not in scope

`send_default_pii` and the salted-user-hash work are deliberately untouched here — different knob, different failure mode, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVJKTGk9KHUTN2xfU59ujX

## The other nine PRs

Same branch name (`tmacey/sentry-scrub-request-bodies`) in each repo. Independent — no merge order required.

| repo | PR | body size |
| --- | --- | --- |
| open-edx-plugins | mitodl/open-edx-plugins#866 | `never` |
| mit-learn | mitodl/mit-learn#3915 | `small` |
| mitxonline | mitodl/mitxonline#3936 | `small` |
| mitxpro | mitodl/mitxpro#4088 | `small` |
| ocw-studio | mitodl/ocw-studio#3198 | `small` |
| odl-video-service | mitodl/odl-video-service#1591 | `small` |
| micromasters | mitodl/micromasters#5561 | `small` (as `request_bodies`, SDK 1.9.0) |
| open-discussions | mitodl/open-discussions#4463 | `small` |
| learn-ai | mitodl/learn-ai#62 | `small` |
| ol-analytics-api | mitodl/ol-analytics-api#54 | `small` |
